### PR TITLE
feat(HEAD): head task refactor to support presence sensing

### DIFF
--- a/head/core/can_task.cpp
+++ b/head/core/can_task.cpp
@@ -19,20 +19,20 @@ auto can_sender_queue = freertos_message_queue::FreeRTOSMessageQueue<
     message_writer_task::TaskMessage>{};
 
 using MotorDispatchTarget = can_dispatch::DispatchParseTarget<
-    motor_message_handler::MotorHandler<head_tasks::QueueClient>,
+    motor_message_handler::MotorHandler<head_tasks::MotorQueueClient>,
     can_messages::ReadMotorDriverRegister, can_messages::SetupRequest,
     can_messages::WriteMotorDriverRegister>;
 using MoveGroupDispatchTarget = can_dispatch::DispatchParseTarget<
-    move_group_handler::MoveGroupHandler<head_tasks::QueueClient>,
+    move_group_handler::MoveGroupHandler<head_tasks::MotorQueueClient>,
     can_messages::AddLinearMoveRequest, can_messages::ClearAllMoveGroupsRequest,
     can_messages::ExecuteMoveGroupRequest, can_messages::GetMoveGroupRequest>;
 using MotionControllerDispatchTarget = can_dispatch::DispatchParseTarget<
-    motion_message_handler::MotionHandler<head_tasks::QueueClient>,
+    motion_message_handler::MotionHandler<head_tasks::MotorQueueClient>,
     can_messages::DisableMotorRequest, can_messages::EnableMotorRequest,
     can_messages::GetMotionConstraintsRequest,
     can_messages::SetMotionConstraints, can_messages::StopRequest>;
 using DeviceInfoDispatchTarget = can_dispatch::DispatchParseTarget<
-    device_info_handler::DeviceInfoHandler<head_tasks::QueueClient>,
+    device_info_handler::DeviceInfoHandler<head_tasks::MotorQueueClient>,
     can_messages::DeviceInfoRequest>;
 
 /** The parsed message handler */

--- a/head/core/tasks.cpp
+++ b/head/core/tasks.cpp
@@ -6,33 +6,37 @@
 #include "motor-control/core/tasks/move_group_task_starter.hpp"
 #include "motor-control/core/tasks/move_status_reporter_task_starter.hpp"
 
-static auto left_tasks = head_tasks::AllTask{};
-static auto left_queues = head_tasks::QueueClient{can_ids::NodeId::head_l};
-static auto right_tasks = head_tasks::AllTask{};
-static auto right_queues = head_tasks::QueueClient{can_ids::NodeId::head_r};
+static auto head_tasks_col = head_tasks::HeadTasks{};
+static auto head_queues = head_tasks::HeadQueueClient{};
+
+static auto left_tasks = head_tasks::MotorTasks{};
+static auto left_queues = head_tasks::MotorQueueClient{can_ids::NodeId::head_l};
+static auto right_tasks = head_tasks::MotorTasks{};
+static auto right_queues =
+    head_tasks::MotorQueueClient{can_ids::NodeId::head_r};
 
 static auto left_mc_task_builder =
     motion_controller_task_starter::TaskStarter<lms::LeadScrewConfig, 512,
-                                                head_tasks::QueueClient>{};
+                                                head_tasks::MotorQueueClient>{};
 static auto right_mc_task_builder =
     motion_controller_task_starter::TaskStarter<lms::LeadScrewConfig, 512,
-                                                head_tasks::QueueClient>{};
+                                                head_tasks::MotorQueueClient>{};
 static auto left_motor_driver_task_builder =
-    motor_driver_task_starter::TaskStarter<512, head_tasks::QueueClient>{};
+    motor_driver_task_starter::TaskStarter<512, head_tasks::MotorQueueClient>{};
 static auto right_motor_driver_task_builder =
-    motor_driver_task_starter::TaskStarter<512, head_tasks::QueueClient>{};
+    motor_driver_task_starter::TaskStarter<512, head_tasks::MotorQueueClient>{};
 static auto left_move_group_task_builder =
-    move_group_task_starter::TaskStarter<512, head_tasks::QueueClient,
-                                         head_tasks::QueueClient>{};
+    move_group_task_starter::TaskStarter<512, head_tasks::MotorQueueClient,
+                                         head_tasks::MotorQueueClient>{};
 static auto right_move_group_task_builder =
-    move_group_task_starter::TaskStarter<512, head_tasks::QueueClient,
-                                         head_tasks::QueueClient>{};
+    move_group_task_starter::TaskStarter<512, head_tasks::MotorQueueClient,
+                                         head_tasks::MotorQueueClient>{};
 static auto left_move_status_task_builder =
-    move_status_reporter_task_starter::TaskStarter<512,
-                                                   head_tasks::QueueClient>{};
+    move_status_reporter_task_starter::TaskStarter<
+        512, head_tasks::MotorQueueClient>{};
 static auto right_move_status_task_builder =
