### PR TITLE
feat(can): filter can messages based on node id

### DIFF
--- a/can/core/can_bus.cpp
+++ b/can/core/can_bus.cpp
@@ -44,3 +44,30 @@ auto can_bus::to_canfd_length(uint32_t length) -> CanFDMessageLength {
     else
         return CanFDMessageLength::l64;
 }
+
+/**
+ * Set up the can bus receive filters.
+ *
+ * @param can_filters CanBusFilters interface.
+ * @param node_id The node id to allow.
+ */
+void can_bus::setup_node_id_filter(CanBusFilters& can_filters, NodeId node_id) {
+    // The node id mask.
+    auto node_id_mask = can_arbitration_id::ArbitrationId{
+        .parts = {.function_code = 0, .node_id = 0xFF, .message_id = 0}};
+
+    // Set up the broadcast filter
+    auto filter = can_arbitration_id::ArbitrationId{.id = 0};
+    filter.parts.node_id = static_cast<uint32_t>(NodeId::broadcast);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
+                           filter.id, node_id_mask.id);
+
+    // Set up the specific node_id filter
+    filter.id = 0;
+    filter.parts.node_id = static_cast<uint32_t>(node_id);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
+                           filter.id, node_id_mask.id);
+
+    // Reject everything else
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::reject, 0, 0);
+}

--- a/gantry/core/axis_type.cpp.in
+++ b/gantry/core/axis_type.cpp.in
@@ -1,3 +1,3 @@
 #include "gantry/core/axis_type.hpp"
 
-constexpr auto gantry_type = can_ids::NodeId::${GANTRY_AXIS_TYPE};
+can_ids::NodeId axis_type::gantry_type = can_ids::NodeId::${GANTRY_AXIS_TYPE};

--- a/gantry/core/axis_type.cpp.in
+++ b/gantry/core/axis_type.cpp.in
@@ -1,3 +1,10 @@
 #include "gantry/core/axis_type.hpp"
 
-can_ids::NodeId axis_type::gantry_type = can_ids::NodeId::${GANTRY_AXIS_TYPE};
+/**
+ * Get the node id for this gantries axis type
+ *
+ * @return A node id
+ */
+auto axis_type::get_node_id() -> can_ids::NodeId {
+    return can_ids::NodeId::${GANTRY_AXIS_TYPE};
+}

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -41,6 +41,7 @@ MESSAGE(STATUS "The gantry axis type is ${GANTRY_AXIS_TYPE}")
 target_link_libraries(gantry
         PUBLIC STM32G491RETx
         STM32G4xx_Drivers_Gantry STM32G4xx_FreeRTOS_Gantry
+        gantry-core
         can-core)
 
 set_target_properties(gantry

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -28,27 +28,31 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
-
 /**
  * Set up the can bus receive filters.
  *
  * @param can_filters CanBusFilters interface.
  */
-static void can_filter_setup(CanBusFilters & can_filters) {
+static void can_filter_setup(CanBusFilters& can_filters) {
     // The node id mask.
-    auto node_id_mask = ArbitrationId {.parts={.function_code=0, .node_id=0xFFFF, .message_id=0}};
+    auto node_id_mask = ArbitrationId{
+        .parts = {.function_code = 0, .node_id = 0xFFFF, .message_id = 0}};
 
     // Set up the broadcast filter
-    auto filter = ArbitrationId{.id=0};
-    filter.parts.node_id=static_cast<unsigned>(NodeId::broadcast);
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0, filter.id, node_id_mask.id);
+    auto filter = ArbitrationId{.id = 0};
+    filter.parts.node_id = static_cast<unsigned>(NodeId::broadcast);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
+                           filter.id, node_id_mask.id);
 
     // Set up the gantry filter
     filter.id = 0;
     filter.parts.node_id = static_cast<unsigned>(axis_type::gantry_type);
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0, filter.id, node_id_mask.id);
-}
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
+                           filter.id, node_id_mask.id);
 
+    // Reject everything else
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::reject, 0, 0);
+}
 
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -28,6 +28,28 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
+
+/**
+ * Set up the can bus receive filters.
+ *
+ * @param can_filters CanBusFilters interface.
+ */
+static void can_filter_setup(CanBusFilters & can_filters) {
+    // The node id mask.
+    auto node_id_mask = ArbitrationId {.parts={.function_code=0, .node_id=0xFFFF, .message_id=0}};
+
+    // Set up the broadcast filter
+    auto filter = ArbitrationId{.id=0};
+    filter.parts.node_id=static_cast<unsigned>(NodeId::broadcast);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0, filter.id, node_id_mask.id);
+
+    // Set up the gantry filter
+    filter.id = 0;
+    filter.parts.node_id = static_cast<unsigned>(axis_type::gantry_type);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0, filter.id, node_id_mask.id);
+}
+
+
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");
 static spi::Spi spi_comms{};
