### PR TITLE
feat(motion-controller): set and get motion constraints

### DIFF
--- a/can/simulator/main.cpp
+++ b/can/simulator/main.cpp
@@ -48,7 +48,7 @@ struct Loopback {
      * The message handling function.
      * @param m A variant of the various message types.
      */
-    void handle(std::variant<std::monostate, MoveRequest, GetSpeedRequest> &m) {
+    void handle(std::variant<std::monostate, MoveRequest> &m) {
         std::visit([this](auto o) { this->visit(o); }, m);
     }
 
@@ -73,8 +73,7 @@ static auto handler = Loopback{canbus};
 // Create a DispatchParseTarget to parse messages in message buffer and pass
 // them to the handler.
 static auto dispatcher =
-    can_dispatch::DispatchParseTarget<Loopback, MoveRequest, GetSpeedRequest>{
-        handler};
+    can_dispatch::DispatchParseTarget<Loopback, MoveRequest>{handler};
 
 // A Message Buffer poller that reads from buffer and send to dispatcher
 static auto poller =

--- a/can/tests/test_dispatch.cpp
+++ b/can/tests/test_dispatch.cpp
@@ -118,10 +118,10 @@ SCENARIO("DispatchBufferTarget") {
         auto subject = DispatchBufferTarget<decltype(l), HeartbeatRequest,
                                             HeartbeatResponse>(l);
 
-        WHEN("Given a GetSpeedResponse") {
+        WHEN("Given a GetMoveGroupResponse") {
             auto arbitration_id = ArbitrationId{.id = 0};
             arbitration_id.parts.message_id =
-                static_cast<uint16_t>(GetSpeedResponse::id);
+                static_cast<uint16_t>(GetMoveGroupResponse::id);
             subject.handle(arbitration_id.id, buff.begin(), buff.end());
             THEN("listeners are not called") { REQUIRE(l.length == 0); }
         }

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -40,22 +40,6 @@ SCENARIO("message deserializing works") {
         }
     }
 
-    GIVEN("a get speed response body") {
-        auto arr = std::array<uint8_t, 4>{1, 2, 3, 4};
-        WHEN("constructed") {
-            auto r = GetSpeedResponse::parse(arr.begin(), arr.end());
-            THEN("it is converted to a the correct structure") {
-                REQUIRE(r.mm_sec == 0x01020304);
-            }
-            THEN("it can be compared for equality") {
-                auto other = r;
-                REQUIRE(other == r);
-                other.mm_sec = 1;
-                REQUIRE(other != r);
-            }
-        }
-    }
-
     GIVEN("a device info response body") {
         auto arr = std::array<uint8_t, 5>{0x20, 2, 3, 4, 5};
         WHEN("constructed") {
@@ -119,22 +103,6 @@ SCENARIO("message serializing works") {
         }
     }
 
-    GIVEN("a get speed response message") {
-        auto message = GetSpeedResponse{{}, 0x12344321};
-        auto arr = std::array<uint8_t, 4>{0, 0, 0, 0};
-        auto body = std::span{arr};
-        WHEN("serialized") {
-            auto size = message.serialize(arr.begin(), arr.end());
-            THEN("it is written into the buffer correctly") {
-                REQUIRE(body.data()[0] == 0x12);
-                REQUIRE(body.data()[1] == 0x34);
-                REQUIRE(body.data()[2] == 0x43);
-                REQUIRE(body.data()[3] == 0x21);
-            }
-            THEN("size must be returned") { REQUIRE(size == 4); }
-        }
-    }
-
     GIVEN("a device info response message") {
         auto message = DeviceInfoResponse{{}, NodeId::pipette, 0x00220033};
         auto arr = std::array<uint8_t, 5>{0, 0, 0, 0, 0};
@@ -149,16 +117,6 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[4] == 0x33);
             }
             THEN("size must be returned") { REQUIRE(size == 5); }
-        }
-    }
-
-    GIVEN("a get speed request message") {
-        auto message = GetSpeedRequest{{}};
-        auto arr = std::array<uint8_t, 4>{0, 0, 0, 0};
-        auto body = std::span{arr};
-        WHEN("serialized") {
-            auto size = message.serialize(arr.begin(), arr.end());
-            THEN("size must be returned") { REQUIRE(size == 0); }
         }
     }
 }

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -64,7 +64,13 @@ static motor_class::Motor motor{
             lms::BeltConfig{.belt_pitch = 2, .pulley_tooth_count = 10},
         .steps_per_rev = 200,
         .microstep = 16},
