### PR TITLE
refactor(can): remove NodeID from CAN message handlers

### DIFF
--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -170,16 +170,15 @@ static motor_class::Motor motor{
 
 static auto move_group_manager = MoveGroupType{};
 /** The parsed message handler */
-static auto can_motor_handler =
-    MotorHandler{message_writer_1, motor, axis_type::get_node_id()};
+static auto can_motor_handler = MotorHandler{message_writer_1, motor};
 static auto can_move_group_handler =
     MoveGroupHandler(message_writer_1, move_group_manager);
-static auto can_move_group_executor_handler = MoveGroupExecutorHandler(
-    message_writer_1, move_group_manager, motor, axis_type::get_node_id());
+static auto can_move_group_executor_handler =
+    MoveGroupExecutorHandler(message_writer_1, move_group_manager, motor);
 
 /** Handler of device info requests. */
-static auto device_info_handler = can_device_info::DeviceInfoHandler(
-    message_writer_1, axis_type::get_node_id(), 0);
+static auto device_info_handler =
+    can_device_info::DeviceInfoHandler(message_writer_1, 0);
 static auto device_info_dispatch_target =
     DispatchParseTarget<decltype(device_info_handler),
                         can_messages::DeviceInfoRequest>{device_info_handler};

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -248,19 +248,18 @@ static motor_class::Motor motor{
     complete_queue};
 
 /** The parsed message handler */
-static auto can_motor_handler =
-    MotorHandler{message_writer_1, motor, NodeId::head};
+static auto can_motor_handler = MotorHandler{message_writer_1, motor};
 static auto move_group_manager = MoveGroupType{};
 
 static auto can_move_group_handler =
     MoveGroupHandler(message_writer_1, move_group_manager);
 
-static auto can_move_group_executor_handler = MoveGroupExecutorHandler(
-    message_writer_1, move_group_manager, motor, NodeId::head);
+static auto can_move_group_executor_handler =
+    MoveGroupExecutorHandler(message_writer_1, move_group_manager, motor);
 
 /** Handler of device info requests. */
 static auto device_info_handler =
-    can_device_info::DeviceInfoHandler(message_writer_1, NodeId::head, 0);
+    can_device_info::DeviceInfoHandler(message_writer_1, 0);
 static auto device_info_dispatch_target =
     DispatchParseTarget<decltype(device_info_handler),
                         can_messages::DeviceInfoRequest>{device_info_handler};

--- a/include/can/core/device_info.hpp
+++ b/include/can/core/device_info.hpp
@@ -26,7 +26,7 @@ class DeviceInfoHandler {
      * @param node_id The node id of this device
      * @param version The firmware version on this device
      */
-    DeviceInfoHandler(MessageWriter &writer, NodeId node_id, uint32_t version)
+    DeviceInfoHandler(MessageWriter &writer, uint32_t version)
         : writer(writer), response{.version = version} {}
     DeviceInfoHandler(const DeviceInfoHandler &) = delete;
     DeviceInfoHandler(const DeviceInfoHandler &&) = delete;

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -20,8 +20,8 @@ class MotorHandler {
                      DisableMotorRequest, GetMotionConstraintsRequest,
                      SetMotionConstraints>;
 
-    MotorHandler(MessageWriter &message_writer, Motor &motor, NodeId node_id)
-        : message_writer{message_writer}, motor{motor}, node_id(node_id) {}
+    MotorHandler(MessageWriter &message_writer, Motor &motor)
+        : message_writer{message_writer}, motor{motor} {}
     MotorHandler(const MotorHandler &) = delete;
     MotorHandler(const MotorHandler &&) = delete;
     MotorHandler &operator=(const MotorHandler &) = delete;
@@ -74,7 +74,6 @@ class MotorHandler {
 
     MessageWriter &message_writer;
     Motor &motor;
-    NodeId node_id;
 };
 
 }  // namespace motor_message_handler

--- a/include/can/core/message_handlers/move_group_executor.hpp
+++ b/include/can/core/message_handlers/move_group_executor.hpp
@@ -20,7 +20,6 @@ template <typename Motor>
 struct TaskEntry {
     MessageWriter &message_writer;
     Motor &motor;
-    NodeId node_id;
     void operator()() {
         while (true) {
             auto try_read = Ack{};
@@ -44,13 +43,11 @@ class MoveGroupExecutorHandler {
 
     MoveGroupExecutorHandler(
         MessageWriter &message_writer,
-        move_group_handler::MoveGroupType &motion_group_manager, Motor &motor,
-        NodeId node_id)
+        move_group_handler::MoveGroupType &motion_group_manager, Motor &motor)
         : message_writer{message_writer},
           motion_group_manager{motion_group_manager},
           motor(motor),
-          node_id(node_id),
-          task_entry{message_writer, motor, node_id},
+          task_entry{message_writer, motor},
           ack_task("ack task", task_entry) {}
     MoveGroupExecutorHandler(const MoveGroupExecutorHandler &) = delete;
     MoveGroupExecutorHandler(const MoveGroupExecutorHandler &&) = delete;
@@ -84,7 +81,6 @@ class MoveGroupExecutorHandler {
     MessageWriter &message_writer;
     move_group_handler::MoveGroupType &motion_group_manager;
     Motor &motor;
-    NodeId node_id;
     TaskEntry<Motor> task_entry;
     freertos_task::FreeRTOSTask<512, 5> ack_task;
 };

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -166,17 +166,15 @@ static motor_class::Motor motor{
 
 static auto move_group_manager = MoveGroupType{};
 /** The parsed message handler */
-static auto can_motor_handler =
-    MotorHandler{message_writer_1, motor, NodeId::pipette};
+static auto can_motor_handler = MotorHandler{message_writer_1, motor};
 static auto can_move_group_handler =
     MoveGroupHandler(message_writer_1, move_group_manager);
-static auto can_move_group_executor_handler = MoveGroupExecutorHandler(
-    message_writer_1, move_group_manager, motor, NodeId::pipette);
+static auto can_move_group_executor_handler =
+    MoveGroupExecutorHandler(message_writer_1, move_group_manager, motor);
 
 static auto i2c_comms = I2C{};
 static auto eeprom_handler = EEPromHandler{message_writer_1, i2c_comms};
-static auto device_info_handler =
-    DeviceInfoHandler{message_writer_1, NodeId::pipette, 0};
+static auto device_info_handler = DeviceInfoHandler{message_writer_1, 0};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target = DispatchParseTarget<


### PR DESCRIPTION
Now that we have the CAN message writer to handle adding the Node ID to the responses, we no longer need to pass the Node ID to the CAN message handlers. 