### PR TITLE
refactor(common): pull RCC clock select into the common directory

### DIFF
--- a/common/firmware/STM32G491RETx/clocking.c
+++ b/common/firmware/STM32G491RETx/clocking.c
@@ -1,0 +1,15 @@
+#include "common/firmware/clocking.h"
+#include "common/firmware/errors.h"
+
+void RCC_Peripheral_Clock_Select() {
+    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
+
+    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_FDCAN | RCC_PERIPHCLK_I2C1;
+    PeriphClkInit.Usart1ClockSelection = RCC_USART1CLKSOURCE_PCLK2;
+    PeriphClkInit.FdcanClockSelection = RCC_FDCANCLKSOURCE_PCLK1;
+    PeriphClkInit.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1;
+    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+        Error_Handler();
+    }
+
+}

--- a/common/firmware/errors/errors.c
+++ b/common/firmware/errors/errors.c
@@ -1,3 +1,7 @@
+#pragma once
+
+#include "stm32g4xx_hal_conf.h"
+
 #include "common/firmware/errors.h"
 
 void Error_Handler(void) {

--- a/common/firmware/errors/errors.c
+++ b/common/firmware/errors/errors.c
@@ -1,0 +1,11 @@
+#include "common/firmware/errors.h"
+
+void Error_Handler(void) {
+    /* USER CODE BEGIN Error_Handler_Debug */
+    /* User can add his own implementation to report the HAL error return state
+     */
+    __disable_irq();
+    while (1) {
+    }
+    /* USER CODE END Error_Handler_Debug */
+}

--- a/common/firmware/spi/spi.c
+++ b/common/firmware/spi/spi.c
@@ -1,6 +1,6 @@
 #include "common/firmware/spi.h"
+#include "common/firmware/errors.h"
 
-static void Spi_Error_Handler(void);
 
 /**
  * @brief SPI MSP Initialization
@@ -105,7 +105,7 @@ SPI_HandleTypeDef MX_SPI2_Init() {
     };
 
     if (HAL_SPI_Init(&hspi2) != HAL_OK) {
-        Spi_Error_Handler();
+        Error_Handler();
     }
     return hspi2;
 }
@@ -127,15 +127,6 @@ void MX_DMA_Init(void) {
     HAL_NVIC_EnableIRQ(DMA1_Channel3_IRQn);
 }
 
-static void Spi_Error_Handler(void) {
-    /* USER CODE BEGIN Error_Handler_Debug */
-    /* User can add his own implementation to report the HAL error return state
-     */
-    __disable_irq();
-    while (1) {
-    }
-    /* USER CODE END Error_Handler_Debug */
-}
 
 void Set_CS_Pin(void) { HAL_GPIO_WritePin(GPIOB, GPIO_PIN_12, GPIO_PIN_SET); }
 

--- a/common/firmware/uart/uart.c
+++ b/common/firmware/uart/uart.c
@@ -1,6 +1,7 @@
 #include "common/firmware/uart.h"
+#include "common/firmware/errors.h"
 
-static void Error_Handler();
+
 /**
  * Initializes the Global MSP.
  */
