### PR TITLE
feat(motion-control): add CAN messages to read/write to motor driver registers

### DIFF
--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -139,7 +139,8 @@ static auto motor_dispatch_target = DispatchParseTarget<
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
     can_messages::DisableMotorRequest,
     can_messages::GetMotionConstraintsRequest,
-    can_messages::SetMotionConstraints>{can_motor_handler};
+    can_messages::SetMotionConstraints, can_messages::WriteMotorDriverRegister,
+    can_messages::ReadMotorDriverRegister>{can_motor_handler};
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -63,7 +63,6 @@ static freertos_message_queue::FreeRTOSMessageQueue<Ack> complete_queue(
     "Complete Queue");
 
 spi::SPI_interface SPI_intf = {
-
     .SPI_handle = &hspi2,
     .GPIO_handle = GPIOB,
     .pin = GPIO_PIN_12,
@@ -82,17 +81,18 @@ struct motion_controller::HardwareConfig PinConfigurations {
 static RegisterConfig register_config_by_axis(GantryAxisType which) {
     switch (which) {
         case GantryAxisType::gantry_x:
-            return RegisterConfig{{DriverRegisters::GCONF, 0x04},
-                                  {DriverRegisters::IHOLD_IRUN, 0x71002},
-                                  {DriverRegisters::CHOPCONF, 0x101D5},
-                                  {DriverRegisters::THIGH, 0xFFFFF},
-                                  {DriverRegisters::COOLCONF, 0x60000}};
+            return RegisterConfig{.gconf = 0x04,
+                                  .ihold_irun = 0x71002,
+                                  .chopconf = 0x101D5,
+                                  .thigh = 0xFFFFF,
+                                  .coolconf = 0x60000};
+
         case GantryAxisType::gantry_y:
-            return RegisterConfig{{DriverRegisters::GCONF, 0x04},
-                                  {DriverRegisters::IHOLD_IRUN, 0x71002},
-                                  {DriverRegisters::CHOPCONF, 0x101D5},
-                                  {DriverRegisters::THIGH, 0xFFFFF},
-                                  {DriverRegisters::COOLCONF, 0x60000}};
+            return RegisterConfig{.gconf = 0x04,
+                                  .ihold_irun = 0x71002,
+                                  .chopconf = 0x101D5,
+                                  .thigh = 0xFFFFF,
+                                  .coolconf = 0x60000};
     }
 }
 
@@ -164,6 +164,9 @@ static auto dispatcher = Dispatcher(
     if (initialize_spi(my_axis_type) != HAL_OK) {
         Error_Handler();
     }
+
+    motor.driver.setup();
+
     can_bus::setup_node_id_filter(can_bus_1, my_node_id);
     can_bus_1.start();
 

--- a/gantry/firmware/can_task.cpp
+++ b/gantry/firmware/can_task.cpp
@@ -16,6 +16,7 @@
 #include "gantry/core/axis_type.h"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/motor.hpp"
+#include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/motor_messages.hpp"
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
@@ -39,6 +40,7 @@ using namespace motor_message_handler;
 using namespace move_group_handler;
 using namespace move_group_executor_handler;
 using namespace motor_messages;
+using namespace motor_driver_config;
 
 static constexpr NodeId node_from_axis(GantryAxisType which) {
     switch (which) {
@@ -77,6 +79,23 @@ struct motion_controller::HardwareConfig PinConfigurations {
         .port = GPIOA, .pin = GPIO_PIN_9, .active_setting = GPIO_PIN_SET},
 };
 
+static RegisterConfig register_config_by_axis(GantryAxisType which) {
+    switch (which) {
+        case GantryAxisType::gantry_x:
+            return RegisterConfig{{DriverRegisters::GCONF, 0x04},
+                                  {DriverRegisters::IHOLD_IRUN, 0x71002},
+                                  {DriverRegisters::CHOPCONF, 0x101D5},
+                                  {DriverRegisters::THIGH, 0xFFFFF},
+                                  {DriverRegisters::COOLCONF, 0x60000}};
+        case GantryAxisType::gantry_y:
+            return RegisterConfig{{DriverRegisters::GCONF, 0x04},
+                                  {DriverRegisters::IHOLD_IRUN, 0x71002},
+                                  {DriverRegisters::CHOPCONF, 0x101D5},
+                                  {DriverRegisters::THIGH, 0xFFFFF},
+                                  {DriverRegisters::COOLCONF, 0x60000}};
+    }
+}
+
 /**
  * TODO: This motor class is only used in motor handler and should be
  * instantiated inside of the MotorHandler class. However, some refactors
@@ -95,6 +114,7 @@ static motor_class::Motor motor{
                       .max_velocity = 2,
                       .min_acceleration = 1,
                       .max_acceleration = 2},
+    register_config_by_axis(my_axis_type),
     motor_queue,
     complete_queue};
 

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -81,11 +81,11 @@ struct motion_controller::HardwareConfig PinConfigurations {
         .port = GPIOC, .pin = GPIO_PIN_4, .active_setting = GPIO_PIN_SET},
 };
 
-RegisterConfig MotorDriverConfigurations{{DriverRegisters::GCONF, 0x04},
-                                         {DriverRegisters::IHOLD_IRUN, 0x70202},
-                                         {DriverRegisters::CHOPCONF, 0x101D5},
-                                         {DriverRegisters::THIGH, 0xFFFFF},
-                                         {DriverRegisters::COOLCONF, 0x60000}};
+RegisterConfig MotorDriverConfigurations{.gconf = 0x04,
+                                         .ihold_irun = 0x70202,
+                                         .chopconf = 0x101D5,
+                                         .thigh = 0xFFFFF,
+                                         .coolconf = 0x60000};
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -159,6 +159,9 @@ static auto dispatcher = Dispatcher(
     if (initialize_spi(&hspi3) != HAL_OK) {
         Error_Handler();
     }
+
+    motor.driver.setup();
+
     can_bus::setup_node_id_filter(can_bus_1, NodeId::head);
     can_bus_1.start();
 

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -15,6 +15,7 @@
 #include "common/firmware/spi_comms.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/motor.hpp"
+#include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/motor_messages.hpp"
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
@@ -36,6 +37,7 @@ using namespace motor_message_handler;
 using namespace move_group_handler;
 using namespace move_group_executor_handler;
 using namespace motor_messages;
+using namespace motor_driver_config;
 using namespace spi;
 
 extern FDCAN_HandleTypeDef fdcan1;
@@ -79,6 +81,12 @@ struct motion_controller::HardwareConfig PinConfigurations {
         .port = GPIOC, .pin = GPIO_PIN_4, .active_setting = GPIO_PIN_SET},
 };
 
+RegisterConfig MotorDriverConfigurations{{DriverRegisters::GCONF, 0x04},
+                                         {DriverRegisters::IHOLD_IRUN, 0x70202},
+                                         {DriverRegisters::CHOPCONF, 0x101D5},
+                                         {DriverRegisters::THIGH, 0xFFFFF},
+                                         {DriverRegisters::COOLCONF, 0x60000}};
+
 /**
  * TODO: This motor class is only used in motor handler and should be
  * instantiated inside of the MotorHandler class. However, some refactors
@@ -97,6 +105,7 @@ static motor_class::Motor motor{
                       .max_velocity = 2,
                       .min_acceleration = 1,
                       .max_acceleration = 2},
+    MotorDriverConfigurations,
     motor_queue,
     complete_queue};
 

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -132,7 +132,8 @@ static auto motor_dispatch_target = DispatchParseTarget<
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
     can_messages::DisableMotorRequest,
     can_messages::GetMotionConstraintsRequest,
-    can_messages::SetMotionConstraints>{can_motor_handler};
+    can_messages::SetMotionConstraints, can_messages::WriteMotorDriverRegister,
+    can_messages::ReadMotorDriverRegister>{can_motor_handler};
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -65,7 +65,11 @@ enum class MessageId : uint16_t {
 
     write_eeprom = 0x2001,
     read_eeprom_request = 0x2002,
-    read_eeprom_response = 0x2003
+    read_eeprom_response = 0x2003,
+
+    write_motor_driver_register_request = 0x30,
+    read_motor_driver_register_request = 0x31,
+    read_motor_driver_register_response = 0x32
 };
 
 }  // namespace can_ids

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -4,12 +4,14 @@
 #include "can/core/message_writer.hpp"
 #include "can/core/messages.hpp"
 #include "common/core/message_queue.hpp"
+#include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/motor_messages.hpp"
 
 namespace motor_message_handler {
 
 using namespace can_message_writer;
 using namespace can_messages;
+using namespace motor_driver_config;
 
 template <class Motor>
 class MotorHandler {
@@ -74,12 +76,17 @@ class MotorHandler {
     }
 
     void visit(WriteMotorDriverRegister &m) {
-        motor.driver.write(m.reg_address, m.data);
+        if (DriverRegisters::is_valid_address(m.reg_address)) {
+            motor.driver.write(DriverRegisters::Addresses(m.reg_address),
+                               m.data);
+        }
     }
 
     void visit(ReadMotorDriverRegister &m) {
         uint32_t data;
-        motor.driver.read(m.reg_address, data);
+        if (DriverRegisters::is_valid_address(m.reg_address)) {
+            motor.driver.read(DriverRegisters::Addresses(m.reg_address), data);
+        }
         ReadMotorDriverRegisterResponse response_msg{
             .reg_address = m.reg_address,
             .data = data,

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -323,4 +323,53 @@ struct GetMotionConstraintsResponse
     bool operator==(const GetMotionConstraintsResponse& other) const = default;
 };
 
+struct WriteMotorDriverRegister
+    : BaseMessage<MessageId::write_motor_driver_register_request> {
+    uint8_t reg_address;
+    uint32_t data;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> WriteMotorDriverRegister {
+        uint8_t reg_address = 0;
+        uint32_t data = 0;
+        body = bit_utils::bytes_to_int(body, limit, reg_address);
+        body = bit_utils::bytes_to_int(body, limit, data);
+        return WriteMotorDriverRegister{.reg_address = reg_address,
+                                        .data = data};
+    }
+
+    bool operator==(const WriteMotorDriverRegister& other) const = default;
+};
+
+struct ReadMotorDriverRegister
+    : BaseMessage<MessageId::read_motor_driver_register_request> {
+    uint8_t reg_address;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> ReadMotorDriverRegister {
+        uint8_t reg_address = 0;
+        body = bit_utils::bytes_to_int(body, limit, reg_address);
+        return ReadMotorDriverRegister{.reg_address = reg_address};
+    }
+
+    bool operator==(const ReadMotorDriverRegister& other) const = default;
+};
+
+struct ReadMotorDriverRegisterResponse
+    : Response<MessageId::read_motor_driver_register_response> {
+    uint8_t reg_address;
+    uint32_t data;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = serialize_node_id(body, limit);
+        iter = bit_utils::int_to_bytes(reg_address, iter, limit);
+        iter = bit_utils::int_to_bytes(data, iter, limit);
+        return iter - body;
+    }
+
+    bool operator==(const ReadMotorDriverRegisterResponse& other) const =
+        default;
+};
+
 }  // namespace can_messages

--- a/include/motor-control/core/motor.hpp
+++ b/include/motor-control/core/motor.hpp
@@ -6,12 +6,14 @@
 #include "linear_motion_system.hpp"
 #include "motion_controller.hpp"
 #include "motor_driver.hpp"
+#include "motor_driver_config.hpp"
 #include "motor_messages.hpp"
 #include "spi.hpp"
 
 namespace motor_class {
 
 using namespace motor_messages;
+using namespace motor_driver_config;
 
 template <spi::TMC2130Spi SpiDriver, template <class> class PendingQueueImpl,
           template <class> class CompletedQueueImpl,
@@ -23,11 +25,11 @@ struct Motor {
     using CompletedQueue = CompletedQueueImpl<Ack>;
     Motor(SpiDriver& spi, lms::LinearMotionSystemConfig<MEConfig> lms_config,
           motion_controller::HardwareConfig& config,
-          MotionConstraints constraints, GenericQueue& queue,
-          CompletedQueue& completed_queue)
+          MotionConstraints constraints, RegisterConfig driver_config,
+          GenericQueue& queue, CompletedQueue& completed_queue)
         : pending_move_queue(queue),
           completed_move_queue(completed_queue),
-          driver{spi},
+          driver{spi, driver_config},
           motion_controller{lms_config, config, constraints, pending_move_queue,
                             completed_move_queue} {}
     GenericQueue& pending_move_queue;

--- a/include/motor-control/core/motor_driver.hpp
+++ b/include/motor-control/core/motor_driver.hpp
@@ -25,9 +25,12 @@ class MotorDriver {
         : spi_comms(spi), register_config(conf) {}
 
     void setup() {
-        for (const auto& [key, value] : register_config) {
-            write(key, value);
-        }
+        write(DriverRegisters::GCONF, register_config.gconf);
+        write(DriverRegisters::IHOLD_IRUN, register_config.ihold_irun);
+        write(DriverRegisters::CHOPCONF, register_config.chopconf);
+        write(DriverRegisters::THIGH, register_config.thigh);
+        write(DriverRegisters::COOLCONF, register_config.coolconf);
+
         process_buffer(rxBuffer, status, data);
     }
 

--- a/include/motor-control/core/motor_driver.hpp
+++ b/include/motor-control/core/motor_driver.hpp
@@ -1,33 +1,12 @@
 #pragma once
 
 #include "common/core/bit_utils.hpp"
+#include "motor_driver_config.hpp"
 #include "spi.hpp"
 
 namespace motor_driver {
 
-/**
- * Implementation of the Motor concept.
- *
- */
-
-enum class DriverRegisters : uint8_t {
-    GCONF = 0x00,
-    GSTAT = 0x01,
-    IOIN = 0x04,
-    IHOLD_IRUN = 0x10,
-    TPOWERDOWN = 0x11,
-    TPWMTHRS = 0x13,
-    TCOOLTHRS = 0x14,
-    THIGH = 0x15,
-    XDIRECT = 0x2D,
-    VDCMIN = 0x33,
-    CHOPCONF = 0x6C,
-    COOLCONF = 0x6D,
-    DCCTRL = 0x6E,
-    DRVSTATUS = 0x6F,
-    PWMCONF = 0x70,
-    ENCM_CTRL = 0x72
-};
+using namespace motor_driver_config;
 
 enum class Mode : uint8_t { WRITE = 0x80, READ = 0x0 };
 
@@ -42,41 +21,21 @@ constexpr auto command_byte(Mode mode, DriverRegisters motor_reg) -> uint8_t {
 template <spi::TMC2130Spi SpiDriver>
 class MotorDriver {
   public:
-    explicit MotorDriver(SpiDriver& spi) : spi_comms(spi) {}
+    explicit MotorDriver(SpiDriver& spi, RegisterConfig conf)
+        : spi_comms(spi), register_config(conf) {}
 
     void setup() {
-        constexpr uint32_t gconf_data = 0x04;
-        constexpr uint32_t ihold_irun_data = 0x70202;
-        constexpr uint32_t chopconf = 0x101D5;
-        constexpr uint32_t thigh = 0xFFFFF;
-        constexpr uint32_t coolconf = 0x60000;
-
-        auto txBuffer = build_command(
-            command_byte(Mode::WRITE, DriverRegisters::GCONF), gconf_data);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
-        txBuffer = build_command(
-            command_byte(Mode::WRITE, DriverRegisters::IHOLD_IRUN),
-            ihold_irun_data);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
-        txBuffer = build_command(
-            command_byte(Mode::WRITE, DriverRegisters::CHOPCONF), chopconf);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
-        txBuffer = build_command(
-            command_byte(Mode::WRITE, DriverRegisters::THIGH), thigh);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
-
-        txBuffer = build_command(
-            command_byte(Mode::WRITE, DriverRegisters::COOLCONF), coolconf);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
+        for (const auto& [key, value] : register_config) {
+            write(key, value);
+        }
         process_buffer(rxBuffer, status, data);
     }
 
     void get_status() {
         reset_data();
         reset_status();
-        auto txBuffer = build_command(
-            command_byte(Mode::READ, DriverRegisters::DRVSTATUS), data);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
+        read(DriverRegisters::DRVSTATUS, data);
+
         process_buffer(rxBuffer, status, data);
     }
 
@@ -103,6 +62,21 @@ class MotorDriver {
         return txBuffer;
     }
 
+    auto read(DriverRegisters motor_reg, uint32_t& command_data) -> BufferType {
+        auto txBuffer =
+            build_command(command_byte(Mode::READ, motor_reg), command_data);
+        spi_comms.transmit_receive(txBuffer, rxBuffer);
+        return txBuffer;
+    }
+
+    auto write(DriverRegisters motor_reg, const uint32_t& command_data)
+        -> BufferType {
+        auto txBuffer =
+            build_command(command_byte(Mode::WRITE, motor_reg), command_data);
+        spi_comms.transmit_receive(txBuffer, rxBuffer);
+        return txBuffer;
+    }
+
     void reset_data() { data = 0x0; }
 
     void reset_status() { status = 0x0; }
@@ -116,6 +90,7 @@ class MotorDriver {
     }
 
     SpiDriver spi_comms;
+    RegisterConfig register_config;
 };
 
 }  // namespace motor_driver

--- a/include/motor-control/core/motor_driver_config.hpp
+++ b/include/motor-control/core/motor_driver_config.hpp
@@ -41,4 +41,9 @@ struct RegisterConfig {
     uint32_t encm_ctrl = 0;
 };
 
+template <typename RA>
+concept RegisterAddress = requires {
+    std::is_same_v<RA, DriverRegisters> || std::is_same_v<RA, uint8_t>;
+};
+
 }  // namespace motor_driver_config

--- a/include/motor-control/core/motor_driver_config.hpp
+++ b/include/motor-control/core/motor_driver_config.hpp
@@ -1,24 +1,81 @@
 #pragma once
 
+#include <array>
+
 namespace motor_driver_config {
 
-enum class DriverRegisters : uint8_t {
-    GCONF = 0x00,
-    GSTAT = 0x01,
-    IOIN = 0x04,
-    IHOLD_IRUN = 0x10,
-    TPOWERDOWN = 0x11,
-    TPWMTHRS = 0x13,
-    TCOOLTHRS = 0x14,
-    THIGH = 0x15,
-    XDIRECT = 0x2D,
-    VDCMIN = 0x33,
-    CHOPCONF = 0x6C,
-    COOLCONF = 0x6D,
-    DCCTRL = 0x6E,
-    DRVSTATUS = 0x6F,
-    PWMCONF = 0x70,
-    ENCM_CTRL = 0x72
+struct DriverRegisters {
+    enum Addresses : uint8_t {
+        GCONF = 0x00,
+        GSTAT = 0x01,
+        IOIN = 0x04,
+        IHOLD_IRUN = 0x10,
+        TPOWERDOWN = 0x11,
+        TPWMTHRS = 0x13,
+        TCOOLTHRS = 0x14,
+        THIGH = 0x15,
+        XDIRECT = 0x2D,
+        VDCMIN = 0x33,
+        CHOPCONF = 0x6C,
+        COOLCONF = 0x6D,
+        DCCTRL = 0x6E,
+        DRVSTATUS = 0x6F,
+        PWMCONF = 0x70,
+        ENCM_CTRL = 0x72,
+        TSTEP = 0x12,
+        MSLUT_0 = 0x60,
+        MSLUT_1 = 0x61,
+        MSLUT_2 = 0x62,
+        MSLUT_3 = 0x63,
+        MSLUT_4 = 0x64,
+        MSLUT_5 = 0x65,
+        MSLUT_6 = 0x66,
+        MSLUT_7 = 0x67,
+        MSLUTSEL = 0x68,
+        MSLUTSTART = 0x69,
+        MSCNT = 0x6A,
+        MSCURACT = 0x6B,
+        PWM_SCALE = 0x71,
+        LOST_STEPS = 0x73,
+    };
+
+    static bool is_valid_address(const uint8_t add) {
+        switch (static_cast<Addresses>(add)) {
+            case GCONF:
+            case GSTAT:
+            case IOIN:
+            case IHOLD_IRUN:
+            case TPOWERDOWN:
+            case TPWMTHRS:
+            case TCOOLTHRS:
+            case THIGH:
+            case XDIRECT:
+            case VDCMIN:
+            case CHOPCONF:
+            case COOLCONF:
+            case DCCTRL:
+            case DRVSTATUS:
+            case PWMCONF:
+            case ENCM_CTRL:
+            case TSTEP:
+            case MSLUT_0:
+            case MSLUT_1:
+            case MSLUT_2:
+            case MSLUT_3:
+            case MSLUT_4:
+            case MSLUT_5:
+            case MSLUT_6:
+            case MSLUT_7:
+            case MSLUTSEL:
+            case MSLUTSTART:
+            case MSCNT:
+            case MSCURACT:
+            case PWM_SCALE:
+            case LOST_STEPS:
+                return true;
+        }
+        return false;
+    }
 };
 
 struct RegisterConfig {
@@ -37,11 +94,6 @@ struct RegisterConfig {
     uint32_t dcctrl = 0;
     uint32_t pwmconf = 0;
     uint32_t encm_ctrl = 0;
-};
-
-template <typename RA>
-concept RegisterAddress = requires {
-    std::is_same_v<RA, DriverRegisters> || std::is_same_v<RA, uint8_t>;
 };
 
 }  // namespace motor_driver_config

--- a/include/motor-control/core/motor_driver_config.hpp
+++ b/include/motor-control/core/motor_driver_config.hpp
@@ -23,6 +23,22 @@ enum class DriverRegisters : uint8_t {
     ENCM_CTRL = 0x72
 };
 
-typedef std::map<DriverRegisters, uint32_t> RegisterConfig;
+struct RegisterConfig {
+    uint32_t gconf = 0;
+    uint32_t gstat = 0;
+    uint32_t ioin = 0;
+    uint32_t ihold_irun = 0;
+    uint32_t tpowerdown = 0;
+    uint32_t tpwnthrs = 0;
+    uint32_t tcoolthrs = 0;
+    uint32_t chopconf = 0;
+    uint32_t thigh = 0;
+    uint32_t coolconf = 0;
+    uint32_t xdirect = 0;
+    uint32_t vdcmin = 0;
+    uint32_t dcctrl = 0;
+    uint32_t pwmconf = 0;
+    uint32_t encm_ctrl = 0;
+};
 
 }  // namespace motor_driver_config

--- a/include/motor-control/core/motor_driver_config.hpp
+++ b/include/motor-control/core/motor_driver_config.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <map>
+
+namespace motor_driver_config {
+
+enum class DriverRegisters : uint8_t {
+    GCONF = 0x00,
+    GSTAT = 0x01,
+    IOIN = 0x04,
+    IHOLD_IRUN = 0x10,
+    TPOWERDOWN = 0x11,
+    TPWMTHRS = 0x13,
+    TCOOLTHRS = 0x14,
+    THIGH = 0x15,
+    XDIRECT = 0x2D,
+    VDCMIN = 0x33,
+    CHOPCONF = 0x6C,
+    COOLCONF = 0x6D,
+    DCCTRL = 0x6E,
+    DRVSTATUS = 0x6F,
+    PWMCONF = 0x70,
+    ENCM_CTRL = 0x72
+};
+
+typedef std::map<DriverRegisters, uint32_t> RegisterConfig;
+
+}  // namespace motor_driver_config

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -72,12 +72,11 @@ struct motion_controller::HardwareConfig PinConfigurations {
         .port = GPIOC, .pin = GPIO_PIN_8, .active_setting = GPIO_PIN_SET},
 };
 
-RegisterConfig MotorDriverConfigurations{{DriverRegisters::GCONF, 0x04},
-                                         {DriverRegisters::IHOLD_IRUN, 0x70202},
-                                         {DriverRegisters::CHOPCONF, 0x101D5},
-                                         {DriverRegisters::THIGH, 0xFFFFF},
-                                         {DriverRegisters::COOLCONF, 0x60000}};
-
+RegisterConfig MotorDriverConfigurations{.gconf = 0x04,
+                                         .ihold_irun = 0x70202,
+                                         .chopconf = 0x101D5,
+                                         .thigh = 0xFFFFF,
+                                         .coolconf = 0x60000};
 /**
  * TODO: This motor class is only used in motor handler and should be
  * instantiated inside of the MotorHandler class. However, some refactors
@@ -152,6 +151,9 @@ static auto dispatcher = Dispatcher(
     if (initialize_spi() != HAL_OK) {
         Error_Handler();
     }
+
+    motor.driver.setup();
+
     can_bus::setup_node_id_filter(can_bus_1, NodeId::pipette);
     can_bus_1.start();
 

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -17,6 +17,7 @@
 #include "common/firmware/spi_comms.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/motor.hpp"
+#include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/motor_messages.hpp"
 #include "pipettes/core/eeprom.hpp"
 #include "pipettes/core/message_handlers/eeprom.hpp"
@@ -42,6 +43,7 @@ using namespace motor_message_handler;
 using namespace move_group_handler;
 using namespace move_group_executor_handler;
 using namespace motor_messages;
+using namespace motor_driver_config;
 
 extern FDCAN_HandleTypeDef fdcan1;
 
@@ -70,6 +72,12 @@ struct motion_controller::HardwareConfig PinConfigurations {
         .port = GPIOC, .pin = GPIO_PIN_8, .active_setting = GPIO_PIN_SET},
 };
 
+RegisterConfig MotorDriverConfigurations{{DriverRegisters::GCONF, 0x04},
+                                         {DriverRegisters::IHOLD_IRUN, 0x70202},
+                                         {DriverRegisters::CHOPCONF, 0x101D5},
+                                         {DriverRegisters::THIGH, 0xFFFFF},
+                                         {DriverRegisters::COOLCONF, 0x60000}};
+
 /**
  * TODO: This motor class is only used in motor handler and should be
  * instantiated inside of the MotorHandler class. However, some refactors
@@ -87,6 +95,7 @@ static motor_class::Motor motor{
                       .max_velocity = 2,
                       .min_acceleration = 1,
                       .max_acceleration = 2},
+    MotorDriverConfigurations,
     motor_queue,
     complete_queue};
 

--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -117,7 +117,8 @@ static auto motor_dispatch_target = DispatchParseTarget<
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
     can_messages::DisableMotorRequest,
     can_messages::GetMotionConstraintsRequest,
-    can_messages::SetMotionConstraints>{can_motor_handler};
+    can_messages::SetMotionConstraints, can_messages::WriteMotorDriverRegister,
+    can_messages::ReadMotorDriverRegister>{can_motor_handler};
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,


### PR DESCRIPTION
This PR adds CAN messages to allow us to read and write to motor driver registers via SPI. Mainly for debug purposes.

I've created a pretty terribly useless concept `RegisterAddress` in case we want to touch any undefined motor register addresses via CAN. Should I be doing this? Let me know your thoughts. 