-    PinConfigurations, motor_queue, complete_queue};
+    PinConfigurations,
+    MotionConstraints{.min_velocity = 1,
+                      .max_velocity = 2,
+                      .min_acceleration = 1,
+                      .max_acceleration = 2},
+    motor_queue,
+    complete_queue};
 
 static auto move_group_manager = MoveGroupType{};
 /** The parsed message handler */
@@ -85,7 +91,9 @@ static auto motor_dispatch_target = DispatchParseTarget<
     decltype(can_motor_handler), can_messages::SetupRequest,
     can_messages::StopRequest, can_messages::GetStatusRequest,
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
-    can_messages::DisableMotorRequest>{can_motor_handler};
+    can_messages::DisableMotorRequest,
+    can_messages::GetMotionConstraintsRequest,
+    can_messages::SetMotionConstraints>{can_motor_handler};
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -74,7 +74,8 @@ static motor_class::Motor motor{
 
 static auto move_group_manager = MoveGroupType{};
 /** The parsed message handler */
-static auto can_motor_handler = MotorHandler{message_writer_1, motor};
+static auto can_motor_handler =
+    MotorHandler{message_writer_1, motor, axis_type::get_node_id()};
 static auto can_move_group_handler =
     MoveGroupHandler(message_writer_1, move_group_manager);
 static auto can_move_group_executor_handler = MoveGroupExecutorHandler(

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -54,7 +54,13 @@ static motor_class::Motor motor{
             lms::BeltConfig{.belt_pitch = 2, .pulley_tooth_count = 10},
         .steps_per_rev = 200,
         .microstep = 16},
-    PinConfigurations, motor_queue, complete_queue};
+    PinConfigurations,
+    MotionConstraints{.min_velocity = 1,
+                      .max_velocity = 2,
+                      .min_acceleration = 1,
+                      .max_acceleration = 2},
+    motor_queue,
+    complete_queue};
 
 /** The parsed message handler */
 static auto can_motor_handler = MotorHandler{message_writer_1, motor};
@@ -70,7 +76,9 @@ static auto motor_dispatch_target = DispatchParseTarget<
     decltype(can_motor_handler), can_messages::SetupRequest,
     can_messages::StopRequest, can_messages::GetStatusRequest,
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
-    can_messages::DisableMotorRequest>{can_motor_handler};
+    can_messages::DisableMotorRequest,
+    can_messages::GetMotionConstraintsRequest,
+    can_messages::SetMotionConstraints>{can_motor_handler};
 /** Dispatcher to the various handlers */
 static auto dispatcher =
     Dispatcher(motor_dispatch_target, device_info_dispatch_target);

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -63,7 +63,8 @@ static motor_class::Motor motor{
     complete_queue};
 
 /** The parsed message handler */
