### PR TITLE
fix: use release build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,16 +21,14 @@ add_subdirectory(python)
 
 # Set a default build type if none was specified
 # From https://blog.kitware.com/cmake-and-the-default-build-type/
-
-# MinSizeRel is the default release type since the binary size is quite important.
-set(default_build_type "Debug")
+set(default_build_type "RelWithDebInfo")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
             STRING "Choose the type of build." FORCE)
     # Set the possible values of build type for cmake-gui
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-            "Debug" "MinSizeRel" "RelWithDebInfo")
+            "RelWithDebInfo" "Debug" "MinSizeRel")
 endif ()
 message("Build type is ${CMAKE_BUILD_TYPE}")
 

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -196,7 +196,7 @@ void MX_TIM7_Init(void) {
     htim7.Instance = TIM7;
     htim7.Init.Prescaler = 849;
     htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim7.Init.Period = 2;
+    htim7.Init.Period = 1;
     htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
     if (HAL_TIM_Base_Init(&htim7) != HAL_OK) {
         Error_Handler();


### PR DESCRIPTION
We were using the Debug build type in cmake with forces `-O0 -g`. Using `RelWithDebInfo` issues `-O2 -g`, which speeds up code by about an order of magnitude, making the execution time of motor interrupts ~750ns instead of ~5us.

While we're at it, speed the head interrupt frequency back up to 100 kHz.

You may have to do a cmake reconfigure with the correct build type to get the benefits of this: `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo --preset=cross` and `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo --preset=cross-pipettes`. New checkouts (or deleting your cmake cache) will use `RelWithDebInfo` by default.