### PR TITLE
refactor(can): use 32 bits for move message parameters

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -22,13 +22,14 @@ SCENARIO("message deserializing works") {
     }
 
     GIVEN("a move request body") {
-        auto arr = std::array<uint8_t, 8>{1, 2, 3, 4, 5, 6, 7, 8};
+        auto arr =
+            std::array<uint8_t, 12>{1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc};
         WHEN("constructed") {
             auto r = MoveRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {
                 REQUIRE(r.duration == 0x01020304);
-                REQUIRE(r.velocity == 0x0506);
-                REQUIRE(r.acceleration == 0x0708);
+                REQUIRE(r.velocity == 0x05060708);
+                REQUIRE(r.acceleration == 0x090a0b0c);
             }
             THEN("it can be compared for equality") {
                 auto other = r;
@@ -92,9 +93,11 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("a set steps request message") {
-        auto message = MoveRequest{
-            .duration = 0x12345678, .velocity = 0xaa, .acceleration = 0xbb};
-        auto arr = std::array<uint8_t, 8>{};
+        auto message =
+            MoveRequest{.duration = 0x12345678,
+                        .velocity = static_cast<int32_t>(0xaabbccdd),
+                        .acceleration = static_cast<int32_t>(0xeeff1100)};
+        auto arr = std::array<uint8_t, 12>{};
         auto body = std::span{arr};
         WHEN("serialized") {
             auto size = message.serialize(arr.begin(), arr.end());
@@ -103,12 +106,16 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[1] == 0x34);
                 REQUIRE(body.data()[2] == 0x56);
                 REQUIRE(body.data()[3] == 0x78);
-                REQUIRE(body.data()[4] == 0x00);
-                REQUIRE(body.data()[5] == 0xaa);
-                REQUIRE(body.data()[6] == 0x00);
-                REQUIRE(body.data()[7] == 0xbb);
+                REQUIRE(body.data()[4] == 0xaa);
+                REQUIRE(body.data()[5] == 0xbb);
+                REQUIRE(body.data()[6] == 0xcc);
+                REQUIRE(body.data()[7] == 0xdd);
+                REQUIRE(body.data()[8] == 0xee);
+                REQUIRE(body.data()[9] == 0xff);
+                REQUIRE(body.data()[10] == 0x11);
+                REQUIRE(body.data()[11] == 0x00);
             }
-            THEN("size must be returned") { REQUIRE(size == 8); }
+            THEN("size must be returned") { REQUIRE(size == 12); }
         }
     }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -13,8 +13,8 @@ namespace can_messages {
 using namespace can_ids;
 
 using ticks = uint32_t;
-using um_per_tick = int16_t;
-using um_per_tick_sq = int16_t;
+using um_per_tick = int32_t;
+using um_per_tick_sq = int32_t;
 
 /**
  * These types model the messages being sent and received over the can bus.
@@ -218,30 +218,27 @@ struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
 struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
     uint8_t group_id;
     uint8_t seq_id;
-    uint16_t duration;
-    int16_t acceleration;
-    int16_t velocity;
+    ticks duration;
+    um_per_tick_sq acceleration;
+    um_per_tick velocity;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> AddLinearMoveRequest {
         uint8_t group_id = 0;
         uint8_t seq_id = 0;
-        uint16_t duration = 0;
-        int16_t acceleration = 0;
-        int16_t velocity = 0;
-        //        uint32_t position = 0;
+        ticks duration = 0;
+        um_per_tick_sq acceleration = 0;
+        um_per_tick velocity = 0;
         body = bit_utils::bytes_to_int(body, limit, group_id);
         body = bit_utils::bytes_to_int(body, limit, seq_id);
         body = bit_utils::bytes_to_int(body, limit, duration);
         body = bit_utils::bytes_to_int(body, limit, acceleration);
         body = bit_utils::bytes_to_int(body, limit, velocity);
-        //        body = bit_utils::bytes_to_int(body, limit, position);
         return AddLinearMoveRequest{.group_id = group_id,
                                     .seq_id = seq_id,
                                     .duration = duration,
                                     .acceleration = acceleration,
                                     .velocity = velocity};
-        //                                    .position = position};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -251,7 +248,6 @@ struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
         iter = bit_utils::int_to_bytes(duration, iter, limit);
         iter = bit_utils::int_to_bytes(acceleration, iter, limit);
         iter = bit_utils::int_to_bytes(velocity, iter, limit);
-        //        iter = bit_utils::int_to_bytes(position, iter, limit);
         return iter - body;
     }
 


### PR DESCRIPTION
This PR updates the parameters `duration`, `velocity` and `acceleration` in CAN move messages to 32 bits.