-static auto can_motor_handler = MotorHandler{message_writer_1, motor};
+static auto can_motor_handler =
+    MotorHandler{message_writer_1, motor, NodeId::head};
 
 /** Handler of device info requests. */
 static auto device_info_handler =

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -51,6 +51,10 @@ enum class MessageId : uint16_t {
     move_request = 0x10,
     move_completed = 0x13,
 
+    set_motion_constraints = 0x1001,
+    get_motion_constraints_request = 0x1002,
+    get_motion_constraints_response = 0x1003,
+
     add_linear_move_request = 0x15,
     get_move_group_request = 0x16,
     get_move_group_response = 0x17,
@@ -59,9 +63,6 @@ enum class MessageId : uint16_t {
     move_group_completed = 0x1A,
 
     setup_request = 0x02,
-
-    get_speed_request = 0x04,
-    get_speed_response = 0x11,
 
     write_eeprom = 0x2001,
     read_eeprom_request = 0x2002,

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -20,8 +20,8 @@ class MotorHandler {
                      DisableMotorRequest, GetMotionConstraintsRequest,
                      SetMotionConstraints>;
 
-    MotorHandler(MessageWriter &message_writer, Motor &motor)
-        : message_writer{message_writer}, motor{motor} {}
+    MotorHandler(MessageWriter &message_writer, Motor &motor, NodeId node_id)
+        : message_writer{message_writer}, motor{motor}, node_id(node_id) {}
     MotorHandler(const MotorHandler &) = delete;
     MotorHandler(const MotorHandler &&) = delete;
     MotorHandler &operator=(const MotorHandler &) = delete;
@@ -64,6 +64,7 @@ class MotorHandler {
             .max_velocity = constraints.max_velocity,
             .min_acceleration = constraints.min_acceleration,
             .max_acceleration = constraints.max_acceleration,
+            .node_id = static_cast<uint8_t>(node_id),
         };
         message_writer.write(NodeId::host, response_msg);
     }
@@ -74,6 +75,7 @@ class MotorHandler {
 
     MessageWriter &message_writer;
     Motor &motor;
+    NodeId node_id;
 };
 
 }  // namespace motor_message_handler

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -5,7 +5,6 @@
 
 #include "common/core/bit_utils.hpp"
 #include "ids.hpp"
-#include "motor-control/core/motor_messages.hpp"
 #include "parse.hpp"
 
 namespace can_messages {
@@ -156,26 +155,6 @@ struct MoveRequest : BaseMessage<MessageId::move_request> {
 };
 
 using SetupRequest = Empty<MessageId::setup_request>;
-
-using GetSpeedRequest = Empty<MessageId::get_speed_request>;
-
-struct GetSpeedResponse : BaseMessage<MessageId::get_speed_response> {
-    uint32_t mm_sec;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> GetSpeedResponse {
-        uint32_t mm_sec = 0;
-        body = bit_utils::bytes_to_int(body, limit, mm_sec);
-        return GetSpeedResponse{.mm_sec = mm_sec};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(mm_sec, body, limit);
-        return iter - body;
-    }
-    bool operator==(const GetSpeedResponse& other) const = default;
-};
 
 struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {
     uint8_t serial_number;
@@ -398,6 +377,79 @@ struct MoveCompleted : BaseMessage<MessageId::move_completed> {
     }
 
     bool operator==(const MoveCompleted& other) const = default;
+};
+
+struct SetMotionConstraints : BaseMessage<MessageId::set_motion_constraints> {
+    um_per_tick min_velocity;
+    um_per_tick max_velocity;
+    um_per_tick_sq min_acceleration;
+    um_per_tick_sq max_acceleration;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> SetMotionConstraints {
+        um_per_tick min_velocity = 0;
+        um_per_tick max_velocity = 0;
+        um_per_tick_sq min_acceleration = 0;
+        um_per_tick_sq max_acceleration = 0;
+        body = bit_utils::bytes_to_int(body, limit, min_velocity);
+        body = bit_utils::bytes_to_int(body, limit, max_velocity);
+        body = bit_utils::bytes_to_int(body, limit, min_acceleration);
+        body = bit_utils::bytes_to_int(body, limit, max_acceleration);
+        return SetMotionConstraints{.min_velocity = min_velocity,
+                                    .max_velocity = max_velocity,
+                                    .min_acceleration = min_acceleration,
+                                    .max_acceleration = max_acceleration};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(min_velocity, body, limit);
+        iter = bit_utils::int_to_bytes(max_velocity, iter, limit);
+        iter = bit_utils::int_to_bytes(min_acceleration, iter, limit);
+        iter = bit_utils::int_to_bytes(max_acceleration, iter, limit);
+        return iter - body;
+    }
+
+    bool operator==(const SetMotionConstraints& other) const = default;
+};
+
+using GetMotionConstraintsRequest =
+    Empty<MessageId::get_motion_constraints_request>;
+
+struct GetMotionConstraintsResponse
+    : BaseMessage<MessageId::set_motion_constraints> {
+    um_per_tick min_velocity;
+    um_per_tick max_velocity;
+    um_per_tick_sq min_acceleration;
+    um_per_tick_sq max_acceleration;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> GetMotionConstraintsResponse {
+        um_per_tick min_velocity = 0;
+        um_per_tick max_velocity = 0;
+        um_per_tick_sq min_acceleration = 0;
+        um_per_tick_sq max_acceleration = 0;
+        body = bit_utils::bytes_to_int(body, limit, min_velocity);
+        body = bit_utils::bytes_to_int(body, limit, max_velocity);
+        body = bit_utils::bytes_to_int(body, limit, min_acceleration);
+        body = bit_utils::bytes_to_int(body, limit, max_acceleration);
+        return GetMotionConstraintsResponse{
+            .min_velocity = min_velocity,
+            .max_velocity = max_velocity,
+            .min_acceleration = min_acceleration,
+            .max_acceleration = max_acceleration};
+    }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(min_velocity, body, limit);
+        iter = bit_utils::int_to_bytes(max_velocity, iter, limit);
+        iter = bit_utils::int_to_bytes(min_acceleration, iter, limit);
+        iter = bit_utils::int_to_bytes(max_acceleration, iter, limit);
+        return iter - body;
+    }
+
+    bool operator==(const GetMotionConstraintsResponse& other) const = default;
 };
 
 }  // namespace can_messages

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -422,6 +422,7 @@ struct GetMotionConstraintsResponse
     um_per_tick max_velocity;
     um_per_tick_sq min_acceleration;
     um_per_tick_sq max_acceleration;
