### PR TITLE
feat(CAN): Add move group handler

### DIFF
--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -50,6 +50,13 @@ enum class MessageId : uint16_t {
 
     move_request = 0x10,
 
+    add_linear_move_request = 0x15,
+    get_move_group_request = 0x16,
+    get_move_group_response = 0x17,
+    execute_move_group_request = 0x18,
+    clear_move_group_request = 0x19,
+    move_group_completed = 0x1A,
+
     setup_request = 0x02,
 
     get_speed_request = 0x04,

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "can/core/can_bus.hpp"
 #include "can/core/message_writer.hpp"
 #include "common/core/message_queue.hpp"
 #include "motor-control/core/motor_messages.hpp"
 
-using namespace can_bus;
 using namespace can_message_writer;
 
 namespace motor_message_handler {

--- a/include/can/core/message_handlers/move_group.hpp
+++ b/include/can/core/message_handlers/move_group.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "can/core/message_writer.hpp"
+#include "can/core/messages.hpp"
+#include "motor-control/core/motor_messages.hpp"
+
+namespace move_group_handler {
+
+using namespace can_message_writer;
+using namespace can_messages;
+
+template <typename MotionGroupManager>
+class MoveGroupHandler {
+  public:
+    using MessageType =
+        std::variant<std::monostate, AddLinearMoveRequest, GetMoveGroupRequest,
+                     ClearMoveGroupRequest>;
+
+    MoveGroupHandler(MessageWriter &message_writer,
+                     MotionGroupManager &motion_group_manager)
+        : message_writer{message_writer},
+          motion_group_manager{motion_group_manager} {}
+    MoveGroupHandler(const MoveGroupHandler &) = delete;
+    MoveGroupHandler(const MoveGroupHandler &&) = delete;
+    MoveGroupHandler &operator=(const MoveGroupHandler &) = delete;
+    MoveGroupHandler &&operator=(const MoveGroupHandler &&) = delete;
+
+    void handle(MessageType &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+  private:
+    void visit(std::monostate &m) {}
+
+    void visit(AddLinearMoveRequest &m) {
+        message_writer.write(NodeId::host, m);
+    }
+
+    void visit(GetMoveGroupRequest &m) {
+        message_writer.write(NodeId::host, m);
+    }
+
+    void visit(ClearMoveGroupRequest &m) {
+        message_writer.write(NodeId::host, m);
+    }
+
+    MessageWriter &message_writer;
+    MotionGroupManager &motion_group_manager;
+};
+
+}  // namespace move_group_handler

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -180,12 +180,169 @@ struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
     static auto parse(Input body, Limit limit) -> ReadFromEEPromResponse {
         uint8_t serial_number = 0;
         body = bit_utils::bytes_to_int(body, limit, serial_number);
-        return ReadFromEEPromResponse{{}, serial_number};
+        return ReadFromEEPromResponse{.serial_number = serial_number};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
+        return iter - body;
+    }
+};
+
+struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
+    uint8_t group_id;
+    uint8_t seq_id;
+    uint32_t duration;
+    int32_t acceleration;
+    int32_t velocity;
+    uint32_t position;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> AddLinearMoveRequest {
+        uint8_t group_id = 0;
+        uint8_t seq_id = 0;
+        uint32_t duration = 0;
+        int32_t acceleration = 0;
+        int32_t velocity = 0;
+        uint32_t position = 0;
+        body = bit_utils::bytes_to_int(body, limit, group_id);
+        body = bit_utils::bytes_to_int(body, limit, seq_id);
+        body = bit_utils::bytes_to_int(body, limit, duration);
+        body = bit_utils::bytes_to_int(body, limit, acceleration);
+        body = bit_utils::bytes_to_int(body, limit, velocity);
+        body = bit_utils::bytes_to_int(body, limit, position);
+        return AddLinearMoveRequest{.group_id = group_id,
+                                    .seq_id = seq_id,
+                                    .duration = duration,
+                                    .acceleration = acceleration,
+                                    .velocity = velocity,
+                                    .position = position};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        iter = bit_utils::int_to_bytes(seq_id, iter, limit);
+        iter = bit_utils::int_to_bytes(duration, iter, limit);
+        iter = bit_utils::int_to_bytes(acceleration, iter, limit);
+        iter = bit_utils::int_to_bytes(velocity, iter, limit);
+        iter = bit_utils::int_to_bytes(position, iter, limit);
+        return iter - body;
+    }
+};
+
+struct GetMoveGroupRequest : BaseMessage<MessageId::get_move_group_request> {
+    uint8_t group_id;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> GetMoveGroupRequest {
+        uint8_t group_id = 0;
+        body = bit_utils::bytes_to_int(body, limit, group_id);
+        return GetMoveGroupRequest{.group_id = group_id};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        return iter - body;
+    }
+};
+
+struct GetMoveGroupResponse : BaseMessage<MessageId::get_move_group_response> {
+    uint8_t group_id;
+    uint8_t num_moves;
+    uint32_t total_duration;
+    uint8_t node_id;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> GetMoveGroupResponse {
+        uint8_t group_id = 0;
+        uint8_t num_moves = 0;
+        uint32_t total_duration = 0;
+        uint8_t node_id = 0;
+        body = bit_utils::bytes_to_int(body, limit, group_id);
+        body = bit_utils::bytes_to_int(body, limit, num_moves);
+        body = bit_utils::bytes_to_int(body, limit, total_duration);
+        body = bit_utils::bytes_to_int(body, limit, node_id);
+        return GetMoveGroupResponse{.group_id = group_id,
+                                    .num_moves = num_moves,
+                                    .total_duration = total_duration,
+                                    .node_id = node_id};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        iter = bit_utils::int_to_bytes(num_moves, iter, limit);
+        iter = bit_utils::int_to_bytes(total_duration, iter, limit);
+        iter = bit_utils::int_to_bytes(node_id, iter, limit);
+        return iter - body;
+    }
+};
+
+struct ExecuteMoveGroupRequest
+    : BaseMessage<MessageId::execute_move_group_request> {
+    uint8_t group_id;
+    uint8_t start_trigger;
+    uint8_t cancel_trigger;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> ExecuteMoveGroupRequest {
+        uint8_t group_id = 0;
+        uint8_t start_trigger = 0;
+        uint8_t cancel_trigger = 0;
+        body = bit_utils::bytes_to_int(body, limit, group_id);
+        body = bit_utils::bytes_to_int(body, limit, start_trigger);
+        body = bit_utils::bytes_to_int(body, limit, cancel_trigger);
+        return ExecuteMoveGroupRequest{.group_id = group_id,
+                                       .start_trigger = start_trigger,
+                                       .cancel_trigger = cancel_trigger};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        iter = bit_utils::int_to_bytes(start_trigger, iter, limit);
+        iter = bit_utils::int_to_bytes(cancel_trigger, iter, limit);
+        return iter - body;
+    }
+};
+
+struct ClearMoveGroupRequest : BaseMessage<MessageId::clear_move_group_request> {
+    uint8_t group_id;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> ClearMoveGroupRequest {
+        uint8_t group_id = 0;
+        body = bit_utils::bytes_to_int(body, limit, group_id);
+        return ClearMoveGroupRequest{.group_id = group_id};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        return iter - body;
+    }
+};
+
+struct MoveGroupCompleted : BaseMessage<MessageId::move_group_completed> {
+    uint8_t group_id;
+    uint8_t node_id;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> MoveGroupCompleted {
+        uint8_t group_id = 0;
+        uint8_t node_id = 0;
+        body = bit_utils::bytes_to_int(body, limit, group_id);
+        body = bit_utils::bytes_to_int(body, limit, node_id);
+        return MoveGroupCompleted{.group_id = group_id, .node_id = node_id};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        iter = bit_utils::int_to_bytes(node_id, iter, limit);
         return iter - body;
     }
 };

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -193,31 +193,31 @@ struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
 struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
     uint8_t group_id;
     uint8_t seq_id;
-    uint32_t duration;
-    int32_t acceleration;
-    int32_t velocity;
-    uint32_t position;
+    uint16_t duration;
+    int16_t acceleration;
+    int16_t velocity;
+    //    uint32_t position;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> AddLinearMoveRequest {
         uint8_t group_id = 0;
         uint8_t seq_id = 0;
-        uint32_t duration = 0;
-        int32_t acceleration = 0;
-        int32_t velocity = 0;
-        uint32_t position = 0;
+        uint16_t duration = 0;
+        int16_t acceleration = 0;
+        int16_t velocity = 0;
+        //        uint32_t position = 0;
         body = bit_utils::bytes_to_int(body, limit, group_id);
         body = bit_utils::bytes_to_int(body, limit, seq_id);
         body = bit_utils::bytes_to_int(body, limit, duration);
         body = bit_utils::bytes_to_int(body, limit, acceleration);
         body = bit_utils::bytes_to_int(body, limit, velocity);
-        body = bit_utils::bytes_to_int(body, limit, position);
+        //        body = bit_utils::bytes_to_int(body, limit, position);
         return AddLinearMoveRequest{.group_id = group_id,
                                     .seq_id = seq_id,
                                     .duration = duration,
                                     .acceleration = acceleration,
-                                    .velocity = velocity,
-                                    .position = position};
+                                    .velocity = velocity};
+        //                                    .position = position};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -227,7 +227,7 @@ struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
         iter = bit_utils::int_to_bytes(duration, iter, limit);
         iter = bit_utils::int_to_bytes(acceleration, iter, limit);
         iter = bit_utils::int_to_bytes(velocity, iter, limit);
