### PR TITLE
refactor(gantry): turn off LED during GPIO initialization

### DIFF
--- a/gantry/firmware/main.cpp
+++ b/gantry/firmware/main.cpp
@@ -16,6 +16,6 @@ auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
     utility_gpio_init();
-    
+
     vTaskStartScheduler();
 }

--- a/gantry/firmware/main.cpp
+++ b/gantry/firmware/main.cpp
@@ -16,6 +16,6 @@ auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
     utility_gpio_init();
-
+    
     vTaskStartScheduler();
 }

--- a/gantry/firmware/utility_gpio.c
+++ b/gantry/firmware/utility_gpio.c
@@ -35,15 +35,17 @@ void LED_drive_gpio_init(void) {
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 }
 
-void turn_on_LED_pin(void) {
+void turn_off_LED_pin(void) {
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_SET);
 }
 
-void turn_off_LED_pin(void) {
+void turn_on_LED_pin(void) {
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_RESET);
 }
 
 void utility_gpio_init(void) {
     limit_switch_gpio_init();
     LED_drive_gpio_init();
+
+    turn_off_LED_pin();
 }


### PR DESCRIPTION
This PR makes sure the D11 LED is not turned on when the gantry axis board starts up