### PR TITLE
feat(can): handle motor status request

### DIFF
--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -94,7 +94,8 @@ static auto motion_group_dispatch_target = DispatchParseTarget<
 
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),
-                        can_messages::ExecuteMoveGroupRequest>{
+                        can_messages::ExecuteMoveGroupRequest,
+                        can_messages::GetMoveStatusRequest>{
         can_move_group_executor_handler};
 
 /** Dispatcher to the various handlers */

--- a/gantry/firmware/step_motor.cpp
+++ b/gantry/firmware/step_motor.cpp
@@ -28,3 +28,12 @@ void start_motor_handler(
 }
 
 void reset_motor_handler() { handler_class.reset(); }
+
+MoveStatus get_move_status() {
+    auto buffered_move = handler_class.get_buffered_move();
+    MoveStatus msg = {.group_id = buffered_move.group_id,
+                      .seq_id = buffered_move.seq_id,
+                      .remaining_duration = handler_class.get_remaining_ticks(),
+                      .current_position = handler_class.get_current_position()};
+    return msg;
+}

--- a/head/firmware/step_motor.cpp
+++ b/head/firmware/step_motor.cpp
@@ -28,3 +28,12 @@ void start_motor_handler(
 }
 
 void reset_motor_handler() { handler_class.reset(); }
+
+MoveStatus get_move_status() {
+    auto buffered_move = handler_class.get_buffered_move();
+    MoveStatus msg = {.group_id = buffered_move.group_id,
+                      .seq_id = buffered_move.seq_id,
+                      .remaining_duration = handler_class.get_remaining_ticks(),
+                      .current_position = handler_class.get_current_position()};
+    return msg;
+}

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -50,6 +50,8 @@ enum class MessageId : uint16_t {
 
     move_request = 0x10,
     move_completed = 0x13,
+    get_move_status_request = 0x30,
+    get_move_status_response = 0x31,
 
     add_linear_move_request = 0x15,
     get_move_group_request = 0x16,

--- a/include/can/core/message_handlers/move_group_executor.hpp
+++ b/include/can/core/message_handlers/move_group_executor.hpp
@@ -40,7 +40,8 @@ struct TaskEntry {
 template <typename Motor>
 class MoveGroupExecutorHandler {
   public:
-    using MessageType = std::variant<std::monostate, ExecuteMoveGroupRequest>;
+    using MessageType = std::variant<std::monostate, ExecuteMoveGroupRequest,
+                                     GetMoveStatusRequest>;
 
     MoveGroupExecutorHandler(
         MessageWriter &message_writer,
@@ -78,6 +79,12 @@ class MoveGroupExecutorHandler {
 
     void visit_move(const AddLinearMoveRequest &m) {
         motor.motion_controller.move(m);
+    }
+
+    void visit(GetMoveStatusRequest &m) {
+        auto msg = motor.motion_controller.read_move_status();
+        msg.node_id = static_cast<uint8_t>(node_id);
+        message_writer.write(NodeId::host, msg);
     }
 
     MessageWriter &message_writer;

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -90,6 +90,10 @@ class MotionController {
         timer_interrupt_stop();
     }
 
+    MoveStatus read_move_status() {
+        return get_move_status();
+    }
+
   private:
     uint32_t steps_per_mm;
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;

--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -173,6 +173,10 @@ class MotorInterruptHandler {
         return bool((current ^ future) & overflow_flag);
     }
 
+    uint64_t get_remaining_ticks() {
+        return buffered_move.duration - tick_count;
+    }
+
     q31_31 get_current_position() { return position_tracker; }
 
     void set_current_position(q31_31 pos_tracker) {

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "can/core/messages.hpp"
+
 typedef int32_t sq0_31;  // 0: signed bit,  1-31: fractional bits
 typedef uint64_t
     q31_31;  // 0: overflow bit, 1-32: integer bits, 33-64: fractional bits
@@ -9,8 +11,11 @@ typedef uint64_t
 using ticks = uint64_t;
 using steps_per_tick = sq0_31;
 using steps_per_tick_sq = sq0_31;
+using steps = q31_31;
 
 namespace motor_messages {
+
+using namespace can_messages;
 
 struct Move {
     ticks duration;  // in ticks
@@ -19,6 +24,8 @@ struct Move {
     uint8_t group_id;
     uint8_t seq_id;
 };
+
+using MoveStatus = GetMoveStatusResponse;
 
 const uint8_t NO_GROUP = 0xff;
 

--- a/include/motor-control/core/step_motor.hpp
+++ b/include/motor-control/core/step_motor.hpp
@@ -9,3 +9,4 @@ void start_motor_handler(
     freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Ack>*
         completed_queue);
 void reset_motor_handler();
+motor_messages::MoveStatus get_move_status();

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -96,7 +96,8 @@ static auto motion_group_dispatch_target = DispatchParseTarget<
 
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),
-                        can_messages::ExecuteMoveGroupRequest>{
+                        can_messages::ExecuteMoveGroupRequest,
+                        can_messages::GetMotorStatusRequest>{
         can_move_group_executor_handler};
 
 static auto eeprom_dispatch_target =

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -97,7 +97,7 @@ static auto motion_group_dispatch_target = DispatchParseTarget<
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),
                         can_messages::ExecuteMoveGroupRequest,
-                        can_messages::GetMotorStatusRequest>{
+                        can_messages::GetMoveStatusRequest>{
         can_move_group_executor_handler};
 
 static auto eeprom_dispatch_target =

--- a/pipettes/firmware/step_motor.cpp
+++ b/pipettes/firmware/step_motor.cpp
@@ -29,3 +29,12 @@ void start_motor_handler(
 }
 
 void reset_motor_handler() { handler_class.reset(); }
+
+MoveStatus get_move_status() {
+    auto buffered_move = handler_class.get_buffered_move();
+    MoveStatus msg = {.group_id = buffered_move.group_id,
+                      .seq_id = buffered_move.seq_id,
+                      .remaining_duration = handler_class.get_remaining_ticks(),
+                      .current_position = handler_class.get_current_position()};
+    return msg;
+}


### PR DESCRIPTION
This allows the status of the currently executed move to be read via can. 