### PR TITLE
chore(gantry): separate gantry targets

### DIFF
--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: "Lint"
         run: cmake --build ./build-cross --target gantry-lint
       - name: "Build"
-        run: cmake --build ./build-cross --target gantry
+        run: cmake --build --preset=gantry
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,6 +71,7 @@
       "displayName": "pipettes binary",
       "description": "Build the pipettes cross binary",
       "configurePreset": "cross-pipettes",
+      "jobs": 4,
       "targets": ["pipettes"]
     },
     {
@@ -78,6 +79,7 @@
       "displayName": "gantry binaries",
       "description": "build the gantry binary targets",
       "configurePreset": "cross",
+      "jobs": 4,
       "targets": ["gantry_x", "gantry_y"]
     },
     {
@@ -85,6 +87,7 @@
       "displayName": "x axis binary",
       "description": "build the x axis binary target",
       "configurePreset": "cross",
+      "jobs": 4,
       "targets": ["gantry_x"]
     },
     {
@@ -92,6 +95,7 @@
       "displayName": "y axis binary",
       "description": "build the y axis binary target",
       "configurePreset": "cross",
+      "jobs": 4,
       "targets": ["gantry_y"]
     },
     {
@@ -99,6 +103,7 @@
       "displayName": "head binary",
       "description": "build the head binary targets",
       "configurePreset": "cross",
+      "jobs": 4,
       "targets": ["head"]
     },
     {
@@ -106,6 +111,7 @@
       "displayName": "tests",
       "description": "build and run all tests",
       "configurePreset": "host-gcc10",
+      "jobs": 4,
       "targets": ["build-and-test"]
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,10 +75,24 @@
     },
     {
       "name": "gantry",
-      "displayName": "gantry binary",
+      "displayName": "gantry binaries",
       "description": "build the gantry binary targets",
       "configurePreset": "cross",
-      "targets": ["gantry"]
+      "targets": ["gantry_x", "gantry_y"]
+    },
+    {
+      "name": "gantry-x",
+      "displayName": "x axis binary",
+      "description": "build the x axis binary target",
+      "configurePreset": "cross",
+      "targets": ["gantry_x"]
+    },
+    {
+      "name": "gantry-y",
+      "displayName": "y axis binary",
+      "description": "build the y axis binary target",
+      "configurePreset": "cross",
+      "targets": ["gantry_y"]
     },
     {
       "name": "head",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -105,7 +105,7 @@
       "name": "tests",
       "displayName": "tests",
       "description": "build and run all tests",
-      "configurePreset": "host",
+      "configurePreset": "host-gcc10",
       "targets": ["build-and-test"]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To setup this directory to run on an STM32G4 system board (gantry and head), you
 
 1. `cmake --preset=cross .`
 2. `cmake --build --preset=gantry --target <TARGET>` or `cmake --build --preset=head --target <TARGET>`
+3. To build a specific gantry you can also use the `gantry_x` and `gantry_y` targets
 
 To setup this directory to run on an STML5 nucleo board (pipettes), you should run:
 
@@ -54,10 +55,11 @@ To setup this directory to run tests, you should run:
 
 #### Gantry Subsystem
 
-The default axis type for the gantry target is X. You can build the Y gantry by running:
+While the `gantry` target builds both, there are separate firmwares (and separate cmake targets) for x and y:
 
-1. `cmake --preset=cross -DGANTRY_AXIS_TYPE=gantry_y .`
-2. `cmake --build --preset=gantry`
+1. `cmake --preset=cross .`
+2. `cmake --build --preset=gantry-x` or `cmake --build --preset=gantry-x --target=gantry-debug-x`
+3. `cmake --build --preset=gantry-y` or `cmake --build --preset=gantry-y --target gantry-debug-y`
 
 ### Cross-compiling vs Host-compiling
 

--- a/gantry/core/CMakeLists.txt
+++ b/gantry/core/CMakeLists.txt
@@ -1,29 +1,4 @@
-# This CMakeLists.txt handles compiling all the parts of the gantry
-# module that are portable between host and cross compilation as a static
-# library. It is included in both host and cross configurations.
-if (NOT GANTRY_AXIS_TYPE)
-    SET(GANTRY_AXIS_TYPE "gantry_x" CACHE STRING "Defines the gantry axis: gantry_x or gantry_y")
-endif ()
-
-
-configure_file(./axis_type.cpp.in ./axis_type.cpp)
-
-set(CORE_NONLINTABLE_SRCS
-        ${CMAKE_CURRENT_BINARY_DIR}/axis_type.cpp)
-
-add_library(gantry-core STATIC
-        ${CORE_NONLINTABLE_SRCS}
-        )
-
-set_target_properties(gantry-core
-        PROPERTIES CXX_STANDARD 20
-        CXX_STANDARD_REQUIRED TRUE)
-
-target_include_directories(gantry-core
-        PUBLIC ${CMAKE_SOURCE_DIR}/include)
-
-target_compile_options(gantry-core
-        PRIVATE
+set(COMPILE_OPTS
         -Wall
         -Werror
         -Weffc++
@@ -31,5 +6,33 @@ target_compile_options(gantry-core
         -Wsign-promo
         -Wextra-semi
         -Wctor-dtor-privacy
-        -fno-rtti
+        -fno-rtti)
+
+add_library(gantry-core-x STATIC
+        axis_type_x.cpp
         )
+
+add_library(gantry-core-y STATIC
+        axis_type_y.cpp)
+
+set_target_properties(gantry-core-x
+        PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED TRUE)
+
+set_target_properties(gantry-core-y
+        PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED TRUE)
+
+
+target_include_directories(gantry-core-x
+        PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+target_include_directories(gantry-core-y
+        PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+
+target_compile_options(gantry-core-x PRIVATE ${COMPILE_OPTS})
+
+target_compile_options(gantry-core-y PRIVATE ${COMPILE_OPTS})

--- a/gantry/core/axis_type_x.cpp
+++ b/gantry/core/axis_type_x.cpp
@@ -5,4 +5,7 @@
  *
  * @return an axis type
  */
-GantryAxisType get_axis_type() { return ${GANTRY_AXIS_TYPE}; }
+extern "C"
+GantryAxisType get_axis_type() {
+    return gantry_x;
+}

--- a/gantry/core/axis_type_x.cpp
+++ b/gantry/core/axis_type_x.cpp
@@ -5,7 +5,4 @@
  *
  * @return an axis type
  */
-extern "C"
-GantryAxisType get_axis_type() {
-    return gantry_x;
-}
+extern "C" GantryAxisType get_axis_type() { return gantry_x; }

--- a/gantry/core/axis_type_y.cpp
+++ b/gantry/core/axis_type_y.cpp
@@ -5,7 +5,4 @@
  *
  * @return A node id
  */
-extern "C"
-GantryAxisType get_axis_type() {
-    return gantry_y;
-}
+extern "C" GantryAxisType get_axis_type() { return gantry_y; }

--- a/gantry/core/axis_type_y.cpp
+++ b/gantry/core/axis_type_y.cpp
@@ -1,0 +1,11 @@
+#include "gantry/core/axis_type.h"
+
+/**
+ * Get the node id for this gantries axis type
+ *
+ * @return A node id
+ */
+extern "C"
+GantryAxisType get_axis_type() {
+    return gantry_y;
+}

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -34,30 +34,51 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         )
 
 
-add_executable(gantry
+add_executable(gantry_x
         ${GANTRY_FW_LINTABLE_SRCS}
         ${GANTRY_FW_NON_LINTABLE_SRCS})
 
-MESSAGE(STATUS "The gantry axis type is ${GANTRY_AXIS_TYPE}")
+add_executable(gantry_y
+        ${GANTRY_FW_LINTABLE_SRCS}
+        ${GANTRY_FW_NON_LINTABLE_SRCS})
 
-target_link_libraries(gantry
+
+target_link_libraries(gantry_x
         PUBLIC STM32G491RETx
         STM32G4xx_Drivers_Gantry STM32G4xx_FreeRTOS_Gantry
-        gantry-core
+        gantry-core-x
         can-core)
 
-set_target_properties(gantry
-        PROPERTIES CXX_STANDARD 20
+target_link_libraries(gantry_y
+        PUBLIC STM32G491RETx
+        STM32G4xx_Drivers_Gantry STM32G4xx_FreeRTOS_Gantry
+        gantry-core-y
+        can-core)
+
+
+set_target_properties(gantry_x
+        PROPERTIES
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED TRUE
         C_STANDARD 11
-        C_STANDARD_REQUIRED TRUE
-        OUTPUT_NAME ${GANTRY_AXIS_TYPE})
+        C_STANDARD_REQUIRED TRUE)
+
+set_target_properties(gantry_y
+        PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED TRUE
+        C_STANDARD 11
+        C_STANDARD_REQUIRED TRUE)
 
 
-target_include_directories(gantry
+target_include_directories(gantry_x
         PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
-target_compile_options(gantry
+target_include_directories(gantry_y
+        PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+
+target_compile_options(gantry_x
         PUBLIC
         -Wall
         $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
@@ -66,6 +87,17 @@ target_compile_options(gantry
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
         $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+
+target_compile_options(gantry_y
+        PUBLIC
+        -Wall
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+
 
 target_include_directories(STM32G4xx_Drivers_Gantry
         PUBLIC .)
@@ -89,10 +121,16 @@ find_program(ARM_GDB
 message(STATUS "Found svd exe at ${GDBSVDTools_gdbsvd_EXECUTABLE}")
 # Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
 # this dir
-set_target_properties(gantry
+set(GDBINIT_FILE "${CMAKE_BINARY_DIR}/common/firmware/STM32G491RETx/gdbinit")
+set_target_properties(gantry_x
         PROPERTIES
         CROSSCOMPILING_EMULATOR
-        "${ARM_GDB};--command=${CMAKE_BINARY_DIR}/common/firmware/STM32G491RETx/gdbinit")
+        "${ARM_GDB};--command=${GDBINIT_FILE}")
+
+set_target_properties(gantry_y
+        PROPERTIES
+        CROSSCOMPILING_EMULATOR
+        "${ARM_GDB};--command=${GDBINIT_FILE}")
 
 
 find_package(Clang)
@@ -125,17 +163,28 @@ set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)
 # done here because it won't be multi-os compatible, and also it
 # should be running the entire time and that's tough to accomplish
 # in a custom command
-add_custom_target(gantry-debug
-        COMMAND gantry
+add_custom_target(gantry-debug-x
+        COMMAND gantry_x
+        USES_TERMINAL
+        )
+
+add_custom_target(gantry-debug-y
+        COMMAND gantry_y
         USES_TERMINAL
         )
 
 
+
+set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32G491RETx/stm32g4discovery.cfg")
 # Runs openocd to flash the board (without using a debugger)
-add_custom_target(gantry-flash
-        COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${COMMON_EXECUTABLE_DIR}/STM32G491RETx/stm32g4discovery.cfg" "-c" "program $<TARGET_FILE:gantry>;reset;exit"
+add_custom_target(gantry-flash-x
+        COMMAND "${OpenOCD_EXECUTABLE}" "-f" ${DISCO_FILE}  "-c" "program $<TARGET_FILE:gantry_x>;reset;exit"
         VERBATIM
         COMMENT "Flashing board"
-        DEPENDS gantry)
+        DEPENDS gantry_x)
 
-unset(GANTRY_AXIS_TYPE CACHE)
+add_custom_target(gantry-flash-y
+        COMMAND "${OpenOCD_EXECUTABLE}" "-f" ${DISCO_FILE} "-c" "program $<TARGET_FILE:gantry_y>;reset;exit"
+        VERBATIM
+        COMMENT "Flashing board"
+        DEPENDS gantry_y)

--- a/gantry/tests/CMakeLists.txt
+++ b/gantry/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ target_compile_options(gantry
         -Wextra-semi
         -Wctor-dtor-privacy
         -fno-rtti)
-target_link_libraries(gantry Catch2::Catch2 gantry-core)
+target_link_libraries(gantry Catch2::Catch2 gantry-core-x)
 
 catch_discover_tests(gantry)
 add_build_and_test_target(gantry)


### PR DESCRIPTION
Having the gantry type defined as a combination of cmake variable and
automatically generated file is good, but the downside is that it
requires a cmake reconfigure in between switching gantry types, which is
kind of annoying when it's a frequent task to want to build and use both
gantry types in sequence. Another way to do it is just to have two side
by side targets. They share all the same code except for the gantry type
cpp files, and each target uses a different one.