### PR TITLE
fix(common): bit_utils: handle size checking

### DIFF
--- a/common/tests/test_bit_utils.cpp
+++ b/common/tests/test_bit_utils.cpp
@@ -5,49 +5,103 @@
 #include "common/core/bit_utils.hpp"
 
 SCENARIO("bytes_to_int works") {
-    GIVEN("a 2 byte span") {
-        auto arr = std::array{1, 2};
-        std::span sp{arr};
-        WHEN("called") {
+    GIVEN("a 2 byte input") {
+        auto arr = std::array<uint8_t, 2>{1, 2};
+        WHEN("parsing 2 bytes from both bytes") {
             uint16_t val = 0;
-            bit_utils::bytes_to_int<uint16_t, int>(sp, val);
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
             THEN("it is converted to a uint16_t") { REQUIRE(val == 0x0102); }
+            THEN("the return iterator points to the end") {
+                REQUIRE(next == arr.cend());
+            }
+        }
+        WHEN("parsing 2 bytes from only 1 byte") {
+            uint16_t val = 0;
+            auto next =
+                bit_utils::bytes_to_int(arr.cbegin(), arr.cbegin() + 1, val);
+            THEN("only the first byte is read") { REQUIRE(val == 0x0100); }
+            THEN("the return points to the second byte") {
+                REQUIRE(next == (arr.cbegin() + 1));
+            }
+        }
+        WHEN("parsing 1 byte from 2 bytes") {
+            uint8_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
+            THEN("only the first byte is read") { REQUIRE(val == 0x01); }
+            THEN("the return points to the second byte") {
+                REQUIRE(next == (std::next(arr.cbegin())));
+            }
+        }
+        WHEN("parsing from a view") {
+            uint16_t val = 0;
+            auto next = bit_utils::bytes_to_int(std::views::all(arr), val);
+            THEN("The parse should provide the right number") {
+                REQUIRE(val == 0x0102);
+                REQUIRE(next == arr.cend());
+            }
         }
     }
-    GIVEN("a 4 byte span") {
-        auto arr = std::array{0xFF, 0xef, 0x3, 0x1};
-        std::span sp{arr};
-        WHEN("called") {
+    GIVEN("a 4 byte input") {
+        auto arr = std::array<uint8_t, 4>{0xFF, 0xef, 0x3, 0x1};
+
+        WHEN("parsing 4 bytes") {
             uint32_t val = 0;
-            bit_utils::bytes_to_int<uint32_t, int>(sp, val);
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
             THEN("it is converted to a uint32_t") {
                 REQUIRE(val == 0xFFEF0301);
+            }
+            THEN("the return points to the end") {
+                REQUIRE(next == arr.cend());
+            }
+        }
+
+        WHEN("called with a 2 byte output request") {
+            uint16_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr, val);
+            THEN("only the first two bytes are converted") {
+                REQUIRE(val == 0xFFEF);
+            }
+            THEN("the return points to 2 bytes in") {
+                REQUIRE(next == (arr.cbegin() + 2));
+            }
+        }
+
+        WHEN("called with an 8 byte output request") {
+            uint64_t val = 0;
+            auto next = bit_utils::bytes_to_int(arr, val);
+            THEN("only the first 4 bytes of the output are filled") {
+                REQUIRE(val == 0xffef030100000000);
+            }
+            THEN("the iterator points to the end") {
+                REQUIRE(next == arr.cend());
             }
         }
     }
     GIVEN("a 1 byte span") {
-        auto arr = std::array{0xdd};
-        std::span sp{arr};
-        WHEN("called") {
+        auto arr = std::array<uint8_t, 1>{0xdd};
+        WHEN("called with a one byte request") {
             uint8_t val = 0;
-            bit_utils::bytes_to_int<uint8_t, int>(sp, val);
+            auto next = bit_utils::bytes_to_int(arr.cbegin(), arr.cend(), val);
             THEN("it is converted to a uint8_t") { REQUIRE(val == 0xDD); }
+            THEN("the iterator points to the end") {
+                REQUIRE(next == arr.cend());
+            }
         }
     }
 }
 
 SCENARIO("int_to_bytes works") {
     GIVEN("some integers") {
-        auto arr = std::array<int, 7>{};
+        auto arr = std::array<uint8_t, 7>{};
         uint32_t i32 = 0x01234567;
         uint16_t i16 = 0x89ab;
         uint8_t i8 = 0xcd;
+        auto iter = arr.begin();
 
         WHEN("called") {
-            auto iter = arr.begin();
-            iter = bit_utils::int_to_bytes(i32, iter);
-            iter = bit_utils::int_to_bytes(i16, iter);
-            iter = bit_utils::int_to_bytes(i8, iter);
+            iter = bit_utils::int_to_bytes(i32, iter, arr.end());
+            iter = bit_utils::int_to_bytes(i16, iter, arr.end());
+            iter = bit_utils::int_to_bytes(i8, iter, arr.end());
             THEN("The values are written into the array") {
                 REQUIRE(arr[0] == 0x01);
                 REQUIRE(arr[1] == 0x23);

--- a/include/common/core/bit_utils.hpp
+++ b/include/common/core/bit_utils.hpp
@@ -1,42 +1,88 @@
 #pragma once
+#include <iterator>
+#include <ranges>
+#include <type_traits>
 
 namespace bit_utils {
-
-static const int byte_mask = 0xFF;
 
 /**
  * Convert a span of bytes into a single integer. The first index being the most
  * significant byte. Big endian.
- * @tparam OutputType The type of the result. Must be an integer.
- * @tparam InputType The type contained in the span. Must be an integer.
- * @param input A span of integers
+ * @tparam InputIter The input iterator to read from, which must refer to a
+ * byte and satisfy InputIterator
+ * @tparam InputEnd The limit to the input, which must satisfy
+ * is_sentinel_for<InputIter>
+ * @tparam OutputIntType The type of the result. Must be an integer.
+ * @param input Input iterator to read from
+ * @param limit Input limit to read until
  * @param output The output parameter.
+ * @returns Iterator to one-past where the last byte was read from.
+ *
+ * If the input iterator pair does not contain enough data to completely specify
+ * OutputType, then OutputType will remain incomplete in the less-significant
+ * parts, e.g. trying to parse a uint32_t from 0x112233 will result in output =
+ * 0x11223300.
  */
-template <typename OutputType, typename InputType>
-requires std::is_integral_v<OutputType> &&std::is_integral_v<InputType> void
-bytes_to_int(const std::span<InputType> &input, OutputType &output) {
+template <typename Input, typename Limit, typename OutputIntType>
+requires std::is_integral_v<OutputIntType>&& std::forward_iterator<Input>&&
+    std::sentinel_for<Limit, Input>&&
+        std::is_same_v<std::iter_value_t<Input>, uint8_t> [[nodiscard]] auto
+        bytes_to_int(Input input, const Limit limit, OutputIntType& output)
+            -> Input {
     output = 0;
-    for (auto byte : input) {
-        output <<= 8;
-        output |= (byte & byte_mask);
+    for (ssize_t byte_index = sizeof(output) - 1;
+         input != limit && byte_index >= 0; input++, byte_index--) {
+        output |= (static_cast<OutputIntType>(*input) << (byte_index * 8));
     }
+    return input;
 }
 
 /**
- * Write an integer into an iterator. Big Endian.
- * @tparam OutputIter An iterator to write into.
- * @tparam InputType The type written into the iterator. Must be an integer.
- * @param input integer
- * @param output An iterator
- * @returns iterator at end of written bytes
+ * overload of bytes_to_int to support direct range or view calls
+ * @tparam InputContainer A type satisfying forward_range containing uint8_t
+ * @tparam OutputIntType The type of the int to return; must satisfy
+ * is_integral_v
+ * @param input The input container to read from
+ * @param output The output int to write to
+ * @returns Iterator at one past the last byte that was read.
+ *
+ * For more details see the overload taking iterators.
  */
-template <typename InputType, typename OutputIter>
-requires std::forward_iterator<OutputIter> &&std::is_integral_v<InputType> auto
-int_to_bytes(InputType input, OutputIter iter) -> OutputIter {
-    for (int x = sizeof(input) - 1; x >= 0; x--) {
-        *iter++ = (input >> (x * 8)) & byte_mask;
+
+template <typename InputContainer, typename OutputIntType>
+requires std::is_integral_v<OutputIntType>&&
+    std::ranges::forward_range<InputContainer>&&
+        std::is_same_v<std::ranges::range_value_t<InputContainer>, uint8_t> auto
+        bytes_to_int(const InputContainer& input, OutputIntType& output)
+            -> std::ranges::iterator_t<const InputContainer> {
+    return bytes_to_int(input.begin(), input.end(), output);
+}
+
+/**
+ * Write an integer into a container. Big Endian.
+ * @tparam Output Output iterator type satisfying output_iterator
+ * @tparam Limit Limit for writing. Must satisfy sentinel_for<Output>.
+ * @tparam InputIntType The type written into the iterator. Must be an integer.
+ * Must satisfy is_integral_v.
+ * @param output iterator to write to
+ * @param limit Limit to write to
+ * @param input integer
+ * @returns iterator one-past-end of written bytes
+ *
+ * Bytes will be written into the container until either the size of the integer
+ * or the size of the container is reached, meaning that output may be partial.
+ */
+template <typename InputIntType, typename Output, typename Limit>
+requires std::is_integral_v<InputIntType>&& std::output_iterator<
+    Output, uint8_t>&& std::same_as<std::iter_value_t<Output>, uint8_t>&&
+    std::forward_iterator<Output>&&
+        std::sentinel_for<Limit, Output> [[nodiscard]] auto
+        int_to_bytes(InputIntType input, Output output, Limit limit) -> Output {
+    for (ssize_t x = sizeof(input) - 1; x >= 0 && output != limit;
+         x--, output++) {
+        *output = (input >> (x * 8));
     }
-    return iter;
+    return output;
 }
 
 }  // namespace bit_utils

--- a/include/firmware/common/uart_comms.hpp
+++ b/include/firmware/common/uart_comms.hpp
@@ -1,22 +1,22 @@
 #pragma once
 
 #include <span>
+
 #include "stm32g4xx_hal_conf.h"
 
 namespace uart_comms {
 
 class Uart {
-public:
+  public:
     explicit Uart(UART_HandleTypeDef *handle) : handle{handle} {}
 
-    void read(std::span <uint8_t> &buff);
+    void read(std::span<uint8_t> &buff);
 
-    void write(const std::span <uint8_t> &buff);
+    void write(const std::span<uint8_t> &buff);
 
-private:
+  private:
     static constexpr auto timeout = 0xFFFF;
     UART_HandleTypeDef *handle;
 };
 
-
-}
+}  // namespace uart_comms

--- a/include/pipettes/core/communication.hpp
+++ b/include/pipettes/core/communication.hpp
@@ -69,21 +69,23 @@ class MessageWriter {
     void write(Writer &communication, const pipette_messages::SentMessage &m);
 
   private:
-    template <typename Iter>
+    template <typename Iter, typename Limit>
     requires std::forward_iterator<Iter> auto write(
-        Iter iter, const pipette_messages::GetSpeedResult &m) -> Iter {
+        Iter iter, const Limit limit, const pipette_messages::GetSpeedResult &m)
+        -> Iter {
         iter = bit_utils::int_to_bytes(
             static_cast<uint32_t>(
                 pipette_messages::MessageType::get_speed_result),
-            iter);
-        return bit_utils::int_to_bytes(m.mm_sec, iter);
+            iter, limit);
+        return bit_utils::int_to_bytes(m.mm_sec, iter, limit);
     }
 
-    template <typename Iter>
-    requires std::forward_iterator<Iter> auto write(Iter iter,
+    template <typename Iter, typename Limit>
+    requires std::forward_iterator<Iter> auto write(Iter iter, Limit limit,
                                                     const std::monostate &m)
         -> Iter {
         static_cast<void>(m);
+        static_cast<void>(limit);
         return iter;
     }
 
@@ -96,7 +98,9 @@ void MessageWriter::write(Writer &communication,
                           const pipette_messages::SentMessage &m) {
     auto *iter = payload_buffer.begin();
 
-    auto visitor = [&iter, this](auto val) { iter = this->write(iter, val); };
+    auto visitor = [&iter, this](auto val) {
+        iter = this->write(iter, payload_buffer.end(), val);
+    };
 
     std::visit(visitor, m);
 


### PR DESCRIPTION
bit_utils didn't have a way to check that its inputs and outputs matched
in size, and had some other safety stuff around appropriate inputs that
wasn't there.

Now, we check the sizes of the available containers (in the for loops);
check the appropriateness of the contained int with an (annoying)
template requirement; and have an overload of bytes_to_int for iterator
pairs as well as a generic container that fulfills range, which should
work with any listlike container or view.