### PR TITLE
fix(uart): modify UART baudrate to match higher clock speed

### DIFF
--- a/gantry/firmware/uart.c
+++ b/gantry/firmware/uart.c
@@ -96,7 +96,7 @@ UART_HandleTypeDef MX_LPUART1_UART_Init() {
     /* USER CODE BEGIN USART1_Init 1 */
 
     /* USER CODE END USART1_Init 1 */
-    uint32_t baud_rate = 9600;
+    uint32_t baud_rate = 115200;
     UART_HandleTypeDef huart1 = {
         .Instance = LPUART1,
         .Init = {.BaudRate = baud_rate,

--- a/pipettes/firmware/uart.c
+++ b/pipettes/firmware/uart.c
@@ -100,7 +100,7 @@ UART_HandleTypeDef MX_LPUART1_UART_Init() {
     /* USER CODE BEGIN USART1_Init 1 */
 
     /* USER CODE END USART1_Init 1 */
-    uint32_t baud_rate = 9600;
+    uint32_t baud_rate = 115200;
     UART_HandleTypeDef huart1 = {
         .Instance = LPUART1,
         .Init = {


### PR DESCRIPTION
## Overview
The higher clock speed was too large for the given baudrate we were using for uart. Updating it to 115200 from 9600 fixes this issue.