### PR TITLE
refactor(can): refactor day!

### DIFF
--- a/can/simulator/rtos_main.cpp
+++ b/can/simulator/rtos_main.cpp
@@ -26,7 +26,7 @@ static auto canbus = sim_canbus::SimCANBus(transport, buffer);
  * templetized with the same message types.
  * @tparam Bus A CanBus type
  */
-template <CanBus Bus>
+template <CanBusWriter Bus>
 struct Loopback {
     /**
      * Constructor

--- a/can/tests/test_dispatch.cpp
+++ b/can/tests/test_dispatch.cpp
@@ -1,6 +1,6 @@
+#include "can/core/arbitration_id.hpp"
 #include "can/core/dispatch.hpp"
 #include "can/core/messages.hpp"
-#include "can/core/arbitration_id.hpp"
 #include "can/tests/mock_message_buffer.hpp"
 #include "catch2/catch.hpp"
 #include "common/core/bit_utils.hpp"

--- a/can/tests/test_dispatch.cpp
+++ b/can/tests/test_dispatch.cpp
@@ -1,11 +1,13 @@
 #include "can/core/dispatch.hpp"
 #include "can/core/messages.hpp"
+#include "can/core/arbitration_id.hpp"
 #include "can/tests/mock_message_buffer.hpp"
 #include "catch2/catch.hpp"
 #include "common/core/bit_utils.hpp"
 
 using namespace can_dispatch;
 using namespace can_messages;
+using namespace can_arbitration_id;
 using namespace mock_message_buffer;
 
 SCENARIO("Dispatcher") {

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -49,7 +49,7 @@ SCENARIO("message deserializing works") {
 
 SCENARIO("message serializing works") {
     GIVEN("a get status response message") {
-        auto message = GetStatusResponse{1, 2};
+        auto message = GetStatusResponse{{}, 1, 2};
         auto arr = std::array<uint8_t, 5>{0, 0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized") {
@@ -66,7 +66,7 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("a set speed request message") {
-        auto message = SetSpeedRequest{0x10023300};
+        auto message = SetSpeedRequest{{}, 0x10023300};
         auto arr = std::array<uint8_t, 4>{0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized") {
@@ -82,7 +82,7 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("a get speed response message") {
-        auto message = GetSpeedResponse{0x12344321};
+        auto message = GetSpeedResponse{{}, 0x12344321};
         auto arr = std::array<uint8_t, 4>{0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized") {
@@ -98,7 +98,7 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("a device info response message") {
-        auto message = DeviceInfoResponse{NodeId::pipette, 0x00220033};
+        auto message = DeviceInfoResponse{{}, NodeId::pipette, 0x00220033};
         auto arr = std::array<uint8_t, 5>{0, 0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized") {
@@ -111,6 +111,16 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[4] == 0x33);
             }
             THEN("size must be returned") { REQUIRE(size == 5); }
+        }
+    }
+
+    GIVEN("a get speed request message") {
+        auto message = GetSpeedRequest{{}};
+        auto arr = std::array<uint8_t, 4>{0, 0, 0, 0};
+        auto body = std::span{arr};
+        WHEN("serialized") {
+            auto size = message.serialize(arr.begin(), arr.end());
+            THEN("size must be returned") { REQUIRE(size == 0); }
         }
     }
 }

--- a/include/can/core/arbitration_id.hpp
+++ b/include/can/core/arbitration_id.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace can_arbitration_id {
+
+/**
+ * The components of a 29-bit arbitration id as a bitfield.
+ */
+struct ArbitrationIdParts {
+    unsigned function_code : 7;
+    unsigned node_id : 8;
+    unsigned message_id : 14;
+    unsigned int padding : 3;
+};
+
+/**
+ * A union of arbitration id in parts or as an integer.
+ */
+union ArbitrationId {
+    ArbitrationIdParts parts;
+    uint32_t id;
+};
+
+}

