### PR TITLE
chore(cmake): pull in changes from cmake-utils that grabs the BSP for G4xx boards

### DIFF
--- a/cmake/FindSTM32G4xx.cmake
+++ b/cmake/FindSTM32G4xx.cmake
@@ -1,0 +1,146 @@
+#[=======================================================================[.rst:
+FindSTM32G4xx
+----------------
+
+Provides a module find backend for the STM32G4xx board support package.
+
+This should not be imported. It should be used with find_package:
+``find_package(STM32G4xx COMPONENTS BSP FreeRTOS USB )``
+
+When called with find package, it will add a static library target of the same
+name, with appropriate definitions, suitable for use in target_link_library.
+
+There are several available subcomponents that callers may want to pick and
+choose from; some of them require different supporting setup in the calling
+project. Each component is namespaced under STM32G4xx.
+
+Provides the variables ``STM32G4xx_BSP_FOUND`` as a bool and ``STM32G4xx_BSP_DIR``
+as the path to the source.
+
+Each component has its own ``STM32G4xx_${COMPONENT}_FOUND`` and so on set
+of exported variables.
+
+The ``Drivers`` subcomponent is always selected no matter whether it is present
+in the components list, since it is the fundamental part of the BSP.
+
+Drivers
++++++++
+
+The Drivers component (``STM32G4xx_Drivers``) contains the drivers and device
+header files. ``find_package`` exported variables are
+``STM32G4xx_Drivers_FOUND``, etc. This is the contents of the ``Drivers/``
+subdirectory of the BSP.
+
+You can select the Drivers component by adding ``Drivers`` to the ``COMPONENTS``
+argument of ``find_package``: ``find_package(STM32G4xx COMPONENTS Drivers)``.
+This can then be added to calling projects by calling
+``target_link_libraries(mytarget STM32G4xx_Drivers)``.
+
+Some options need to be set by the calling project on the imported
+``STM32G4xx_Drivers`` target before it can be used. Specifically,
+
+- ``target_compile_definitions`` should be used on the library target to set
+the appropriate board definition for the boardfile for the specific processor
+being used (i.e.
+``target_compile_definitions(STM32G4xx_Drivers PUBLIC STM32G4xx)``)
+- ``target_include_directories`` should be used to add an include directory that
+contains the STM32 hal conf file ``stm32g4xx_hal_conf.h``, which is included by
+the library to provide the individual HAL module enable/disable flags
+
+
+FreeRTOS
+++++++++
+
+The FreeRTOS component (``STM32G4xx_FreeRTOS``) contains a port of FreeRTOS to
+the STM32. This is the ``Middlewares/Third_Party/FreeRTOS`` subdirectory, or at
+least most of it (this isn't compiler-sensitive, it always selects the GCC version
+ of compiler-dependent options).
+
+You can select the FreeRTOS component by adding ``FreeRTOS`` to the ``COMPONENTS``
+argument of ``find_package``: ``find_package(STM32G4xx COMPONENTS FreeRTOS)``.
+This can then be added to calling projects by calling
+``target_link_libraries(mytarget STM32G4xx_FreeRTOS)``.
+
+Some options need to be set by the calling project on the imported
+``STM32G4xx_FreeRTOS`` target before it can be used. Specifically,
+
+- ``target_compile_definitions`` should be used on the library target to set
+the appropriate board definition for the boardfile for the specific processor
+being used (i.e.
+  ``target_compile_definitions(STM32G4xx_FreeRTOS PUBLIC STM32G4xx)``)
+- ``target_include_directories`` should be used to add an include directory that
+contains a ``FreeRTOSConfig.h`` file that sets FreeRTOS configuration options.
+- The caller can also set a CMake property on the imported
+``STM32G4xx_FreeRTOS`` component called ``FREERTOS_HEAP_IMPLEMENTATION`` to
+select the heap implementation from the ones provided by freertos. These should
+be the names of the one of the heap implementation c files without the extension,
+e.g.
+``set_target_properties(STM32G4xx_FreeRTOS PROPERTIES FREERTOS_HEAP_IMPLEMENTATION "heap_5")``
+
+#]=======================================================================]
+
+
+include(FetchContent)
+
+FetchContent_Declare(
+        STM32_G491RE_BSP_SOURCE
+        GIT_REPOSITORY "https://github.com/STMicroelectronics/STM32CubeG4"
+        GIT_TAG "v1.11.2"
+        GIT_SHALLOW
+        PREFIX ${CMAKE_SOURCE_DIR}/stm32-tools/
+        SOURCE_DIR ${CMAKE_SOURCE_DIR}/stm32-tools/stm32g4xx-bsp
+)
+
+FetchContent_MakeAvailable(STM32_G491RE_BSP_SOURCE)
+FetchContent_GetProperties(STM32_G491RE_BSP_SOURCE
+        SOURCE_DIR bsp_source
+        POPULATED bsp_populated
+        )
+
+set(STM32G4xx_BSP_FOUND ${bsp_populated} PARENT_SCOPE)
+set(STM32G4xx_BSP_DIRECTORY ${bsp_source} PARENT_SCOPE)
+set(STM32G4xx_BSP_VERSION "1.11.2" PARENT_SCOPE)
+set(STM32G4xx_BSP_VERSION_STRING "1.11.2" PARENT_SCOPE)
+
+file(GLOB_RECURSE hal_driver_sources ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Src/*.c)
+add_library(
+        STM32G4xx_Drivers STATIC
+        ${hal_driver_sources})
+
+target_include_directories(
+        STM32G4xx_Drivers
+        PUBLIC ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc
+        ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc/Legacy
+        ${bsp_source}/Drivers/CMSIS/Device/ST/STM32G4xx/Include
+        ${bsp_source}/Drivers/CMSIS/Core/Include)
+
+set_target_properties(
+        STM32G4xx_Drivers
+        PROPERTIES C_STANDARD 11
+        C_STANDARD_REQUIRED TRUE)
+set(STM32G4xx_Drivers_FOUND ${bsp_populated} PARENT_SCOPE)
+
+
+if ("FreeRTOS" IN_LIST STM32G4xx_FIND_COMPONENTS)
+    set(freertos_source ${bsp_source}/Middlewares/Third_Party/FreeRTOS/Source)
+    set(freertos_port_source ${freertos_source}/portable/GCC/ARM_CM4F)
+    file(GLOB freertos_common_sources ${freertos_source}/*.c)
+
+    add_library(
+            STM32G4xx_FreeRTOS STATIC
+            ${freertos_common_sources}
+            ${freertos_port_source}/port.c
+            $<IF:$<BOOL:$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>>,${freertos_source}/portable/MemMang/$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>.c,"">)
+
+    target_include_directories(
+            STM32G4xx_FreeRTOS
+            PUBLIC ${freertos_source}/include
+            ${freertos_port_source})
+
+    set(STM32G4xx_FreeRTOS_FOUND ${bsp_populated} PARENT_SCOPE)
+    set_target_properties(
+            STM32G4xx_FreeRTOS
+            PROPERTIES C_STANDARD 11
+            C_STANDARD_REQUIRED TRUE)
+
+endif()

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,1 +1,35 @@
 # cmake-utils
+
+This is a repository containing cmake scripts useful in embedded c/c++ projects used at opentrons.
+
+If you are at opentrons and you are reading this file somewhere other than the web interface for https://github.com/Opentrons/cmake-utils , it is almost certainly checked into your project with [git subtree](https://www.atlassian.com/git/tutorials/git-subtree), and *you should not check in changes in your own repo's source.* Instead, you should open a pull request on cmake-utils.
+
+## Updating cmake-utils subtree in your project
+
+When you want to get changes from cmake-utils, you can update your local subtree and commit that change into either your branch or your mainline:
+`git checkout -b chore_update-cmake-utils`
+`git subtree pull --prefix cmake cmake-utils main --squash`
+`git push --set-upstream origin chore_update-cmake-utils`
+Then open a PR in your local repo.
+
+The subtree checkout should be managed like any other file and changed only in pull requests.
+
+## Testing changes to other projects
+
+Since there's no indication in this repo of which projects use this repo, we can only do a best-effort attempt to test the cmake changes here with other projects. Please make this best-effort attempt! This can be done by either copying the changes to those other projects temporarily, or doing a `git subtree pull` in those other projects to the branch you're testing here.
+
+## How should I use this in my project?
+
+The CMake modules here are designed for reuse, but to reuse cmake modules they have to be somewhere that cmake can find them. You should either submodule or subtree this repo into where you want to use it, probably in a directory called `cmake`. You can then add the directory to cmake's module path in your top-level `CMakeList.txt` (or whichever `CMakeList.txt` you want to use the utils in if it's not the top level):
+
+`set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})`
+
+Adding this project by subtree is a better way to work than adding it as a submodule because it will conform more closely to the way this project is developed. If you add this project by subtree to another (this other project will be called the "host project" after this), then the host project controls which commit is subtreed in - it's whatever commit was specified the last time a `git subtree pull` was done in the host project. If `git subtree pull` specified a branch, then the commit that was the head of that branch at the time of the `git subtree pull` will be checked in and never changed.
+
+However, if the host project uses `git submodule add` to add this repo, then it adds it by symbolic name, which means that subsequent `git submodule update`s may change the commit used in the host project without changing the host project's tracked state. Since this project's `main` branch might be updated anytime, it is generally not a good idea to do this. So use `git subtree`, and anytime you do a `git subtree pull` make sure to test the results.
+
+## What will the modules here do?
+
+The modules in this repo are mostly designed to download and create build systems for various native code dependencies; there are also a couple that download and create synthetic targets for various useful tools. The exact way to use each module depends on what that module is.
+
+Modules that download dependencies or tools will download to a subdirectory called `stm32-tools/${name}/${system}`. For instance, `FindSTM32F303BSP` will download the BSP to `stm32-tools/stm32f303bsp/Linux` on Linux, or `stm32-tools/stm32f303bsp/Darwin` on OSX. Modules whose names start with `Find` generally adhere to the expectations of a [cmake find package module](https://cmake.org/cmake/help/v3.19/manual/cmake-packages.7.html) and set the appropriate cache variables.


### PR DESCRIPTION
## Overview

Closes #7. We need to update the cmake folder with changes from the cmake-utils file so that code can actually be built for G4xx boards.