-        iter = bit_utils::int_to_bytes(position, iter, limit);
+        //        iter = bit_utils::int_to_bytes(position, iter, limit);
         return iter - body;
     }
 };
@@ -309,7 +309,8 @@ struct ExecuteMoveGroupRequest
     }
 };
 
-struct ClearMoveGroupRequest : BaseMessage<MessageId::clear_move_group_request> {
+struct ClearMoveGroupRequest
+    : BaseMessage<MessageId::clear_move_group_request> {
     uint8_t group_id;
 
     template <bit_utils::ByteIterator Input, typename Limit>

--- a/include/motor-control/core/motion_group.hpp
+++ b/include/motor-control/core/motion_group.hpp
@@ -1,0 +1,2 @@
+
+class MotionGroupManager {};

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -13,11 +13,27 @@ namespace motor_messages {
 // for now.
 struct CanMove {
     uint32_t target_position;  // in mm
+    int32_t velocity;
+    int32_t acceleration;
+    uint32_t motion_group_id;
+    uint32_t sequence;
 };
 
 struct Move {
     q31_31 target_position;  // in steps
     sq0_31 velocity;
     sq0_31 acceleration;
+    //    uint8_t group_id;
+    //    uint8_t seq_id;
+    //    uint32_t duration;  // in ticks
 };
+
+enum class AckMessageId : uint8_t { complete = 0x1, error = 0x04 };
+
+struct Ack {
+    uint8_t group_id;
+    uint8_t seq_id;
+    AckMessageId ack_id;
+};
+
 }  // namespace motor_messages


### PR DESCRIPTION
This PR adds a MoveGroupHandler to handle CAN messages that (1) add linear move to move group, (2) get the list of moves that the firmware will execute in a specific move group, (3) clear the moves in a specific move group. 