-    move_status_reporter_task_starter::TaskStarter<512,
-                                                   head_tasks::QueueClient>{};
+    move_status_reporter_task_starter::TaskStarter<
+        512, head_tasks::MotorQueueClient>{};
 
 /**
  * Start gantry tasks.
@@ -45,10 +49,17 @@ void head_tasks::start_tasks(
     motion_controller::MotionController<lms::LeadScrewConfig>&
         right_motion_controller,
     motor_driver::MotorDriver& right_motor_driver) {
-    // LEFT and RIGHT each get the same can task message queue
+    // Start the head tasks
     auto& can_writer = can_task::start_writer(can_bus);
     can_task::start_reader(can_bus);
 
+    // Assign head task collection task pointers
+    head_tasks_col.can_writer = &can_writer;
+
+    // Assign head queue client message queue pointers
+    head_queues.set_queue(&can_writer.get_queue());
+
+    // Start the left motor tasks
     auto& left_motion =
         left_mc_task_builder.start(5, left_motion_controller, left_queues);
     auto& left_motor =
@@ -58,12 +69,13 @@ void head_tasks::start_tasks(
     auto& left_move_status_reporter =
         left_move_status_task_builder.start(5, left_queues);
 
-    left_tasks.can_writer = &can_writer;
+    // Assign left motor task collection task pointers
     left_tasks.motion_controller = &left_motion;
     left_tasks.motor_driver = &left_motor;
     left_tasks.move_group = &left_move_group;
     left_tasks.move_status_reporter = &left_move_status_reporter;
 
+    // Assign left motor queue client message queue pointers
     left_queues.motion_queue = &left_motion.get_queue();
     left_queues.motor_queue = &left_motor.get_queue();
     left_queues.move_group_queue = &left_move_group.get_queue();
@@ -71,6 +83,7 @@ void head_tasks::start_tasks(
     left_queues.move_status_report_queue =
         &left_move_status_reporter.get_queue();
 
+    // Start the right motor tasks
     auto& right_motion =
         right_mc_task_builder.start(5, right_motion_controller, right_queues);
     auto& right_motor = right_motor_driver_task_builder.start(
@@ -80,12 +93,13 @@ void head_tasks::start_tasks(
     auto& right_move_status_reporter =
         right_move_status_task_builder.start(5, right_queues);
 
-    right_tasks.can_writer = &can_writer;
+    // Assign right motor task collection task pointers
     right_tasks.motion_controller = &right_motion;
     right_tasks.motor_driver = &right_motor;
     right_tasks.move_group = &right_move_group;
     right_tasks.move_status_reporter = &right_move_status_reporter;
 
+    // Assign right motor queue client message queue pointers
     right_queues.motion_queue = &right_motion.get_queue();
     right_queues.motor_queue = &right_motor.get_queue();
     right_queues.move_group_queue = &right_move_group.get_queue();
@@ -94,33 +108,46 @@ void head_tasks::start_tasks(
         &right_move_status_reporter.get_queue();
 }
 
-head_tasks::QueueClient::QueueClient(can_ids::NodeId this_fw)
+// Implementation of HeadQueueClient
+
+head_tasks::HeadQueueClient::HeadQueueClient()
+    : can_message_writer::MessageWriter{can_ids::NodeId::head} {}
+
+// Implementation of MotorQueueClient
+
+head_tasks::MotorQueueClient::MotorQueueClient(can_ids::NodeId this_fw)
     : can_message_writer::MessageWriter{this_fw} {}
 
-void head_tasks::QueueClient::send_motion_controller_queue(
+void head_tasks::MotorQueueClient::send_motion_controller_queue(
     const motion_controller_task::TaskMessage& m) {
     motion_queue->try_write(m);
 }
 
-void head_tasks::QueueClient::send_motor_driver_queue(
+void head_tasks::MotorQueueClient::send_motor_driver_queue(
     const motor_driver_task::TaskMessage& m) {
     motor_queue->try_write(m);
 }
 
-void head_tasks::QueueClient::send_move_group_queue(
+void head_tasks::MotorQueueClient::send_move_group_queue(
     const move_group_task::TaskMessage& m) {
     move_group_queue->try_write(m);
 }
 
-void head_tasks::QueueClient::send_move_status_reporter_queue(
+void head_tasks::MotorQueueClient::send_move_status_reporter_queue(
     const move_status_reporter_task::TaskMessage& m) {
     move_status_report_queue->try_write(m);
 }
 
-auto head_tasks::get_right_tasks() -> AllTask& { return right_tasks; }
+auto head_tasks::get_tasks() -> HeadTasks& { return head_tasks_col; }
 
-auto head_tasks::get_left_tasks() -> AllTask& { return left_tasks; }
+auto head_tasks::get_queue_client() -> HeadQueueClient& { return head_queues; }
 
-auto head_tasks::get_right_queues() -> QueueClient& { return right_queues; }
+auto head_tasks::get_right_tasks() -> MotorTasks& { return right_tasks; }
 
-auto head_tasks::get_left_queues() -> QueueClient& { return left_queues; }
+auto head_tasks::get_left_tasks() -> MotorTasks& { return left_tasks; }
+
+auto head_tasks::get_right_queues() -> MotorQueueClient& {
+    return right_queues;
+}
+
+auto head_tasks::get_left_queues() -> MotorQueueClient& { return left_queues; }

--- a/include/head/core/tasks.hpp
+++ b/include/head/core/tasks.hpp
@@ -22,10 +22,27 @@ void start_tasks(can_bus::CanBus& can_bus,
                  motor_driver::MotorDriver& right_motor_driver);
 
 /**
- * Access to all the message queues in the system.
+ * The client for all head message queues not associated with a single motor.
+ * This will be a singleton.
  */
