### PR TITLE
feat(can): Can device id message

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -99,7 +99,7 @@ SCENARIO("message serializing works") {
 
     GIVEN("a device info response message") {
         auto message = DeviceInfoResponse{NodeId::pipette, 0x00220033};
-        auto arr = std::array<uint8_t, 5>{0,0, 0, 0, 0};
+        auto arr = std::array<uint8_t, 5>{0, 0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized") {
             auto size = message.serialize(arr.begin(), arr.end());

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -34,6 +34,17 @@ SCENARIO("message deserializing works") {
             }
         }
     }
+
+    GIVEN("a device info response body") {
+        auto arr = std::array<uint8_t, 5>{1, 2, 3, 4, 5};
+        WHEN("constructed") {
+            auto r = DeviceInfoResponse::parse(arr.begin(), arr.end());
+            THEN("it is converted to a the correct structure") {
+                REQUIRE(r.node_id == NodeId::pipette);
+                REQUIRE(r.version == 0x02030405);
+            }
+        }
+    }
 }
 
 SCENARIO("message serializing works") {
@@ -83,6 +94,23 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[3] == 0x21);
             }
             THEN("size must be returned") { REQUIRE(size == 4); }
+        }
+    }
+
+    GIVEN("a device info response message") {
+        auto message = DeviceInfoResponse{NodeId::pipette, 0x00220033};
+        auto arr = std::array<uint8_t, 5>{0,0, 0, 0, 0};
+        auto body = std::span{arr};
+        WHEN("serialized") {
+            auto size = message.serialize(arr.begin(), arr.end());
+            THEN("it is written into the buffer correctly") {
+                REQUIRE(body.data()[0] == 0x01);
+                REQUIRE(body.data()[1] == 0x00);
+                REQUIRE(body.data()[2] == 0x22);
+                REQUIRE(body.data()[3] == 0x00);
+                REQUIRE(body.data()[4] == 0x33);
+            }
+            THEN("size must be returned") { REQUIRE(size == 5); }
         }
     }
 }

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "ids.hpp"
+#include "message_writer.hpp"
+#include "messages.hpp"
+#include "can_bus.hpp"
+
+
+using namespace can_ids;
+using namespace can_message_writer;
+using namespace can_messages;
+
+
+namespace can_device_info {
+
+/**
+ * A HandlesMessages implementing class that will respond to DeviceInfoRequest
+ * with a DeviceInfoResponse.
+ *
+ * @tparam Writer The can bus writer type.
+ */
+template <can_bus::CanBus Writer>
+class DeviceInfoHandler {
+  public:
+    /**
+     * Constructor
+     *
+     * @param writer A message writer for sending the response
+     * @param node_id The node id of this device
+     * @param version The firmware version on this device
+     */
+    DeviceInfoHandler(MessageWriter<Writer> & writer, NodeId node_id, uint32_t version): writer(writer), response(node_id, version) {}
+    DeviceInfoHandler(const DeviceInfoHandler &) = delete;
+    DeviceInfoHandler(const DeviceInfoHandler &&) = delete;
+    DeviceInfoHandler &operator=(const DeviceInfoHandler &) = delete;
+    DeviceInfoHandler &&operator=(const DeviceInfoHandler &&) = delete;
+
+    using MessageType = std::variant<std::monostate, DeviceInfoRequest>;
+
+    /**
+     * Message handler
+     * @param m The incoming message.
+     */
+    void handle(MessageType &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+  private:
+    void visit(std::monostate &m) {}
+
+    void visit(DeviceInfoRequest &m) {
+        writer.write(NodeId::host, response);
+    }
+
+    DeviceInfoResponse response;
+    MessageWriter<Writer> & writer;
+};
+
+}

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -29,7 +29,7 @@ class DeviceInfoHandler {
      */
     DeviceInfoHandler(MessageWriter<Writer> &writer, NodeId node_id,
                       uint32_t version)
-        : writer(writer), response(node_id, version) {}
+        : writer(writer), response{node_id, version} {}
     DeviceInfoHandler(const DeviceInfoHandler &) = delete;
     DeviceInfoHandler(const DeviceInfoHandler &&) = delete;
     DeviceInfoHandler &operator=(const DeviceInfoHandler &) = delete;
@@ -50,8 +50,8 @@ class DeviceInfoHandler {
 
     void visit(DeviceInfoRequest &m) { writer.write(NodeId::host, response); }
 
-    DeviceInfoResponse response;
     MessageWriter<Writer> &writer;
+    DeviceInfoResponse response;
 };
 
 }  // namespace can_device_info

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
+#include "can_bus.hpp"
 #include "ids.hpp"
 #include "message_writer.hpp"
 #include "messages.hpp"
-#include "can_bus.hpp"
-
 
 using namespace can_ids;
 using namespace can_message_writer;
 using namespace can_messages;
-
 
 namespace can_device_info {
 
@@ -29,7 +27,9 @@ class DeviceInfoHandler {
      * @param node_id The node id of this device
      * @param version The firmware version on this device
      */
-    DeviceInfoHandler(MessageWriter<Writer> & writer, NodeId node_id, uint32_t version): writer(writer), response(node_id, version) {}
+    DeviceInfoHandler(MessageWriter<Writer> &writer, NodeId node_id,
+                      uint32_t version)
+        : writer(writer), response(node_id, version) {}
     DeviceInfoHandler(const DeviceInfoHandler &) = delete;
     DeviceInfoHandler(const DeviceInfoHandler &&) = delete;
     DeviceInfoHandler &operator=(const DeviceInfoHandler &) = delete;
@@ -48,12 +48,10 @@ class DeviceInfoHandler {
   private:
     void visit(std::monostate &m) {}
 
-    void visit(DeviceInfoRequest &m) {
-        writer.write(NodeId::host, response);
-    }
+    void visit(DeviceInfoRequest &m) { writer.write(NodeId::host, response); }
 
     DeviceInfoResponse response;
-    MessageWriter<Writer> & writer;
+    MessageWriter<Writer> &writer;
 };
 
-}
+}  // namespace can_device_info

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -45,6 +45,44 @@ struct HeartbeatResponse {
     }
 };
 
