### PR TITLE
chore(ci): Integrate Github Action

### DIFF
--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -6,8 +6,7 @@ jobs:
     name: OT-3 Emulator
     steps:
       - uses: actions/checkout@v2
-      - id: foo
-        run: sudo modprobe vcan
+      - run: sudo modprobe vcan
         uses: Opentrons/ot3-emulator@v0.1
         with:
           ot3-firmware-commit-id: ${{ github.sha }}

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -2,7 +2,7 @@ on: [push]
 
 jobs:
   ot3-emulator:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-20.04"
     name: OT-3 Emulator
     steps:
       - uses: actions/checkout@v2
@@ -10,5 +10,3 @@ jobs:
         uses: Opentrons/ot3-emulator@v0.1
         with:
           ot3-firmware-commit-id: ${{ github.sha }}
-      - run: echo "Hello World"
-        shell: bash

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: foo
-        uses: Opentrons/ot3-emulator@v1
+        uses: Opentrons/ot3-emulator@v0.1
         with:
           ot3-firmware-commit-id: ${{ github.sha }}
       - run: echo "Hello World"

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -5,6 +5,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     name: OT-3 Emulator
     steps:
+      - run: sudo apt-get install linux-modules-extra-$(uname -r)
       - run: sudo modprobe vcan
       - uses: actions/checkout@v2
       - uses: Opentrons/ot3-emulator@v0.1

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -10,4 +10,5 @@ jobs:
         uses: Opentrons/ot3-emulator@v1
         with:
           ot3-firmware-commit-id: ${{ github.sha }}
-        run: echo "Hello World"
+      - run: echo "Hello World"
+        shell: bash

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -1,13 +1,17 @@
-on: [push]
+on: [pull_request, push]
 
 jobs:
   ot3-emulator:
     runs-on: "ubuntu-20.04"
     name: OT-3 Emulator
     steps:
-      - run: sudo apt-get install linux-modules-extra-$(uname -r)
-      - run: sudo modprobe vcan
-      - uses: actions/checkout@v2
-      - uses: Opentrons/ot3-emulator@v0.1
+      - name: Setup SocketCan
+      run: |
+        sudo apt-get install linux-modules-extra-$(uname -r)
+        sudo modprobe vcan
+      - name: Checkout firmware repo
+        uses: actions/checkout@v2
+      - name: Run OT-3 Emulator
+        uses: Opentrons/ot3-emulator@v1.0
         with:
           ot3-firmware-commit-id: ${{ github.sha }}

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -5,8 +5,8 @@ jobs:
     runs-on: "ubuntu-20.04"
     name: OT-3 Emulator
     steps:
-      - uses: actions/checkout@v2
       - run: sudo modprobe vcan
-        uses: Opentrons/ot3-emulator@v0.1
+      - uses: actions/checkout@v2
+      - uses: Opentrons/ot3-emulator@v0.1
         with:
           ot3-firmware-commit-id: ${{ github.sha }}

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -6,9 +6,9 @@ jobs:
     name: OT-3 Emulator
     steps:
       - name: Setup SocketCan
-      run: |
-        sudo apt-get install linux-modules-extra-$(uname -r)
-        sudo modprobe vcan
+        run: |
+          sudo apt-get install linux-modules-extra-$(uname -r)
+          sudo modprobe vcan
       - name: Checkout firmware repo
         uses: actions/checkout@v2
       - name: Run OT-3 Emulator

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -1,0 +1,12 @@
+on: [push]
+
+jobs:
+  ot3-emulator:
+    runs-on: ubuntu-latest
+    name: OT-3 Emulator
+    steps:
+      - uses: actions/checkout@v2
+      - id: foo
+        uses: Opentrons/ot3-emulator@v1
+        with:
+          ot3-firmware-commit-id: {{ github.sha }}

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: foo
+        run: sudo modprobe vcan
         uses: Opentrons/ot3-emulator@v0.1
         with:
           ot3-firmware-commit-id: ${{ github.sha }}

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -9,4 +9,5 @@ jobs:
       - id: foo
         uses: Opentrons/ot3-emulator@v1
         with:
-          ot3-firmware-commit-id: {{ github.sha }}
+          ot3-firmware-commit-id: ${{ github.sha }}
+        run: echo "Hello World"


### PR DESCRIPTION
Create Github Action that spins up OT-3 Emulator with latest version of firmware. 

Using an ubuntu 20.04 system, setup SocketCan driver, checkout the firmware repo, spin up the emulator with pushed/pull requested version of the firmware.

Currently the emulator just runs a simple script where it receives some CAN commands, echos them back, and exits. 

Down the line it will be updated with tests