### PR TITLE
refactor(motor-control): update move request

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -1,5 +1,3 @@
-#include <iostream>
-
 #include "can/core/messages.hpp"
 #include "catch2/catch.hpp"
 

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -1,3 +1,5 @@
+#include <iostream>
+
 #include "can/core/messages.hpp"
 #include "catch2/catch.hpp"
 
@@ -26,12 +28,14 @@ SCENARIO("message deserializing works") {
         WHEN("constructed") {
             auto r = MoveRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {
-                REQUIRE(r.target_position == 0x01020304);
+                REQUIRE(r.duration == 0x01020304);
+                REQUIRE(r.velocity == 0x0506);
+                REQUIRE(r.acceleration == 0x0708);
             }
             THEN("it can be compared for equality") {
                 auto other = r;
                 REQUIRE(other == r);
-                other.target_position = 10;
+                other.duration = 10;
                 REQUIRE(other != r);
             }
         }
@@ -90,18 +94,23 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("a set steps request message") {
-        auto message = MoveRequest{{}, 0x10023300};
+        auto message = MoveRequest{
+            .duration = 0x12345678, .velocity = 0xaa, .acceleration = 0xbb};
         auto arr = std::array<uint8_t, 8>{};
         auto body = std::span{arr};
         WHEN("serialized") {
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is written into the buffer correctly") {
-                REQUIRE(body.data()[0] == 0x10);
-                REQUIRE(body.data()[1] == 0x02);
-                REQUIRE(body.data()[2] == 0x33);
-                REQUIRE(body.data()[3] == 0x00);
+                REQUIRE(body.data()[0] == 0x12);
+                REQUIRE(body.data()[1] == 0x34);
+                REQUIRE(body.data()[2] == 0x56);
+                REQUIRE(body.data()[3] == 0x78);
+                REQUIRE(body.data()[4] == 0x00);
+                REQUIRE(body.data()[5] == 0xaa);
+                REQUIRE(body.data()[6] == 0x00);
+                REQUIRE(body.data()[7] == 0xbb);
             }
-            THEN("size must be returned") { REQUIRE(size == 4); }
+            THEN("size must be returned") { REQUIRE(size == 8); }
         }
     }
 

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -23,6 +23,7 @@ using namespace can_message_writer;
 using namespace can_ids;
 using namespace can_dispatch;
 using namespace motor_message_handler;
+using namespace motor_messages;
 
 extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -22,6 +22,7 @@ using namespace can_message_writer;
 using namespace can_ids;
 using namespace can_dispatch;
 using namespace motor_message_handler;
+using namespace motor_messages;
 
 extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);

