### PR TITLE
refactor(can-sim): can simulation transport create method

### DIFF
--- a/can/CMakeLists.txt
+++ b/can/CMakeLists.txt
@@ -2,10 +2,8 @@ if (${CMAKE_CROSSCOMPILING})
 #    add_subdirectory(firmware)
 else()
     add_subdirectory(tests)
-    if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
-        # Simulator requires linux only kernel interfaces
-        add_subdirectory(simulator)
-    endif()
+    add_subdirectory(simlib)
+    add_subdirectory(simulator)
 endif()
 
 add_subdirectory(core)

--- a/can/simlib/CMakeLists.txt
+++ b/can/simlib/CMakeLists.txt
@@ -1,0 +1,4 @@
+function(target_can_simlib TARGET)
+    target_sources(${TARGET} PUBLIC
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/transport.cpp)
+endfunction()

--- a/can/simlib/transport.cpp
+++ b/can/simlib/transport.cpp
@@ -1,4 +1,5 @@
 #include "can/simlib/transport.hpp"
+
 #include "common/core/freertos_synchronization.hpp"
 #ifdef USE_SOCKETCAN
 #include "can/simlib/socketcan_transport.hpp"
@@ -10,7 +11,8 @@
  * Create simulating bus transport
  * @return pointer to bus transport
  */
