### PR TITLE
Head motor handlers

### DIFF
--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -169,7 +169,7 @@ static auto motion_group_dispatch_target = DispatchParseTarget<
     can_move_group_handler};
 
 static auto motion_group_dispatch_target2 = DispatchParseTarget<
-    decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,
+    decltype(can_move_group_handler2), can_messages::AddLinearMoveRequest,
     can_messages::GetMoveGroupRequest, can_messages::ClearAllMoveGroupsRequest>{
     can_move_group_handler2};
 

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -171,7 +171,8 @@ static auto motor_dispatch_target2 = DispatchParseTarget<
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
     can_messages::DisableMotorRequest,
     can_messages::GetMotionConstraintsRequest,
-    can_messages::SetMotionConstraints>{can_motor_handler2};
+    can_messages::SetMotionConstraints, can_messages::WriteMotorDriverRegister,
+    can_messages::ReadMotorDriverRegister>{can_motor_handler2};
 
 static auto motion_group_dispatch_target = DispatchParseTarget<
     decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -169,9 +169,9 @@ static auto motion_group_dispatch_target = DispatchParseTarget<
     can_move_group_handler};
 
 static auto motion_group_dispatch_target2 = DispatchParseTarget<
-    decltype(can_move_group_handler2), can_messages::AddLinearMoveRequest,
+    decltype(can_move_group_handler), can_messages::AddLinearMoveRequest,
     can_messages::GetMoveGroupRequest, can_messages::ClearAllMoveGroupsRequest>{
-    can_move_group_handler2};
+    can_move_group_handler};
 
 static auto motion_group_executor_dispatch_target =
     DispatchParseTarget<decltype(can_move_group_executor_handler),

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -178,10 +178,15 @@ static auto motion_group_executor_dispatch_target =
                         can_messages::ExecuteMoveGroupRequest>{
         can_move_group_executor_handler};
 
+static auto motion_group_executor_dispatch_target2 =
+    DispatchParseTarget<decltype(can_move_group_executor_handler2),
+                        can_messages::ExecuteMoveGroupRequest>{
+        can_move_group_executor_handler2};
+
 /** Dispatcher to the various handlers */
 static auto dispatcher = Dispatcher(
     motor_dispatch_target, motion_group_dispatch_target,
-    motion_group_executor_dispatch_target,
+    motion_group_dispatch_target2, motion_group_executor_dispatch_target,
     motion_group_executor_dispatch_target2, device_info_dispatch_target);
 
 [[noreturn]] void task_entry() {

--- a/head/firmware/can_task.cpp
+++ b/head/firmware/can_task.cpp
@@ -166,7 +166,7 @@ static auto motor_dispatch_target = DispatchParseTarget<
     can_messages::ReadMotorDriverRegister>{can_motor_handler};
 
 static auto motor_dispatch_target2 = DispatchParseTarget<
-    decltype(can_motor_handler), can_messages::SetupRequest,
+    decltype(can_motor_handler2), can_messages::SetupRequest,
     can_messages::StopRequest, can_messages::GetStatusRequest,
     can_messages::MoveRequest, can_messages::EnableMotorRequest,
     can_messages::DisableMotorRequest,

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -4,9 +4,8 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     if (hspi->Instance == SPI2) {
         /* Peripheral clock enable */
-        __HAL_RCC_SPI2_CLK_ENABLE();
-        __HAL_RCC_GPIOA_CLK_ENABLE();
         __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPIOC_CLK_ENABLE();
         /**SPI2 GPIO Configuration
         PB12     ------> SPI2_NSS
         PB13     ------> SPI2_SCK
@@ -28,6 +27,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
         GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
         HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_RESET);
 
         GPIO_InitStruct.Pin = GPIO_PIN_6 | GPIO_PIN_7;
         GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;

--- a/head/firmware/tim7.c
+++ b/head/firmware/tim7.c
@@ -72,16 +72,22 @@ void timer_interrupt_start() { HAL_TIM_Base_Start_IT(&htim7); }
 void timer_interrupt_stop() { HAL_TIM_Base_Stop_IT(&htim7); }
 
 // todo: parametrize
-void turn_on_step_pin() { HAL_GPIO_WritePin(GPIOC, GPIO_PIN_0, GPIO_PIN_SET); }
+void turn_on_step_pin() {
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_0, GPIO_PIN_SET);
+}
 
 void turn_off_step_pin() {
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_6, GPIO_PIN_RESET);
     HAL_GPIO_WritePin(GPIOC, GPIO_PIN_0, GPIO_PIN_RESET);
 }
 
 void turn_on_direction_pin() {
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, GPIO_PIN_SET);
     HAL_GPIO_WritePin(GPIOC, GPIO_PIN_1, GPIO_PIN_SET);
 }
 
 void turn_off_direction_pin() {
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_7, GPIO_PIN_RESET);
     HAL_GPIO_WritePin(GPIOC, GPIO_PIN_1, GPIO_PIN_RESET);
 }


### PR DESCRIPTION
Add dispatch handlers for a and z motors. Make a and z motors move with the same move group and task. Follow up PR to add unique IDs to both motors, and dedicated tasks. 