### PR TITLE
refactor(pipettes): Can pipettes handlers

### DIFF
--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -5,6 +5,8 @@
 #include "arbitration_id.hpp"
 #include "can_bus.hpp"
 #include "message_core.hpp"
+#include "common/core/freertos_synchronization.hpp"
+#include "common/core/synchronization.hpp"
 
 namespace can_message_writer {
 
@@ -22,7 +24,8 @@ class MessageWriter {
      */
     template <message_core::Serializable Serializable>
     void write(can_ids::NodeId node, const Serializable& message) {
-        auto arbitration_id = can_arbitration_id::ArbitrationId{.id = 0};
+        auto lock = synchronization::Lock{mutex};
+        arbitration_id.id = 0;
         arbitration_id.parts.message_id = static_cast<uint16_t>(message.id);
         // TODO (al 2021-08-03): populate this from Message?
         arbitration_id.parts.function_code = 0;
@@ -34,6 +37,8 @@ class MessageWriter {
 
   private:
     Writer& writer;
+    freertos_synchronization::FreeRTOSMutex mutex{};
+    can_arbitration_id::ArbitrationId arbitration_id{};
     std::array<uint8_t, message_core::MaxMessageSize> buffer{};
 };
 

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -4,9 +4,9 @@
 
 #include "arbitration_id.hpp"
 #include "can_bus.hpp"
-#include "message_core.hpp"
 #include "common/core/freertos_synchronization.hpp"
 #include "common/core/synchronization.hpp"
+#include "message_core.hpp"
 
 namespace can_message_writer {
 

--- a/include/motor-control/core/move_message.hpp
+++ b/include/motor-control/core/move_message.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace motor_command {
+
+/**
+ * TBD....
+ */
+struct Move {
+    uint32_t steps;
+    uint32_t increment;
+};
+
+}

--- a/include/pipettes/core/message_handlers/eeprom.hpp
+++ b/include/pipettes/core/message_handlers/eeprom.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "can/core/can_bus.hpp"
-#include "common/core/message_queue.hpp"
 #include "can/core/message_writer.hpp"
+#include "common/core/message_queue.hpp"
 #include "pipettes/core/eeprom.hpp"
 
 using namespace can_bus;
@@ -14,9 +14,11 @@ namespace eeprom_message_handler {
 template <CanBusWriter Writer, EEPromPolicy I2CComm>
 class EEPromHandler {
   public:
-    using MessageType = std::variant<std::monostate, WriteToEEPromRequest, ReadFromEEPromRequest>;
+    using MessageType = std::variant<std::monostate, WriteToEEPromRequest,
+                                     ReadFromEEPromRequest>;
 
-    explicit EEPromHandler(MessageWriter<Writer>& message_writer, I2CComm &i2c) : message_writer(message_writer), i2c(i2c) {}
+    explicit EEPromHandler(MessageWriter<Writer> &message_writer, I2CComm &i2c)
+        : message_writer(message_writer), i2c(i2c) {}
     EEPromHandler(const EEPromHandler &) = delete;
     EEPromHandler(const EEPromHandler &&) = delete;
     EEPromHandler &operator=(const EEPromHandler &) = delete;
@@ -37,8 +39,8 @@ class EEPromHandler {
         message_writer.write(NodeId::host, message);
     }
 
-    MessageWriter<Writer> & message_writer;
+    MessageWriter<Writer> &message_writer;
     I2CComm &i2c;
 };
 
-}
+}  // namespace eeprom_message_handler

--- a/include/pipettes/core/message_handlers/eeprom.hpp
+++ b/include/pipettes/core/message_handlers/eeprom.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "can/core/can_bus.hpp"
+#include "common/core/message_queue.hpp"
+#include "can/core/message_writer.hpp"
+#include "pipettes/core/eeprom.hpp"
+
+using namespace can_bus;
+using namespace can_message_writer;
+using namespace eeprom;
+
+namespace eeprom_message_handler {
+
+template <CanBusWriter Writer, EEPromPolicy I2CComm>
+class EEPromHandler {
+  public:
+    using MessageType = std::variant<std::monostate, WriteToEEPromRequest, ReadFromEEPromRequest>;
+
+    explicit EEPromHandler(MessageWriter<Writer>& message_writer, I2CComm &i2c) : message_writer(message_writer), i2c(i2c) {}
+    EEPromHandler(const EEPromHandler &) = delete;
+    EEPromHandler(const EEPromHandler &&) = delete;
+    EEPromHandler &operator=(const EEPromHandler &) = delete;
+    EEPromHandler &&operator=(const EEPromHandler &&) = delete;
+
+    void handle(MessageType &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+  private:
+    void visit(std::monostate &m) {}
+
+    void visit(WriteToEEPromRequest &m) { eeprom::write(i2c, m.serial_number); }
+
+    void visit(ReadFromEEPromRequest &m) {
+        const uint8_t serial_number = eeprom::read(i2c);
+        auto message = ReadFromEEPromResponse{{}, serial_number};
+        message_writer.write(NodeId::host, message);
+    }
+
+    MessageWriter<Writer> & message_writer;
+    I2CComm &i2c;
+};
+
+}

--- a/include/pipettes/core/message_handlers/motor.hpp
+++ b/include/pipettes/core/message_handlers/motor.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "can/core/can_bus.hpp"
+#include "common/core/message_queue.hpp"
+#include "can/core/message_writer.hpp"
+#include "motor-control/core/move_message.hpp"
+
+using namespace can_bus;
+using namespace can_message_writer;
+
+namespace motor_message_handler {
+
+template <can_bus::CanBusWriter Writer, MessageQueue<motor_command::Move> Queue>
+class MotorHandler {
+  public:
+    using MessageType =
+        std::variant<std::monostate, SetSpeedRequest, GetSpeedRequest,
+        StopRequest, GetStatusRequest, MoveRequest>;
+
+    MotorHandler(MessageWriter<Writer> & message_writer, Queue & message_queue): message_writer{message_writer}, message_queue{message_queue} {}
+    MotorHandler(const MotorHandler &) = delete;
+    MotorHandler(const MotorHandler &&) = delete;
+    MotorHandler &operator=(const MotorHandler &) = delete;
+    MotorHandler &&operator=(const MotorHandler &&) = delete;
+
+    void handle(MessageType &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+  private:
+    void visit(std::monostate &m) {}
+
+    void visit(SetSpeedRequest &m) { message_writer.write(NodeId::host, m); }
+
+    void visit(GetSpeedRequest &m) { message_writer.write(NodeId::host, m); }
+
+    void visit(StopRequest &m) { message_writer.write(NodeId::gantry, m); }
+
+    void visit(GetStatusRequest &m) { message_writer.write(NodeId::host, m); }
+
+    void visit(MoveRequest &m) { message_writer.write(NodeId::host, m); }
+
+    MessageWriter<Writer> & message_writer;
+    Queue & message_queue;
+};
+
+}

--- a/include/pipettes/core/message_handlers/motor.hpp
+++ b/include/pipettes/core/message_handlers/motor.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "can/core/can_bus.hpp"
-#include "common/core/message_queue.hpp"
 #include "can/core/message_writer.hpp"
+#include "common/core/message_queue.hpp"
 #include "motor-control/core/move_message.hpp"
 
 using namespace can_bus;
@@ -15,9 +15,10 @@ class MotorHandler {
   public:
     using MessageType =
         std::variant<std::monostate, SetSpeedRequest, GetSpeedRequest,
-        StopRequest, GetStatusRequest, MoveRequest>;
+                     StopRequest, GetStatusRequest, MoveRequest>;
 
-    MotorHandler(MessageWriter<Writer> & message_writer, Queue & message_queue): message_writer{message_writer}, message_queue{message_queue} {}
+    MotorHandler(MessageWriter<Writer> &message_writer, Queue &message_queue)
+        : message_writer{message_writer}, message_queue{message_queue} {}
     MotorHandler(const MotorHandler &) = delete;
     MotorHandler(const MotorHandler &&) = delete;
     MotorHandler &operator=(const MotorHandler &) = delete;
@@ -40,8 +41,8 @@ class MotorHandler {
 
     void visit(MoveRequest &m) { message_writer.write(NodeId::host, m); }
 
-    MessageWriter<Writer> & message_writer;
-    Queue & message_queue;
+    MessageWriter<Writer> &message_writer;
+    Queue &message_queue;
 };
 
-}
+}  // namespace motor_message_handler

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -13,6 +13,8 @@
 #include "common/firmware/errors.h"
 #include "common/firmware/i2c_comms.hpp"
 #include "pipettes/core/eeprom.hpp"
+#include "pipettes/core/message_handlers/eeprom.hpp"
+#include "pipettes/core/message_handlers/motor.hpp"
 
 using namespace hal_can_bus;
 using namespace can_messages;
@@ -22,79 +24,41 @@ using namespace freertos_task;
 using namespace can_message_writer;
 using namespace i2c;
 using namespace can_device_info;
+using namespace eeprom_message_handler;
+using namespace motor_message_handler;
 
 extern FDCAN_HandleTypeDef fdcan1;
 
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
-struct MotorHandler {
-    using MessageType =
-        std::variant<std::monostate, SetSpeedRequest, GetSpeedRequest,
-                     StopRequest, GetStatusRequest, MoveRequest>;
-    MotorHandler() {}
-    MotorHandler(const MotorHandler &) = delete;
-    MotorHandler(const MotorHandler &&) = delete;
-    MotorHandler &operator=(const MotorHandler &) = delete;
-    MotorHandler &&operator=(const MotorHandler &&) = delete;
 
-    void handle(MessageType &m) {
-        std::visit([this](auto o) { this->visit(o); }, m);
-    }
-
-    void visit(std::monostate &m) {}
-
-    void visit(SetSpeedRequest &m) { message_writer_1.write(NodeId::host, m); }
-
-    void visit(GetSpeedRequest &m) { message_writer_1.write(NodeId::host, m); }
-
-    void visit(StopRequest &m) { message_writer_1.write(NodeId::gantry, m); }
-
-    void visit(GetStatusRequest &m) { message_writer_1.write(NodeId::host, m); }
-
-    void visit(MoveRequest &m) { message_writer_1.write(NodeId::host, m); }
+template<typename T>
+class MQ {
+  public:
+    bool try_send(const T, uint32_t timeout) {return true;}
+    bool try_send(const T) {return true;}
+    bool try_recv(T *) {return true;}
+    bool has_message() const { return false;}
 };
 
-struct EEPromHandler {
-    using MessageType = std::variant<std::monostate, WriteToEEPromRequest,
-                                     ReadFromEEPromRequest>;
-    explicit EEPromHandler(I2C &i2c) : i2c(i2c) {}
-    EEPromHandler(const EEPromHandler &) = delete;
-    EEPromHandler(const EEPromHandler &&) = delete;
-    EEPromHandler &operator=(const EEPromHandler &) = delete;
-    EEPromHandler &&operator=(const EEPromHandler &&) = delete;
-    I2C &i2c;
-
-    void handle(MessageType &m) {
-        std::visit([this](auto o) { this->visit(o); }, m);
-    }
-
-    void visit(std::monostate &m) {}
-
-    void visit(WriteToEEPromRequest &m) { eeprom::write(i2c, m.serial_number); }
-
-    void visit(ReadFromEEPromRequest &m) {
-        const uint8_t serial_number = eeprom::read(i2c);
-        auto message = ReadFromEEPromResponse{{}, serial_number};
-        message_writer_1.write(NodeId::host, message);
-    }
-};
+static auto mq = MQ<motor_command::Move>{};
 
 /** The parsed message handler */
-static auto motor_handler = MotorHandler{};
+static auto motor_handler = MotorHandler{message_writer_1, mq};
 static auto i2c_comms = I2C{};
-static auto eeprom_handler = EEPromHandler{i2c_comms};
+static auto eeprom_handler = EEPromHandler{message_writer_1, i2c_comms};
 static auto device_info_handler =
     DeviceInfoHandler{message_writer_1, NodeId::pipette, 0};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target = DispatchParseTarget<
-    MotorHandler, can_messages::SetSpeedRequest, can_messages::GetSpeedRequest,
+    decltype(motor_handler), can_messages::SetSpeedRequest, can_messages::GetSpeedRequest,
     can_messages::StopRequest, can_messages::GetStatusRequest,
     can_messages::MoveRequest>{motor_handler};
 
 static auto eeprom_dispatch_target =
-    DispatchParseTarget<EEPromHandler, can_messages::WriteToEEPromRequest,
+    DispatchParseTarget<decltype(eeprom_handler), can_messages::WriteToEEPromRequest,
                         can_messages::ReadFromEEPromRequest>{eeprom_handler};
 
 static auto device_info_dispatch_target =
@@ -105,22 +69,16 @@ static auto device_info_dispatch_target =
 static auto dispatcher = Dispatcher(
     motor_dispatch_target, eeprom_dispatch_target, device_info_dispatch_target);
 
-struct Task {
-    [[noreturn]] void operator()() {
-        if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
-            Error_Handler();
-        }
-
-        can_bus_1.start();
-
-        auto poller = FreeRTOSCanBufferPoller(
-            hal_can_message_buffer::get_message_buffer(), dispatcher);
-        poller();
+[[noreturn]] void task_entry() {
+    if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
+        Error_Handler();
     }
-};
+    can_bus_1.start();
+    auto poller = FreeRTOSCanBufferPoller(
+        hal_can_message_buffer::get_message_buffer(), dispatcher);
+    poller();
+}
 
-static auto task_entry = Task{};
-
-auto static task = FreeRTOSTask<256, 5, Task>("can task", task_entry);
+auto static task = FreeRTOSTask<256, 5, void(*)()>("can task", task_entry);
 
 void can_task::start() {}

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -32,14 +32,13 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
-
-template<typename T>
+template <typename T>
 class MQ {
   public:
-    bool try_send(const T, uint32_t timeout) {return true;}
-    bool try_send(const T) {return true;}
-    bool try_recv(T *) {return true;}
-    bool has_message() const { return false;}
+    bool try_send(const T, uint32_t timeout) { return true; }
+    bool try_send(const T) { return true; }
+    bool try_recv(T *) { return true; }
+    bool has_message() const { return false; }
 };
 
 static auto mq = MQ<motor_command::Move>{};
@@ -53,12 +52,13 @@ static auto device_info_handler =
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target = DispatchParseTarget<
-    decltype(motor_handler), can_messages::SetSpeedRequest, can_messages::GetSpeedRequest,
-    can_messages::StopRequest, can_messages::GetStatusRequest,
-    can_messages::MoveRequest>{motor_handler};
+    decltype(motor_handler), can_messages::SetSpeedRequest,
+    can_messages::GetSpeedRequest, can_messages::StopRequest,
+    can_messages::GetStatusRequest, can_messages::MoveRequest>{motor_handler};
 
 static auto eeprom_dispatch_target =
-    DispatchParseTarget<decltype(eeprom_handler), can_messages::WriteToEEPromRequest,
+    DispatchParseTarget<decltype(eeprom_handler),
+                        can_messages::WriteToEEPromRequest,
                         can_messages::ReadFromEEPromRequest>{eeprom_handler};
 
 static auto device_info_dispatch_target =
@@ -79,6 +79,6 @@ static auto dispatcher = Dispatcher(
     poller();
 }
 
-auto static task = FreeRTOSTask<256, 5, void(*)()>("can task", task_entry);
+auto static task = FreeRTOSTask<256, 5, void (*)()>("can task", task_entry);
 
 void can_task::start() {}

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -32,6 +32,8 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
+/** TODO (al, 2021-09-21): Remove this and replace with a proper FreeRTOS
+ * message queue. **/
 template <typename T>
 class MQ {
   public:


### PR DESCRIPTION
- move eeprom and motor handlers out of can_task.cpp and into `include/pipette/core/message_handlers`. 
- fix a race condition in `MessageWriter`
- add a minimal Move command structure.

This PR is part of a pairing with @Laura-Danielle to address comments in https://github.com/Opentrons/ot3-firmware/pull/78.

More to come in a future PR.