@@ -76,6 +98,7 @@ static auto dispatcher =
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
+    can_filter_setup(can_bus_1);
     can_bus_1.start();
 
     auto poller = FreeRTOSCanBufferPoller(

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -40,13 +40,13 @@ static void can_filter_setup(CanBusFilters& can_filters) {
 
     // Set up the broadcast filter
     auto filter = ArbitrationId{.id = 0};
-    filter.parts.node_id = static_cast<unsigned>(NodeId::broadcast);
+    filter.parts.node_id = static_cast<uint32_t>(NodeId::broadcast);
     can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
                            filter.id, node_id_mask.id);
 
     // Set up the gantry filter
     filter.id = 0;
-    filter.parts.node_id = static_cast<unsigned>(axis_type::gantry_type);
+    filter.parts.node_id = static_cast<uint32_t>(axis_type::get_node_id());
     can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
                            filter.id, node_id_mask.id);
 
@@ -84,7 +84,7 @@ static auto can_motor_handler = MotorHandler{message_writer_1, motor};
 
 /** Handler of device info requests. */
 static auto device_info_handler = can_device_info::DeviceInfoHandler(
-    message_writer_1, axis_type::gantry_type, 0);
+    message_writer_1, axis_type::get_node_id(), 0);
 static auto device_info_dispatch_target =
     DispatchParseTarget<decltype(device_info_handler),
                         can_messages::DeviceInfoRequest>{device_info_handler};

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -27,7 +27,6 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
-
 /**
  * Set up the can bus receive filters.
  *

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -27,6 +27,33 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
+
+/**
+ * Set up the can bus receive filters.
+ *
+ * @param can_filters CanBusFilters interface.
+ */
+static void can_filter_setup(CanBusFilters& can_filters) {
+    // The node id mask.
+    auto node_id_mask = ArbitrationId{
+        .parts = {.function_code = 0, .node_id = 0xFFFF, .message_id = 0}};
+
+    // Set up the broadcast filter
+    auto filter = ArbitrationId{.id = 0};
+    filter.parts.node_id = static_cast<uint32_t>(NodeId::broadcast);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
+                           filter.id, node_id_mask.id);
+
+    // Set up the head filter
+    filter.id = 0;
+    filter.parts.node_id = static_cast<uint32_t>(NodeId::head);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
+                           filter.id, node_id_mask.id);
+
+    // Reject everything else
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::reject, 0, 0);
+}
+
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");
 static spi::Spi spi_comms{};
@@ -75,6 +102,7 @@ static auto dispatcher =
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
+    can_filter_setup(can_bus_1);
     can_bus_1.start();
 
     auto poller = FreeRTOSCanBufferPoller(

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -27,32 +27,6 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
-/**
- * Set up the can bus receive filters.
- *
- * @param can_filters CanBusFilters interface.
- */
-static void can_filter_setup(CanBusFilters& can_filters) {
-    // The node id mask.
-    auto node_id_mask = ArbitrationId{
-        .parts = {.function_code = 0, .node_id = 0xFFFF, .message_id = 0}};
-
-    // Set up the broadcast filter
-    auto filter = ArbitrationId{.id = 0};
-    filter.parts.node_id = static_cast<uint32_t>(NodeId::broadcast);
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
-                           filter.id, node_id_mask.id);
-
-    // Set up the head filter
-    filter.id = 0;
-    filter.parts.node_id = static_cast<uint32_t>(NodeId::head);
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
-                           filter.id, node_id_mask.id);
-
-    // Reject everything else
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::reject, 0, 0);
-}
-
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");
 static spi::Spi spi_comms{};
