### PR TITLE
chore(can): make message structs comparable

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -12,6 +12,12 @@ SCENARIO("message deserializing works") {
                 REQUIRE(r.data == 0x02030405);
                 REQUIRE(r.status == 0x01);
             }
+            THEN("it can be compared for equality") {
+                auto other = r;
+                REQUIRE(other == r);
+                other.data = 24;
+                REQUIRE(other != r);
+            }
         }
     }
 
@@ -21,6 +27,12 @@ SCENARIO("message deserializing works") {
             auto r = MoveRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {
                 REQUIRE(r.target_position == 0x01020304);
+            }
+            THEN("it can be compared for equality") {
+                auto other = r;
+                REQUIRE(other == r);
+                other.target_position = 10;
+                REQUIRE(other != r);
             }
         }
     }
@@ -32,6 +44,12 @@ SCENARIO("message deserializing works") {
             THEN("it is converted to a the correct structure") {
                 REQUIRE(r.mm_sec == 0x01020304);
             }
+            THEN("it can be compared for equality") {
+                auto other = r;
+                REQUIRE(other == r);
+                other.mm_sec = 1;
+                REQUIRE(other != r);
+            }
         }
     }
 
@@ -42,6 +60,12 @@ SCENARIO("message deserializing works") {
             THEN("it is converted to a the correct structure") {
                 REQUIRE(r.node_id == NodeId::pipette);
                 REQUIRE(r.version == 0x02030405);
+            }
+            THEN("it can be compared for equality") {
+                auto other = r;
+                REQUIRE(other == r);
+                other.version = 125;
+                REQUIRE(other != r);
             }
         }
     }

--- a/common/tests/test_move_group.cpp
+++ b/common/tests/test_move_group.cpp
@@ -5,13 +5,6 @@
 #include "catch2/catch.hpp"
 #include "motor-control/core/motion_group.hpp"
 
