### PR TITLE
feat(eeprom): add eeprom messages to CANBus

### DIFF
--- a/common/firmware/i2c/i2c_comms.cpp
+++ b/common/firmware/i2c/i2c_comms.cpp
@@ -18,12 +18,6 @@ using namespace i2c;
  *
  */
 
-/*
- * TODO(LC 08/19/2021): We should set this configuration whenever an I2C
- * instance is created. Because we are currently not creating one, this should
- * be moved in a followup PR.
- * */
-
 I2C::I2C() : handle(MX_I2C_Init()) {}
 
 void I2C::transmit(uint8_t value) {

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -65,8 +65,9 @@ enum class MessageId : uint16_t {
 
     get_speed_request = 0x04,
     get_speed_response = 0x11,
-    read_eeprom = 0x2001,
-    write_eeprom = 0x2002
+    write_eeprom = 0x2001,
+    read_eeprom_request = 0x2002,
+    read_eeprom_response = 0x2003
 };
 
 }  // namespace can_ids

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -65,6 +65,8 @@ enum class MessageId : uint16_t {
 
     get_speed_request = 0x04,
     get_speed_response = 0x11,
+    read_eeprom = 0x2001,
+    write_eeprom = 0x2002
 };
 
 }  // namespace can_ids

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -177,40 +177,52 @@ struct GetSpeedResponse {
 
 struct WriteToEEPromRequest {
     static const auto id = MessageId::write_eeprom;
-    uint32_t mm_sec;
+    uint8_t serial_number;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> WriteToEEPromRequest {
-        uint32_t mm_sec = 0;
-        body = bit_utils::bytes_to_int(body, limit, mm_sec);
-        return WriteToEEPromRequest{mm_sec};
+        uint8_t serial_number = 0;
+        body = bit_utils::bytes_to_int(body, limit, serial_number);
+        return WriteToEEPromRequest{serial_number};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(mm_sec, body, limit);
+        auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
         return iter - body;
     }
 };
 
-
 struct ReadFromEEPromRequest {
-    static const auto id = MessageId::read_eeprom;
-    uint32_t mm_sec;
+    static const auto id = MessageId::read_eeprom_request;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> ReadFromEEPromRequest {
-        uint32_t mm_sec = 0;
-        body = bit_utils::bytes_to_int(body, limit, mm_sec);
-        return ReadFromEEPromRequest{mm_sec};
+        return ReadFromEEPromRequest{};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(mm_sec, body, limit);
-        return iter - body;
+        return 0;
     }
 };
 
+struct ReadFromEEPromResponse {
+    static const auto id = MessageId::read_eeprom_response;
+    uint8_t serial_number;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> ReadFromEEPromResponse {
+        uint8_t serial_number = 0;
+        body = bit_utils::bytes_to_int(body, limit, serial_number);
+        return ReadFromEEPromResponse{serial_number};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
+        return iter - body;
+    }
+};
 
 }  // namespace can_messages

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -175,4 +175,42 @@ struct GetSpeedResponse {
     }
 };
 
+struct WriteToEEPromRequest {
+    static const auto id = MessageId::write_eeprom;
+    uint32_t mm_sec;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> WriteToEEPromRequest {
+        uint32_t mm_sec = 0;
+        body = bit_utils::bytes_to_int(body, limit, mm_sec);
+        return WriteToEEPromRequest{mm_sec};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(mm_sec, body, limit);
+        return iter - body;
+    }
+};
+
+
+struct ReadFromEEPromRequest {
+    static const auto id = MessageId::read_eeprom;
+    uint32_t mm_sec;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> ReadFromEEPromRequest {
+        uint32_t mm_sec = 0;
+        body = bit_utils::bytes_to_int(body, limit, mm_sec);
+        return ReadFromEEPromRequest{mm_sec};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(mm_sec, body, limit);
+        return iter - body;
+    }
+};
+
+
 }  // namespace can_messages

--- a/include/pipettes/core/eeprom.hpp
+++ b/include/pipettes/core/eeprom.hpp
@@ -10,7 +10,7 @@
  * A template and helper functions describing
  */
 
-namespace i2c {
+namespace eeprom {
 template <class I2C>
 concept EEPromPolicy =
     requires(I2C i2c_comms, const uint8_t transmit,
@@ -20,12 +20,12 @@ concept EEPromPolicy =
     {i2c_comms.receive(receive)};
 };
 
-template <i2c::EEPromPolicy EEPromWriter>
+template <eeprom::EEPromPolicy EEPromWriter>
 void write(EEPromWriter writer, const uint8_t serial_number) {
     writer.transmit(serial_number);
 }
 
-template <i2c::EEPromPolicy EEPromWriter>
+template <eeprom::EEPromPolicy EEPromWriter>
 uint8_t read(EEPromWriter writer) {
     using BufferType = std::array<uint8_t, writer.BUFFER_SIZE>;
     BufferType rxBuffer{0};
@@ -36,4 +36,4 @@ uint8_t read(EEPromWriter writer) {
     bit_utils::bytes_to_int(rxBuffer, data);
     return data;
 }
-}  // namespace i2c
+}  // namespace eeprom

--- a/pipettes/tests/test_eeprom.cpp
+++ b/pipettes/tests/test_eeprom.cpp
@@ -4,7 +4,7 @@
 #include "pipettes/core/eeprom.hpp"
 
 using namespace test_eeprom;
-using namespace i2c;
+using namespace eeprom;
 
 SCENARIO("read and write pipette serial numbers") {
     GIVEN("write command") {


### PR DESCRIPTION
## Overview
Closes ticket RET-110 in jira. With this PR you should be able to read and write to the eeprom via CAN messaging. I randomly picked the arbitration IDs, if you don't like them I'm very open to changing it.

## Review requests
Is the size of messages OK, or will it be a problem in CANBus? Anything else I didn't account for?