@@ -101,7 +75,7 @@ static auto dispatcher =
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
-    can_filter_setup(can_bus_1);
+    can_bus::setup_node_id_filter(can_bus_1, NodeId::head);
     can_bus_1.start();
 
     auto poller = FreeRTOSCanBufferPoller(

--- a/include/can/core/can_bus.hpp
+++ b/include/can/core/can_bus.hpp
@@ -3,6 +3,7 @@
 #include <concepts>
 #include <cstdint>
 
+#include "can/core/arbitration_id.hpp"
 #include "can/core/parse.hpp"
 
 namespace can_bus {
@@ -91,5 +92,14 @@ class CanBusFilters {
 
     virtual ~CanBusFilters() {}
 };
+
+/**
+ * Set up the can bus receive filter to receive only broadcast messages and
+ * messages targeting node_id.
+ *
+ * @param can_filters CanBusFilters interface.
+ * @param node_id The node id to allow.
+ */
+void setup_node_id_filter(CanBusFilters& can_filters, NodeId node_id);
 
 }  // namespace can_bus

--- a/include/gantry/core/axis_type.hpp
+++ b/include/gantry/core/axis_type.hpp
@@ -1,6 +1,16 @@
 #pragma once
 #include "can/core/ids.hpp"
 
+/**
+ * Methods that are generated for specific gantry axis.
+ */
 namespace axis_type {
-extern can_ids::NodeId gantry_type;
+
+/**
+ * Get the node id for this gantry's axis type
+ *
+ * @return A node id
+ */
+auto get_node_id() -> can_ids::NodeId;
+
 }  // namespace axis_type

--- a/include/gantry/core/axis_type.hpp
+++ b/include/gantry/core/axis_type.hpp
@@ -2,5 +2,5 @@
 #include "can/core/ids.hpp"
 
 namespace axis_type {
-can_ids::NodeId gantry_type;
+extern can_ids::NodeId gantry_type;
 }  // namespace axis_type

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -37,6 +37,32 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
+/**
+ * Set up the can bus receive filters.
+ *
+ * @param can_filters CanBusFilters interface.
+ */
+static void can_filter_setup(CanBusFilters& can_filters) {
+    // The node id mask.
+    auto node_id_mask = ArbitrationId{
+        .parts = {.function_code = 0, .node_id = 0xFFFF, .message_id = 0}};
+
+    // Set up the broadcast filter
+    auto filter = ArbitrationId{.id = 0};
+    filter.parts.node_id = static_cast<unsigned>(NodeId::broadcast);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
+                           filter.id, node_id_mask.id);
+
+    // Set up the pipette filter
+    filter.id = 0;
+    filter.parts.node_id = static_cast<unsigned>(NodeId::pipette);
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
+                           filter.id, node_id_mask.id);
+
+    // Reject everything else
+    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::reject, 0, 0);
+}
+
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");
 static spi::Spi spi_comms{};
@@ -92,7 +118,10 @@ static auto dispatcher = Dispatcher(
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
+
+    can_filter_setup(can_bus_1);
     can_bus_1.start();
+
     auto poller = FreeRTOSCanBufferPoller(
         hal_can_message_buffer::get_message_buffer(), dispatcher);
     poller();

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -37,32 +37,6 @@ extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
 static auto message_writer_1 = MessageWriter(can_bus_1);
 
-/**
- * Set up the can bus receive filters.
- *
- * @param can_filters CanBusFilters interface.
- */
-static void can_filter_setup(CanBusFilters& can_filters) {
-    // The node id mask.
-    auto node_id_mask = ArbitrationId{
-        .parts = {.function_code = 0, .node_id = 0xFFFF, .message_id = 0}};
-
-    // Set up the broadcast filter
-    auto filter = ArbitrationId{.id = 0};
-    filter.parts.node_id = static_cast<uint32_t>(NodeId::broadcast);
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
-                           filter.id, node_id_mask.id);
-
-    // Set up the pipette filter
-    filter.id = 0;
-    filter.parts.node_id = static_cast<uint32_t>(NodeId::pipette);
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
-                           filter.id, node_id_mask.id);
-
-    // Reject everything else
-    can_filters.add_filter(CanFilterType::mask, CanFilterConfig::reject, 0, 0);
-}
-
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");
 static spi::Spi spi_comms{};
@@ -118,8 +92,7 @@ static auto dispatcher = Dispatcher(
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
-
-    can_filter_setup(can_bus_1);
+    can_bus::setup_node_id_filter(can_bus_1, NodeId::pipette);
     can_bus_1.start();
 
     auto poller = FreeRTOSCanBufferPoller(

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -49,13 +49,13 @@ static void can_filter_setup(CanBusFilters& can_filters) {
 
     // Set up the broadcast filter
     auto filter = ArbitrationId{.id = 0};
-    filter.parts.node_id = static_cast<unsigned>(NodeId::broadcast);
+    filter.parts.node_id = static_cast<uint32_t>(NodeId::broadcast);
     can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo0,
                            filter.id, node_id_mask.id);
 
     // Set up the pipette filter
     filter.id = 0;
-    filter.parts.node_id = static_cast<unsigned>(NodeId::pipette);
+    filter.parts.node_id = static_cast<uint32_t>(NodeId::pipette);
     can_filters.add_filter(CanFilterType::mask, CanFilterConfig::to_fifo1,
                            filter.id, node_id_mask.id);
 


### PR DESCRIPTION
gantry and pipette projects only accept broadcast and messages for their own node ids