### PR TITLE
chore: enable werror on all firmware targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,13 +54,13 @@ if (${CMAKE_CROSSCOMPILING})
 
 endif ()
 
+set(LINT_TARGETS "")
 add_subdirectory(common)
 add_subdirectory(can)
 add_subdirectory(pipettes)
 add_subdirectory(gantry)
 add_subdirectory(head)
-
-
+list(REMOVE_DUPLICATES LINT_TARGETS)
 
 find_package(Clang)
 
@@ -93,5 +93,5 @@ add_custom_target(
 add_custom_target(
         lint
         ALL
-        DEPENDS gantry-lint pipettes-lint head-lint
+        DEPENDS ${LINT_TARGETS}
 )

--- a/can/firmware/hal_can_message_buffer.cpp
+++ b/can/firmware/hal_can_message_buffer.cpp
@@ -8,7 +8,11 @@
 #include "can/firmware/utils.hpp"
 #include "common/core/freertos_synchronization.hpp"
 #include "common/core/synchronization.hpp"
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
 #include "platform_specific_hal_conf.h"
+#pragma GCC diagnostic pop
 
 using namespace hal_can_message_buffer;
 

--- a/can/firmware/utils.cpp
+++ b/can/firmware/utils.cpp
@@ -1,6 +1,10 @@
 #include "can/firmware/utils.hpp"
 
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
 #include "platform_specific_hal_fdcan.h"
+#pragma GCC diagnostic pop
 
 using namespace can_bus;
 

--- a/common/firmware/i2c/i2c_comms.cpp
+++ b/common/firmware/i2c/i2c_comms.cpp
@@ -1,6 +1,10 @@
 #include "common/firmware/i2c_comms.hpp"
 
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
 #include "common/firmware/i2c.h"
+#pragma GCC diagnostic pop
 
 using namespace i2c;
 

--- a/gantry/CMakeLists.txt
+++ b/gantry/CMakeLists.txt
@@ -29,3 +29,5 @@ add_custom_target(
         gantry-format-ci
         COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -Werror --ferror-limit=0 -n ${GANTRY_SOURCES_FOR_FORMAT}
 )
+
+set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -115,6 +115,9 @@ list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
 add_custom_target(gantry-lint
         ALL
         COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${GANTRY_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SRCS} --config=)
+list(APPEND LINT_TARGETS "gantry-lint")
+set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)
+
 
 # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
 # arguable misuse of the concept) to the appropriate cross-gdb with

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -26,6 +26,7 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/clocking.c
         ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tim7.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/can/can.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -9,18 +9,23 @@
 #include "can/core/message_handlers/move_group_executor.hpp"
 #include "can/core/message_writer.hpp"
 #include "can/core/messages.hpp"
-#include "can/firmware/hal_can_bus.hpp"
-#include "can/firmware/hal_can_message_buffer.hpp"
 #include "common/core/freertos_message_queue.hpp"
 #include "common/core/freertos_task.hpp"
-#include "common/firmware/can.h"
 #include "common/firmware/errors.h"
 #include "common/firmware/spi_comms.hpp"
 #include "gantry/core/axis_type.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/motor.hpp"
 #include "motor-control/core/motor_messages.hpp"
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "can/firmware/hal_can_bus.hpp"
+#include "can/firmware/hal_can_message_buffer.hpp"
+#include "common/firmware/can.h"
+#include "motor_hardware.h"
 #include "platform_specific_hal_conf.h"
+#pragma GCC diagnostic pop
 
 using namespace freertos_task;
 using namespace freertos_can_dispatch;
@@ -45,91 +50,6 @@ static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
 static freertos_message_queue::FreeRTOSMessageQueue<Ack> complete_queue(
     "Complete Queue");
 