+struct DeviceInfoRequest {
+    static const auto id = MessageId::device_info_request;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> DeviceInfoRequest {
+        return DeviceInfoRequest{};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        return 0;
+    }
+};
+
+struct DeviceInfoResponse {
+    static const auto id = MessageId::device_info_response;
+
+    NodeId node_id;
+    uint32_t version;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> DeviceInfoResponse {
+        uint8_t node_id;
+        uint32_t version;
+        body = bit_utils::bytes_to_int(body, limit, node_id);
+        body = bit_utils::bytes_to_int(body, limit, version);
+        return DeviceInfoResponse{static_cast<NodeId>(node_id), version};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(static_cast<uint8_t>(node_id), body, limit);
+        iter = bit_utils::int_to_bytes(version, iter, limit);
+        return iter - body;
+    }
+};
+
+
 struct StopRequest {
     static const auto id = MessageId::stop_request;
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -65,15 +65,18 @@ struct DeviceInfoResponse {
     /**
      *   TODO (al, 2021-09-13)
      *   Seth's thoughts on future of payload
-     *   IMO we should set this up for a couple more things than just version, and
-     *   then can care about version in general a little less. I don't think it's
-     *   necessarily critical to get right the first time, but we could do something like:
+     *   IMO we should set this up for a couple more things than just version,
+     * and then can care about version in general a little less. I don't think
+     * it's necessarily critical to get right the first time, but we could do
+     * something like:
      *   - two bits of build type (dev, testing, release)
      *   - a byte or two of like message schema version
      *   - a four byte incrementing version seems fine i suppose
-     *   - a byte or two for well-known-id system identification through some centrally defined enum
+     *   - a byte or two for well-known-id system identification through some
+     * centrally defined enum
      *   - at some point we'll want a serial number probably
-     *   - a hardware revision unless we want to fold that into the well-known-id
+     *   - a hardware revision unless we want to fold that into the
+     * well-known-id
      */
     NodeId node_id;
     uint32_t version;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -76,12 +76,12 @@ struct DeviceInfoResponse {
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(static_cast<uint8_t>(node_id), body, limit);
+        auto iter =
+            bit_utils::int_to_bytes(static_cast<uint8_t>(node_id), body, limit);
         iter = bit_utils::int_to_bytes(version, iter, limit);
         return iter - body;
     }
 };
-
 
 struct StopRequest {
     static const auto id = MessageId::stop_request;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -62,6 +62,19 @@ struct DeviceInfoRequest {
 struct DeviceInfoResponse {
     static const auto id = MessageId::device_info_response;
 
+    /**
+     *   TODO (al, 2021-09-13)
+     *   Seth's thoughts on future of payload
+     *   IMO we should set this up for a couple more things than just version, and
+     *   then can care about version in general a little less. I don't think it's
+     *   necessarily critical to get right the first time, but we could do something like:
+     *   - two bits of build type (dev, testing, release)
+     *   - a byte or two of like message schema version
+     *   - a four byte incrementing version seems fine i suppose
+     *   - a byte or two for well-known-id system identification through some centrally defined enum
+     *   - at some point we'll want a serial number probably
+     *   - a hardware revision unless we want to fold that into the well-known-id
+     */
     NodeId node_id;
     uint32_t version;
 

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -82,29 +82,26 @@ struct EEPromHandler {
 static auto motor_handler = MotorHandler{};
 static auto i2c_comms = I2C{};
 static auto eeprom_handler = EEPromHandler{i2c_comms};
-static auto device_info_handler = DeviceInfoHandler{message_writer_1, NodeId::pipette, 0};
+static auto device_info_handler =
+    DeviceInfoHandler{message_writer_1, NodeId::pipette, 0};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target = DispatchParseTarget<
-    MotorHandler, can_messages::SetSpeedRequest,
-    can_messages::GetSpeedRequest, can_messages::StopRequest,
-    can_messages::GetStatusRequest, can_messages::MoveRequest>{motor_handler};
+    MotorHandler, can_messages::SetSpeedRequest, can_messages::GetSpeedRequest,
+    can_messages::StopRequest, can_messages::GetStatusRequest,
+    can_messages::MoveRequest>{motor_handler};
 
 static auto eeprom_dispatch_target =
-    DispatchParseTarget<EEPromHandler,
-                                can_messages::WriteToEEPromRequest,
-                                can_messages::ReadFromEEPromRequest>{
-        eeprom_handler};
+    DispatchParseTarget<EEPromHandler, can_messages::WriteToEEPromRequest,
+                        can_messages::ReadFromEEPromRequest>{eeprom_handler};
 
 static auto device_info_dispatch_target =
-    DispatchParseTarget<decltype(device_info_handler), can_messages::DeviceInfoRequest>{
-        device_info_handler};
-
+    DispatchParseTarget<decltype(device_info_handler),
+                        can_messages::DeviceInfoRequest>{device_info_handler};
 
 /** Dispatcher to the various handlers */
-static auto dispatcher = Dispatcher(motor_dispatch_target,
-                                    eeprom_dispatch_target,
-                                    device_info_dispatch_target);
+static auto dispatcher = Dispatcher(
+    motor_dispatch_target, eeprom_dispatch_target, device_info_dispatch_target);
 
 struct Task {
     [[noreturn]] void operator()() {


### PR DESCRIPTION
- Fill out `DeviceInfoRequest` and `DeviceInfoResponse` messages
- Add `DeviceInfoHandler` to handle device info messages. 
- Pipette sub-project handles `DeviceInfoRequest` messages.

closes RET-164 in Jira.