### PR TITLE
fix(cansim): add CAN_CHANNEL environment variable.

### DIFF
--- a/can/README.md
+++ b/can/README.md
@@ -19,3 +19,22 @@ Tools to use SocketCAN's VCAN interface for simulation in a Linux system.
 ### Tests
 
 Unit tests.
+
+
+## Simulator
+
+This is an application that uses SocketCan vcan (virtual) driver and runs only on linux. It will loopback commands that it receives.
+
+### Building the simulator (Linux Only!)
+
+- Follow the setup guide in [README](../README.md)
+- run `cmake --build ./build-host --target can-simulator`
+
+### Start VCAN
+
+- add link `sudo ip link add dev vcan0 type vcan fd on`
+- start it up `sudo ip link set up vcan0`
+
+### Configuring
+
+By default, the simulator will use `vcan0`. To override this, set the `CAN_CHANNEL` environment variable.

--- a/can/simulator/rtos_main.cpp
+++ b/can/simulator/rtos_main.cpp
@@ -85,8 +85,8 @@ static auto dispatcher_task =
  * The socket can reader. Reads from socket and writes to message buffer.
  */
 void can_bus_poll_task(void *) {
-    const char *channel = std::getenv(ChannelEnvironmentVariableName);
-    channel = channel ? channel : DefaultChannel;
+    const char * env_channel_val = std::getenv(ChannelEnvironmentVariableName);
+    auto channel = env_channel_val ? env_channel_val : DefaultChannel;
 
     transport.open(channel);
     while (canbus.read_message()) {

--- a/can/simulator/rtos_main.cpp
+++ b/can/simulator/rtos_main.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <variant>
 
 #include "can/core/dispatch.hpp"
@@ -15,6 +16,9 @@ using namespace can_message_buffer;
 using namespace can_messages;
 using namespace freertos_can_dispatch;
 using namespace freertos_task;
+
+static auto constexpr ChannelEnvironmentVariableName = "CAN_CHANNEL";
+static auto constexpr DefaultChannel = "vcan0";
 
 static auto constexpr ReceiveBufferSize = 1024;
 static auto buffer = FreeRTOSMessageBuffer<ReceiveBufferSize>{};
@@ -81,7 +85,10 @@ static auto dispatcher_task =
  * The socket can reader. Reads from socket and writes to message buffer.
  */
 void can_bus_poll_task(void *) {
-    transport.open("vcan0");
+    const char *channel = std::getenv(ChannelEnvironmentVariableName);
+    channel = channel ? channel : DefaultChannel;
+
+    transport.open(channel);
     while (canbus.read_message()) {
     }
 }

--- a/can/simulator/socket_can.cpp
+++ b/can/simulator/socket_can.cpp
@@ -32,7 +32,7 @@ auto SocketCanTransport::open(const char *address) -> bool {
 
     if (setsockopt(s, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &use_canfd,
                    sizeof(use_canfd))) {
-        printf("Unable to enable can fd.");
+        printf("Failed to enable can fd.");
         return false;
     }
 
@@ -45,6 +45,7 @@ auto SocketCanTransport::open(const char *address) -> bool {
     if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
         return false;
     }
+    std::cout << "Connected to " << address << std::endl;
     handle = s;
     return true;
 }

--- a/can/simulator/socket_can.cpp
+++ b/can/simulator/socket_can.cpp
@@ -32,7 +32,7 @@ auto SocketCanTransport::open(const char *address) -> bool {
 
     if (setsockopt(s, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &use_canfd,
                    sizeof(use_canfd))) {
-        printf("Failed to enable can fd.");
+        std::cout << "Failed to enable can fd." << std::endl;
         return false;
     }
 


### PR DESCRIPTION
We had been hard coding the channel to `vcan0`. This allows changing it using an environment variable.