### PR TITLE
refactor(can): make motor message handler execute actual motor control functions

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -20,8 +20,7 @@ SCENARIO("message deserializing works") {
         WHEN("constructed") {
             auto r = MoveRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {
-                REQUIRE(r.distance == 0x01020304);
-                REQUIRE(r.speed == 0x05060708);
+                REQUIRE(r.steps == 0x01020304);
             }
         }
     }
@@ -66,8 +65,8 @@ SCENARIO("message serializing works") {
         }
     }
 
-    GIVEN("a set speed request message") {
-        auto message = MoveRequest{{}, 0x10023300, 0x33221100};
+    GIVEN("a set steps request message") {
+        auto message = MoveRequest{{}, 0x10023300};
         auto arr = std::array<uint8_t, 8>{};
         auto body = std::span{arr};
         WHEN("serialized") {
@@ -77,12 +76,8 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[1] == 0x02);
                 REQUIRE(body.data()[2] == 0x33);
                 REQUIRE(body.data()[3] == 0x00);
-                REQUIRE(body.data()[4] == 0x33);
-                REQUIRE(body.data()[5] == 0x22);
-                REQUIRE(body.data()[6] == 0x11);
-                REQUIRE(body.data()[7] == 0x00);
             }
-            THEN("size must be returned") { REQUIRE(size == 8); }
+            THEN("size must be returned") { REQUIRE(size == 4); }
         }
     }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -113,22 +113,18 @@ struct GetStatusResponse : BaseMessage<MessageId::get_status_response> {
 };
 
 struct MoveRequest : BaseMessage<MessageId::move_request> {
-    uint32_t distance;
-    uint32_t speed;
+    uint32_t steps;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> MoveRequest {
-        uint32_t distance = 0;
-        uint32_t speed = 0;
-        body = bit_utils::bytes_to_int(body, limit, distance);
-        body = bit_utils::bytes_to_int(body, limit, speed);
-        return MoveRequest{{}, distance, speed};
+        uint32_t steps = 0;
+        body = bit_utils::bytes_to_int(body, limit, steps);
+        return MoveRequest{{}, steps};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(distance, body, limit);
-        iter = bit_utils::int_to_bytes(speed, iter, limit);
+        auto iter = bit_utils::int_to_bytes(steps, body, limit);
         return iter - body;
     }
 };


### PR DESCRIPTION
## Overview
With this PR, you should be able to send CAN messages to execute actual motor control. As noted with the TODO message, there is definitely some refactors we can do around templating the motor control stuff.

@amitlissack whenever you make it to the office next, I would appreciate us trying to test this together.