-void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    if (hspi->Instance == SPI2) {
-        /* Peripheral clock enable */
-        __HAL_RCC_SPI2_CLK_ENABLE();
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        __HAL_RCC_GPIOB_CLK_ENABLE();
-        __HAL_RCC_GPIOC_CLK_ENABLE();
-        /**SPI2 GPIO Configuration
-        PB12  ------> SPI2_CS
-        PB13  ------> SPI2_SCK
-        PB14  ------> SPI2_MISO
-        PB15  ------> SPI2_MOSI
-        Step/Dir
-        PB1   ------> Motor Dir Pin
-        PC8   ------> Motor Step Pin
-        Enable
-        PA9   ------> Motor Enable Pin
-        */
-        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-        // Chip select
-        GPIO_InitStruct.Pin = GPIO_PIN_12;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-        // Dir
-        GPIO_InitStruct.Pin = GPIO_PIN_1;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-        // Step
-        GPIO_InitStruct.Pin = GPIO_PIN_8;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-                      &GPIO_InitStruct);
-
-        // Enable
-        GPIO_InitStruct.Pin = GPIO_PIN_9;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOA,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-                      &GPIO_InitStruct);
-    }
-}
-SPI_HandleTypeDef hspi2 = {
-    .Instance = SPI2,
-    .Init = {.Mode = SPI_MODE_MASTER,
-             .Direction = SPI_DIRECTION_2LINES,
-             .DataSize = SPI_DATASIZE_8BIT,
-             .CLKPolarity = SPI_POLARITY_HIGH,
-             .CLKPhase = SPI_PHASE_2EDGE,
-             .NSS = SPI_NSS_SOFT,
-             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
-             .FirstBit = SPI_FIRSTBIT_MSB,
-             .TIMode = SPI_TIMODE_DISABLE,
-             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
-             .CRCPolynomial = 7,
-             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
-             .NSSPMode = SPI_NSS_PULSE_DISABLE}
-
-};
-
-/**
- * @brief SPI MSP De-Initialization
- * This function freeze the hardware resources used in this example
- * @param hspi: SPI handle pointer
- * @retval None
- */
-void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
-    if (hspi->Instance == SPI2) {
-        /* Peripheral clock disable */
-        __HAL_RCC_SPI2_CLK_DISABLE();
-        HAL_GPIO_DeInit(GPIOB, GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 |
-                                   GPIO_PIN_15 | GPIO_PIN_1);
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_9);
-        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_8);
-    }
-}
 spi::SPI_interface SPI_intf = {
 
     .SPI_handle = &hspi2,
@@ -210,8 +130,8 @@ static auto dispatcher = Dispatcher(
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
-    __HAL_RCC_SPI2_CLK_ENABLE();
-    if (HAL_SPI_Init(&hspi2) != HAL_OK) {
+
+    if (initialize_spi() != HAL_OK) {
         Error_Handler();
     }
     can_bus::setup_node_id_filter(can_bus_1, axis_type::get_node_id());

--- a/gantry/firmware/main.cpp
+++ b/gantry/firmware/main.cpp
@@ -4,13 +4,18 @@
 
 // clang-format off
 #include "FreeRTOS.h"
-#include "system_stm32g4xx.h"
 #include "task.h"
+#include "system_stm32g4xx.h"
 // clang-format on
 
-#include "common/firmware/can_task.hpp"
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
 #include "common/firmware/clocking.h"
 #include "common/firmware/utility_gpio.h"
+#pragma GCC diagnostic pop
+
+#include "common/firmware/can_task.hpp"
 
 auto main() -> int {
     HardwareInit();

--- a/gantry/firmware/motor_hardware.c
+++ b/gantry/firmware/motor_hardware.c
@@ -1,0 +1,92 @@
+#include "motor_hardware.h"
+
+void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock enable */
+        __HAL_RCC_SPI2_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**SPI2 GPIO Configuration
+        PB12  ------> SPI2_CS
+        PB13  ------> SPI2_SCK
+        PB14  ------> SPI2_MISO
+        PB15  ------> SPI2_MOSI
+        Step/Dir
+        PB1   ------> Motor Dir Pin
+        PC8   ------> Motor Step Pin
+        Enable
+        PA9   ------> Motor Enable Pin
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        // Chip select
+        GPIO_InitStruct.Pin = GPIO_PIN_12;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        // Dir
+        GPIO_InitStruct.Pin = GPIO_PIN_1;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        // Step
+        GPIO_InitStruct.Pin = GPIO_PIN_8;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                      &GPIO_InitStruct);
+
+        // Enable
+        GPIO_InitStruct.Pin = GPIO_PIN_9;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOA,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                      &GPIO_InitStruct);
+    }
+}
+SPI_HandleTypeDef hspi2 = {
+    .Instance = SPI2,
+    .Init = {.Mode = SPI_MODE_MASTER,
+             .Direction = SPI_DIRECTION_2LINES,
+             .DataSize = SPI_DATASIZE_8BIT,
+             .CLKPolarity = SPI_POLARITY_HIGH,
+             .CLKPhase = SPI_PHASE_2EDGE,
+             .NSS = SPI_NSS_SOFT,
+             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
+             .FirstBit = SPI_FIRSTBIT_MSB,
+             .TIMode = SPI_TIMODE_DISABLE,
+             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
+             .CRCPolynomial = 7,
+             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
+             .NSSPMode = SPI_NSS_PULSE_DISABLE}
+
+};
+
+/**
+ * @brief SPI MSP De-Initialization
+ * This function freeze the hardware resources used in this example
+ * @param hspi: SPI handle pointer
+ * @retval None
+ */
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock disable */
+        __HAL_RCC_SPI2_CLK_DISABLE();
+        HAL_GPIO_DeInit(GPIOB, GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 |
+                                   GPIO_PIN_15 | GPIO_PIN_1);
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_9);
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_8);
+    }
+}
+
+HAL_StatusTypeDef initialize_spi() {
+    __HAL_RCC_SPI2_CLK_ENABLE();
+    return HAL_SPI_Init(&hspi2);
+}