@@ -137,23 +138,4 @@ UART_HandleTypeDef MX_LPUART1_UART_Init() {
 
     /* USER CODE END USART1_Init 2 */
     return huart1;
-}
-
-void RCC_Peripheral_Clock_Select() {
-    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
-
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_FDCAN;
-    PeriphClkInit.Usart1ClockSelection = RCC_USART1CLKSOURCE_PCLK2;
-    PeriphClkInit.FdcanClockSelection = RCC_FDCANCLKSOURCE_PCLK1;
-    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
-        Error_Handler();
-    }
-
-}
-
-static void Error_Handler() {
-    for(;;) {
-        HAL_GPIO_TogglePin(GPIOA, GPIO_PIN_5);
-        HAL_Delay(100);
-    }
 }

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -19,6 +19,8 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         ${COMMON_EXECUTABLE_DIR}/uart/uart.c
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/can/can.c
+        ${COMMON_EXECUTABLE_DIR}/errors/errors.c
+        ${COMMON_EXECUTABLE_DIR}/STM32G491RETx/clocking.c
         ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c)
 
 add_executable(gantry

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -16,11 +16,11 @@ set(GANTRY_FW_LINTABLE_SRCS
 set(GANTRY_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/system_stm32g4xx.c
         ${CMAKE_CURRENT_SOURCE_DIR}/stm32g4xx_it.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/clocking.c
         ${COMMON_EXECUTABLE_DIR}/uart/uart.c
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/can/can.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
-        ${COMMON_EXECUTABLE_DIR}/STM32G491RETx/clocking.c
         ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c)
 
 add_executable(gantry

--- a/gantry/firmware/clocking.c
+++ b/gantry/firmware/clocking.c
@@ -1,13 +1,16 @@
+#pragma once
+
+#include "stm32g4xx_hal_conf.h"
+
 #include "common/firmware/clocking.h"
 #include "common/firmware/errors.h"
 
 void RCC_Peripheral_Clock_Select() {
     RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
 
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_FDCAN | RCC_PERIPHCLK_I2C1;
+    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_FDCAN;
     PeriphClkInit.Usart1ClockSelection = RCC_USART1CLKSOURCE_PCLK2;
     PeriphClkInit.FdcanClockSelection = RCC_FDCANCLKSOURCE_PCLK1;
-    PeriphClkInit.I2c1ClockSelection = RCC_I2C1CLKSOURCE_PCLK1;
     if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
         Error_Handler();
     }

--- a/gantry/firmware/main.cpp
+++ b/gantry/firmware/main.cpp
@@ -9,6 +9,7 @@
 #include "task.h"
 // clang-format on
 
+#include "common/firmware/clocking.h"
 #include "common/firmware/spi.h"
 #include "common/firmware/uart.h"
 

--- a/include/common/firmware/clocking.h
+++ b/include/common/firmware/clocking.h
@@ -1,11 +1,14 @@
-#include "stm32g4xx_hal_conf.h"
-
+#ifndef __CLOCKING_H__
+#define __CLOCKING_H__
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
+
 void RCC_Peripheral_Clock_Select();
 
 #ifdef __cplusplus
 }  // extern "C"
-#endif // __cplusplus
+#endif  // __cplusplus
+
+#endif // __CLOCKING_H__

--- a/include/common/firmware/clocking.h
+++ b/include/common/firmware/clocking.h
@@ -1,15 +1,11 @@
 #include "stm32g4xx_hal_conf.h"
 
 
-#ifndef __UART_H__
-#define __UART_H__
-
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-UART_HandleTypeDef MX_LPUART1_UART_Init();
+void RCC_Peripheral_Clock_Select();
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif // __cplusplus
-
-#endif // __UART_H__

--- a/include/common/firmware/errors.h
+++ b/include/common/firmware/errors.h
@@ -1,15 +1,9 @@
 #include "stm32g4xx_hal_conf.h"
 
-
-#ifndef __UART_H__
-#define __UART_H__
-
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-UART_HandleTypeDef MX_LPUART1_UART_Init();
+void Error_Handler();
 #ifdef __cplusplus
 }  // extern "C"
 #endif // __cplusplus
-
-#endif // __UART_H__

--- a/include/common/firmware/errors.h
+++ b/include/common/firmware/errors.h
@@ -1,9 +1,1 @@
-#include "stm32g4xx_hal_conf.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif  // __cplusplus
 void Error_Handler();
-#ifdef __cplusplus
-}  // extern "C"
-#endif // __cplusplus

--- a/include/common/firmware/spi.h
+++ b/include/common/firmware/spi.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "stm32g4xx_hal_conf.h"
 
 #ifndef __SPI_H__

--- a/include/common/firmware/uart.h
+++ b/include/common/firmware/uart.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "stm32g4xx_hal_conf.h"
 
 

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -18,11 +18,11 @@ set(PIPETTE_FW_LINTABLE_SRCS
 set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/system_stm32g4xx.c
     ${CMAKE_CURRENT_SOURCE_DIR}/stm32g4xx_it.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/clocking.c
     ${COMMON_EXECUTABLE_DIR}/uart/uart.c
     ${COMMON_EXECUTABLE_DIR}/spi/spi.c
     ${COMMON_EXECUTABLE_DIR}/can/can.c
     ${COMMON_EXECUTABLE_DIR}/errors/errors.c
-    ${COMMON_EXECUTABLE_DIR}/STM32G491RETx/clocking.c
     ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c)
 
 add_executable(pipettes

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -21,6 +21,8 @@ set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${COMMON_EXECUTABLE_DIR}/uart/uart.c
     ${COMMON_EXECUTABLE_DIR}/spi/spi.c
     ${COMMON_EXECUTABLE_DIR}/can/can.c
+    ${COMMON_EXECUTABLE_DIR}/errors/errors.c
+    ${COMMON_EXECUTABLE_DIR}/STM32G491RETx/clocking.c
     ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c)
 
 add_executable(pipettes

--- a/pipettes/firmware/clocking.c
+++ b/pipettes/firmware/clocking.c
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "stm32g4xx_hal_conf.h"
+
+#include "common/firmware/clocking.h"
+#include "common/firmware/errors.h"
+
+void RCC_Peripheral_Clock_Select() {
+    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
+
+    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_FDCAN;
+    PeriphClkInit.Usart1ClockSelection = RCC_USART1CLKSOURCE_PCLK2;
+    PeriphClkInit.FdcanClockSelection = RCC_FDCANCLKSOURCE_PCLK1;
+    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit) != HAL_OK) {
+        Error_Handler();
+    }
+
+}

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -10,6 +10,7 @@
 // clang-format on
 
 #include "common/firmware/can_task.hpp"
+#include "common/firmware/clocking.h"
 #include "common/firmware/spi.h"
 #include "common/firmware/uart.h"
 #include "common/firmware/uart_comms.hpp"


### PR DESCRIPTION
## Overview

We shouldn't have the RCC clock select function be dependent on UART. This PR separates that function, and also error handler functions into their own C files that can be used as needed.

# Review Requests
Are we OK with the file locations/naming/functionality as is? Anything you'd like changed?