### PR TITLE
fix(pipettes): use 1/32 microstepping

### DIFF
--- a/pipettes/firmware/can_task.cpp
+++ b/pipettes/firmware/can_task.cpp
@@ -89,7 +89,7 @@ static motor_handler::MotorInterruptHandler plunger_interrupt(motor_queue,
 // microstepping is currently set to 32 μsteps.
 RegisterConfig MotorDriverConfigurations{.gconf = 0x04,
                                          .ihold_irun = 0x70202,
-                                         .chopconf = 0x50101D5,
+                                         .chopconf = 0x30101D5,
                                          .thigh = 0xFFFFF,
                                          .coolconf = 0x60000};
 


### PR DESCRIPTION
The microstepping value of chopconf sets the _number of native 1/256th
microsteps_ to move when the driver sees a step pulse. So setting this
to 4 means it takes 2^4=16 1/256 microsteps every pulse, which is 1/16th
microstepping conveniently enough, but for 1/32nd microstepping this
needs to be set to 3 not 5 - 2^3 (8) steps per pulse is 256/8=32
microsteps per quarter cycle.