--- a/gantry/firmware/motor_hardware.h
+++ b/gantry/firmware/motor_hardware.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "platform_specific_hal_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+extern SPI_HandleTypeDef hspi2;
+
+HAL_StatusTypeDef initialize_spi(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/head/CMakeLists.txt
+++ b/head/CMakeLists.txt
@@ -27,3 +27,5 @@ add_custom_target(
   head-format-ci
   COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -Werror --ferror-limit=0 -n ${HEAD_SOURCES_FOR_FORMAT}
 )
+
+set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -25,6 +25,7 @@ set(HEAD_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/stm32g4xx_it.c
         ${CMAKE_CURRENT_SOURCE_DIR}/clocking.c
         ${CMAKE_CURRENT_SOURCE_DIR}/tim7.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/can/can.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -107,7 +107,8 @@ list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
 add_custom_target(head-lint
         ALL
         COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${HEAD_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES} --config=)
-
+list(APPEND LINT_TARGETS head-lint)
+set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)
 # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
 # arguable misuse of the concept) to the appropriate cross-gdb with
 # remote-target. You should make sure st-util is running; that's not

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -9,17 +9,22 @@
 #include "can/core/message_handlers/move_group_executor.hpp"
 #include "can/core/message_writer.hpp"
 #include "can/core/messages.hpp"
-#include "can/firmware/hal_can_bus.hpp"
-#include "can/firmware/hal_can_message_buffer.hpp"
 #include "common/core/freertos_message_queue.hpp"
 #include "common/core/freertos_task.hpp"
-#include "common/firmware/can.h"
 #include "common/firmware/errors.h"
 #include "common/firmware/spi_comms.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/motor.hpp"
 #include "motor-control/core/motor_messages.hpp"
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "can/firmware/hal_can_bus.hpp"
+#include "can/firmware/hal_can_message_buffer.hpp"
+#include "common/firmware/can.h"
+#include "motor_hardware.h"
 #include "platform_specific_hal_conf.h"
+#pragma GCC diagnostic pop
 
 using namespace freertos_task;
 using namespace freertos_can_dispatch;
@@ -48,158 +53,6 @@ static freertos_message_queue::FreeRTOSMessageQueue<Ack> complete_queue(
  * @param hspi: SPI handle pointer
  * @retval None
  */
-void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    if (hspi->Instance == SPI2) {
-        /* Peripheral clock enable */
-        __HAL_RCC_SPI2_CLK_ENABLE();
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        __HAL_RCC_GPIOB_CLK_ENABLE();
-        /**SPI2 GPIO Configuration
-        PB12     ------> SPI2_NSS
-        PB13     ------> SPI2_SCK
-        PB14     ------> SPI2_MISO
-        PB15     ------> SPI2_MOSI
-         Step/Dir
-         PC7  ---> Dir Pin Motor A
-         PC6  ---> Step Pin Motor A
-        */
-        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-        // Chip select and tmc2130 clock and enable
-        GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_0 | GPIO_PIN_11;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0, GPIO_PIN_RESET);
-
-        GPIO_InitStruct.Pin = GPIO_PIN_6 | GPIO_PIN_7;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-                      &GPIO_InitStruct);
-    }
-
-    else if (hspi->Instance == SPI3) {
-        /* Peripheral clock enable */
-        __HAL_RCC_SPI3_CLK_ENABLE();
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        __HAL_RCC_GPIOC_CLK_ENABLE();
-        /**SPI3 GPIO Configuration
-        PA4     ------> SPI3_NSS
-        PC10     ------> SPI3_SCK
-        PC11     ------> SPI3_MISO
-        PC12     ------> SPI3_MOSI
-         Step/Dir
-         PC1  ---> Dir Pin Motor on SPI3 (Z-axis)
-         PC0  ---> Step Pin Motor on SPI3 (Z-axis)
-        */
-        GPIO_InitStruct.Pin = GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-        GPIO_InitStruct.Alternate = GPIO_AF6_SPI3;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-        // Chip select
-        GPIO_InitStruct.Pin = GPIO_PIN_4;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
-        // Ctrl/Dir/Step pin for motor on SPI3 (Z-axis)
-        GPIO_InitStruct.Pin = GPIO_PIN_4;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-                      &GPIO_InitStruct);
-    }
-}
-
-/**
- * @brief SPI MSP De-Initialization
- * This function denits SPI for Z/A motors
- * @param hspi: SPI2 handle pointer
- * @retval None
- */
-void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
-    if (hspi->Instance == SPI2) {
-        /* Peripheral clock disable */
-        __HAL_RCC_SPI2_CLK_DISABLE();
-
-        /**SPI2 GPIO Configuration
-        PB12     ------> SPI2_NSS
-        PB13     ------> SPI2_SCK
-        PB14     ------> SPI2_MISO
-        PB15     ------> SPI2_MOSI
-
-        Step/Dir
-         PC7  ---> Dir Pin Motor on SPI2 (A-axis)
-         PC6  ---> Step Pin Motor on SPI2 (A-axis)
-        */
-        HAL_GPIO_DeInit(GPIOB,
-                        GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15);
-        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_6 | GPIO_PIN_7);
-    } else if (hspi->Instance == SPI3) {
-        /* Peripheral clock disable */
-        __HAL_RCC_SPI2_CLK_DISABLE();
-
-        /**SPI3 GPIO Configuration
-        PA04     ------> SPI3_NSS
-        PC10     ------> SPI3_SCK
-        PC11     ------> SPI3_MISO
-        PC12     ------> SPI3_MOSI
-        Step/Dir
-         PC1  ---> Dir Pin Motor on SPI3 (Z-axis)
-         PC0  ---> Step Pin Motor on SPI3 (Z-axis)
-        */
-        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12 |
-                                   GPIO_PIN_0 | GPIO_PIN_1);
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_4);
-    }
-}
-SPI_HandleTypeDef hspi2 = {
-    .Instance = SPI2,
-    .Init = {.Mode = SPI_MODE_MASTER,
-             .Direction = SPI_DIRECTION_2LINES,
-             .DataSize = SPI_DATASIZE_8BIT,
-             .CLKPolarity = SPI_POLARITY_HIGH,
-             .CLKPhase = SPI_PHASE_2EDGE,
-             .NSS = SPI_NSS_SOFT,
-             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
-             .FirstBit = SPI_FIRSTBIT_MSB,
-             .TIMode = SPI_TIMODE_DISABLE,
-             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
-             .CRCPolynomial = 7,
-             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
-             .NSSPMode = SPI_NSS_PULSE_DISABLE}
-
-};
-
-SPI_HandleTypeDef hspi3 = {
-    .Instance = SPI3,
-    .Init = {.Mode = SPI_MODE_MASTER,
-             .Direction = SPI_DIRECTION_2LINES,
-             .DataSize = SPI_DATASIZE_8BIT,
-             .CLKPolarity = SPI_POLARITY_HIGH,
-             .CLKPhase = SPI_PHASE_2EDGE,
-             .NSS = SPI_NSS_SOFT,
-             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
-             .FirstBit = SPI_FIRSTBIT_MSB,
-             .TIMode = SPI_TIMODE_DISABLE,
-             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
-             .CRCPolynomial = 7,
-             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
-             .NSSPMode = SPI_NSS_PULSE_DISABLE}
-
-};
 
 spi::SPI_interface SPI_intf2 = {
 
@@ -291,12 +144,10 @@ static auto dispatcher = Dispatcher(
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
-    __HAL_RCC_SPI2_CLK_ENABLE();
-    if (HAL_SPI_Init(&hspi2) != HAL_OK) {
+    if (initialize_spi(&hspi2) != HAL_OK) {
         Error_Handler();
     }
-    __HAL_RCC_SPI3_CLK_ENABLE();
-    if (HAL_SPI_Init(&hspi3) != HAL_OK) {
+    if (initialize_spi(&hspi3) != HAL_OK) {
         Error_Handler();
     }
     can_bus::setup_node_id_filter(can_bus_1, NodeId::head);

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -4,11 +4,15 @@
 
 // clang-format off
 #include "FreeRTOS.h"
-#include "system_stm32g4xx.h"
-#include "stm32g4xx_hal_conf.h"
-#include "stm32g4xx_hal.h"
 #include "task.h"
+#include "system_stm32g4xx.h"
 // clang-format on
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_conf.h"
+#pragma GCC diagnostic pop
 
 #include "common/firmware/can_task.hpp"
 #include "common/firmware/clocking.h"

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -1,0 +1,165 @@
+#include "motor_hardware.h"
+
+void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock enable */
+        __HAL_RCC_SPI2_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        /**SPI2 GPIO Configuration
+        PB12     ------> SPI2_NSS
+        PB13     ------> SPI2_SCK
+        PB14     ------> SPI2_MISO
+        PB15     ------> SPI2_MOSI
+         Step/Dir
+         PC7  ---> Dir Pin Motor A
+         PC6  ---> Step Pin Motor A
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        // Chip select and tmc2130 clock and enable
+        GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_0 | GPIO_PIN_11;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0, GPIO_PIN_RESET);
+
+        GPIO_InitStruct.Pin = GPIO_PIN_6 | GPIO_PIN_7;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                      &GPIO_InitStruct);
+    }
+
+    else if (hspi->Instance == SPI3) {
+        /* Peripheral clock enable */
+        __HAL_RCC_SPI3_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**SPI3 GPIO Configuration
+        PA4     ------> SPI3_NSS
+        PC10     ------> SPI3_SCK
+        PC11     ------> SPI3_MISO
+        PC12     ------> SPI3_MOSI
+         Step/Dir
+         PC1  ---> Dir Pin Motor on SPI3 (Z-axis)
+         PC0  ---> Step Pin Motor on SPI3 (Z-axis)
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF6_SPI3;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        // Chip select
+        GPIO_InitStruct.Pin = GPIO_PIN_4;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+        // Ctrl/Dir/Step pin for motor on SPI3 (Z-axis)
+        GPIO_InitStruct.Pin = GPIO_PIN_4;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                      &GPIO_InitStruct);
+    }
+}
+
+/**
+ * @brief SPI MSP De-Initialization
+ * This function denits SPI for Z/A motors
+ * @param hspi: SPI2 handle pointer
+ * @retval None
+ */
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock disable */
+        __HAL_RCC_SPI2_CLK_DISABLE();
+
+        /**SPI2 GPIO Configuration
+        PB12     ------> SPI2_NSS
+        PB13     ------> SPI2_SCK
+        PB14     ------> SPI2_MISO
+        PB15     ------> SPI2_MOSI
+
+        Step/Dir
+         PC7  ---> Dir Pin Motor on SPI2 (A-axis)
+         PC6  ---> Step Pin Motor on SPI2 (A-axis)
+        */
+        HAL_GPIO_DeInit(GPIOB,
+                        GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15);
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_6 | GPIO_PIN_7);
+    } else if (hspi->Instance == SPI3) {
+        /* Peripheral clock disable */
+        __HAL_RCC_SPI2_CLK_DISABLE();
+
+        /**SPI3 GPIO Configuration
+        PA04     ------> SPI3_NSS
+        PC10     ------> SPI3_SCK
+        PC11     ------> SPI3_MISO
+        PC12     ------> SPI3_MOSI
+        Step/Dir
+         PC1  ---> Dir Pin Motor on SPI3 (Z-axis)
+         PC0  ---> Step Pin Motor on SPI3 (Z-axis)
+        */
+        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12 |
+                                   GPIO_PIN_0 | GPIO_PIN_1);
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_4);
+    }
+}
+SPI_HandleTypeDef hspi2 = {
+    .Instance = SPI2,
+    .Init = {.Mode = SPI_MODE_MASTER,
+             .Direction = SPI_DIRECTION_2LINES,
+             .DataSize = SPI_DATASIZE_8BIT,
+             .CLKPolarity = SPI_POLARITY_HIGH,
+             .CLKPhase = SPI_PHASE_2EDGE,
+             .NSS = SPI_NSS_SOFT,
+             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
+             .FirstBit = SPI_FIRSTBIT_MSB,
+             .TIMode = SPI_TIMODE_DISABLE,
+             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
+             .CRCPolynomial = 7,
+             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
+             .NSSPMode = SPI_NSS_PULSE_DISABLE}
+
+};
+
+SPI_HandleTypeDef hspi3 = {
+    .Instance = SPI3,
+    .Init = {.Mode = SPI_MODE_MASTER,
+             .Direction = SPI_DIRECTION_2LINES,
+             .DataSize = SPI_DATASIZE_8BIT,
+             .CLKPolarity = SPI_POLARITY_HIGH,
+             .CLKPhase = SPI_PHASE_2EDGE,
+             .NSS = SPI_NSS_SOFT,
+             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
+             .FirstBit = SPI_FIRSTBIT_MSB,
+             .TIMode = SPI_TIMODE_DISABLE,
+             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
+             .CRCPolynomial = 7,
+             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
+             .NSSPMode = SPI_NSS_PULSE_DISABLE}
+
+};
+
+HAL_StatusTypeDef initialize_spi(SPI_HandleTypeDef* hspi) {
+    if (hspi->Instance == SPI2) {
+        __HAL_RCC_SPI2_CLK_ENABLE();
+    } else if (hspi->Instance == SPI3) {
+        __HAL_RCC_SPI3_CLK_ENABLE();
+    } else {
+        return HAL_ERROR;
+    }
+    return HAL_SPI_Init(hspi);
+}

