### PR TITLE
refactor(gantry): create separate executables for gantry_x and gantry_y

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 
 CMakeFiles
+CMakeCache.txt
 
 cmake_install.cmake
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,81 @@
 # ot3_firmware
 
-This repository holds the firmware for the OT-3 and all of its peripheral systems. **Note** that the cmake directory is actually a subtree of cmake-utils. Do not make changes to the `cmake-utils` directory in the ot3_firmware repository. Instead, navigate to the [CMake Utils Repository](https://github.com/Opentrons/cmake-utils). 
+This repository holds the firmware for the OT-3 and all of its peripheral systems. **Note** that the cmake directory is
+actually a subtree of cmake-utils. Do not make changes to the `cmake-utils` directory in the ot3_firmware repository.
+Instead, navigate to the [CMake Utils Repository](https://github.com/Opentrons/cmake-utils).
 
 ## Structure of directories
+
 Aside from the common directory, each repository should contain a `firmware`, `include`, `src`, `tests` folder.
+
 1. `firmware` should hold code that will be controlling the peripheral system.
-2. `include` should hold the majority of the header files you will need. This folder should include another subset of directories labeled `firmware`, `src` and `tests` for import cleaness.
-3. `src` should include any libraries, 3D party or otherwise, that are required for `firmware` to control the peripheral system.
+2. `include` should hold the majority of the header files you will need. This folder should include another subset of
+   directories labeled `firmware`, `src` and `tests` for import cleaness.
+3. `src` should include any libraries, 3D party or otherwise, that are required for `firmware` to control the peripheral
+   system.
 4. `tests` should include tests for the firmware folder.
 
 ## Setup
+
 To setup this directory to run on a nucleo board, you should run:
+
 1. `cmake --preset=cross .`
 2. `cmake --build ./build-cross --target <TARGET>`
 
 To setup this directory to run tests, you should run:
-1. `cmake --preset=host .`
-	If you are on OSX, you almost certainly want to force cmake to select gcc as the compiler used for building tests, because the version of clang built into osx is weird. We don't really want to always specify the compiler to use in tests, so forcing gcc is a separate cmake config preset, and it requires installing gcc 10:
 
-	`brew install gcc@10`
-	`cmake --preset=host-gcc10 .`
+1. `cmake --preset=host .`
+   If you are on OSX, you almost certainly want to force cmake to select gcc as the compiler used for building tests,
+   because the version of clang built into osx is weird. We don't really want to always specify the compiler to use in
+   tests, so forcing gcc is a separate cmake config preset, and it requires installing gcc 10:
+
+   `brew install gcc@10`
+   `cmake --preset=host-gcc10 .`
 2. `cmake --build ./build-host --target build-and-test`, which will run all of the tests available in each periphery.
 3. or, `cmake --build ./build-host --target <TARGET>-build-and-test`
 
+#### Gantry Subsystem
+
+The default axis type for the gantry target is X. You can build the Y gantry by running:
+
+1. `cmake --preset=cross -DGANTRY_AXIS_TYPE=gantry_y .`
+2. `cmake --build ./build-cross --target gantry`
+
 ### Cross-compiling vs Host-compiling
-As you saw above, two different presets were used to run tests vs running on a physical device. Cross-compiling will generally be used when the code needs to be ported to other devices (in this case the microcontroller) while host-compiling is used when you want to run things like tests. For more information check out this helpful [article](https://landley.net/writing/docs/cross-compiling.html).
+
+As you saw above, two different presets were used to run tests vs running on a physical device. Cross-compiling will
+generally be used when the code needs to be ported to other devices (in this case the microcontroller) while
+host-compiling is used when you want to run things like tests. For more information check out this
+helpful [article](https://landley.net/writing/docs/cross-compiling.html).
 
 ## Run
+
 Connect to an STM32 nucleo board and run either:
+
 1. `make <TARGET>-debug` inside the build-cross folder
 2. or, `cmake --build ./build-cross --target <TARGET>-debug` from the top-level folder.
 
 ### Debug
+
 If you run into trouble starting a gcc connection to your nucleo board, you should (while connected to the board):
 
 Start openocd:
+
 1. Navigate to `stm32-tools/openocd/Darwin`
 2. `./bin  scripts/board/st_nucleo_f3.cfg`
 
 Start gcc:
+
 1. `./stm32-tools/gcc-arm-embedded/Darwin/bin/arm-none-eabi-gdb-py <TARGET>`
 2. `target extended-remote :3333`
 
 And then run all the lines before the error to see what is causing the problem.
 
 ## Common
+
 The common directory will hold code that should be shared amongst all peripheral systems.
 
 ## Pipettes
-This is the top-level directory for running the pipette peripheral system. Eventually, we will most likely have separate directories for different applications on the pipettes.
+
+This is the top-level directory for running the pipette peripheral system. Eventually, we will most likely have separate
+directories for different applications on the pipettes.

--- a/gantry/CMakeLists.txt
+++ b/gantry/CMakeLists.txt
@@ -1,12 +1,12 @@
 # gantry source tree
 
-# add_subdirectory(src)
+add_subdirectory(core)
 
 if (${CMAKE_CROSSCOMPILING})
-  add_subdirectory(firmware)
-else()
-   add_subdirectory(tests)
-endif()
+    add_subdirectory(firmware)
+else ()
+    add_subdirectory(tests)
+endif ()
 
 file(GLOB_RECURSE GANTRY_SOURCES_FOR_FORMAT ./*.cpp ./*.hpp ../include/gantry/*.hpp)
 
@@ -16,13 +16,13 @@ file(GLOB_RECURSE GANTRY_SOURCES_FOR_FORMAT ./*.cpp ./*.hpp ../include/gantry/*.
 
 # Target for use during dev - edits files
 add_custom_target(
-  gantry-format
-  ALL
-  COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -i ${GANTRY_SOURCES_FOR_FORMAT}
-  )
+        gantry-format
+        ALL
+        COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -i ${GANTRY_SOURCES_FOR_FORMAT}
+)
 
 # Target for use in ci - warnings are errors, doesn't edit files
 add_custom_target(
-  gantry-format-ci
-  COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -Werror --ferror-limit=0 -n ${GANTRY_SOURCES_FOR_FORMAT}
+        gantry-format-ci
+        COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -Werror --ferror-limit=0 -n ${GANTRY_SOURCES_FOR_FORMAT}
 )

--- a/gantry/core/CMakeLists.txt
+++ b/gantry/core/CMakeLists.txt
@@ -1,26 +1,35 @@
 # This CMakeLists.txt handles compiling all the parts of the gantry
 # module that are portable between host and cross compilation as a static
 # library. It is included in both host and cross configurations.
+if (NOT GANTRY_AXIS_TYPE)
+    SET(GANTRY_AXIS_TYPE "gantry_x" CACHE STRING "Defines the gantry axis: gantry_x or gantry_y")
+endif ()
+
+
+configure_file(./axis_type.cpp.in ./axis_type.cpp)
+
+set(CORE_NONLINTABLE_SRCS
+        ${CMAKE_CURRENT_BINARY_DIR}/axis_type.cpp)
 
 add_library(gantry-core STATIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/
-  )
+        ${CORE_NONLINTABLE_SRCS}
+        )
 
 set_target_properties(gantry-core
-  PROPERTIES CXX_STANDARD 20
-             CXX_STANDARD_REQUIRED TRUE)
+        PROPERTIES CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED TRUE)
 
 target_include_directories(gantry-core
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+        PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
 target_compile_options(gantry-core
-  PRIVATE
-  -Wall
-  -Werror
-  -Weffc++
-  -Wreorder
-  -Wsign-promo
-  -Wextra-semi
-  -Wctor-dtor-privacy
-  -fno-rtti
-  )
+        PRIVATE
+        -Wall
+        -Werror
+        -Weffc++
+        -Wreorder
+        -Wsign-promo
+        -Wextra-semi
+        -Wctor-dtor-privacy
+        -fno-rtti
+        )

--- a/gantry/core/axis_type.cpp.in
+++ b/gantry/core/axis_type.cpp.in
@@ -1,0 +1,5 @@
+#include "gantry/axis_type.hpp"
+
+static constexpr const char* _AXIS_TYPE = "${GANTRY_AXIS_TYPE}";
+
+const char* axis_type::get_axis() { return _AXIS_TYPE; }

--- a/gantry/core/axis_type.cpp.in
+++ b/gantry/core/axis_type.cpp.in
@@ -1,5 +1,3 @@
-#include "gantry/axis_type.hpp"
+#include "gantry/core/axis_type.hpp"
 
-static constexpr const char* _AXIS_TYPE = "${GANTRY_AXIS_TYPE}";
-
-const char* axis_type::get_axis() { return _AXIS_TYPE; }
+constexpr auto gantry_type = can_ids::NodeId::${GANTRY_AXIS_TYPE};

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -4,6 +4,8 @@ find_package(STM32G4xx)
 add_STM32G4_driver("Gantry")
 add_STM32G4_freertos("Gantry")
 
+SET(GANTRY_AXIS_TYPE "X" CACHE STRING "Defines the gantry axis: X or Y")
+
 set(COMMON_EXECUTABLE_DIR "${CMAKE_SOURCE_DIR}/common/firmware")
 
 set(CAN_FW_DIR "${CMAKE_SOURCE_DIR}/can/firmware")
@@ -34,6 +36,8 @@ add_executable(gantry
         ${GANTRY_FW_LINTABLE_SRCS}
         ${GANTRY_FW_NON_LINTABLE_SRCS})
 
+MESSAGE(STATUS "The gantry axis type is ${GANTRY_AXIS_TYPE}")
+
 target_link_libraries(gantry
         PUBLIC STM32G491RETx
         STM32G4xx_Drivers_Gantry STM32G4xx_FreeRTOS_Gantry
@@ -44,6 +48,9 @@ set_target_properties(gantry
         CXX_STANDARD_REQUIRED TRUE
         C_STANDARD 11
         C_STANDARD_REQUIRED TRUE)
+
+target_compile_definitions(gantry
+        PUBLIC GANTRY_AXIS_TYPE)
 
 target_include_directories(gantry
         PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -4,7 +4,9 @@ find_package(STM32G4xx)
 add_STM32G4_driver("Gantry")
 add_STM32G4_freertos("Gantry")
 
-SET(GANTRY_AXIS_TYPE "X" CACHE STRING "Defines the gantry axis: X or Y")
+if (NOT GANTRY_AXIS_TYPE)
+    SET(GANTRY_AXIS_TYPE "X" CACHE STRING "Defines the gantry axis: X or Y")
+endif ()
 
 set(COMMON_EXECUTABLE_DIR "${CMAKE_SOURCE_DIR}/common/firmware")
 
@@ -47,7 +49,8 @@ set_target_properties(gantry
         PROPERTIES CXX_STANDARD 20
         CXX_STANDARD_REQUIRED TRUE
         C_STANDARD 11
-        C_STANDARD_REQUIRED TRUE)
+        C_STANDARD_REQUIRED TRUE
+        OUTPUT_NAME "gantry_${GANTRY_AXIS_TYPE}")
 
 target_compile_definitions(gantry
         PUBLIC GANTRY_AXIS_TYPE)
@@ -132,3 +135,5 @@ add_custom_target(gantry-flash
         VERBATIM
         COMMENT "Flashing board"
         DEPENDS gantry)
+
+unset(GANTRY_AXIS_TYPE CACHE)

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -4,10 +4,6 @@ find_package(STM32G4xx)
 add_STM32G4_driver("Gantry")
 add_STM32G4_freertos("Gantry")
 
-if (NOT GANTRY_AXIS_TYPE)
-    SET(GANTRY_AXIS_TYPE "X" CACHE STRING "Defines the gantry axis: X or Y")
-endif ()
-
 set(COMMON_EXECUTABLE_DIR "${CMAKE_SOURCE_DIR}/common/firmware")
 
 set(CAN_FW_DIR "${CMAKE_SOURCE_DIR}/can/firmware")
@@ -32,7 +28,9 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/can/can.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
-        ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c)
+        ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c
+        )
+
 
 add_executable(gantry
         ${GANTRY_FW_LINTABLE_SRCS}
@@ -50,10 +48,8 @@ set_target_properties(gantry
         CXX_STANDARD_REQUIRED TRUE
         C_STANDARD 11
         C_STANDARD_REQUIRED TRUE
-        OUTPUT_NAME "gantry_${GANTRY_AXIS_TYPE}")
+        OUTPUT_NAME ${GANTRY_AXIS_TYPE})
 
-target_compile_definitions(gantry
-        PUBLIC GANTRY_AXIS_TYPE)
 
 target_include_directories(gantry
         PUBLIC ${CMAKE_SOURCE_DIR}/include)
@@ -115,7 +111,7 @@ list(TRANSFORM CLANG_EXTRA_ARGS PREPEND --extra-arg=-I)
 list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
 add_custom_target(gantry-lint
         ALL
-        COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${GANTRY_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES} --config=)
+        COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${GANTRY_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SRCS} --config=)
 
 # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
 # arguable misuse of the concept) to the appropriate cross-gdb with

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -11,6 +11,7 @@
 #include "common/firmware/can.h"
 #include "common/firmware/errors.h"
 #include "common/firmware/spi_comms.hpp"
+#include "gantry/core/axis_type.hpp"
 #include "motor-control/core/motor.hpp"
 #include "motor-control/core/motor_messages.hpp"
 #include "pipettes/core/message_handlers/motor.hpp"
@@ -56,8 +57,8 @@ static motor_class::Motor motor{
 static auto can_motor_handler = MotorHandler{message_writer_1, motor};
 
 /** Handler of device info requests. */
-static auto device_info_handler =
-    can_device_info::DeviceInfoHandler(message_writer_1, NodeId::gantry, 0);
+static auto device_info_handler = can_device_info::DeviceInfoHandler(
+    message_writer_1, axis_type::gantry_type, 0);
 static auto device_info_dispatch_target =
     DispatchParseTarget<decltype(device_info_handler),
                         can_messages::DeviceInfoRequest>{device_info_handler};

--- a/gantry/tests/CMakeLists.txt
+++ b/gantry/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 # this CMakeLists.txt file is only used when host-compiling to build tests
+
 find_package(Catch2 REQUIRED)
 include(CTest)
 include(Catch)
@@ -10,7 +11,7 @@ add_executable(
         test_linear_motion_config.cpp
 )
 
-target_include_directories(gantry PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+target_include_directories(gantry PUBLIC ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(gantry
         PROPERTIES
         CXX_STANDARD 20
@@ -26,7 +27,7 @@ target_compile_options(gantry
         -Wextra-semi
         -Wctor-dtor-privacy
         -fno-rtti)
-target_link_libraries(gantry Catch2::Catch2)
+target_link_libraries(gantry Catch2::Catch2 gantry-core)
 
 catch_discover_tests(gantry)
 add_build_and_test_target(gantry)

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -25,7 +25,9 @@ enum class NodeId : uint8_t {
     broadcast = 0x00,
     host = 0x10,
     pipette = 0x20,
-    gantry = 0x40,
+    gantry_x = 0x30,
+    gantry_y = 0x40,
+    undefined = 0xFF,
 };
 
 /**

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -27,7 +27,6 @@ enum class NodeId : uint8_t {
     pipette = 0x20,
     gantry_x = 0x30,
     gantry_y = 0x40,
-    undefined = 0xFF,
 };
 
 /**

--- a/include/gantry/core/axis_type.hpp
+++ b/include/gantry/core/axis_type.hpp
@@ -1,5 +1,6 @@
 #pragma once
+#include "can/core/ids.hpp"
 
 namespace axis_type {
-auto get_axis() -> const char*;
-}
+can_ids::NodeId gantry_type;
+}  // namespace axis_type

--- a/include/gantry/core/axis_type.hpp
+++ b/include/gantry/core/axis_type.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace axis_type {
+auto get_axis() -> const char*;
+}


### PR DESCRIPTION
This PR creates the executables for `gantry_x` and `gantry_y` separately through defining the variable `GANTRY_AXIS_TYPE`.

Default is `gantry_x`. Running `cmake --preset=cross -DGANTRY_AXIS_TYPE=gantry_y .` would allow the subsequent executable built for the Y gantry.