-auto can_transport::create() -> std::shared_ptr<can_transport::BusTransportBase> {
+auto can_transport::create()
+    -> std::shared_ptr<can_transport::BusTransportBase> {
 #ifdef USE_SOCKETCAN
     auto constexpr ChannelEnvironmentVariableName = "CAN_CHANNEL";
     auto constexpr DefaultChannel = "vcan0";

--- a/can/simlib/transport.cpp
+++ b/can/simlib/transport.cpp
@@ -1,0 +1,43 @@
+#include "can/simlib/transport.hpp"
+#include "common/core/freertos_synchronization.hpp"
+#ifdef USE_SOCKETCAN
+#include "can/simlib/socketcan_transport.hpp"
+#else
+#include "can/simlib/socket_transport.hpp"
+#endif
+
+/**
+ * Create simulating bus transport
+ * @return pointer to bus transport
+ */
+auto can_transport::create() -> std::shared_ptr<can_transport::BusTransportBase> {
+#ifdef USE_SOCKETCAN
+    auto constexpr ChannelEnvironmentVariableName = "CAN_CHANNEL";
+    auto constexpr DefaultChannel = "vcan0";
+
+    const char* env_channel_val = std::getenv(ChannelEnvironmentVariableName);
+    auto channel = env_channel_val ? env_channel_val : DefaultChannel;
+    auto transport = std::make_shared<socketcan_transport::SocketCanTransport<
+        freertos_synchronization::FreeRTOSCriticalSection>>();
+
+    transport->open(channel);
+#else
+    auto constexpr ServerIpEnvironmentVariableName = "CAN_SERVER_IP";
+    auto constexpr DefaultServerIp = "127.0.0.1";
+    auto constexpr PortEnvironmentVariableName = "CAN_PORT";
+    auto constexpr DefaultPort = 9898;
+
+    const char* env_server_ip_val =
+        std::getenv(ServerIpEnvironmentVariableName);
+    auto ip = env_server_ip_val ? env_server_ip_val : DefaultServerIp;
+    const char* env_port_val = std::getenv(PortEnvironmentVariableName);
+    auto port =
+        env_port_val ? std::strtoul(env_port_val, nullptr, 10) : DefaultPort;
+
+    auto transport = std::make_shared<socket_transport::SocketTransport<
+        freertos_synchronization::FreeRTOSCriticalSection>>();
+
+    transport->open(ip, port);
+#endif
+    return transport;
+}

--- a/can/simulator/CMakeLists.txt
+++ b/can/simulator/CMakeLists.txt
@@ -32,6 +32,14 @@ add_executable(
         freertos_idle_timer_task.cpp
 )
 
+target_can_simlib(can-simulator)
+
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+    target_compile_definitions(can-simulator PUBLIC USE_SOCKETCAN)
+endif()
+
+target_compile_definitions(can-simulator PUBLIC ENABLE_LOGGING)
+
 target_link_libraries(can-simulator PRIVATE can-core freertos pthread)
 
 set_target_properties(can-simulator

--- a/can/simulator/main.cpp
+++ b/can/simulator/main.cpp
@@ -72,32 +72,23 @@ static auto read_can_message_buffer_writer =
     can_message_buffer::CanMessageBufferWriter(read_can_message_buffer);
 
 /**
- * New CAN message callback.
- *
- * @param identifier Arbitration id
- * @param data Message data
- * @param length Message data length
+ * The can bus poller.
  */
-void callback(uint32_t identifier, uint8_t *data, uint8_t length) {
-    read_can_message_buffer_writer.send_from_isr(identifier, data,
-                                                 data + length);
-}
+static auto can_bus_poller = FreeRTOSCanReader<1024, decltype(dispatcher)>{canbus, dispatcher};
 
 /**
- * The socket can reader. Reads from socket and writes to message buffer.
+ * Task entry point
  */
-void can_bus_poll_task_entry() {
-    // A Message Buffer poller that reads from buffer and send to dispatcher
-    static auto poller = freertos_can_dispatch::FreeRTOSCanBufferPoller(
-        read_can_message_buffer, dispatcher);
-    poller();
+static void task_entry(void) {
+    can_bus_poller();
 }
 
 /**
  * The message buffer polling task.
  */
 static auto can_bus_poll_task =
-    FreeRTOSTask<2048, 5>("can_poll", can_bus_poll_task_entry);
+    FreeRTOSTask<2048, 5>("can_poll", task_entry);
+
 
 int main() {
     vTaskStartScheduler();

--- a/can/simulator/main.cpp
+++ b/can/simulator/main.cpp
@@ -74,21 +74,18 @@ static auto read_can_message_buffer_writer =
 /**
  * The can bus poller.
  */
-static auto can_bus_poller = FreeRTOSCanReader<1024, decltype(dispatcher)>{canbus, dispatcher};
+static auto can_bus_poller =
+    FreeRTOSCanReader<1024, decltype(dispatcher)>{canbus, dispatcher};
 
 /**
  * Task entry point
  */
-static void task_entry(void) {
-    can_bus_poller();
-}
+static void task_entry(void) { can_bus_poller(); }
 
 /**
  * The message buffer polling task.
  */
-static auto can_bus_poll_task =
-    FreeRTOSTask<2048, 5>("can_poll", task_entry);
-
+static auto can_bus_poll_task = FreeRTOSTask<2048, 5>("can_poll", task_entry);
 
 int main() {
     vTaskStartScheduler();

--- a/gantry/simulator/CMakeLists.txt
+++ b/gantry/simulator/CMakeLists.txt
@@ -50,6 +50,9 @@ endif()
 target_compile_definitions(gantry_x_simulator PUBLIC ENABLE_LOGGING)
 target_compile_definitions(gantry_y_simulator PUBLIC ENABLE_LOGGING)
 
+target_can_simlib(gantry_x_simulator)
+target_can_simlib(gantry_y_simulator)
+
 target_gantry_core_x(gantry_x_simulator)
 target_gantry_core_y(gantry_y_simulator)
 

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -1,40 +1,18 @@
 #include "gantry/core/interfaces.hpp"
 
 #include "can/simlib/sim_canbus.hpp"
+#include "can/simlib/transport.hpp"
 #include "gantry/core/utils.hpp"
 #include "motor-control/core/motor_interrupt_handler.hpp"
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
-
-#ifdef USE_SOCKETCAN
-#include "can/simlib/socketcan_transport.hpp"
-#else
-#include "can/simlib/socket_transport.hpp"
-#endif
-
 #include "common/core/freertos_synchronization.hpp"
 #include "common/simulation/spi.hpp"
-
-#ifdef USE_SOCKETCAN
-static auto constexpr ChannelEnvironmentVariableName = "CAN_CHANNEL";
-static auto constexpr DefaultChannel = "vcan0";
-
-static auto transport = socketcan_transport::SocketCanTransport<
-    freertos_synchronization::FreeRTOSCriticalSection>{};
-#else
-static auto constexpr ServerIpEnvironmentVariableName = "CAN_SERVER_IP";
-static auto constexpr DefaultServerIp = "127.0.0.1";
-static auto constexpr PortEnvironmentVariableName = "CAN_PORT";
-static auto constexpr DefaultPort = 9898;
-
-static auto transport = socket_transport::SocketTransport<
-    freertos_synchronization::FreeRTOSCriticalSection>{};
-#endif
 
 /**
  * The CAN bus.
  */
-static auto canbus = sim_canbus::SimCANBus(transport);
+static auto canbus = sim_canbus::SimCANBus(can_transport::create());
 
 /**
  * The SPI bus.
@@ -87,19 +65,6 @@ static motor_interrupt_driver::MotorInterruptDriver A(motor_queue,
                                                       motor_interrupt);
 
 void interfaces::initialize() {
-#ifdef USE_SOCKETCAN
-    const char* env_channel_val = std::getenv(ChannelEnvironmentVariableName);
-    auto channel = env_channel_val ? env_channel_val : DefaultChannel;
-    transport.open(channel);
-#else
-    const char* env_server_ip_val =
-        std::getenv(ServerIpEnvironmentVariableName);
-    auto ip = env_server_ip_val ? env_server_ip_val : DefaultServerIp;
-    const char* env_port_val = std::getenv(PortEnvironmentVariableName);
-    auto port =
-        env_port_val ? std::strtoul(env_port_val, nullptr, 10) : DefaultPort;
-    transport.open(ip, port);
-#endif
 }
 
 auto interfaces::get_can_bus() -> can_bus::CanBus& { return canbus; }

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -2,12 +2,12 @@
 
 #include "can/simlib/sim_canbus.hpp"
 #include "can/simlib/transport.hpp"
+#include "common/core/freertos_synchronization.hpp"
+#include "common/simulation/spi.hpp"
 #include "gantry/core/utils.hpp"
 #include "motor-control/core/motor_interrupt_handler.hpp"
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
-#include "common/core/freertos_synchronization.hpp"
-#include "common/simulation/spi.hpp"
 
 /**
  * The CAN bus.
@@ -64,8 +64,7 @@ static motor_handler::MotorInterruptHandler motor_interrupt(motor_queue,
 static motor_interrupt_driver::MotorInterruptDriver A(motor_queue,
                                                       motor_interrupt);
 
-void interfaces::initialize() {
-}
+void interfaces::initialize() {}
 
 auto interfaces::get_can_bus() -> can_bus::CanBus& { return canbus; }
 

--- a/include/can/firmware/hal_can_bus.hpp
+++ b/include/can/firmware/hal_can_bus.hpp
@@ -21,8 +21,8 @@ class HalCanBus : public CanBus {
 
     HalCanBus(const HalCanBus&) = default;
     auto operator=(const HalCanBus&) -> HalCanBus& = default;
-    HalCanBus(const HalCanBus&&) = default;
-    auto operator=(const HalCanBus&&) -> HalCanBus&& = default;
+    HalCanBus(HalCanBus&&) = default;
+    auto operator=(HalCanBus&&) -> HalCanBus& = default;
     ~HalCanBus() final = default;
 
     /**

--- a/include/can/firmware/hal_can_bus.hpp
+++ b/include/can/firmware/hal_can_bus.hpp
@@ -19,10 +19,10 @@ class HalCanBus : public CanBus {
      */
     explicit HalCanBus(HAL_CAN_HANDLE handle) : handle{handle} {}
 
-    HalCanBus(const HalCanBus&) = delete;
-    auto operator=(const HalCanBus&) -> HalCanBus& = delete;
-    HalCanBus(const HalCanBus&&) = delete;
-    auto operator=(const HalCanBus&&) -> HalCanBus&& = delete;
+    HalCanBus(const HalCanBus&) = default;
+    auto operator=(const HalCanBus&) -> HalCanBus& = default;
+    HalCanBus(const HalCanBus&&) = default;
+    auto operator=(const HalCanBus&&) -> HalCanBus&& = default;
     ~HalCanBus() final = default;
 
     /**

--- a/include/can/simlib/sim_canbus.hpp
+++ b/include/can/simlib/sim_canbus.hpp
@@ -21,9 +21,9 @@ using namespace freertos_task;
  */
 class SimCANBus : public CanBus {
   public:
-    using TranportType = std::shared_ptr<can_transport::BusTransportBase>;
+    using TransportType = std::shared_ptr<can_transport::BusTransportBase>;
 
-    explicit SimCANBus(TranportType transport)
+    explicit SimCANBus(TransportType transport)
         : transport{transport}, reader{*this}, reader_task{"", reader} {}
     SimCANBus(const SimCANBus&) = delete;
     SimCANBus(const SimCANBus&&) = delete;
@@ -105,7 +105,7 @@ class SimCANBus : public CanBus {
         std::array<uint8_t, message_core::MaxMessageSize> read_buffer{};
     };
 
-    TranportType transport;
+    TransportType transport;
     Reader reader;
     void* new_message_callback_data{nullptr};
     IncomingMessageCallback new_message_callback{nullptr};

--- a/include/can/simlib/sim_canbus.hpp
+++ b/include/can/simlib/sim_canbus.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <memory>
 #include <array>
+#include <memory>
 #include <vector>
 
 #include "can/core/can_bus.hpp"
@@ -54,7 +54,7 @@ class SimCANBus : public CanBus {
     void send(uint32_t arbitration_id, uint8_t* buffer,
               CanFDMessageLength buffer_length) {
         transport->write(arbitration_id, buffer,
-                        static_cast<uint32_t>(buffer_length));
+                         static_cast<uint32_t>(buffer_length));
     }
 
     /**

--- a/include/can/simlib/socket_transport.hpp
+++ b/include/can/simlib/socket_transport.hpp
@@ -7,6 +7,9 @@
 
 #include <algorithm>
 
+#include "FreeRTOS.h"
+#include "task.h"
+
 #include "can/core/message_core.hpp"
 #include "common/core/logging.hpp"
 #include "common/core/synchronization.hpp"

--- a/include/can/simlib/socket_transport.hpp
+++ b/include/can/simlib/socket_transport.hpp
@@ -8,11 +8,10 @@
 #include <algorithm>
 
 #include "FreeRTOS.h"
-#include "task.h"
-
 #include "can/core/message_core.hpp"
 #include "common/core/logging.hpp"
 #include "common/core/synchronization.hpp"
+#include "task.h"
 #include "transport.hpp"
 
 namespace socket_transport {

--- a/include/can/simlib/transport.hpp
+++ b/include/can/simlib/transport.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 namespace can_transport {
 
 /**
@@ -28,5 +30,13 @@ class BusTransportBase {
     virtual auto read(uint32_t& arb_id, uint8_t* buff, uint32_t& buff_len)
         -> bool = 0;
 };
+
+/**
+ * Create an appropriate BusTransportBase.
+ *
+ * @return pointer to BusTransportBase.
+ */
+auto create() -> std::shared_ptr<BusTransportBase>;
+
 
 }  // namespace can_transport

--- a/include/can/simlib/transport.hpp
+++ b/include/can/simlib/transport.hpp
@@ -38,5 +38,4 @@ class BusTransportBase {
  */
 auto create() -> std::shared_ptr<BusTransportBase>;
 
-
 }  // namespace can_transport

--- a/python/opentrons_ot3_firmware/messages/payloads.py
+++ b/python/opentrons_ot3_firmware/messages/payloads.py
@@ -130,6 +130,7 @@ class MotionConstraintsPayload(utils.BinarySerializable):
 @dataclass
 class MotionConstraintsResponsePayload(MotionConstraintsPayload, ResponsePayload):
     """The min and max velocity and acceleration of a motion system."""
+
     ...
 
 


### PR DESCRIPTION
Create a `create` method to build the socket transport for `SimCanBus`. 

- Can simulator app (FMA loopback) uses the new create method. Can use plain old sockets.
- Gantry simulator uses new create method.