-bool operator==(const can_messages::AddLinearMoveRequest& a,
-                const can_messages::AddLinearMoveRequest& b) {
-    return a.duration == b.duration && a.seq_id == b.seq_id &&
-           a.acceleration == b.acceleration && a.group_id == b.group_id &&
-           a.velocity == b.velocity;
-}
-
 SCENARIO("Testing a move group") {
     auto group = move_group::MoveGroup<5, can_messages::AddLinearMoveRequest>{};
 

--- a/common/tests/test_move_group.cpp
+++ b/common/tests/test_move_group.cpp
@@ -13,7 +13,7 @@ bool operator==(const can_messages::AddLinearMoveRequest& a,
 }
 
 SCENARIO("Testing a move group") {
-    auto group = move_group::MoveGroup<5>{};
+    auto group = move_group::MoveGroup<5, can_messages::AddLinearMoveRequest>{};
 
     GIVEN("a move group") {
         WHEN("is created") {

--- a/include/can/core/message_handlers/move_group.hpp
+++ b/include/can/core/message_handlers/move_group.hpp
@@ -13,18 +13,19 @@ using namespace can_messages;
 constexpr std::size_t max_groups = 6;
 constexpr std::size_t max_moves_per_group = 5;
 
+using MoveGroupType =
+    move_group::MoveGroupManager<max_groups, max_moves_per_group,
+                                 AddLinearMoveRequest>;
+
 class MoveGroupHandler {
   public:
     using MessageType =
         std::variant<std::monostate, AddLinearMoveRequest, GetMoveGroupRequest,
                      ClearMoveGroupRequest>;
-
-    MoveGroupHandler(
-        MessageWriter &message_writer,
-        move_group::MoveGroupManager<max_groups, max_moves_per_group, AddLinearMoveRequest>
-            &motion_group_manager)
+    MoveGroupHandler(MessageWriter &message_writer,
+                     MoveGroupType &motion_group_manager)
         : message_writer{message_writer},
-          motion_group_manager{motion_group_manager} {}
+          motion_group_manager(motion_group_manager) {}
     MoveGroupHandler(const MoveGroupHandler &) = delete;
     MoveGroupHandler(const MoveGroupHandler &&) = delete;
     MoveGroupHandler &operator=(const MoveGroupHandler &) = delete;
@@ -59,8 +60,7 @@ class MoveGroupHandler {
     }
 
     MessageWriter &message_writer;
-    move_group::MoveGroupManager<max_moves_per_group, max_groups>
-        &motion_group_manager;
+    MoveGroupType &motion_group_manager;
 };
 
 }  // namespace move_group_handler

--- a/include/can/core/message_handlers/move_group.hpp
+++ b/include/can/core/message_handlers/move_group.hpp
@@ -21,7 +21,7 @@ class MoveGroupHandler {
 
     MoveGroupHandler(
         MessageWriter &message_writer,
-        move_group::MoveGroupManager<max_moves_per_group, max_groups>
+        move_group::MoveGroupManager<max_groups, max_moves_per_group, AddLinearMoveRequest>
             &motion_group_manager)
         : message_writer{message_writer},
           motion_group_manager{motion_group_manager} {}

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -21,6 +21,7 @@ template <MessageId MId>
 struct BaseMessage {
     /** Satisfy the HasMessageID concept */
     static const auto id = MId;
+    bool operator==(const BaseMessage& other) const = default;
 };
 
 /**
@@ -39,6 +40,8 @@ struct Empty : BaseMessage<MId> {
     auto serialize(Output body, Limit limit) const -> uint8_t {
         return 0;
     }
+
+    bool operator==(const Empty& other) const = default;
 };
 
 using HeartbeatRequest = Empty<MessageId::heartbeat_request>;
@@ -83,6 +86,7 @@ struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
         iter = bit_utils::int_to_bytes(version, iter, limit);
         return iter - body;
     }
+    bool operator==(const DeviceInfoResponse& other) const = default;
 };
 
 using StopRequest = Empty<MessageId::stop_request>;
@@ -114,6 +118,7 @@ struct GetStatusResponse : BaseMessage<MessageId::get_status_response> {
         iter = bit_utils::int_to_bytes(data, iter, limit);
         return iter - body;
     }
+    bool operator==(const GetStatusResponse& other) const = default;
 };
 
 struct MoveRequest : BaseMessage<MessageId::move_request> {
@@ -131,6 +136,7 @@ struct MoveRequest : BaseMessage<MessageId::move_request> {
         auto iter = bit_utils::int_to_bytes(target_position, body, limit);
         return iter - body;
     }
+    bool operator==(const MoveRequest& other) const = default;
 };
 
 using SetupRequest = Empty<MessageId::setup_request>;
@@ -152,6 +158,7 @@ struct GetSpeedResponse : BaseMessage<MessageId::get_speed_response> {
         auto iter = bit_utils::int_to_bytes(mm_sec, body, limit);
         return iter - body;
     }
+    bool operator==(const GetSpeedResponse& other) const = default;
 };
 
 struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {
@@ -169,6 +176,7 @@ struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {
         auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
         return iter - body;
     }
+    bool operator==(const WriteToEEPromRequest& other) const = default;
 };
 
 using ReadFromEEPromRequest = Empty<MessageId::read_eeprom_request>;
@@ -188,6 +196,7 @@ struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
         auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
         return iter - body;
     }
+    bool operator==(const ReadFromEEPromResponse& other) const = default;
 };
 
 struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
@@ -230,6 +239,8 @@ struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
         //        iter = bit_utils::int_to_bytes(position, iter, limit);
         return iter - body;
     }
+
+    bool operator==(const AddLinearMoveRequest& other) const = default;
 };
 
 struct GetMoveGroupRequest : BaseMessage<MessageId::get_move_group_request> {
@@ -247,6 +258,8 @@ struct GetMoveGroupRequest : BaseMessage<MessageId::get_move_group_request> {
         auto iter = bit_utils::int_to_bytes(group_id, body, limit);
         return iter - body;
     }
+
+    bool operator==(const GetMoveGroupRequest& other) const = default;
 };
 
 struct GetMoveGroupResponse : BaseMessage<MessageId::get_move_group_response> {
@@ -279,6 +292,7 @@ struct GetMoveGroupResponse : BaseMessage<MessageId::get_move_group_response> {
         iter = bit_utils::int_to_bytes(node_id, iter, limit);
         return iter - body;
     }
+    bool operator==(const GetMoveGroupResponse& other) const = default;
 };
 
 struct ExecuteMoveGroupRequest
@@ -307,6 +321,7 @@ struct ExecuteMoveGroupRequest
         iter = bit_utils::int_to_bytes(cancel_trigger, iter, limit);
         return iter - body;
     }
+    bool operator==(const ExecuteMoveGroupRequest& other) const = default;
 };
 
 struct ClearMoveGroupRequest
@@ -325,6 +340,7 @@ struct ClearMoveGroupRequest
         auto iter = bit_utils::int_to_bytes(group_id, body, limit);
         return iter - body;
     }
+    bool operator==(const ClearMoveGroupRequest& other) const = default;
 };
 
 struct MoveGroupCompleted : BaseMessage<MessageId::move_group_completed> {
@@ -346,6 +362,8 @@ struct MoveGroupCompleted : BaseMessage<MessageId::move_group_completed> {
         iter = bit_utils::int_to_bytes(node_id, iter, limit);
         return iter - body;
     }
+
+    bool operator==(const MoveGroupCompleted& other) const = default;
 };
 
 }  // namespace can_messages

--- a/include/motor-control/core/motion_group.hpp
+++ b/include/motor-control/core/motion_group.hpp
@@ -10,18 +10,16 @@
 namespace move_group {
 
 template <typename Candidate>
-concept Groupable = requires(Candidate C){
+concept Groupable = requires(Candidate C) {
     std::is_integral_v<decltype(C.duration)>;
     std::is_integral_v<decltype(C.group_id)>;
     std::is_integral_v<decltype(C.seq_id)>;
 };
 
-template <std::size_t GroupSize,
-          Groupable...MoveStructs>
+template <std::size_t GroupSize, Groupable... MoveStructs>
 class MoveGroup {
   public:
-    using MoveTypes =
-        std::variant<std::monostate, MoveStructs...>;
+    using MoveTypes = std::variant<std::monostate, MoveStructs...>;
 
     MoveGroup() {}
 
@@ -105,14 +103,12 @@ class MoveGroup {
         return 0;
     }
 
-    static auto visit_duration(const auto& m)
-        -> uint32_t {
-        return m.duration;
-    }
+    static auto visit_duration(const auto& m) -> uint32_t { return m.duration; }
 };
 
-template <std::size_t GroupCount, std::size_t GroupSize, Groupable...MoveStructs>
-using MoveGroupManager = std::array<MoveGroup<GroupSize, MoveStructs...>, GroupCount>;
-
+template <std::size_t GroupCount, std::size_t GroupSize,
+          Groupable... MoveStructs>
+using MoveGroupManager =
+    std::array<MoveGroup<GroupSize, MoveStructs...>, GroupCount>;
 
 }  // namespace move_group

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -63,9 +63,7 @@ static motor_class::Motor motor{
         .microstep = 16},
     PinConfigurations, motor_queue};
 
-static auto move_group_manager =
-    move_group::MoveGroupManager<move_group_handler::max_moves_per_group,
-                                 move_group_handler::max_groups>{};
+static auto move_group_manager = MoveGroupType{};
 /** The parsed message handler */
 static auto can_motor_handler = MotorHandler{message_writer_1, motor};
 static auto can_move_group_handler =


### PR DESCRIPTION
We can use C++-20 default comparison operators for these messages just
fine, we just have to have one in the base class as well.