--- a/head/firmware/motor_hardware.h
+++ b/head/firmware/motor_hardware.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "platform_specific_hal_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+extern SPI_HandleTypeDef hspi3;
+extern SPI_HandleTypeDef hspi2;
+
+HAL_StatusTypeDef initialize_spi(SPI_HandleTypeDef* hspi);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/include/can/firmware/hal_can_bus.hpp
+++ b/include/can/firmware/hal_can_bus.hpp
@@ -6,7 +6,11 @@
 #include "can/core/ids.hpp"
 #include "can/core/parse.hpp"
 #include "common/core/freertos_synchronization.hpp"
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
 #include "platform_specific_hal_fdcan.h"
+#pragma GCC diagnostic pop
 
 namespace hal_can_bus {
 

--- a/include/common/firmware/spi_comms.hpp
+++ b/include/common/firmware/spi_comms.hpp
@@ -2,7 +2,11 @@
 #include <cstdint>
 #include <span>
 
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
 #include "platform_specific_hal_conf.h"
+#pragma GCC diagnostic pop
 
 namespace spi {
 struct SPI_interface {

--- a/pipettes/CMakeLists.txt
+++ b/pipettes/CMakeLists.txt
@@ -27,3 +27,5 @@ add_custom_target(
   pipettes-format-ci
   COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -Werror --ferror-limit=0 -n ${PIPETTES_SOURCES_FOR_FORMAT}
 )
+
+set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -29,6 +29,7 @@ set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/i2c.c
     ${CMAKE_CURRENT_SOURCE_DIR}/can.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
     ${COMMON_EXECUTABLE_DIR}/errors/errors.c
     ${COMMON_EXECUTABLE_DIR}/spi/spi.c
     ${COMMON_EXECUTABLE_DIR}/motor_driver/motor.c)
@@ -57,6 +58,7 @@ target_include_directories(
 target_compile_options(pipettes
         PUBLIC
         -Wall
+        -Werror
         $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
         $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
         $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -114,7 +114,8 @@ list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
 add_custom_target(pipettes-lint
         ALL
         COMMAND ${Clang_CLANGTIDY_EXECUTABLE} ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${PIPETTE_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES} --config=)
-
+list(APPEND LINT_TARGETS pipettes-lint)
+set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)
 # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
 # arguable misuse of the concept) to the appropriate cross-gdb with
 # remote-target. You should make sure st-util is running; that's not

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -10,10 +10,8 @@
 #include "can/core/message_handlers/move_group_executor.hpp"
 #include "can/core/message_writer.hpp"
 #include "can/core/messages.hpp"
-#include "can/firmware/hal_can_message_buffer.hpp"
 #include "common/core/freertos_message_queue.hpp"
 #include "common/core/freertos_task.hpp"
-#include "common/firmware/can.h"
 #include "common/firmware/errors.h"
 #include "common/firmware/i2c_comms.hpp"
 #include "common/firmware/spi_comms.hpp"
@@ -22,7 +20,14 @@
 #include "motor-control/core/motor_messages.hpp"
 #include "pipettes/core/eeprom.hpp"
 #include "pipettes/core/message_handlers/eeprom.hpp"
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "can/firmware/hal_can_message_buffer.hpp"
+#include "common/firmware/can.h"
+#include "motor_hardware.h"
 #include "platform_specific_hal_conf.h"
+#pragma GCC diagnostic pop
 
 using namespace hal_can_bus;
 using namespace can_messages;
@@ -47,85 +52,6 @@ static freertos_message_queue::FreeRTOSMessageQueue<Move> motor_queue(
     "Motor Queue");
 static freertos_message_queue::FreeRTOSMessageQueue<Ack> complete_queue(
     "Complete Queue");
-
-void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    if (hspi->Instance == SPI2) {
-        /* Peripheral clock enable */
-        __HAL_RCC_SPI2_CLK_ENABLE();
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        __HAL_RCC_GPIOB_CLK_ENABLE();
-        /**SPI2 GPIO Configuration
-        PC6     ------> SPI2_CS
-        PB13     ------> SPI2_SCK
-        PB14     ------> SPI2_CIPO
-        PB15     ------> SPI2_COPI
-
-         Step/Dir
-         PC3  ---> Dir Pin
-         PC7  ---> Step Pin
-         Enable
-         PC8  ---> Enable Pin
-        */
-        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
-        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-        // Chip select
-        GPIO_InitStruct.Pin = GPIO_PIN_6;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-        // Enable/Dir/Step pin
-        GPIO_InitStruct.Pin = GPIO_PIN_3 | GPIO_PIN_7 | GPIO_PIN_8;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
-        GPIO_InitStruct.Pin = GPIO_PIN_7 | GPIO_PIN_8;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-                      &GPIO_InitStruct);
-    }
-}
-SPI_HandleTypeDef hspi2 = {
-    .Instance = SPI2,
-    .Init = {.Mode = SPI_MODE_MASTER,
-             .Direction = SPI_DIRECTION_2LINES,
-             .DataSize = SPI_DATASIZE_8BIT,
-             .CLKPolarity = SPI_POLARITY_HIGH,
-             .CLKPhase = SPI_PHASE_2EDGE,
-             .NSS = SPI_NSS_SOFT,
-             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
-             .FirstBit = SPI_FIRSTBIT_MSB,
-             .TIMode = SPI_TIMODE_DISABLE,
-             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
-             .CRCPolynomial = 7,
-             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
-             .NSSPMode = SPI_NSS_PULSE_DISABLE}
-
-};
-
-void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
-    if (hspi->Instance == SPI2) {
-        /* Peripheral clock disable */
-        __HAL_RCC_SPI2_CLK_DISABLE();
-
-        /**SPI2 GPIO Configuration
-        PB12     ------> SPI2_NSS
-        PB13     ------> SPI2_SCK
-        PB14     ------> SPI2_MISO
-        PB15     ------> SPI2_MOSI
-        */
-        HAL_GPIO_DeInit(GPIOB,
-                        GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15);
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_8 | GPIO_PIN_9);
-    }
-}
 
 spi::SPI_interface SPI_intf = {
 
@@ -213,8 +139,8 @@ static auto dispatcher = Dispatcher(
     if (MX_FDCAN1_Init(&fdcan1) != HAL_OK) {
         Error_Handler();
     }
-    __HAL_RCC_SPI2_CLK_ENABLE();
-    if (HAL_SPI_Init(&hspi2) != HAL_OK) {
+
+    if (initialize_spi() != HAL_OK) {
         Error_Handler();
     }
     can_bus::setup_node_id_filter(can_bus_1, NodeId::pipette);

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -1,0 +1,87 @@
+#include "motor_hardware.h"
+
+HAL_StatusTypeDef initialize_spi(void);
+
+void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock enable */
+        __HAL_RCC_SPI2_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        /**SPI2 GPIO Configuration
+        PC6     ------> SPI2_CS
+        PB13     ------> SPI2_SCK
+        PB14     ------> SPI2_CIPO
+        PB15     ------> SPI2_COPI
+
+         Step/Dir
+         PC3  ---> Dir Pin
+         PC7  ---> Step Pin
+         Enable
+         PC8  ---> Enable Pin
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        // Chip select
+        GPIO_InitStruct.Pin = GPIO_PIN_6;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        // Enable/Dir/Step pin
+        GPIO_InitStruct.Pin = GPIO_PIN_3 | GPIO_PIN_7 | GPIO_PIN_8;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        GPIO_InitStruct.Pin = GPIO_PIN_7 | GPIO_PIN_8;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                      &GPIO_InitStruct);
+    }
+}
+SPI_HandleTypeDef hspi2 = {
+    .Instance = SPI2,
+    .Init = {.Mode = SPI_MODE_MASTER,
+             .Direction = SPI_DIRECTION_2LINES,
+             .DataSize = SPI_DATASIZE_8BIT,
+             .CLKPolarity = SPI_POLARITY_HIGH,
+             .CLKPhase = SPI_PHASE_2EDGE,
+             .NSS = SPI_NSS_SOFT,
+             .BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32,
+             .FirstBit = SPI_FIRSTBIT_MSB,
+             .TIMode = SPI_TIMODE_DISABLE,
+             .CRCCalculation = SPI_CRCCALCULATION_DISABLE,
+             .CRCPolynomial = 7,
+             .CRCLength = SPI_CRC_LENGTH_DATASIZE,
+             .NSSPMode = SPI_NSS_PULSE_DISABLE}
+
+};
+
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
+    if (hspi->Instance == SPI2) {
+        /* Peripheral clock disable */
+        __HAL_RCC_SPI2_CLK_DISABLE();
+
+        /**SPI2 GPIO Configuration
+        PB12     ------> SPI2_NSS
+        PB13     ------> SPI2_SCK
+        PB14     ------> SPI2_MISO
+        PB15     ------> SPI2_MOSI
+        */
+        HAL_GPIO_DeInit(GPIOB,
+                        GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15);
+        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_8 | GPIO_PIN_9);
+    }
+}
+
+HAL_StatusTypeDef initialize_spi(void) {
+    __HAL_RCC_SPI2_CLK_ENABLE();
+    return HAL_SPI_Init(&hspi2);
+}