-struct QueueClient : can_message_writer::MessageWriter {
-    QueueClient(can_ids::NodeId this_fw);
+struct HeadQueueClient : can_message_writer::MessageWriter {
+    HeadQueueClient();
+};
+
+/**
+ * Access to all tasks not associated with a motor. This will be a singleton.
+ */
+struct HeadTasks {
+    message_writer_task::MessageWriterTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* can_writer{nullptr};
+};
+
+/**
+ * The client for all the per motor message queues. There will be one for the
+ * left and one for the right.
+ */
+struct MotorQueueClient : can_message_writer::MessageWriter {
+    MotorQueueClient(can_ids::NodeId this_fw);
 
     void send_motion_controller_queue(
         const motion_controller_task::TaskMessage& m);
@@ -49,47 +66,58 @@ struct QueueClient : can_message_writer::MessageWriter {
 };
 
 /**
- * Access to all tasks in the system.
+ * Access to all tasks associated with a motor. There will be one for the left
+ * and one for the right.
  */
-struct AllTask {
-    message_writer_task::MessageWriterTask<
-        freertos_message_queue::FreeRTOSMessageQueue>* can_writer{nullptr};
+struct MotorTasks {
     motor_driver_task::MotorDriverTask<
-        freertos_message_queue::FreeRTOSMessageQueue, QueueClient>*
+        freertos_message_queue::FreeRTOSMessageQueue, MotorQueueClient>*
         motor_driver{nullptr};
     motion_controller_task::MotionControllerTask<
         freertos_message_queue::FreeRTOSMessageQueue, lms::LeadScrewConfig,
-        QueueClient>* motion_controller{nullptr};
+        MotorQueueClient>* motion_controller{nullptr};
     move_status_reporter_task::MoveStatusReporterTask<
-        freertos_message_queue::FreeRTOSMessageQueue, QueueClient>*
+        freertos_message_queue::FreeRTOSMessageQueue, MotorQueueClient>*
         move_status_reporter{nullptr};
     move_group_task::MoveGroupTask<freertos_message_queue::FreeRTOSMessageQueue,
-                                   QueueClient, QueueClient>* move_group{
-        nullptr};
+                                   MotorQueueClient, MotorQueueClient>*
+        move_group{nullptr};
 };
+
+/**
+ * Access to the head tasks singleton
+ * @return
+ */
+[[nodiscard]] auto get_tasks() -> HeadTasks&;
+
+/**
+ * Access to the head queues singleton
+ * @return
+ */
+[[nodiscard]] auto get_queue_client() -> HeadQueueClient&;
 
 /**
  * Access to the right tasks singleton
  * @return
  */
-[[nodiscard]] auto get_right_tasks() -> AllTask&;
+[[nodiscard]] auto get_right_tasks() -> MotorTasks&;
 
 /**
  * Access to the left tasks singleton
  * @return
  */
-[[nodiscard]] auto get_left_tasks() -> AllTask&;
+[[nodiscard]] auto get_left_tasks() -> MotorTasks&;
 
 /**
  * Access to the left queues singleton
  * @return
  */
-[[nodiscard]] auto get_left_queues() -> QueueClient&;
+[[nodiscard]] auto get_left_queues() -> MotorQueueClient&;
 
 /**
  * Access to the right queues singleton
  * @return
  */
-[[nodiscard]] auto get_right_queues() -> QueueClient&;
+[[nodiscard]] auto get_right_queues() -> MotorQueueClient&;
 
 }  // namespace head_tasks


### PR DESCRIPTION
## Summary

The head FW has three node ids: HEAD, HEAD_LEFT, and HEAD_RIGHT.  This PR adds ability for HEAD FW to respond as node id HEAD rather than either HEAD_LEFT or HEAD_RIGHT.

The presence sensing driver should not be addressable as LEFT or RIGHT. 

## Changes
Create a new task and queue collection for head that is independent of motor.