--- a/include/can/core/message_handlers/move_group_executor.hpp
+++ b/include/can/core/message_handlers/move_group_executor.hpp
@@ -14,6 +14,7 @@ namespace move_group_executor_handler {
 
 using namespace can_message_writer;
 using namespace can_messages;
+using namespace motor_messages;
 
 template <typename Motor>
 struct TaskEntry {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -123,18 +123,28 @@ struct GetStatusResponse : BaseMessage<MessageId::get_status_response> {
 };
 
 struct MoveRequest : BaseMessage<MessageId::move_request> {
-    uint32_t target_position;
+    uint32_t duration;
+    int16_t acceleration;
+    int16_t velocity;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> MoveRequest {
-        uint32_t target_position = 0;
-        body = bit_utils::bytes_to_int(body, limit, target_position);
-        return MoveRequest{.target_position = target_position};
+        uint32_t duration = 0;
+        int16_t acceleration = 0;
+        int16_t velocity = 0;
+        body = bit_utils::bytes_to_int(body, limit, duration);
+        body = bit_utils::bytes_to_int(body, limit, acceleration);
+        body = bit_utils::bytes_to_int(body, limit, velocity);
+        return MoveRequest{.duration = duration,
+                           .acceleration = acceleration,
+                           .velocity = velocity};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(target_position, body, limit);
+        auto iter = bit_utils::int_to_bytes(duration, body, limit);
+        bit_utils::int_to_bytes(acceleration, body, limit);
+        bit_utils::int_to_bytes(velocity, body, limit);
         return iter - body;
     }
     bool operator==(const MoveRequest& other) const = default;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -124,27 +124,27 @@ struct GetStatusResponse : BaseMessage<MessageId::get_status_response> {
 
 struct MoveRequest : BaseMessage<MessageId::move_request> {
     uint32_t duration;
-    int16_t acceleration;
     int16_t velocity;
+    int16_t acceleration;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> MoveRequest {
         uint32_t duration = 0;
-        int16_t acceleration = 0;
         int16_t velocity = 0;
+        int16_t acceleration = 0;
         body = bit_utils::bytes_to_int(body, limit, duration);
-        body = bit_utils::bytes_to_int(body, limit, acceleration);
         body = bit_utils::bytes_to_int(body, limit, velocity);
+        body = bit_utils::bytes_to_int(body, limit, acceleration);
         return MoveRequest{.duration = duration,
-                           .acceleration = acceleration,
-                           .velocity = velocity};
+                           .velocity = velocity,
+                           .acceleration = acceleration};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter = bit_utils::int_to_bytes(duration, body, limit);
-        bit_utils::int_to_bytes(acceleration, body, limit);
-        bit_utils::int_to_bytes(velocity, body, limit);
+        iter = bit_utils::int_to_bytes(velocity, iter, limit);
+        iter = bit_utils::int_to_bytes(acceleration, iter, limit);
         return iter - body;
     }
     bool operator==(const MoveRequest& other) const = default;
@@ -216,7 +216,6 @@ struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
     uint16_t duration;
     int16_t acceleration;
     int16_t velocity;
-    //    uint32_t position;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> AddLinearMoveRequest {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -12,7 +12,7 @@ namespace can_messages {
 
 using namespace can_ids;
 
-using ticks = uint64_t;
+using ticks = uint32_t;
 using um_per_tick = int16_t;
 using um_per_tick_sq = int16_t;
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -5,11 +5,16 @@
 
 #include "common/core/bit_utils.hpp"
 #include "ids.hpp"
+#include "motor-control/core/motor_messages.hpp"
 #include "parse.hpp"
 
 namespace can_messages {
 
 using namespace can_ids;
+
+using ticks = uint64_t;
+using um_per_tick = int16_t;
+using um_per_tick_sq = int16_t;
 
 /**
  * These types model the messages being sent and received over the can bus.
@@ -123,15 +128,15 @@ struct GetStatusResponse : BaseMessage<MessageId::get_status_response> {
 };
 
 struct MoveRequest : BaseMessage<MessageId::move_request> {
-    uint32_t duration;
-    int16_t velocity;
-    int16_t acceleration;
+    ticks duration;
+    um_per_tick velocity;
+    um_per_tick_sq acceleration;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> MoveRequest {
-        uint32_t duration = 0;
-        int16_t velocity = 0;
-        int16_t acceleration = 0;
+        ticks duration = 0;
+        um_per_tick velocity = 0;
+        um_per_tick_sq acceleration = 0;
         body = bit_utils::bytes_to_int(body, limit, duration);
         body = bit_utils::bytes_to_int(body, limit, velocity);
         body = bit_utils::bytes_to_int(body, limit, acceleration);

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include <variant>
 
 #include "can/core/messages.hpp"
 #include "common/firmware/motor.h"
@@ -29,7 +30,7 @@ requires MessageQueue<QueueImpl<Move>, Move> &&
     MessageQueue<CompletedQueueImpl<Ack>, Ack>
 class MotionController {
   public:
-    using GenericQueue = QueueImpl<Move>;
+    using GenericQueue = QqueueImpl<Move>;
     using CompletedQueue = CompletedQueueImpl<Ack>;
     MotionController(lms::LinearMotionSystemConfig<MEConfig> lms_config,
                      HardwareConfig& config, GenericQueue& queue,
@@ -65,21 +66,22 @@ class MotionController {
     void set_acceleration(uint32_t a) { acc = a; }
 
     void move(const can_messages::MoveRequest& can_msg) {
-        uint64_t converted_steps =
-            static_cast<int64_t>(can_msg.target_position * steps_per_mm) << 31;
-        Move msg{.target_position = converted_steps,
-                 .velocity = default_velocity};
+        GenericMove msg{
+            .duration = can_msg.duration,
+            .acceleration = can_msg.acceleration,
+            .velocity = can_msg.velocity,
+        };
         queue.try_write(msg);
     }
 
     void move(const can_messages::AddLinearMoveRequest& can_msg) {
         uint64_t converted_steps =
             static_cast<int64_t>(can_msg.velocity * steps_per_mm) << 31;
-        Move msg{.target_position = converted_steps,
-                 .velocity = can_msg.velocity,
-                 .acceleration = can_msg.acceleration,
-                 .group_id = can_msg.group_id,
-                 .seq_id = can_msg.seq_id};
+        MoveGroupMove msg{.target_position = converted_steps,
+                          .velocity = can_msg.velocity,
+                          .acceleration = can_msg.acceleration,
+                          .group_id = can_msg.group_id,
+                          .seq_id = can_msg.seq_id};
         queue.try_write(msg);
     }
 

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -61,10 +61,6 @@ class MotionController {
             static_cast<uint32_t>(linear_motion_sys_config.get_steps_per_mm());
     }
 
-    void set_speed(uint32_t s) { speed = s; }
-
-    void set_acceleration(uint32_t a) { acc = a; }
-
     void move(const can_messages::MoveRequest& can_msg) {
         Move msg{
             .duration = can_msg.duration,
@@ -94,15 +90,9 @@ class MotionController {
         timer_interrupt_stop();
     }
 
-    auto get_speed() -> uint32_t { return speed; }
-    auto get_acceleration() -> uint32_t { return acc; }
     auto get_direction() -> bool { return direction; }
 
   private:
-    const sq0_31 default_velocity = 0x1 << 30;
-    uint32_t acc = 0x0;
-    uint32_t speed = 0x0;  // mm/s
-    uint32_t dist = 0x0;
     bool direction = true;  // direction true: forward, false: backward
     uint32_t steps_per_mm;
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -66,8 +66,8 @@ class MotionController {
             .duration = can_msg.duration,
             .velocity = can_msg.velocity,
             .acceleration = can_msg.acceleration,
-            .group_id = 0xFF,
-            .seq_id = 0xFF,
+            .group_id = NO_GROUP,
+            .seq_id = NO_GROUP,
         };
         queue.try_write(msg);
     }

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -30,7 +30,7 @@ requires MessageQueue<QueueImpl<Move>, Move> &&
     MessageQueue<CompletedQueueImpl<Ack>, Ack>
 class MotionController {
   public:
-    using GenericQueue = QqueueImpl<Move>;
+    using GenericQueue = QueueImpl<Move>;
     using CompletedQueue = CompletedQueueImpl<Ack>;
     MotionController(lms::LinearMotionSystemConfig<MEConfig> lms_config,
                      HardwareConfig& config, GenericQueue& queue,
@@ -66,22 +66,22 @@ class MotionController {
     void set_acceleration(uint32_t a) { acc = a; }
 
     void move(const can_messages::MoveRequest& can_msg) {
-        GenericMove msg{
+        Move msg{
             .duration = can_msg.duration,
-            .acceleration = can_msg.acceleration,
             .velocity = can_msg.velocity,
+            .acceleration = can_msg.acceleration,
+            .group_id = 0xFF,
+            .seq_id = 0xFF,
         };
         queue.try_write(msg);
     }
 
     void move(const can_messages::AddLinearMoveRequest& can_msg) {
-        uint64_t converted_steps =
-            static_cast<int64_t>(can_msg.velocity * steps_per_mm) << 31;
-        MoveGroupMove msg{.target_position = converted_steps,
-                          .velocity = can_msg.velocity,
-                          .acceleration = can_msg.acceleration,
-                          .group_id = can_msg.group_id,
-                          .seq_id = can_msg.seq_id};
+        Move msg{.duration = can_msg.duration,
+                 .velocity = can_msg.velocity,
+                 .acceleration = can_msg.acceleration,
+                 .group_id = can_msg.group_id,
+                 .seq_id = can_msg.seq_id};
         queue.try_write(msg);
     }
 

--- a/include/motor-control/core/motor.hpp
+++ b/include/motor-control/core/motor.hpp
@@ -11,6 +11,8 @@
 
 namespace motor_class {
 
+using namespace motor_messages;
+
 template <spi::TMC2130Spi SpiDriver, template <class> class PendingQueueImpl,
           template <class> class CompletedQueueImpl,
           lms::MotorMechanicalConfig MEConfig>

--- a/include/motor-control/core/motor_driver.hpp
+++ b/include/motor-control/core/motor_driver.hpp
@@ -46,7 +46,7 @@ class MotorDriver {
 
     void setup() {
         constexpr uint32_t gconf_data = 0x04;
-        constexpr uint32_t ihold_irun_data = 0x71703;
+        constexpr uint32_t ihold_irun_data = 0x70202;
         constexpr uint32_t chopconf = 0x101D5;
         constexpr uint32_t thigh = 0xFFFFF;
         constexpr uint32_t coolconf = 0x60000;

--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -100,7 +100,7 @@ class MotorInterruptHandler {
     void finish_current_move() {
         has_active_move = false;
         tick_count = 0x0;
-        if (buffered_move.group_id != 0xFF) {
+        if (buffered_move.group_id != NO_GROUP) {
             auto ack = Ack{.group_id = buffered_move.group_id,
                            .seq_id = buffered_move.seq_id,
                            .ack_id = AckMessageId::complete};
@@ -139,6 +139,9 @@ class MotorInterruptHandler {
             finish_current_move();
             if (has_messages()) {
                 update_move();
+                if (can_step() && tick()) {
+                    return true;
+                }
             }
             return false;
         }

--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -98,11 +98,13 @@ class MotorInterruptHandler {
 
     void finish_current_move() {
         has_active_move = false;
-        auto ack = Ack{.group_id = buffered_move.group_id,
-                       .seq_id = buffered_move.seq_id,
-                       .ack_id = AckMessageId::complete};
-        if (completed_queue) {
-            static_cast<void>(completed_queue->try_write_isr(ack));
+        if (buffered_move.group_id != 0xFF) {
+            auto ack = Ack{.group_id = buffered_move.group_id,
+                           .seq_id = buffered_move.seq_id,
+                           .ack_id = AckMessageId::complete};
+            if (completed_queue) {
+                static_cast<void>(completed_queue->try_write_isr(ack));
+            }
         }
         set_buffered_move(Move{});
     }

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -8,13 +8,23 @@ typedef uint64_t
 
 namespace motor_messages {
 
-struct Move {
-    q31_31 target_position;  // in steps
+struct GenericMove {
+    uint32_t duration;
+    sq0_31 acceleration;
+    sq0_31 velocity;
+};
+
+struct MoveGroupMove {
+    uint32_t duration;  // in ticks
     sq0_31 velocity;
     sq0_31 acceleration;
     uint8_t group_id;
     uint8_t seq_id;
-    //    uint32_t duration;  // in ticks
+};
+
+template <typename MT>
+concept MoveType = requires {
+    std::is_same_v<MT, GenericMove> || std::is_same_v<MT, MoveGroupMove>;
 };
 
 enum class AckMessageId : uint8_t { complete = 0x1, error = 0x04 };

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -8,23 +8,12 @@ typedef uint64_t
 
 namespace motor_messages {
 
-struct GenericMove {
-    uint32_t duration;
-    sq0_31 acceleration;
-    sq0_31 velocity;
-};
-
-struct MoveGroupMove {
+struct Move {
     uint32_t duration;  // in ticks
     sq0_31 velocity;
     sq0_31 acceleration;
     uint8_t group_id;
     uint8_t seq_id;
-};
-
-template <typename MT>
-concept MoveType = requires {
-    std::is_same_v<MT, GenericMove> || std::is_same_v<MT, MoveGroupMove>;
 };
 
 enum class AckMessageId : uint8_t { complete = 0x1, error = 0x04 };

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -6,15 +6,21 @@ typedef int32_t sq0_31;  // 0: signed bit,  1-31: fractional bits
 typedef uint64_t
     q31_31;  // 0: overflow bit, 1-32: integer bits, 33-64: fractional bits
 
+using ticks = uint64_t;
+using steps_per_tick = sq0_31;
+using steps_per_tick_sq = sq0_31;
+
 namespace motor_messages {
 
 struct Move {
-    uint64_t duration;  // in ticks
-    sq0_31 velocity;
-    sq0_31 acceleration;
+    ticks duration;  // in ticks
+    steps_per_tick velocity;
+    steps_per_tick_sq acceleration;
     uint8_t group_id;
     uint8_t seq_id;
 };
+
+const uint8_t NO_GROUP = 0xff;
 
 enum class AckMessageId : uint8_t { complete = 0x1, error = 0x04 };
 

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -9,7 +9,7 @@ typedef uint64_t
 namespace motor_messages {
 
 struct Move {
-    uint32_t duration;  // in ticks
+    uint64_t duration;  // in ticks
     sq0_31 velocity;
     sq0_31 acceleration;
     uint8_t group_id;

--- a/include/motor-control/core/step_motor.hpp
+++ b/include/motor-control/core/step_motor.hpp
@@ -2,8 +2,10 @@
 
 #include "common/core/freertos_message_queue.hpp"
 #include "motor-control/core/motor_interrupt_handler.hpp"
+#include "motor-control/core/motor_messages.hpp"
 
 void start_motor_handler(
-    freertos_message_queue::FreeRTOSMessageQueue<Move>* queue,
-    freertos_message_queue::FreeRTOSMessageQueue<Ack>* completed_queue);
+    freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>* queue,
+    freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Ack>*
+        completed_queue);
 void reset_motor_handler();

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -35,6 +35,7 @@ using namespace eeprom_message_handler;
 using namespace motor_message_handler;
 using namespace move_group_handler;
 using namespace move_group_executor_handler;
+using namespace motor_messages;
 
 extern FDCAN_HandleTypeDef fdcan1;
 

--- a/pipettes/tests/test_motor_interrupt_queue.cpp
+++ b/pipettes/tests/test_motor_interrupt_queue.cpp
@@ -19,13 +19,13 @@ SCENARIO("queue multiple move messages") {
         WHEN("add multiple moves to the queue") {
             THEN("all the moves should exist in order") {
                 constexpr Move msg1 =
-                    Move{.target_position = 100, .velocity = default_velocity};
+                    Move{.duration = 100, .velocity = default_velocity};
                 constexpr Move msg2 =
-                    Move{.target_position = 400, .velocity = default_velocity};
+                    Move{.duration = 400, .velocity = default_velocity};
                 constexpr Move msg3 =
-                    Move{.target_position = 7000, .velocity = default_velocity};
+                    Move{.duration = 7000, .velocity = default_velocity};
                 constexpr Move msg4 =
-                    Move{.target_position = 800, .velocity = default_velocity};
+                    Move{.duration = 800, .velocity = default_velocity};
                 queue.try_write(msg1);
                 queue.try_write(msg2);
                 queue.try_write(msg3);

--- a/pipettes/tests/test_motor_pulse.cpp
+++ b/pipettes/tests/test_motor_pulse.cpp
@@ -5,117 +5,190 @@
 using namespace motor_handler;
 
 #define TO_RADIX 31
-static constexpr sq0_31 default_velocity = 0x1 << (TO_RADIX - 1);
+static constexpr sq0_31 default_velocity =
+    0x1 << (TO_RADIX - 1);  // half a step per tick
 
-TEST_CASE("position starts at zero") {
-    MotorInterruptHandler<mock_message_queue::MockMessageQueue,
-                          mock_message_queue::MockMessageQueue>
-        handler{};
-    handler.set_current_position(0x0);
-
-    GIVEN("a positive direction") {
-        q31_31 target = 0x1LL << TO_RADIX;
-        Move msg1 =
-            Move{.target_position = target, .velocity = default_velocity};
-        handler.set_buffered_move(msg1);
-
-        THEN("we should take two tick to step one") {
-            REQUIRE(!handler.tick());
-            REQUIRE(handler.tick());
-            AND_THEN("that position should be greater than zero") {
-                REQUIRE(handler.get_current_position() > 0x0);
+TEST_CASE("Constant velocity") {
+    GIVEN("a duration of 1 tick and velocity at half a step per tick") {
+        MotorInterruptHandler<mock_message_queue::MockMessageQueue,
+                              mock_message_queue::MockMessageQueue>
+            handler{};
+        handler.set_current_position(0x0);
+        WHEN("moving at half a step per tick") {
+            Move msg1 = Move{.duration = 1, .velocity = default_velocity};
+            handler.set_buffered_move(msg1);
+            THEN("motor would not step in the 1st tick") {
+                REQUIRE(!handler.tick());
+                AND_THEN("the position tracker should match half a step") {
+                    REQUIRE(handler.get_current_position() == default_velocity);
+                }
             }
         }
     }
-}
 
-TEST_CASE("move less than a full step") {
-    MotorInterruptHandler<mock_message_queue::MockMessageQueue,
-                          mock_message_queue::MockMessageQueue>
-        handler{};
-    handler.set_current_position(0x0);
-
-    // equivalent of 5.5 steps
-    q31_31 initial_target = 51LL << (TO_RADIX - 2);
-    // equivalent of 0.5 steps
-    const q31_31 fractional_step = 1LL << (TO_RADIX - 2);
-
-    GIVEN("one fractional move") {
-        Move msg1 = Move{.target_position = initial_target,
-                         .velocity = default_velocity};
-        handler.set_buffered_move(msg1);
-        THEN("tick the position 12 whole steps") {
-            for (int i = 0; i < 12; i++) {
+    GIVEN("a duration of 2 ticks and velocity at half a step per tick") {
+        MotorInterruptHandler<mock_message_queue::MockMessageQueue,
+                              mock_message_queue::MockMessageQueue>
+            handler{};
+        WHEN("moving at half a step per tick") {
+            Move msg1 = Move{.duration = 2, .velocity = default_velocity};
+            handler.set_buffered_move(msg1);
+            THEN("motor would step in the 2nd tick") {
                 REQUIRE(!handler.tick());
                 REQUIRE(handler.tick());
-            }
-            AND_THEN(
-                "the last tick should return false as it is a fractional "
-                "step") {
-                REQUIRE(!handler.tick());
-                // position should be all the full steps, without the fractional
-                // step.
-                REQUIRE(handler.get_current_position() ==
-                        initial_target - fractional_step);
+                AND_THEN("the position tracker should match exactly one step") {
+                    auto distance_traveled =
+                        static_cast<uint64_t>(default_velocity) * 2;
+                    REQUIRE(handler.get_current_position() ==
+                            distance_traveled);
+                }
             }
         }
     }
 
-    GIVEN("two fractional moves") {
-        // equivalent of 11 steps
-        q31_31 doubled_target = initial_target << 1;
-        const q31_31 starting_position = initial_target - fractional_step;
-        handler.set_current_position(starting_position);
-
-        Move msg1 = Move{.target_position = doubled_target,
-                         .velocity = default_velocity};
+    GIVEN("a motor handler") {
+        MotorInterruptHandler<mock_message_queue::MockMessageQueue,
+                              mock_message_queue::MockMessageQueue>
+            handler{};
+        auto velocity =
+            static_cast<sq0_31>(0.3 * static_cast<double>(1LL << (TO_RADIX)));
+        auto msg1 = Move{.duration = 4, .velocity = velocity};
         handler.set_buffered_move(msg1);
 
-        WHEN(
-            "we are on the second move, we should be able to tick at the "
-            "end.") {
-            REQUIRE(handler.get_current_position() == starting_position);
-            THEN(
-                "tick the position 13 times, since we are moving an extra "
-                "whole step") {
-                for (int i = 0; i < 13; i++) {
-                    REQUIRE(handler.tick());
-                    REQUIRE(!handler.tick());
-                }
-                AND_THEN(
-                    "the current position should be exactly the doubled "
-                    "target") {
-                    REQUIRE(handler.get_current_position() == doubled_target);
+        WHEN("you move at +0.3 velocity") {
+            REQUIRE(!handler.tick());
+            REQUIRE(!handler.tick());
+            REQUIRE(!handler.tick());
+
+            THEN("the fourth tick should step") {
+                REQUIRE(handler.tick());
+                REQUIRE(handler.get_current_position() ==
+                        static_cast<q31_31>(velocity) * 4);
+
+                AND_WHEN("moving in the other direction") {
+                    msg1.velocity = -velocity;
+                    handler.set_buffered_move(msg1);
+
+                    THEN("the first tick should step") {
+                        REQUIRE(handler.tick());
+                        REQUIRE(!handler.tick());
+                        REQUIRE(!handler.tick());
+                        REQUIRE(!handler.tick());
+                        REQUIRE(handler.get_current_position() == 0x0);
+                    }
                 }
             }
         }
     }
 }
 
-TEST_CASE("position starts above zero") {
-    MotorInterruptHandler<mock_message_queue::MockMessageQueue,
-                          mock_message_queue::MockMessageQueue>
-        handler{};
-    q31_31 starting_position = 200LL << TO_RADIX;
-    handler.set_current_position(starting_position);
-    sq0_31 increment = (1LL << (TO_RADIX - 2));
+TEST_CASE("Non-zero acceleration") {
+    GIVEN("a motor handler") {
+        MotorInterruptHandler<mock_message_queue::MockMessageQueue,
+                              mock_message_queue::MockMessageQueue>
+            handler{};
+        WHEN("move starts at 0 velocity with positive acceleration") {
+            auto msg = Move{.duration = 3,
+                            .velocity = 0,
+                            .acceleration = 1 << (TO_RADIX - 2)};
+            handler.set_buffered_move(msg);
+            THEN("the third tick should step") {
+                REQUIRE(!handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(handler.tick());
+                REQUIRE(handler.get_current_position() ==
+                        ((1LL << (TO_RADIX)) + (1LL << (TO_RADIX - 1))));
+            }
+        }
+        WHEN("move starts at 0 velocity with negative acceleration") {
+            handler.set_current_position((1LL << (TO_RADIX)) +
+                                         (1LL << (TO_RADIX - 1)));
+            auto msg = Move{.duration = 3,
+                            .velocity = 0,
+                            .acceleration = -(1 << (TO_RADIX - 2))};
+            handler.set_buffered_move(msg);
+            THEN("only the second tick should step") {
+                REQUIRE(!handler.tick());
+                REQUIRE(handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(handler.get_current_position() == 0x0);
+            }
+        }
 
-    GIVEN("Some number of steps in a positive direction") {
-        q31_31 target = starting_position + increment;
-        Move msg1 = Move{.target_position = target, .velocity = increment};
-        handler.set_buffered_move(msg1);
-        handler.tick();
-        REQUIRE(handler.get_current_position() == target);
+        WHEN("move starts at positive velocity with negative acceleration") {
+            auto msg = Move{.duration = 3,
+                            .velocity = 1 << (TO_RADIX - 1),
+                            .acceleration = -(1 << (TO_RADIX - 3))};
+            handler.set_buffered_move(msg);
+            handler.set_current_position(0x70000000);
+            THEN("the third and fifth ticks should step") {
+                REQUIRE(handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(handler.get_current_position() ==
+                        (static_cast<q31_31>(0x70000000) + 0x60000000));
+            }
+        }
+        WHEN("move starts at negative velocity with positive acceleration") {
+            auto msg = Move{.duration = 4,
+                            .velocity = -1 << (TO_RADIX - 1),
+                            .acceleration = 1 << (TO_RADIX - 2)};
+            handler.set_buffered_move(msg);
+            THEN("the third and forth ticks should step") {
+                REQUIRE(!handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(!handler.tick());
+                REQUIRE(handler.tick());
+                REQUIRE(handler.get_current_position() ==
+                        (-1LL << (TO_RADIX)) + (5LL << (TO_RADIX - 1)));
+            }
+        }
     }
+}
 
-    GIVEN("Some number of steps in a negative direction") {
-        increment = -increment;
-        q31_31 target = starting_position + increment;
-        sq0_31 velocity_init = increment;
-        Move msg1 = Move{.target_position = target, .velocity = velocity_init};
-        handler.set_buffered_move(msg1);
-        handler.tick();
-        REQUIRE(handler.get_current_position() == target);
+TEST_CASE("Compute move sequence") {
+    GIVEN("a motor handler") {
+        MotorInterruptHandler<mock_message_queue::MockMessageQueue,
+                              mock_message_queue::MockMessageQueue>
+            handler{};
+        mock_message_queue::MockMessageQueue<Move> queue;
+        mock_message_queue::MockMessageQueue<Ack> completed_queue;
+        handler.set_message_queue(&queue, &completed_queue);
+
+        handler.set_current_position(0x0);
+        auto msg1 = Move{.duration = 2, .velocity = default_velocity};
+        queue.try_write_isr(msg1);
+        handler.update_move();
+
+        WHEN("a move duration is up, and the queue is empty") {
+            for (int i = 0; i < 2; i++) {
+                handler.pulse();
+            }
+
+            THEN("we do not move") {
+                handler.pulse();
+                REQUIRE(!handler.can_step());
+                REQUIRE(!handler.has_active_move);
+            }
+        }
+        WHEN("a move duration is up, and there is a move in the queue") {
+            auto msg2 = Move{.duration = 5, .velocity = -default_velocity};
+            queue.try_write_isr(msg2);
+
+            for (int i = 0; i < 2; i++) {
+                handler.pulse();
+            }
+
+            THEN("we immediately switch to the new move") {
+                handler.pulse();
+                REQUIRE(handler.can_step());
+                REQUIRE(handler.has_active_move);
+                REQUIRE(handler.get_buffered_move().velocity == msg2.velocity);
+                REQUIRE(handler.get_buffered_move().duration == msg2.duration);
+            }
+        }
     }
 }
 
@@ -128,10 +201,10 @@ TEST_CASE("moves that result in out of range positions") {
     handler.set_message_queue(&queue, &completed_queue);
 
     GIVEN("Move past the largest possible value for position") {
-        // Reaching the max possible position will probably be almost impossible
-        // to do in the system. Rather than testing that tick detects this type
-        // of overflow, we should just check that the overflow function works
-        // correctly for very large numbers.
+        // Reaching the max possible position will probably be almost
+        // impossible to do in the system. Rather than testing that tick
+        // detects this type of overflow, we should just check that the
+        // overflow function works correctly for very large numbers.
 
         q31_31 position_1 = 0x4000000000000000;
         q31_31 position_2 = position_1 + position_1;
@@ -143,11 +216,12 @@ TEST_CASE("moves that result in out of range positions") {
         q31_31 current_position = 0x0;
         const sq0_31 neg_velocity = -default_velocity;
         handler.set_current_position(current_position);
-        const q31_31 target = 0x7FFFFFF7 << 8;
-        Move msg1 = Move{.target_position = target, .velocity = neg_velocity};
+        Move msg1 = Move{.duration = 2, .velocity = neg_velocity};
         handler.set_buffered_move(msg1);
 
-        THEN("the motor should not pulse, and position should be unchanged.") {
+        THEN(
+            "the motor should not pulse, and position should be "
+            "unchanged.") {
             // (TODO lc): we don't have true error handling yet
             // this should probably return some type of error in
             // the instance of an overflow.


### PR DESCRIPTION
We're now passing in `duration` (number of ticks) instead of `target position` (number of steps) in the move request. Velocity and acceleration in the move request are now also getting passed down to the motor interrupt handler. 

 