### PR TITLE
feat(can): simulate hardware filtering

### DIFF
--- a/include/can/simlib/filter.hpp
+++ b/include/can/simlib/filter.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "can/core/types.h"
+
+namespace sim_filter {
+
+/**
+ * A filtering callable
+ */
+class Filter {
+  public:
+    /**
+     * Constructor
+     * @param type how va1 and val2 are interpreted as a filter.
+     * @param config what should happen if the filter matches
+     * @param val1 filter value 1
+     * @param val2 filter value 2
+     */
+    Filter(CanFilterType type, CanFilterConfig config, uint32_t val1,
+           uint32_t val2)
+        : type{type}, config{config}, val1{val1}, val2{val2} {}
+
+    /**
+     * Method called to apply fi
+     * @param arbitration_id
+     * @return True if message is to be accepted by this filter.
+     */
+    bool operator()(uint32_t arbitration_id) const {
+        auto matches = false;
+        switch (type) {
+            case (CanFilterType::mask):
+                matches = (val2 & arbitration_id) == val1;
+                break;
+            case (CanFilterType::range):
+                matches = arbitration_id >= val1 && arbitration_id <= val2;
+                break;
+            case (CanFilterType::exact):
+                matches = arbitration_id == val1 || arbitration_id == val2;
+                break;
+        }
+        // Return true only if the filter matched and the config is not reject.
+        return matches ? config != CanFilterConfig::reject : false;
+    }
+
+  private:
+    CanFilterType type;
+    CanFilterConfig config;
+    uint32_t val1;
+    uint32_t val2;
+};
+
+}  // namespace sim_filter

--- a/include/can/simlib/sim_canbus.hpp
+++ b/include/can/simlib/sim_canbus.hpp
@@ -80,6 +80,8 @@ class SimCANBus : public CanBus {
                     continue;
                 }
 
+                // If there are filters and any of them return true we can
+                // accept the message.
                 if (bus.filters.empty() ||
                     std::any_of(
                         bus.filters.cbegin(), bus.filters.cend(),

--- a/include/can/simlib/sim_canbus.hpp
+++ b/include/can/simlib/sim_canbus.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <array>
+#include <vector>
 
 #include "can/core/can_bus.hpp"
 #include "can/core/message_core.hpp"
+#include "can/simlib/filter.hpp"
 #include "can/simlib/transport.hpp"
 #include "common/core/freertos_task.hpp"
+#include "common/core/logging.hpp"
 
 namespace sim_canbus {
 
@@ -35,7 +38,9 @@ class SimCANBus : public CanBus {
      * or maximum arbitration id
      */
     void add_filter(CanFilterType type, CanFilterConfig config, uint32_t val1,
-                    uint32_t val2) {}
+                    uint32_t val2) {
+        filters.push_back(sim_filter::Filter(type, config, val1, val2));
+    }
 
     /**
      * Send a buffer on can bus
@@ -74,10 +79,19 @@ class SimCANBus : public CanBus {
                                         read_length)) {
                     continue;
                 }
-                if (bus.new_message_callback) {
-                    bus.new_message_callback(bus.new_message_callback_data,
-                                             arb_id, read_buffer.begin(),
-                                             read_length);
+
+                if (bus.filters.empty() ||
+                    std::any_of(
+                        bus.filters.cbegin(), bus.filters.cend(),
+                        [arb_id](const auto& f) { return f(arb_id); })) {
+                    if (bus.new_message_callback) {
+                        bus.new_message_callback(bus.new_message_callback_data,
+                                                 arb_id, read_buffer.begin(),
+                                                 read_length);
+                    }
+                } else {
+                    LOG("Message with arb_id %X and length %d is rejected\n",
+                        arb_id, read_length);
                 }
             }
         }
@@ -91,6 +105,7 @@ class SimCANBus : public CanBus {
     void* new_message_callback_data{nullptr};
     IncomingMessageCallback new_message_callback{nullptr};
     FreeRTOSTask<256, 5> reader_task;
+    std::vector<sim_filter::Filter> filters{};
 };
 
 }  // namespace sim_canbus


### PR DESCRIPTION
`SimCANBus` needs to implement `add_filter` to support the HAL can message filtering. 