### PR TITLE
chore: Change name of emulation repo in Github action

### DIFF
--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout firmware repo
         uses: actions/checkout@v2
       - name: Run OT-3 Emulator
-        uses: Opentrons/ot3-emulator@v1.1
+        uses: Opentrons/opentrons-emulation@v1.1
         with:
           ot3-firmware-commit-id: ${{ github.sha }}
+          modules-commit-id: latest


### PR DESCRIPTION
Changing name of `ot3-emulator` repo to `opentrons-emulation`. This PR fixes the Github Action to point to the correct repo name