### PR TITLE
refactor(spi): remove HAL includes where possible

### DIFF
--- a/common/firmware/spi/spi.c
+++ b/common/firmware/spi/spi.c
@@ -1,6 +1,9 @@
 #include "common/firmware/spi.h"
 #include "common/firmware/errors.h"
 
+#include "stm32g4xx_hal_conf.h"
+
+SPI_HandleTypeDef handle;
 
 /**
  * @brief SPI MSP Initialization
@@ -110,26 +113,16 @@ SPI_HandleTypeDef MX_SPI2_Init() {
     return hspi2;
 }
 
-/**
- * Enable DMA controller clock
- */
-void MX_DMA_Init(void) {
-    /* DMA controller clock enable */
-    __HAL_RCC_DMAMUX1_CLK_ENABLE();
-    __HAL_RCC_DMA1_CLK_ENABLE();
-
-    /* DMA interrupt init */
-    /* DMA1_Channel2_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(DMA1_Channel2_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(DMA1_Channel2_IRQn);
-    /* DMA1_Channel3_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(DMA1_Channel3_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(DMA1_Channel3_IRQn);
+void SPI2_init() {
+    handle = MX_SPI2_Init();
 }
 
+void Set_CS_Pin() { HAL_GPIO_WritePin(GPIOB, GPIO_PIN_12, GPIO_PIN_SET); }
 
-void Set_CS_Pin(void) { HAL_GPIO_WritePin(GPIOB, GPIO_PIN_12, GPIO_PIN_SET); }
-
-void Reset_CS_Pin(void) {
+void Reset_CS_Pin() {
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_12, GPIO_PIN_RESET);
+}
+
+void hal_transmit_receive(uint8_t* transmit, uint8_t* receive, uint16_t buff_size, uint32_t timeout) {
+    HAL_SPI_TransmitReceive(&handle, transmit, receive, buff_size, timeout);
 }

--- a/common/firmware/spi/spi_comms.cpp
+++ b/common/firmware/spi/spi_comms.cpp
@@ -22,19 +22,15 @@ using namespace spi;
  */
 
 /*
- * Private Functions
- */
-
-/*
  * Public Functions
  */
 
-Spi::Spi() : handle(MX_SPI2_Init()) {}
+Spi::Spi() { SPI2_init(); }
 
 void Spi::transmit_receive(const BufferType& transmit, BufferType& receive) {
     Reset_CS_Pin();
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    HAL_SPI_TransmitReceive(&handle, const_cast<uint8_t*>(transmit.data()),
-                            receive.data(), BUFFER_SIZE, TIMEOUT);
+    hal_transmit_receive(const_cast<uint8_t*>(transmit.data()), receive.data(),
+                         BUFFER_SIZE, TIMEOUT);
     Set_CS_Pin();
 }

--- a/gantry/firmware/main.cpp
+++ b/gantry/firmware/main.cpp
@@ -10,51 +10,13 @@
 // clang-format on
 
 #include "common/firmware/clocking.h"
-#include "common/firmware/spi.h"
 #include "common/firmware/uart.h"
-
-constexpr auto stack_size = 100;
-static std::array<StackType_t, stack_size>
-    stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-// Internal FreeRTOS data structure
-static StaticTask_t
-    data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-static void spiTask(void *spiParam);
-
-static const int BUFFER_SIZE = 5;
-static const int SPI_TASK_DELAY = 20;
-static const uint8_t COMMAND = 0x6B;
-
-static void spiTask(void *spiParam) {
-    static_cast<void>(spiParam);
-
-    std::array<uint8_t, BUFFER_SIZE> aTxBuffer = {COMMAND, 0, 0, 0, 0};
-    std::array<uint8_t, BUFFER_SIZE> aRxBuffer{};
-    Set_CS_Pin();
-    //        MX_DMA_Init();
-    SPI_HandleTypeDef hspi2 = MX_SPI2_Init();
-    constexpr auto timeout = 0xFFFF;
-
-    for (;;) {
-        Reset_CS_Pin();
-        HAL_SPI_TransmitReceive(&hspi2, aTxBuffer.data(), aRxBuffer.data(),
-                                BUFFER_SIZE, timeout);
-        Set_CS_Pin();
-        vTaskDelay(SPI_TASK_DELAY);
-    }
-}
 
 auto main() -> int {
     HardwareInit();
     /** Initializes the peripherals clocks
      */
     RCC_Peripheral_Clock_Select();
-    MX_SPI2_Init();
-
-    xTaskCreateStatic(spiTask, "SPI Task", stack.size(), nullptr, 1,
-                      stack.data(), &data);
     vTaskStartScheduler();
 
     return 0;

--- a/include/common/firmware/spi.h
+++ b/include/common/firmware/spi.h
@@ -1,21 +1,15 @@
 #pragma once
-
-#include "stm32g4xx_hal_conf.h"
-
-#ifndef __SPI_H__
-#define __SPI_H__
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
-SPI_HandleTypeDef MX_SPI2_Init();
-void MX_DMA_Init();
+void SPI2_init();
 void Set_CS_Pin();
 void Reset_CS_Pin();
+void hal_transmit_receive(uint8_t* transmit, uint8_t *receive, uint16_t buff_size, uint32_t timeout);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
-
-#endif // __SPI_H__

--- a/include/common/firmware/spi_comms.hpp
+++ b/include/common/firmware/spi_comms.hpp
@@ -1,7 +1,6 @@
 #pragma once
+#include <cstdint>
 #include <span>
-
-#include "stm32g4xx_hal_conf.h"
 
 namespace spi {
 class Spi {
@@ -12,7 +11,6 @@ class Spi {
     void transmit_receive(const BufferType& transmit, BufferType& receive);
 
   private:
-    static constexpr auto TIMEOUT = 0xFFFF;
-    SPI_HandleTypeDef handle;
+    static constexpr uint32_t TIMEOUT = 0xFFFF;
 };
 }  // namespace spi


### PR DESCRIPTION
# Overview

To reduce warnings emitted from macros in the st bsp files, we should try to ensure that we are not
importing hal files unnecessarily in our SPI comms module.

RET-193

# Review requests. Let me know if any syntax or other things seem weird. Will need to test on Monday.