+    uint8_t node_id;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> GetMotionConstraintsResponse {
@@ -429,15 +430,18 @@ struct GetMotionConstraintsResponse
         um_per_tick max_velocity = 0;
         um_per_tick_sq min_acceleration = 0;
         um_per_tick_sq max_acceleration = 0;
+        uint8_t node_id = 0;
         body = bit_utils::bytes_to_int(body, limit, min_velocity);
         body = bit_utils::bytes_to_int(body, limit, max_velocity);
         body = bit_utils::bytes_to_int(body, limit, min_acceleration);
         body = bit_utils::bytes_to_int(body, limit, max_acceleration);
+        body = bit_utils::bytes_to_int(body, limit, node_id);
         return GetMotionConstraintsResponse{
             .min_velocity = min_velocity,
             .max_velocity = max_velocity,
             .min_acceleration = min_acceleration,
-            .max_acceleration = max_acceleration};
+            .max_acceleration = max_acceleration,
+            .node_id = node_id};
     }
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -446,6 +450,7 @@ struct GetMotionConstraintsResponse
         iter = bit_utils::int_to_bytes(max_velocity, iter, limit);
         iter = bit_utils::int_to_bytes(min_acceleration, iter, limit);
         iter = bit_utils::int_to_bytes(max_acceleration, iter, limit);
+        iter = bit_utils::int_to_bytes(node_id, iter, limit);
         return iter - body;
     }
 

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -33,10 +33,11 @@ class MotionController {
     using GenericQueue = QueueImpl<Move>;
     using CompletedQueue = CompletedQueueImpl<Ack>;
     MotionController(lms::LinearMotionSystemConfig<MEConfig> lms_config,
-                     HardwareConfig& config, GenericQueue& queue,
-                     CompletedQueue& completed_queue)
+                     HardwareConfig& config, MotionConstraints constraints,
+                     GenericQueue& queue, CompletedQueue& completed_queue)
         : linear_motion_sys_config(lms_config),
           hardware_config(config),
+          motion_constraints(constraints),
           queue(queue),
           completed_queue(completed_queue) {
         timer_init();
@@ -90,12 +91,24 @@ class MotionController {
         timer_interrupt_stop();
     }
 
+    void set_motion_constraints(
+        const can_messages::SetMotionConstraints& can_msg) {
+        motion_constraints =
+            MotionConstraints{.min_velocity = can_msg.min_velocity,
+                              .max_velocity = can_msg.max_velocity,
+                              .min_acceleration = can_msg.min_acceleration,
+                              .max_acceleration = can_msg.max_acceleration};
+    }
+
+    MotionConstraints get_motion_constraints() { return motion_constraints; }
+
   private:
     uint32_t steps_per_mm;
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;
     HardwareConfig& hardware_config;
     GenericQueue& queue;
     CompletedQueue& completed_queue;
+    MotionConstraints motion_constraints;
 };
 
 }  // namespace motion_controller

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -106,9 +106,9 @@ class MotionController {
     uint32_t steps_per_mm;
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;
     HardwareConfig& hardware_config;
+    MotionConstraints motion_constraints;
     GenericQueue& queue;
     CompletedQueue& completed_queue;
-    MotionConstraints motion_constraints;
 };
 
 }  // namespace motion_controller

