### PR TITLE
refactor(can): add Node ID to all CAN responses

### DIFF
--- a/can/simulator/main.cpp
+++ b/can/simulator/main.cpp
@@ -56,14 +56,10 @@ struct Loopback {
 
     void visit(std::monostate &m) {}
 
-    /**
-     * Handler for all message types.
-     * @param m Serializable.
-     */
-    template <message_core::ResponseMessage ResponseMessage>
-    void visit(ResponseMessage &m) {
-        // Loop it back
-        writer.write(NodeId::host, m);
+    void visit(MoveRequest &m) {
+        auto response = MoveCompleted{
+            .group_id = 0, .seq_id = 1, .current_position = 2, .ack_id = 3};
+        message.writer(NodeId::host, response);
     }
 
     can_message_writer::MessageWriter writer;

--- a/can/simulator/main.cpp
+++ b/can/simulator/main.cpp
@@ -39,7 +39,8 @@ struct Loopback {
      * Constructor
      * @param can_bus A CanBus instance.
      */
-    Loopback(can_bus::CanBusWriter &can_bus) : writer{canbus, node_id} {}
+    Loopback(can_bus::CanBusWriter &can_bus, can_ids::NodeId node_id)
+        : writer{canbus, node_id} {}
     Loopback(const Loopback &) = delete;
     Loopback(const Loopback &&) = delete;
     auto operator=(const Loopback &) -> Loopback & = delete;

--- a/can/simulator/main.cpp
+++ b/can/simulator/main.cpp
@@ -59,7 +59,7 @@ struct Loopback {
     void visit(MoveRequest &m) {
         auto response = MoveCompleted{
             .group_id = 0, .seq_id = 1, .current_position = 2, .ack_id = 3};
-        message.writer(NodeId::host, response);
+        writer.write(NodeId::host, response);
     }
 
     can_message_writer::MessageWriter writer;

--- a/can/simulator/main.cpp
+++ b/can/simulator/main.cpp
@@ -3,6 +3,7 @@
 
 #include "can/core/dispatch.hpp"
 #include "can/core/freertos_can_dispatch.hpp"
+#include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
 #include "can/core/messages.hpp"
 #include "can/simlib/sim_canbus.hpp"
@@ -38,7 +39,7 @@ struct Loopback {
      * Constructor
      * @param can_bus A CanBus instance.
      */
-    Loopback(can_bus::CanBusWriter &can_bus) : writer{canbus} {}
+    Loopback(can_bus::CanBusWriter &can_bus) : writer{canbus, node_id} {}
     Loopback(const Loopback &) = delete;
     Loopback(const Loopback &&) = delete;
     auto operator=(const Loopback &) -> Loopback & = delete;
@@ -58,8 +59,8 @@ struct Loopback {
      * Handler for all message types.
      * @param m Serializable.
      */
-    template <message_core::Serializable Serializable>
-    void visit(const Serializable &m) {
+    template <message_core::ResponseMessage ResponseMessage>
+    void visit(ResponseMessage &m) {
         // Loop it back
         writer.write(NodeId::host, m);
     }
@@ -68,7 +69,7 @@ struct Loopback {
 };
 
 // Create global handler
-static auto handler = Loopback{canbus};
+static auto handler = Loopback{canbus, can_ids::NodeId::host};
 
 // Create a DispatchParseTarget to parse messages in message buffer and pass
 // them to the handler.

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -65,10 +65,13 @@ SCENARIO("message serializing works") {
         }
     }
 
-    GIVEN("a MoveGroupCompleted message") {
-        auto message = MoveGroupCompleted{.group_id = 1};
+    GIVEN("a MoveCompleted message") {
+        auto message = MoveCompleted{.group_id = 1,
+                                     .seq_id = 2,
+                                     .current_position = 0x3456789a,
+                                     .ack_id = 1};
         message.set_node_id(can_ids::NodeId::pipette);
-        auto arr = std::array<uint8_t, 2>{};
+        auto arr = std::array<uint8_t, 8>{};
         auto body = std::span{arr};
         WHEN("serialized") {
             auto size = message.serialize(arr.begin(), arr.end());
@@ -76,8 +79,14 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[0] ==
                         static_cast<uint8_t>(can_ids::NodeId::pipette));
                 REQUIRE(body.data()[1] == 1);
+                REQUIRE(body.data()[2] == 2);
+                REQUIRE(body.data()[3] == 0x34);
+                REQUIRE(body.data()[4] == 0x56);
+                REQUIRE(body.data()[5] == 0x78);
+                REQUIRE(body.data()[6] == 0x9a);
+                REQUIRE(body.data()[7] == 1);
             }
-            THEN("size must be returned") { REQUIRE(size == 2); }
+            THEN("size must be returned") { REQUIRE(size == 8); }
         }
     }
 

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -1,26 +1,10 @@
+#include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
 #include "catch2/catch.hpp"
 
 using namespace can_messages;
 
 SCENARIO("message deserializing works") {
-    GIVEN("a get status response body") {
-        auto arr = std::array<uint8_t, 5>{1, 2, 3, 4, 5};
-        WHEN("constructed") {
-            auto r = GetStatusResponse::parse(arr.begin(), arr.end());
-            THEN("it is converted to a the correct structure") {
-                REQUIRE(r.data == 0x02030405);
-                REQUIRE(r.status == 0x01);
-            }
-            THEN("it can be compared for equality") {
-                auto other = r;
-                REQUIRE(other == r);
-                other.data = 24;
-                REQUIRE(other != r);
-            }
-        }
-    }
-
     GIVEN("a move request body") {
         auto arr =
             std::array<uint8_t, 12>{1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc};
@@ -40,18 +24,20 @@ SCENARIO("message deserializing works") {
         }
     }
 
-    GIVEN("a device info response body") {
-        auto arr = std::array<uint8_t, 5>{0x20, 2, 3, 4, 5};
+    GIVEN("a set steps request message") {
+        auto arr = std::array<uint8_t, 12>{0x12, 0x34, 0x56, 0x78, 0xaa, 0xbb,
+                                           0xcc, 0xdd, 0xee, 0xff, 0x11, 0x00};
         WHEN("constructed") {
-            auto r = DeviceInfoResponse::parse(arr.begin(), arr.end());
+            auto r = MoveRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {
-                REQUIRE(r.node_id == NodeId::pipette);
-                REQUIRE(r.version == 0x02030405);
+                REQUIRE(r.duration == 0x12345678);
+                REQUIRE(r.velocity == static_cast<int32_t>(0xaabbccdd));
+                REQUIRE(r.acceleration == static_cast<int32_t>(0xeeff1100));
             }
             THEN("it can be compared for equality") {
                 auto other = r;
                 REQUIRE(other == r);
-                other.version = 125;
+                other.duration = 125;
                 REQUIRE(other != r);
             }
         }
@@ -60,19 +46,22 @@ SCENARIO("message deserializing works") {
 
 SCENARIO("message serializing works") {
     GIVEN("a get status response message") {
-        auto message = GetStatusResponse{{}, 1, 2};
-        auto arr = std::array<uint8_t, 5>{0, 0, 0, 0, 0};
+        auto message = GetStatusResponse{.status = 1, .data = 2};
+        message.set_node_id(can_ids::NodeId::pipette);
+        auto arr = std::array<uint8_t, 6>{0, 0, 0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized") {
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is written into the buffer correctly") {
-                REQUIRE(body.data()[0] == 1);
-                REQUIRE(body.data()[1] == 0);
+                REQUIRE(body.data()[0] ==
+                        static_cast<uint8_t>(can_ids::NodeId::pipette));
+                REQUIRE(body.data()[1] == 1);
                 REQUIRE(body.data()[2] == 0);
                 REQUIRE(body.data()[3] == 0);
-                REQUIRE(body.data()[4] == 2);
+                REQUIRE(body.data()[4] == 0);
+                REQUIRE(body.data()[5] == 2);
             }
-            THEN("size must be returned") { REQUIRE(size == 5); }
+            THEN("size must be returned") { REQUIRE(size == 6); }
         }
     }
 
@@ -104,13 +93,15 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("a device info response message") {
-        auto message = DeviceInfoResponse{{}, NodeId::pipette, 0x00220033};
+        auto message = DeviceInfoResponse{.version = 0x00220033};
+        message.set_node_id(can_ids::NodeId::pipette);
         auto arr = std::array<uint8_t, 5>{0, 0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized") {
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is written into the buffer correctly") {
-                REQUIRE(body.data()[0] == 0x20);
+                REQUIRE(body.data()[0] ==
+                        static_cast<uint8_t>(can_ids::NodeId::pipette));
                 REQUIRE(body.data()[1] == 0x00);
                 REQUIRE(body.data()[2] == 0x22);
                 REQUIRE(body.data()[3] == 0x00);

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -65,30 +65,19 @@ SCENARIO("message serializing works") {
         }
     }
 
-    GIVEN("a set steps request message") {
-        auto message =
-            MoveRequest{.duration = 0x12345678,
-                        .velocity = static_cast<int32_t>(0xaabbccdd),
-                        .acceleration = static_cast<int32_t>(0xeeff1100)};
-        auto arr = std::array<uint8_t, 12>{};
+    GIVEN("a MoveGroupCompleted message") {
+        auto message = MoveGroupCompleted{.group_id = 1};
+        message.set_node_id(can_ids::NodeId::pipette);
+        auto arr = std::array<uint8_t, 2>{};
         auto body = std::span{arr};
         WHEN("serialized") {
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is written into the buffer correctly") {
-                REQUIRE(body.data()[0] == 0x12);
-                REQUIRE(body.data()[1] == 0x34);
-                REQUIRE(body.data()[2] == 0x56);
-                REQUIRE(body.data()[3] == 0x78);
-                REQUIRE(body.data()[4] == 0xaa);
-                REQUIRE(body.data()[5] == 0xbb);
-                REQUIRE(body.data()[6] == 0xcc);
-                REQUIRE(body.data()[7] == 0xdd);
-                REQUIRE(body.data()[8] == 0xee);
-                REQUIRE(body.data()[9] == 0xff);
-                REQUIRE(body.data()[10] == 0x11);
-                REQUIRE(body.data()[11] == 0x00);
+                REQUIRE(body.data()[0] ==
+                        static_cast<uint8_t>(can_ids::NodeId::pipette));
+                REQUIRE(body.data()[1] == 1);
             }
-            THEN("size must be returned") { REQUIRE(size == 12); }
+            THEN("size must be returned") { REQUIRE(size == 2); }
         }
     }
 

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -36,7 +36,8 @@ using namespace motor_messages;
 
 extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
-static auto message_writer_1 = MessageWriter(can_bus_1);
+static auto message_writer_1 =
+    MessageWriter(can_bus_1, axis_type::get_node_id());
 
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -26,7 +26,7 @@ using namespace motor_messages;
 
 extern FDCAN_HandleTypeDef fdcan1;
 static auto can_bus_1 = HalCanBus(&fdcan1);
-static auto message_writer_1 = MessageWriter(can_bus_1);
+static auto message_writer_1 = MessageWriter(can_bus_1, NodeId::head);
 
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -27,7 +27,7 @@ class DeviceInfoHandler {
      * @param version The firmware version on this device
      */
     DeviceInfoHandler(MessageWriter &writer, NodeId node_id, uint32_t version)
-        : writer(writer), response{.node_id = node_id, .version = version} {}
+        : writer(writer), response{.version = version} {}
     DeviceInfoHandler(const DeviceInfoHandler &) = delete;
     DeviceInfoHandler(const DeviceInfoHandler &&) = delete;
     DeviceInfoHandler &operator=(const DeviceInfoHandler &) = delete;

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -60,7 +60,6 @@ enum class MessageId : uint16_t {
     get_move_group_response = 0x17,
     execute_move_group_request = 0x18,
     clear_all_move_groups_request = 0x19,
-    move_group_completed = 0x1A,
 
     setup_request = 0x02,
 

--- a/include/can/core/message_core.hpp
+++ b/include/can/core/message_core.hpp
@@ -27,6 +27,19 @@ concept HasMessageID = requires {
 };
 
 /**
+ * Concept describing an item that has a node id
+ * @tparam T
+ */
+template <typename T>
+concept HasNodeID = requires {
+    /**
+     * Has a node id member. This is the NodeID that the Serializable
+     * knows how to serialize.
+     */
+    { T::node_id } -> std::convertible_to<NodeId>;
+};
+
+/**
  * The concept describing the interface of a parsable can message
  * @tparam T
  */
@@ -59,6 +72,17 @@ template <typename T>
 concept CanMessage = requires(T& t) {
     {HasMessageID<T>};
     {Parsable<T>};
+    {Serializable<T>};
+};
+
+/**
+ * The concept describing a can response message.
+ * @tparam T
+ */
+template <typename T>
+concept CanResponseMessage = requires(T& t) {
+    {HasMessageID<T>};
+    {HasNodeID<T>};
     {Serializable<T>};
 };
 

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -64,7 +64,6 @@ class MotorHandler {
             .max_velocity = constraints.max_velocity,
             .min_acceleration = constraints.min_acceleration,
             .max_acceleration = constraints.max_acceleration,
-            .node_id = static_cast<uint8_t>(node_id),
         };
         message_writer.write(NodeId::host, response_msg);
     }

--- a/include/can/core/message_handlers/move_group.hpp
+++ b/include/can/core/message_handlers/move_group.hpp
@@ -47,8 +47,7 @@ class MoveGroupHandler {
         auto response = GetMoveGroupResponse{
             .group_id = m.group_id,
             .num_moves = static_cast<uint8_t>(group.size()),
-            .total_duration = group.get_duration(),
-            .node_id = static_cast<uint8_t>(can_ids::NodeId::host)};
+            .total_duration = group.get_duration()};
 
         message_writer.write(NodeId::host, response);
     }

--- a/include/can/core/message_handlers/move_group_executor.hpp
+++ b/include/can/core/message_handlers/move_group_executor.hpp
@@ -31,7 +31,6 @@ struct TaskEntry {
                     .current_position = try_read.current_position,
                     .ack_id = static_cast<uint8_t>(
                         motor_messages::AckMessageId::complete),
-                    .node_id = static_cast<uint8_t>(node_id),
                 };
                 message_writer.write(NodeId::host, msg);
             }

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -6,13 +6,16 @@
 #include "can_bus.hpp"
 #include "common/core/freertos_synchronization.hpp"
 #include "common/core/synchronization.hpp"
+#include "ids.hpp"
 #include "message_core.hpp"
 
 namespace can_message_writer {
 
 class MessageWriter {
   public:
-    explicit MessageWriter(can_bus::CanBusWriter& writer) : writer{writer} {}
+    explicit MessageWriter(can_bus::CanBusWriter& writer,
+                           can_ids::NodeId node_id)
+        : writer{writer}, node_id(node_id) {}
 
     /**
      * Write a message to the can bus
@@ -21,14 +24,15 @@ class MessageWriter {
      * @param node The node id
      * @param message The message to send
      */
-    template <message_core::Serializable Serializable>
-    void write(can_ids::NodeId node, const Serializable& message) {
+    template <message_core::CanResponseMessage ResponseMessage>
+    void write(can_ids::NodeId node, ResponseMessage& message) {
         auto lock = synchronization::Lock{mutex};
         arbitration_id.id = 0;
         arbitration_id.parts.message_id = static_cast<uint16_t>(message.id);
         // TODO (al 2021-08-03): populate this from Message?
         arbitration_id.parts.function_code = 0;
         arbitration_id.parts.node_id = static_cast<unsigned int>(node);
+        message.set_node_id(node_id);
         auto length = message.serialize(buffer.begin(), buffer.end());
         writer.send(arbitration_id.id, buffer.data(),
                     can_bus::to_canfd_length(length));
@@ -39,6 +43,7 @@ class MessageWriter {
     freertos_synchronization::FreeRTOSMutex mutex{};
     can_arbitration_id::ArbitrationId arbitration_id{};
     std::array<uint8_t, message_core::MaxMessageSize> buffer{};
+    can_ids::NodeId node_id;
 };
 
 }  // namespace can_message_writer

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -48,13 +48,26 @@ struct Empty : BaseMessage<MId> {
     bool operator==(const Empty& other) const = default;
 };
 
+template <MessageId MId>
+struct Response : BaseMessage<MId> {
+    NodeId node_id;
+
+    void set_node_id(NodeId id) { node_id = id; }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize_node_id(Output body, Limit limit) const {
+        return bit_utils::int_to_bytes(static_cast<uint8_t>(node_id), body,
+                                       limit);
+    }
+};
+
 using HeartbeatRequest = Empty<MessageId::heartbeat_request>;
 
 using HeartbeatResponse = Empty<MessageId::heartbeat_response>;
 
 using DeviceInfoRequest = Empty<MessageId::device_info_request>;
 
-struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
+struct DeviceInfoResponse : Response<MessageId::device_info_response> {
     /**
      *   TODO (al, 2021-09-13)
      *   Seth's thoughts on future of payload
@@ -71,23 +84,11 @@ struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
      *   - a hardware revision unless we want to fold that into the
      * well-known-id
      */
-    NodeId node_id;
     uint32_t version;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> DeviceInfoResponse {
-        uint8_t node_id;
-        uint32_t version;
-        body = bit_utils::bytes_to_int(body, limit, node_id);
-        body = bit_utils::bytes_to_int(body, limit, version);
-        return DeviceInfoResponse{.node_id = static_cast<NodeId>(node_id),
-                                  .version = version};
-    }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter =
-            bit_utils::int_to_bytes(static_cast<uint8_t>(node_id), body, limit);
+        auto iter = serialize_node_id(body, limit);
         iter = bit_utils::int_to_bytes(version, iter, limit);
         return iter - body;
     }
@@ -102,24 +103,14 @@ using EnableMotorRequest = Empty<MessageId::enable_motor_request>;
 
 using DisableMotorRequest = Empty<MessageId::disable_motor_request>;
 
-struct GetStatusResponse : BaseMessage<MessageId::get_status_response> {
+struct GetStatusResponse : Response<MessageId::get_status_response> {
     uint8_t status;
     uint32_t data;
 
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> GetStatusResponse {
-        uint8_t status = 0;
-        uint32_t data = 0;
-
-        body = bit_utils::bytes_to_int(body, limit, status);
-        body = bit_utils::bytes_to_int(body, limit, data);
-
-        return GetStatusResponse{.status = status, .data = data};
-    }
-
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(status, body, limit);
+        auto iter = serialize_node_id(body, limit);
+        iter = bit_utils::int_to_bytes(status, iter, limit);
         iter = bit_utils::int_to_bytes(data, iter, limit);
         return iter - body;
     }
@@ -176,19 +167,13 @@ struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {
 
 using ReadFromEEPromRequest = Empty<MessageId::read_eeprom_request>;
 
-struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
+struct ReadFromEEPromResponse : Response<MessageId::read_eeprom_response> {
     uint8_t serial_number;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> ReadFromEEPromResponse {
-        uint8_t serial_number = 0;
-        body = bit_utils::bytes_to_int(body, limit, serial_number);
-        return ReadFromEEPromResponse{.serial_number = serial_number};
-    }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
+        auto iter = serialize_node_id(body, limit);
+        iter = bit_utils::int_to_bytes(serial_number, iter, limit);
         return iter - body;
     }
     bool operator==(const ReadFromEEPromResponse& other) const = default;
@@ -252,34 +237,17 @@ struct GetMoveGroupRequest : BaseMessage<MessageId::get_move_group_request> {
     bool operator==(const GetMoveGroupRequest& other) const = default;
 };
 
-struct GetMoveGroupResponse : BaseMessage<MessageId::get_move_group_response> {
+struct GetMoveGroupResponse : Response<MessageId::get_move_group_response> {
     uint8_t group_id;
     uint8_t num_moves;
     uint32_t total_duration;
-    uint8_t node_id;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> GetMoveGroupResponse {
-        uint8_t group_id = 0;
-        uint8_t num_moves = 0;
-        uint32_t total_duration = 0;
-        uint8_t node_id = 0;
-        body = bit_utils::bytes_to_int(body, limit, group_id);
-        body = bit_utils::bytes_to_int(body, limit, num_moves);
-        body = bit_utils::bytes_to_int(body, limit, total_duration);
-        body = bit_utils::bytes_to_int(body, limit, node_id);
-        return GetMoveGroupResponse{.group_id = group_id,
-                                    .num_moves = num_moves,
-                                    .total_duration = total_duration,
-                                    .node_id = node_id};
-    }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        auto iter = serialize_node_id(body, limit);
+        iter = bit_utils::int_to_bytes(group_id, iter, limit);
         iter = bit_utils::int_to_bytes(num_moves, iter, limit);
         iter = bit_utils::int_to_bytes(total_duration, iter, limit);
-        iter = bit_utils::int_to_bytes(node_id, iter, limit);
         return iter - body;
     }
     bool operator==(const GetMoveGroupResponse& other) const = default;
@@ -317,62 +285,32 @@ struct ExecuteMoveGroupRequest
 using ClearAllMoveGroupsRequest =
     Empty<MessageId::clear_all_move_groups_request>;
 
-struct MoveGroupCompleted : BaseMessage<MessageId::move_group_completed> {
+struct MoveGroupCompleted : Response<MessageId::move_group_completed> {
     uint8_t group_id;
-    uint8_t node_id;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> MoveGroupCompleted {
-        uint8_t group_id = 0;
-        uint8_t node_id = 0;
-        body = bit_utils::bytes_to_int(body, limit, group_id);
-        body = bit_utils::bytes_to_int(body, limit, node_id);
-        return MoveGroupCompleted{.group_id = group_id, .node_id = node_id};
-    }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
-        iter = bit_utils::int_to_bytes(node_id, iter, limit);
+        auto iter = serialize_node_id(body, limit);
+        iter = bit_utils::int_to_bytes(group_id, iter, limit);
         return iter - body;
     }
 
     bool operator==(const MoveGroupCompleted& other) const = default;
 };
 
-struct MoveCompleted : BaseMessage<MessageId::move_completed> {
+struct MoveCompleted : Response<MessageId::move_completed> {
     uint8_t group_id;
     uint8_t seq_id;
     uint32_t current_position;
     uint8_t ack_id;
-    uint8_t node_id;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> MoveCompleted {
-        uint8_t group_id = 0;
-        uint8_t seq_id = 0;
-        uint32_t current_position = 0;
-        uint8_t ack_id = 0;
-        uint8_t node_id = 0;
-        body = bit_utils::bytes_to_int(body, limit, group_id);
-        body = bit_utils::bytes_to_int(body, limit, seq_id);
-        body = bit_utils::bytes_to_int(body, limit, current_position);
-        body = bit_utils::bytes_to_int(body, limit, ack_id);
-        body = bit_utils::bytes_to_int(body, limit, node_id);
-        return MoveCompleted{.group_id = group_id,
-                             .seq_id = seq_id,
-                             .current_position = current_position,
-                             .ack_id = ack_id,
-                             .node_id = node_id};
-    }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
+        auto iter = serialize_node_id(body, limit);
+        iter = bit_utils::int_to_bytes(group_id, iter, limit);
         iter = bit_utils::int_to_bytes(seq_id, iter, limit);
         iter = bit_utils::int_to_bytes(current_position, iter, limit);
         iter = bit_utils::int_to_bytes(ack_id, iter, limit);
-        iter = bit_utils::int_to_bytes(node_id, iter, limit);
         return iter - body;
     }
 
@@ -417,40 +355,19 @@ using GetMotionConstraintsRequest =
     Empty<MessageId::get_motion_constraints_request>;
 
 struct GetMotionConstraintsResponse
-    : BaseMessage<MessageId::set_motion_constraints> {
+    : Response<MessageId::set_motion_constraints> {
     um_per_tick min_velocity;
     um_per_tick max_velocity;
     um_per_tick_sq min_acceleration;
     um_per_tick_sq max_acceleration;
-    uint8_t node_id;
-
-    template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> GetMotionConstraintsResponse {
-        um_per_tick min_velocity = 0;
-        um_per_tick max_velocity = 0;
-        um_per_tick_sq min_acceleration = 0;
-        um_per_tick_sq max_acceleration = 0;
-        uint8_t node_id = 0;
-        body = bit_utils::bytes_to_int(body, limit, min_velocity);
-        body = bit_utils::bytes_to_int(body, limit, max_velocity);
-        body = bit_utils::bytes_to_int(body, limit, min_acceleration);
-        body = bit_utils::bytes_to_int(body, limit, max_acceleration);
-        body = bit_utils::bytes_to_int(body, limit, node_id);
-        return GetMotionConstraintsResponse{
-            .min_velocity = min_velocity,
-            .max_velocity = max_velocity,
-            .min_acceleration = min_acceleration,
-            .max_acceleration = max_acceleration,
-            .node_id = node_id};
-    }
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(min_velocity, body, limit);
+        auto iter = serialize_node_id(body, limit);
+        iter = bit_utils::int_to_bytes(min_velocity, iter, limit);
         iter = bit_utils::int_to_bytes(max_velocity, iter, limit);
         iter = bit_utils::int_to_bytes(min_acceleration, iter, limit);
         iter = bit_utils::int_to_bytes(max_acceleration, iter, limit);
-        iter = bit_utils::int_to_bytes(node_id, iter, limit);
         return iter - body;
     }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -256,19 +256,6 @@ struct ExecuteMoveGroupRequest
 using ClearAllMoveGroupsRequest =
     Empty<MessageId::clear_all_move_groups_request>;
 
-struct MoveGroupCompleted : Response<MessageId::move_group_completed> {
-    uint8_t group_id;
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = serialize_node_id(body, limit);
-        iter = bit_utils::int_to_bytes(group_id, iter, limit);
-        return iter - body;
-    }
-
-    bool operator==(const MoveGroupCompleted& other) const = default;
-};
-
 struct MoveCompleted : Response<MessageId::move_completed> {
     uint8_t group_id;
     uint8_t seq_id;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -59,6 +59,12 @@ struct Response : BaseMessage<MId> {
         return bit_utils::int_to_bytes(static_cast<uint8_t>(node_id), body,
                                        limit);
     }
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = serialize_node_id(body, limit);
+        return iter - body;
+    }
 };
 
 using HeartbeatRequest = Empty<MessageId::heartbeat_request>;
@@ -135,13 +141,6 @@ struct MoveRequest : BaseMessage<MessageId::move_request> {
                            .acceleration = acceleration};
     }
 
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(duration, body, limit);
-        iter = bit_utils::int_to_bytes(velocity, iter, limit);
-        iter = bit_utils::int_to_bytes(acceleration, iter, limit);
-        return iter - body;
-    }
     bool operator==(const MoveRequest& other) const = default;
 };
 
@@ -157,11 +156,6 @@ struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {
         return WriteToEEPromRequest{.serial_number = serial_number};
     }
 
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
-        return iter - body;
-    }
     bool operator==(const WriteToEEPromRequest& other) const = default;
 };
 
@@ -205,16 +199,6 @@ struct AddLinearMoveRequest : BaseMessage<MessageId::add_linear_move_request> {
                                     .velocity = velocity};
     }
 
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
-        iter = bit_utils::int_to_bytes(seq_id, iter, limit);
-        iter = bit_utils::int_to_bytes(duration, iter, limit);
-        iter = bit_utils::int_to_bytes(acceleration, iter, limit);
-        iter = bit_utils::int_to_bytes(velocity, iter, limit);
-        return iter - body;
-    }
-
     bool operator==(const AddLinearMoveRequest& other) const = default;
 };
 
@@ -226,12 +210,6 @@ struct GetMoveGroupRequest : BaseMessage<MessageId::get_move_group_request> {
         uint8_t group_id = 0;
         body = bit_utils::bytes_to_int(body, limit, group_id);
         return GetMoveGroupRequest{.group_id = group_id};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
-        return iter - body;
     }
 
     bool operator==(const GetMoveGroupRequest& other) const = default;
@@ -272,13 +250,6 @@ struct ExecuteMoveGroupRequest
                                        .cancel_trigger = cancel_trigger};
     }
 
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(group_id, body, limit);
-        iter = bit_utils::int_to_bytes(start_trigger, iter, limit);
-        iter = bit_utils::int_to_bytes(cancel_trigger, iter, limit);
-        return iter - body;
-    }
     bool operator==(const ExecuteMoveGroupRequest& other) const = default;
 };
 
@@ -337,15 +308,6 @@ struct SetMotionConstraints : BaseMessage<MessageId::set_motion_constraints> {
                                     .max_velocity = max_velocity,
                                     .min_acceleration = min_acceleration,
                                     .max_acceleration = max_acceleration};
-    }
-
-    template <bit_utils::ByteIterator Output, typename Limit>
-    auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(min_velocity, body, limit);
-        iter = bit_utils::int_to_bytes(max_velocity, iter, limit);
-        iter = bit_utils::int_to_bytes(min_acceleration, iter, limit);
-        iter = bit_utils::int_to_bytes(max_acceleration, iter, limit);
-        return iter - body;
     }
 
     bool operator==(const SetMotionConstraints& other) const = default;

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -40,7 +40,7 @@ using namespace motor_messages;
 extern FDCAN_HandleTypeDef fdcan1;
 
 static auto can_bus_1 = HalCanBus(&fdcan1);
-static auto message_writer_1 = MessageWriter(can_bus_1);
+static auto message_writer_1 = MessageWriter(can_bus_1, NodeId::pipette);
 
 static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");


### PR DESCRIPTION
As a followup on https://github.com/Opentrons/opentrons/pull/8772, this PR adds a NodeId to all of the CAN responses from firmware. 