### PR TITLE
feat(can): add clear all move groups request.

### DIFF
--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -89,8 +89,8 @@ static auto motor_dispatch_target = DispatchParseTarget<
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,
-    can_messages::GetMoveGroupRequest, can_messages::ClearMoveGroupRequest>{
-    can_move_group_handler};
+    can_messages::GetMoveGroupRequest, can_messages::ClearMoveGroupRequest,
+    can_messages::ClearAllMoveGroupsRequest>{can_move_group_handler};
 
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -89,8 +89,8 @@ static auto motor_dispatch_target = DispatchParseTarget<
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,
-    can_messages::GetMoveGroupRequest, can_messages::ClearMoveGroupRequest,
-    can_messages::ClearAllMoveGroupsRequest>{can_move_group_handler};
+    can_messages::GetMoveGroupRequest, can_messages::ClearAllMoveGroupsRequest>{
+    can_move_group_handler};
 
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -55,8 +55,7 @@ enum class MessageId : uint16_t {
     get_move_group_request = 0x16,
     get_move_group_response = 0x17,
     execute_move_group_request = 0x18,
-    clear_move_group_request = 0x19,
-    clear_all_move_groups_request = 0x1B,
+    clear_all_move_groups_request = 0x19,
     move_group_completed = 0x1A,
 
     setup_request = 0x02,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -56,6 +56,7 @@ enum class MessageId : uint16_t {
     get_move_group_response = 0x17,
     execute_move_group_request = 0x18,
     clear_move_group_request = 0x19,
+    clear_all_move_groups_request = 0x1B,
     move_group_completed = 0x1A,
 
     setup_request = 0x02,

--- a/include/can/core/message_handlers/move_group.hpp
+++ b/include/can/core/message_handlers/move_group.hpp
@@ -54,12 +54,12 @@ class MoveGroupHandler {
     }
 
     void visit(ClearMoveGroupRequest &m) {
-        auto group = motion_group_manager[m.group_id];
+        auto& group = motion_group_manager[m.group_id];
         group.clear();
     }
 
     void visit(ClearAllMoveGroupsRequest &m) {
-        for (auto group : motion_group_manager) {
+        for (auto& group : motion_group_manager) {
             group.clear();
         }
     }

--- a/include/can/core/message_handlers/move_group.hpp
+++ b/include/can/core/message_handlers/move_group.hpp
@@ -20,7 +20,7 @@ class MoveGroupHandler {
   public:
     using MessageType =
         std::variant<std::monostate, AddLinearMoveRequest, GetMoveGroupRequest,
-                     ClearMoveGroupRequest, ClearAllMoveGroupsRequest>;
+                     ClearAllMoveGroupsRequest>;
     MoveGroupHandler(MessageWriter &message_writer,
                      MoveGroupType &motion_group_manager)
         : message_writer{message_writer},
@@ -43,7 +43,7 @@ class MoveGroupHandler {
 
     void visit(GetMoveGroupRequest &m) {
         auto group = motion_group_manager[m.group_id];
-        // TODO (al, 2021-10-19): Get the real node id here.
+        // TODO (al, 2021-10-19): Get the real node id of this FW.
         auto response = GetMoveGroupResponse{
             .group_id = m.group_id,
             .num_moves = static_cast<uint8_t>(group.size()),
@@ -53,13 +53,8 @@ class MoveGroupHandler {
         message_writer.write(NodeId::host, response);
     }
 
-    void visit(ClearMoveGroupRequest &m) {
-        auto& group = motion_group_manager[m.group_id];
-        group.clear();
-    }
-
     void visit(ClearAllMoveGroupsRequest &m) {
-        for (auto& group : motion_group_manager) {
+        for (auto &group : motion_group_manager) {
             group.clear();
         }
     }

--- a/include/can/core/message_handlers/move_group.hpp
+++ b/include/can/core/message_handlers/move_group.hpp
@@ -20,7 +20,7 @@ class MoveGroupHandler {
   public:
     using MessageType =
         std::variant<std::monostate, AddLinearMoveRequest, GetMoveGroupRequest,
-                     ClearMoveGroupRequest>;
+                     ClearMoveGroupRequest, ClearAllMoveGroupsRequest>;
     MoveGroupHandler(MessageWriter &message_writer,
                      MoveGroupType &motion_group_manager)
         : message_writer{message_writer},
@@ -56,6 +56,12 @@ class MoveGroupHandler {
     void visit(ClearMoveGroupRequest &m) {
         auto group = motion_group_manager[m.group_id];
         group.clear();
+    }
+
+    void visit(ClearAllMoveGroupsRequest &m) {
+        for (auto group : motion_group_manager) {
+            group.clear();
+        }
     }
 
     MessageWriter &message_writer;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -354,6 +354,9 @@ struct ClearMoveGroupRequest
     bool operator==(const ClearMoveGroupRequest& other) const = default;
 };
 
+using ClearAllMoveGroupsRequest =
+    Empty<MessageId::clear_all_move_groups_request>;
+
 struct MoveGroupCompleted : BaseMessage<MessageId::move_group_completed> {
     uint8_t group_id;
     uint8_t node_id;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -335,25 +335,6 @@ struct ExecuteMoveGroupRequest
     bool operator==(const ExecuteMoveGroupRequest& other) const = default;
 };
 
-struct ClearMoveGroupRequest
-    : BaseMessage<MessageId::clear_move_group_request> {
-    uint8_t group_id;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> ClearMoveGroupRequest {
-        uint8_t group_id = 0;
-        body = bit_utils::bytes_to_int(body, limit, group_id);
-        return ClearMoveGroupRequest{.group_id = group_id};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
-        return iter - body;
-    }
-    bool operator==(const ClearMoveGroupRequest& other) const = default;
-};
-
 using ClearAllMoveGroupsRequest =
     Empty<MessageId::clear_all_move_groups_request>;
 

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -91,8 +91,8 @@ static auto motor_dispatch_target = DispatchParseTarget<
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,
-    can_messages::GetMoveGroupRequest, can_messages::ClearMoveGroupRequest,
-    can_messages::ClearAllMoveGroupsRequest>{can_move_group_handler};
+    can_messages::GetMoveGroupRequest, can_messages::ClearAllMoveGroupsRequest>{
+    can_move_group_handler};
 
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -91,8 +91,8 @@ static auto motor_dispatch_target = DispatchParseTarget<
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,
-    can_messages::GetMoveGroupRequest, can_messages::ClearMoveGroupRequest>{
-    can_move_group_handler};
+    can_messages::GetMoveGroupRequest, can_messages::ClearMoveGroupRequest,
+    can_messages::ClearAllMoveGroupsRequest>{can_move_group_handler};
 
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),


### PR DESCRIPTION
Add `ClearAllMoveGroupsRequest` to empty all move groups. 

Should consider just removing the message that clears them one at a time. Not clear what the use case is for that.