### PR TITLE
fix(pipettes): make timer interrupt 100KHz

### DIFF
--- a/pipettes/firmware/tim7.c
+++ b/pipettes/firmware/tim7.c
@@ -29,7 +29,7 @@ void MX_TIM7_Init(void) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
 
     htim7.Instance = TIM7;
-    htim7.Init.Prescaler = 0;
+    htim7.Init.Prescaler = 499;
     htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim7.Init.Period = 1;
     htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
@@ -68,7 +68,9 @@ void timer_init() {
 }
 
 
-void timer_interrupt_start() { HAL_TIM_Base_Start_IT(&htim7); }
+void timer_interrupt_start() {
+    HAL_TIM_Base_Start_IT(&htim7);
+}
 
 void timer_interrupt_stop() { HAL_TIM_Base_Stop_IT(&htim7); }
 


### PR DESCRIPTION
## Overview
The timer interrupt for motor control in the pipettes subproject was going too fast. The result is
that the CAN task could never finish its initialization process, and thus, the timer interrupt for
FDCAN would never get called when a message was sent from python.

For now, we are setting the interrupt in pipettes to be 100KHz -- and we will do the same in a follow-up PR for the gantry/head subprojects. At some point in the future, we may want to change the interrupt to match the minimum frequency requirement for the motors.