--- a/include/can/core/arbitration_id.hpp
+++ b/include/can/core/arbitration_id.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace can_arbitration_id {
 
 /**

--- a/include/can/core/arbitration_id.hpp
+++ b/include/can/core/arbitration_id.hpp
@@ -22,4 +22,4 @@ union ArbitrationId {
     uint32_t id;
 };
 
-}
+}  // namespace can_arbitration_id

--- a/include/can/core/can_bus.hpp
+++ b/include/can/core/can_bus.hpp
@@ -54,18 +54,28 @@ enum class CanFDMessageLength {
 auto to_canfd_length(uint32_t length) -> CanFDMessageLength;
 
 /**
- * Concept describing a Can Bus .
+ * Concept describing a class that sends messages on a Can Bus .
  *
- * @tparam CAN The can bus implementation
+ * @tparam CAN The template argument
  */
 template <class CAN>
-concept CanBus = requires(CAN can, uint32_t arbitration_id, uint8_t* buffer,
-                          CanFDMessageLength buffer_length,
-                          CanFilterType filter_type,
-                          CanFilterConfig filter_config) {
+concept CanBusWriter = requires(CAN can, uint32_t arbitration_id,
+                                uint8_t* buffer,
+                                CanFDMessageLength buffer_length) {
+    {can.send(arbitration_id, buffer, buffer_length)};
+};
+
+/**
+ * Concept describing a class that filters inbound messages on Can Bus.
+ *
+ * @tparam CAN The template argument
+ */
+template <class CAN>
+concept CanBusFiltering = requires(CAN can, uint32_t arbitration_id,
+                                   CanFilterType filter_type,
+                                   CanFilterConfig filter_config) {
     {can.add_filter(filter_type, filter_config, arbitration_id,
                     arbitration_id)};
-    {can.send(arbitration_id, buffer, buffer_length)};
 };
 
 }  // namespace can_bus

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -29,7 +29,7 @@ class DeviceInfoHandler {
      */
     DeviceInfoHandler(MessageWriter<Writer> &writer, NodeId node_id,
                       uint32_t version)
-        : writer(writer), response{node_id, version} {}
+        : writer(writer), response{{}, node_id, version} {}
     DeviceInfoHandler(const DeviceInfoHandler &) = delete;
     DeviceInfoHandler(const DeviceInfoHandler &&) = delete;
     DeviceInfoHandler &operator=(const DeviceInfoHandler &) = delete;

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -17,7 +17,7 @@ namespace can_device_info {
  *
  * @tparam Writer The can bus writer type.
  */
-template <can_bus::CanBus Writer>
+template <can_bus::CanBusWriter Writer>
 class DeviceInfoHandler {
   public:
     /**

--- a/include/can/core/dispatch.hpp
+++ b/include/can/core/dispatch.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include "can/core/ids.hpp"
-#include "can_message_buffer.hpp"
 #include "common/core/bit_utils.hpp"
 #include "common/core/message_buffer.hpp"
 #include "parse.hpp"
+#include "ids.hpp"
+#include "can_message_buffer.hpp"
+#include "arbitration_id.hpp"
 
 using namespace can_parse;
 using namespace can_message_buffer;
+using namespace can_arbitration_id;
 
 namespace can_dispatch {
 

--- a/include/can/core/dispatch.hpp
+++ b/include/can/core/dispatch.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "arbitration_id.hpp"
+#include "can_message_buffer.hpp"
 #include "common/core/bit_utils.hpp"
 #include "common/core/message_buffer.hpp"
-#include "parse.hpp"
 #include "ids.hpp"
-#include "can_message_buffer.hpp"
-#include "arbitration_id.hpp"
+#include "parse.hpp"
 
 using namespace can_parse;
 using namespace can_message_buffer;

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -5,24 +5,6 @@
 namespace can_ids {
 
 /**
- * The components of a 29-bit arbitration id as a bitfield.
- */
-struct ArbitrationIdParts {
-    unsigned function_code : 7;
-    unsigned node_id : 8;
-    unsigned message_id : 14;
-    unsigned int padding : 3;
-};
-
-/**
- * A union of arbitration id in parts or as an integer.
- */
-union ArbitrationId {
-    ArbitrationIdParts parts;
-    uint32_t id;
-};
-
-/**
  * Function code definitions.
  */
 enum class FunctionCode : uint8_t {

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -8,7 +8,7 @@
 
 namespace can_message_writer {
 
-template <can_bus::CanBus Writer>
+template <can_bus::CanBusWriter Writer>
 class MessageWriter {
   public:
     explicit MessageWriter(Writer& writer) : writer{writer} {}
@@ -22,7 +22,7 @@ class MessageWriter {
      */
     template <message_core::Serializable Serializable>
     void write(can_ids::NodeId node, const Serializable& message) {
-        arbitration_id.id = 0;
+        auto arbitration_id = can_ids::ArbitrationId{.id = 0};
         arbitration_id.parts.message_id = static_cast<uint16_t>(message.id);
         // TODO (al 2021-08-03): populate this from Message?
         arbitration_id.parts.function_code = 0;
@@ -34,8 +34,7 @@ class MessageWriter {
 
   private:
     Writer& writer;
-    std::array<uint8_t, 64> buffer{};
-    can_ids::ArbitrationId arbitration_id{};
+    std::array<uint8_t, message_core::MaxMessageSize> buffer{};
 };
 
 }  // namespace can_message_writer

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -2,8 +2,8 @@
 
 #include <array>
 
+#include "arbitration_id.hpp"
 #include "can_bus.hpp"
-#include "ids.hpp"
 #include "message_core.hpp"
 
 namespace can_message_writer {
@@ -22,7 +22,7 @@ class MessageWriter {
      */
     template <message_core::Serializable Serializable>
     void write(can_ids::NodeId node, const Serializable& message) {
-        auto arbitration_id = can_ids::ArbitrationId{.id = 0};
+        auto arbitration_id = can_arbitration_id::ArbitrationId{.id = 0};
         arbitration_id.parts.message_id = static_cast<uint16_t>(message.id);
         // TODO (al 2021-08-03): populate this from Message?
         arbitration_id.parts.function_code = 0;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -17,12 +17,22 @@ namespace can_messages {
  * The objects must implement the Parsable concept to deserialize the payload.
  */
 
-struct HeartbeatRequest {
-    static const auto id = MessageId::heartbeat_request;
+template <MessageId MId>
+struct BaseMessage {
+    /** Satisfy the HasMessageID concept */
+    static const auto id = MId;
+};
 
+/**
+ * A message with no payload.
+ *
+ * @tparam MId
+ */
+template <MessageId MId>
+struct Empty : BaseMessage<MId> {
     template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> HeartbeatRequest {
-        return HeartbeatRequest{};
+    static auto parse(Input body, Limit limit) -> Empty {
+        return Empty{};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -31,37 +41,13 @@ struct HeartbeatRequest {
     }
 };
 
-struct HeartbeatResponse {
-    static const auto id = MessageId::heartbeat_response;
+using HeartbeatRequest = Empty<MessageId::heartbeat_request>;
 
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> HeartbeatResponse {
-        return HeartbeatResponse{};
-    }
+using HeartbeatResponse = Empty<MessageId::heartbeat_response>;
 
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
+using DeviceInfoRequest = Empty<MessageId::device_info_request>;
 
-struct DeviceInfoRequest {
-    static const auto id = MessageId::device_info_request;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> DeviceInfoRequest {
-        return DeviceInfoRequest{};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
-
-struct DeviceInfoResponse {
-    static const auto id = MessageId::device_info_response;
-
+struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
     /**
      *   TODO (al, 2021-09-13)
      *   Seth's thoughts on future of payload
@@ -87,7 +73,7 @@ struct DeviceInfoResponse {
         uint32_t version;
         body = bit_utils::bytes_to_int(body, limit, node_id);
         body = bit_utils::bytes_to_int(body, limit, version);
-        return DeviceInfoResponse{static_cast<NodeId>(node_id), version};
+        return DeviceInfoResponse{{}, static_cast<NodeId>(node_id), version};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -99,36 +85,11 @@ struct DeviceInfoResponse {
     }
 };
 
-struct StopRequest {
-    static const auto id = MessageId::stop_request;
+using StopRequest = Empty<MessageId::stop_request>;
 
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> StopRequest {
-        return StopRequest{};
-    }
+using GetStatusRequest = Empty<MessageId::get_status_request>;
 
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
-
-struct GetStatusRequest {
-    static const auto id = MessageId::get_status_request;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> GetStatusRequest {
-        return GetStatusRequest{};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
-
-struct GetStatusResponse {
-    static const auto id = MessageId::get_status_response;
+struct GetStatusResponse : BaseMessage<MessageId::get_status_response> {
     uint8_t status;
     uint32_t data;
 
@@ -140,7 +101,7 @@ struct GetStatusResponse {
         body = bit_utils::bytes_to_int(body, limit, status);
         body = bit_utils::bytes_to_int(body, limit, data);
 
-        return GetStatusResponse{status, data};
+        return GetStatusResponse{{}, status, data};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -151,43 +112,18 @@ struct GetStatusResponse {
     }
 };
 
-struct MoveRequest {
-    static const auto id = MessageId::move_request;
+using MoveRequest = Empty<MessageId::move_request>;
 
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> MoveRequest {
-        return MoveRequest{};
-    }
+using SetupRequest = Empty<MessageId::setup_request>;
 
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
-
-struct SetupRequest {
-    static const auto id = MessageId::setup_request;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> SetupRequest {
-        return SetupRequest{};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
-
-struct SetSpeedRequest {
-    static const auto id = MessageId::set_speed_request;
+struct SetSpeedRequest : BaseMessage<MessageId::set_speed_request> {
     uint32_t mm_sec;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SetSpeedRequest {
         uint32_t mm_sec = 0;
         body = bit_utils::bytes_to_int(body, limit, mm_sec);
-        return SetSpeedRequest{mm_sec};
+        return SetSpeedRequest{{}, mm_sec};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -197,29 +133,16 @@ struct SetSpeedRequest {
     }
 };
 
-struct GetSpeedRequest {
-    static const auto id = MessageId::get_speed_request;
+using GetSpeedRequest = Empty<MessageId::get_speed_request>;
 
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> GetSpeedRequest {
-        return GetSpeedRequest{};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
-
-struct GetSpeedResponse {
-    static const auto id = MessageId::get_speed_response;
+struct GetSpeedResponse : BaseMessage<MessageId::get_speed_response> {
     uint32_t mm_sec;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> GetSpeedResponse {
         uint32_t mm_sec = 0;
         body = bit_utils::bytes_to_int(body, limit, mm_sec);
-        return GetSpeedResponse{mm_sec};
+        return GetSpeedResponse{{}, mm_sec};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -229,15 +152,14 @@ struct GetSpeedResponse {
     }
 };
 
-struct WriteToEEPromRequest {
-    static const auto id = MessageId::write_eeprom;
+struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {
     uint8_t serial_number;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> WriteToEEPromRequest {
         uint8_t serial_number = 0;
         body = bit_utils::bytes_to_int(body, limit, serial_number);
-        return WriteToEEPromRequest{serial_number};
+        return WriteToEEPromRequest{{}, serial_number};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -247,29 +169,16 @@ struct WriteToEEPromRequest {
     }
 };
 
-struct ReadFromEEPromRequest {
-    static const auto id = MessageId::read_eeprom_request;
+using ReadFromEEPromRequest = Empty<MessageId::read_eeprom_request>;
 
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> ReadFromEEPromRequest {
-        return ReadFromEEPromRequest{};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        return 0;
-    }
-};
-
-struct ReadFromEEPromResponse {
-    static const auto id = MessageId::read_eeprom_response;
+struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
     uint8_t serial_number;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> ReadFromEEPromResponse {
         uint8_t serial_number = 0;
         body = bit_utils::bytes_to_int(body, limit, serial_number);
-        return ReadFromEEPromResponse{serial_number};
+        return ReadFromEEPromResponse{{}, serial_number};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -73,7 +73,7 @@ struct EEPromHandler {
 
     void visit(ReadFromEEPromRequest &m) {
         const uint8_t serial_number = eeprom::read(i2c);
-        auto message = ReadFromEEPromResponse{serial_number};
+        auto message = ReadFromEEPromResponse{{}, serial_number};
         message_writer_1.write(NodeId::host, message);
     }
 };


### PR DESCRIPTION
- Move arbitration id data structures to their own file.
- Reduce the verbosity of messages.hpp by defining some base classes.
- Separate CanBus concept into two. There was no reason to mix `send` with `add_filter`.
- Fix a data race in MessageWriter.