### PR TITLE
refactor(pipettes): reduce some of the warnings generated in the pipettes project

### DIFF
--- a/common/firmware/errors/errors.c
+++ b/common/firmware/errors/errors.c
@@ -1,7 +1,4 @@
-#pragma once
-
 #include "stm32g4xx_hal_conf.h"
-
 #include "common/firmware/errors.h"
 
 void Error_Handler(void) {

--- a/include/can/core/freertos_can_dispatch.hpp
+++ b/include/can/core/freertos_can_dispatch.hpp
@@ -34,7 +34,7 @@ class FreeRTOSCanBufferPoller {
     /**
      * Task entry point.
      */
-    void operator()() {
+    [[noreturn]] void operator()() {
         for (;;) {
             reader.read(portMAX_DELAY);
         }

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -34,8 +34,8 @@ class MessageWriter {
 
   private:
     Writer& writer;
-    std::array<uint8_t, 64> buffer;
-    can_ids::ArbitrationId arbitration_id;
+    std::array<uint8_t, 64> buffer{};
+    can_ids::ArbitrationId arbitration_id{};
 };
 
 }  // namespace can_message_writer

--- a/include/common/core/freertos_synchronization.hpp
+++ b/include/common/core/freertos_synchronization.hpp
@@ -22,8 +22,8 @@ class FreeRTOSMutex {
     int get_count() { return uxSemaphoreGetCount(handle); }
 
   private:
-    SemaphoreHandle_t handle;
-    StaticSemaphore_t static_data;
+    SemaphoreHandle_t handle{};
+    StaticSemaphore_t static_data{};
 };
 
 }  // namespace freertos_synchronization

--- a/include/common/core/freertos_task.hpp
+++ b/include/common/core/freertos_task.hpp
@@ -28,8 +28,8 @@ class FreeRTOSTask {
         instance->entry();
     }
     Entry entry;
-    TaskHandle_t handle;
-    StaticTask_t static_task;
+    TaskHandle_t handle{};
+    StaticTask_t static_task{};
     std::array<StackType_t, StackDepth> backing{};
 };
 

--- a/include/common/firmware/clocking.h
+++ b/include/common/firmware/clocking.h
@@ -1,5 +1,4 @@
-#ifndef __CLOCKING_H__
-#define __CLOCKING_H__
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -10,5 +9,3 @@ void RCC_Peripheral_Clock_Select();
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
-
-#endif // __CLOCKING_H__

--- a/include/common/firmware/errors.h
+++ b/include/common/firmware/errors.h
@@ -1,1 +1,3 @@
+#pragma once
+
 void Error_Handler();

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -104,7 +104,12 @@ static auto dispatcher = Dispatcher(
     motor_dispatch_target, eeprom_dispatch_target, device_info_dispatch_target);
 
 struct Task {
-    [[noreturn]] void operator()() {
+    /**
+     *     Technically, void operator does return due to weird overload reasons.
+     *     Not sure how to resolve this other than removing noreturn.
+     */
+
+    void operator()() {
         if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
             //            Error_Handler();
         }

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -104,12 +104,7 @@ static auto dispatcher = Dispatcher(
     motor_dispatch_target, eeprom_dispatch_target, device_info_dispatch_target);
 
 struct Task {
-    /**
-     *     Technically, void operator does return due to weird overload reasons.
-     *     Not sure how to resolve this other than removing noreturn.
-     */
-
-    void operator()() {
+    [[noreturn]] void operator()() {
         if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
             //            Error_Handler();
         }

--- a/pipettes/firmware/clocking.c
+++ b/pipettes/firmware/clocking.c
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "stm32g4xx_hal_conf.h"
 
 #include "common/firmware/clocking.h"

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -5,25 +5,16 @@
 // clang-format off
 #include "FreeRTOS.h"
 #include "system_stm32g4xx.h"
-#include "stm32g4xx_hal_conf.h"
-#include "stm32g4xx_hal.h"
 #include "task.h"
 // clang-format on
 
 #include "common/firmware/can_task.hpp"
 #include "common/firmware/clocking.h"
-#include "common/firmware/spi.h"
-#include "common/firmware/spi_comms.hpp"
-#include "common/firmware/uart.h"
-#include "common/firmware/uart_comms.hpp"
-#include "common/firmware/uart_task.hpp"
-#include "motor-control/core/motor.hpp"
 #include "pipettes/core/communication.hpp"
 
 auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
-    uart_task::start();
     can_task::start();
 
     vTaskStartScheduler();

--- a/pipettes/firmware/system_stm32g4xx.c
+++ b/pipettes/firmware/system_stm32g4xx.c
@@ -81,6 +81,8 @@
 #include "stm32g4xx.h"
 #include "stm32g4xx_hal.h"
 
+#include "common/firmware/errors.h"
+
 #if !defined(HSE_VALUE)
 #define HSE_VALUE 24000000U /*!< Value of the External oscillator in Hz */
 #endif                      /* HSE_VALUE */


### PR DESCRIPTION
## Overview

There are quite a lot of warnings, related to different things. I have tried to reduce warnings that
were unrelated to the HAL layer of things. Some of these files were touched in the FreeRTOS PR, but
I plan to open a separate PR for that once the motor controller task stuff is in a good place. There
were a few CAN related warnings that I did not know how to resolve.

RET-191