### PR TITLE
feat(pipettes): add a function to handle the motor driver clock pin in pipettes

### DIFF
--- a/common/firmware/spi/spi_comms.cpp
+++ b/common/firmware/spi/spi_comms.cpp
@@ -25,7 +25,7 @@ using namespace spi;
  * Public Functions
  */
 
-Spi::Spi() { SPI2_init(); }
+Spi::Spi() { SPI2_init(); motor_driver_CLK_gpio_init();}
 
 void Spi::transmit_receive(const BufferType& transmit, BufferType& receive) {
     Reset_CS_Pin();

--- a/include/common/firmware/spi.h
+++ b/include/common/firmware/spi.h
@@ -9,6 +9,7 @@ void SPI2_init();
 void Set_CS_Pin();
 void Reset_CS_Pin();
 void hal_transmit_receive(uint8_t* transmit, uint8_t *receive, uint16_t buff_size, uint32_t timeout);
+void motor_driver_CLK_gpio_init();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/pipettes/firmware/spi.c
+++ b/pipettes/firmware/spi.c
@@ -125,3 +125,14 @@ void Reset_CS_Pin() {
 void hal_transmit_receive(uint8_t* transmit, uint8_t* receive, uint16_t buff_size, uint32_t timeout) {
     HAL_SPI_TransmitReceive(&handle, transmit, receive, buff_size, timeout);
 }
+
+void motor_driver_CLK_gpio_init() {
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    // Driver Clock Pin
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_2;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_2, GPIO_PIN_RESET);
+}


### PR DESCRIPTION
## Overview
For now, we should set the clock pin of the motor driver to low in the pipettes subproject. Dependent on #133 and #142 being merged.