### PR TITLE
refactor(pipettes): port all GPIO pins to match the pipette main board

### DIFF
--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -28,7 +28,7 @@ set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/tim7.c
     ${CMAKE_CURRENT_SOURCE_DIR}/i2c.c
     ${CMAKE_CURRENT_SOURCE_DIR}/can.c
-    ${COMMON_EXECUTABLE_DIR}/spi/spi.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/spi.c
     ${COMMON_EXECUTABLE_DIR}/errors/errors.c
     ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c)
 

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -50,9 +50,9 @@ static freertos_message_queue::FreeRTOSMessageQueue<Ack> complete_queue(
 static spi::Spi spi_comms{};
 
 struct motion_controller::HardwareConfig PinConfigurations {
-    .direction = {.port = GPIOB, .pin = GPIO_PIN_1},
-    .step = {.port = GPIOA, .pin = GPIO_PIN_8},
-    .enable = {.port = GPIOA, .pin = GPIO_PIN_10},
+    .direction = {.port = GPIOC, .pin = GPIO_PIN_3},
+    .step = {.port = GPIOC, .pin = GPIO_PIN_7},
+    .enable = {.port = GPIOC, .pin = GPIO_PIN_8},
 };
 
 /**

--- a/pipettes/firmware/i2c.c
+++ b/pipettes/firmware/i2c.c
@@ -5,19 +5,19 @@ static I2C_HandleTypeDef hi2c;
 
 void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
 
-    // PIN PB7 is SCL
-    // PIN PB8-BOOT0 is SDA
+    // PIN PC0 is SCL
+    // PIN PC1 is SDA
     if(hi2c->Instance==I2C1) {
         __HAL_RCC_I2C1_CLK_ENABLE();
         __HAL_RCC_GPIOB_CLK_ENABLE();
         GPIO_InitTypeDef GPIO_InitStruct = {0};
-        GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9;
+        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_PULLUP;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
         HAL_GPIO_Init(
-            GPIOB,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+            GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
             &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     }
 }

--- a/pipettes/firmware/i2c.c
+++ b/pipettes/firmware/i2c.c
@@ -11,7 +11,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         __HAL_RCC_I2C1_CLK_ENABLE();
         __HAL_RCC_GPIOB_CLK_ENABLE();
         GPIO_InitTypeDef GPIO_InitStruct = {0};
-        GPIO_InitStruct.Pin = GPIO_PIN_7 | GPIO_PIN_8;
+        GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_PULLUP;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;

--- a/pipettes/firmware/spi.c
+++ b/pipettes/firmware/spi.c
@@ -1,0 +1,127 @@
+#include "common/firmware/spi.h"
+#include "common/firmware/errors.h"
+
+#include "platform_specific_hal_conf.h"
+
+SPI_HandleTypeDef handle;
+
+/**
+ * @brief SPI MSP Initialization
+ * This function configures the hardware resources used in this example
+ * @param hspi: SPI handle pointer
+ * @retval None
+ */
+void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
+
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock enable */
+        __HAL_RCC_SPI2_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        /**SPI2 GPIO Configuration
+        PC6     ------> SPI2_CS
+        PB13     ------> SPI2_SCK
+        PB14     ------> SPI2_CIPO
+        PB15     ------> SPI2_COPI
+
+         Step/Dir
+         PC3  ---> Dir Pin
+         PC7  ---> Step Pin
+         Enable
+         PC8  ---> Enable Pin
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        // Chip select
+        GPIO_InitStruct.Pin = GPIO_PIN_6;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        // Enable/Dir/Step pin
+        GPIO_InitStruct.Pin = GPIO_PIN_3 | GPIO_PIN_7 | GPIO_PIN_8;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = GPIO_PIN_7 | GPIO_PIN_8;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                      &GPIO_InitStruct);
+    }
+}
+
+/**
+ * @brief SPI MSP De-Initialization
+ * This function freeze the hardware resources used in this example
+ * @param hspi: SPI handle pointer
+ * @retval None
+ */
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock disable */
+        __HAL_RCC_SPI2_CLK_DISABLE();
+
+        /**SPI2 GPIO Configuration
+        PB12     ------> SPI2_NSS
+        PB13     ------> SPI2_SCK
+        PB14     ------> SPI2_MISO
+        PB15     ------> SPI2_MOSI
+        */
+        HAL_GPIO_DeInit(GPIOB,
+                        GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15);
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_8 | GPIO_PIN_9);
+    }
+}
+
+/**
+ * @brief SPI2 Initialization Function
+ * @param None
+ * @retval None
+ */
+SPI_HandleTypeDef MX_SPI2_Init() {
+    /* SPI2 parameter configuration*/
+    __HAL_RCC_SPI2_CLK_ENABLE();
+    SPI_HandleTypeDef hspi2 = {
+        .Instance = SPI2,
+        .Init = {.Mode = SPI_MODE_MASTER,
+            .Direction = SPI_DIRECTION_2LINES,
+            .DataSize = SPI_DATASIZE_8BIT,
+            .CLKPolarity = SPI_POLARITY_HIGH,
+            .CLKPhase = SPI_PHASE_2EDGE,
+            .NSS = SPI_NSS_SOFT,
+            .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
+            .FirstBit = SPI_FIRSTBIT_MSB,
+            .TIMode = SPI_TIMODE_DISABLE,
+            .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
+            .CRCPolynomial = 7,
+            .CRCLength = SPI_CRC_LENGTH_DATASIZE,
+            .NSSPMode = SPI_NSS_PULSE_DISABLE}
+
+    };
+
+    if (HAL_SPI_Init(&hspi2) != HAL_OK) {
+        Error_Handler();
+    }
+    return hspi2;
+}
+
+void SPI2_init() {
+    handle = MX_SPI2_Init();
+}
+
+void Set_CS_Pin() { HAL_GPIO_WritePin(GPIOB, GPIO_PIN_12, GPIO_PIN_SET); }
+
+void Reset_CS_Pin() {
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_12, GPIO_PIN_RESET);
+}
+
+void hal_transmit_receive(uint8_t* transmit, uint8_t* receive, uint16_t buff_size, uint32_t timeout) {
+    HAL_SPI_TransmitReceive(&handle, transmit, receive, buff_size, timeout);
+}

--- a/pipettes/firmware/tim7.c
+++ b/pipettes/firmware/tim7.c
@@ -16,9 +16,9 @@ void MX_GPIO_Init(void) {
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOB_CLK_ENABLE();
 
-    /*Configure GPIO pin : LD2_Pin */
+    /*Configure GPIO pin : PA0 which can be used as a timer */
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Pin = GPIO_PIN_5;
+    GPIO_InitStruct.Pin = GPIO_PIN_0;
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
@@ -67,12 +67,13 @@ void timer_init() {
     MX_TIM7_Init();
 }
 
+
 void timer_interrupt_start() { HAL_TIM_Base_Start_IT(&htim7); }
 
 void timer_interrupt_stop() { HAL_TIM_Base_Stop_IT(&htim7); }
 
-void turn_on_step_pin() { HAL_GPIO_WritePin(GPIOA, GPIO_PIN_8, GPIO_PIN_SET); }
+void turn_on_step_pin() { HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, GPIO_PIN_SET); }
 
 void turn_off_step_pin() {
-    HAL_GPIO_WritePin(GPIOA, GPIO_PIN_8, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, GPIO_PIN_RESET);
 }


### PR DESCRIPTION
## Overview

We want to start using the pipette main board for firmware development since it has the new MCU
embedded in it already.

closes RET-232