### PR TITLE
refactor(headers): move using namespace within namespace blocks in headers

### DIFF
--- a/include/can/core/can_bus.hpp
+++ b/include/can/core/can_bus.hpp
@@ -4,9 +4,12 @@
 #include <cstdint>
 
 #include "can/core/arbitration_id.hpp"
+#include "can/core/ids.hpp"
 #include "can/core/parse.hpp"
 
 namespace can_bus {
+
+using namespace can_ids;
 
 enum class CanFilterConfig {
     reject,

--- a/include/can/core/can_message_buffer.hpp
+++ b/include/can/core/can_message_buffer.hpp
@@ -6,9 +6,9 @@
 #include "common/core/message_buffer.hpp"
 #include "message_core.hpp"
 
-using namespace message_buffer;
-
 namespace can_message_buffer {
+
+using namespace message_buffer;
 
 /**
  * Class to write can arbitration ids and data payload into a MessageBuffer.

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -5,11 +5,11 @@
 #include "message_writer.hpp"
 #include "messages.hpp"
 
+namespace can_device_info {
+
 using namespace can_ids;
 using namespace can_message_writer;
 using namespace can_messages;
-
-namespace can_device_info {
 
 /**
  * A HandlesMessages implementing class that will respond to DeviceInfoRequest

--- a/include/can/core/dispatch.hpp
+++ b/include/can/core/dispatch.hpp
@@ -7,11 +7,11 @@
 #include "ids.hpp"
 #include "parse.hpp"
 
+namespace can_dispatch {
+
 using namespace can_parse;
 using namespace can_message_buffer;
 using namespace can_arbitration_id;
-
-namespace can_dispatch {
 
 /**
  * A message id lookup.

--- a/include/can/core/freertos_can_dispatch.hpp
+++ b/include/can/core/freertos_can_dispatch.hpp
@@ -6,13 +6,13 @@
 #include "dispatch.hpp"
 #include "message_core.hpp"
 
+namespace freertos_can_dispatch {
+
 using namespace message_core;
 using namespace message_buffer;
 using namespace can_message_buffer;
 using namespace can_dispatch;
 using namespace freertos_message_buffer;
-
-namespace freertos_can_dispatch {
 
 /**
  * A FreeRTOS task entry point that polls a MessageBuffer.

--- a/include/can/core/message_core.hpp
+++ b/include/can/core/message_core.hpp
@@ -4,9 +4,9 @@
 
 #include "ids.hpp"
 
-using namespace can_ids;
-
 namespace message_core {
+
+using namespace can_ids;
 
 /**
  * Maximum bytes in can message payload

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "can/core/message_writer.hpp"
+#include "can/core/messages.hpp"
 #include "common/core/message_queue.hpp"
 #include "motor-control/core/motor_messages.hpp"
 
-using namespace can_message_writer;
-
 namespace motor_message_handler {
+
+using namespace can_message_writer;
+using namespace can_messages;
 
 template <class Motor>
 class MotorHandler {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -7,9 +7,9 @@
 #include "ids.hpp"
 #include "parse.hpp"
 
-using namespace can_ids;
-
 namespace can_messages {
+
+using namespace can_ids;
 
 /**
  * These types model the messages being sent and received over the can bus.

--- a/include/can/core/parse.hpp
+++ b/include/can/core/parse.hpp
@@ -6,10 +6,10 @@
 #include "ids.hpp"
 #include "message_core.hpp"
 
+namespace can_parse {
+
 using namespace can_ids;
 using namespace message_core;
-
-namespace can_parse {
 
 /**
  * Parser of can message bodies.

--- a/include/can/firmware/hal_can_bus.hpp
+++ b/include/can/firmware/hal_can_bus.hpp
@@ -8,10 +8,10 @@
 #include "common/core/freertos_synchronization.hpp"
 #include "stm32g4xx_hal_fdcan.h"
 
+namespace hal_can_bus {
+
 using namespace can_bus;
 using namespace can_ids;
-
-namespace hal_can_bus {
 
 /**
  * HAL FD CAN wrapper.

--- a/include/can/simulator/sim_canbus.hpp
+++ b/include/can/simulator/sim_canbus.hpp
@@ -7,9 +7,9 @@
 #include "can/core/message_core.hpp"
 #include "common/core/message_buffer.hpp"
 
-using namespace can_bus;
-
 namespace sim_canbus {
+
+using namespace can_bus;
 
 template <class T>
 concept BusTransport = requires(T t, uint32_t arb_id, uint32_t& out_arb_id,

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -8,9 +8,9 @@
 #include "motor_messages.hpp"
 #include "step_motor.hpp"
 
-using namespace motor_messages;
-
 namespace motion_controller {
+
+using namespace motor_messages;
 
 struct HardwareConfig {
     struct PinConfig direction;

--- a/include/pipettes/core/message_handlers/eeprom.hpp
+++ b/include/pipettes/core/message_handlers/eeprom.hpp
@@ -2,14 +2,16 @@
 
 #include "can/core/can_bus.hpp"
 #include "can/core/message_writer.hpp"
+#include "can/core/messages.hpp"
 #include "common/core/message_queue.hpp"
 #include "pipettes/core/eeprom.hpp"
+
+namespace eeprom_message_handler {
 
 using namespace can_bus;
 using namespace can_message_writer;
 using namespace eeprom;
-
-namespace eeprom_message_handler {
+using namespace can_messages;
 
 template <EEPromPolicy I2CComm>
 class EEPromHandler {


### PR DESCRIPTION
Only uses `using namespace` in header files if it's within namespace block.