--- a/include/motor-control/core/motor.hpp
+++ b/include/motor-control/core/motor.hpp
@@ -22,12 +22,13 @@ struct Motor {
     using GenericQueue = PendingQueueImpl<Move>;
     using CompletedQueue = CompletedQueueImpl<Ack>;
     Motor(SpiDriver& spi, lms::LinearMotionSystemConfig<MEConfig> lms_config,
-          motion_controller::HardwareConfig& config, GenericQueue& queue,
+          motion_controller::HardwareConfig& config,
+          MotionConstraints constraints, GenericQueue& queue,
           CompletedQueue& completed_queue)
         : pending_move_queue(queue),
           completed_move_queue(completed_queue),
           driver{spi},
-          motion_controller{lms_config, config, pending_move_queue,
+          motion_controller{lms_config, config, constraints, pending_move_queue,
                             completed_move_queue} {}
     GenericQueue& pending_move_queue;
     CompletedQueue& completed_move_queue;

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "can/core/messages.hpp"
+
 typedef int32_t sq0_31;  // 0: signed bit,  1-31: fractional bits
 typedef uint64_t
     q31_31;  // 0: overflow bit, 1-32: integer bits, 33-64: fractional bits
@@ -11,6 +13,16 @@ using steps_per_tick = sq0_31;
 using steps_per_tick_sq = sq0_31;
 
 namespace motor_messages {
+
+using um_per_tick = can_messages::um_per_tick;
+using um_per_tick_sq = can_messages::um_per_tick_sq;
+
+struct MotionConstraints {
+    um_per_tick min_velocity;
+    um_per_tick max_velocity;
+    um_per_tick_sq min_acceleration;
+    um_per_tick_sq max_acceleration;
+};
 
 struct Move {
     ticks duration;  // in ticks

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -77,7 +77,8 @@ static motor_class::Motor motor{
 
 static auto move_group_manager = MoveGroupType{};
 /** The parsed message handler */
-static auto can_motor_handler = MotorHandler{message_writer_1, motor};
+static auto can_motor_handler =
+    MotorHandler{message_writer_1, motor, NodeId::pipette};
 static auto can_move_group_handler =
     MoveGroupHandler(message_writer_1, move_group_manager);
 static auto can_move_group_executor_handler = MoveGroupExecutorHandler(

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -67,7 +67,13 @@ static motor_class::Motor motor{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 2},
         .steps_per_rev = 200,
         .microstep = 16},
-    PinConfigurations, motor_queue, complete_queue};
+    PinConfigurations,
+    MotionConstraints{.min_velocity = 1,
+                      .max_velocity = 2,
+                      .min_acceleration = 1,
+                      .max_acceleration = 2},
+    motor_queue,
+    complete_queue};
 
 static auto move_group_manager = MoveGroupType{};
 /** The parsed message handler */
@@ -87,7 +93,9 @@ static auto motor_dispatch_target = DispatchParseTarget<
     decltype(can_motor_handler), can_messages::SetupRequest,
     can_messages::StopRequest, can_messages::GetStatusRequest,
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
-    can_messages::DisableMotorRequest>{can_motor_handler};
+    can_messages::DisableMotorRequest,
+    can_messages::GetMotionConstraintsRequest,
+    can_messages::SetMotionConstraints>{can_motor_handler};
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,


### PR DESCRIPTION
This PR does the following:
1. allows the ability to set and retrieve min&max velocity and acceleration for each subsystem via CAN
2. sets the initial values for min&max velocity and acceleration for each subsystem (values are arbitrary and should be modified in the future)
3. remove GetSpeedRequest&Response

Note: The firmware will only store, update and send over the motion constraints via CAN and not use them to evaluate or reject any moves. That should be handled on the Python side instead. 

closes RET-41 and closes RET-78


Corresponding changes on the Python side: https://github.com/Opentrons/opentrons/pull/8772 