--- a/pipettes/firmware/motor_hardware.h
+++ b/pipettes/firmware/motor_hardware.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "platform_specific_hal_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+extern SPI_HandleTypeDef hspi2;
+
+HAL_StatusTypeDef initialize_spi(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/pipettes/firmware/step_motor.cpp
+++ b/pipettes/firmware/step_motor.cpp
@@ -1,8 +1,12 @@
 #include "motor-control/core/step_motor.hpp"
 
-#include "common/firmware/timer_interrupt.h"
 #include "motor-control/core/motor_messages.hpp"
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "common/firmware/timer_interrupt.h"
 #include "stm32l5xx_hal.h"
+#pragma GCC diagnostic pop
 
 using namespace motor_messages;
 


### PR DESCRIPTION
```
              _,-'|
           ,-'._  |
 .||,      |####\ |
\.`',/     \####| |
= ,. =      |###| | i cast -Werror
/ || \    ,-'\#/,'`.
  ||     ,'   `,,. `.
  ,|____,' , ,;' \| |
 (3|\    _/|/'   _| |
  ||/,-''  | >-'' _,\\
  ||'      ==\ ,-'  ,'
  ||       |  V \ ,|
  ||       |    |` |
  ||       |    |   \
  ||       |    \    \
  ||       |     |    \
  ||       |      \_,-'
  ||       |___,,--")_\
  ||         |_|   ccc/
  ||        ccc/
  ||                hjm
```
You have been visited by the -Werror -Wizard, who has fixed all the compiler warnings and enabled `-Werror` so that they are now compiler errors instead. No more shall we tolerate these warnings! Remove them with extreme prejudice.