### PR TITLE
fix(spi): read requires two transmissions.

### DIFF
--- a/common/simulation/spi.cpp
+++ b/common/simulation/spi.cpp
@@ -19,6 +19,10 @@ void sim_spi::SimTMC2130Spi::transmit_receive(
     constexpr uint8_t write_mask =
         static_cast<uint8_t>(spi::TMC2130Spi::Mode::WRITE);
 
+    auto out_iter = receive.begin();
+    // Write status byte into buffer.
+    out_iter = bit_utils::int_to_bytes(status, out_iter, receive.end());
+
     uint8_t reg = control & ~write_mask;
 
     if (control & write_mask) {
@@ -26,12 +30,9 @@ void sim_spi::SimTMC2130Spi::transmit_receive(
         register_map[reg] = data;
     } else {
         // A read command will return the data from the previous read command.
-        auto out_iter = receive.begin();
-        out_iter =
-            bit_utils::int_to_bytes(read_register, out_iter, receive.end());
         out_iter = bit_utils::int_to_bytes(register_map[read_register],
                                            out_iter, receive.end());
-        // For the next read.
-        read_register = reg;
     }
+    // The register is cached for the next read operation.
+    read_register = reg;
 }

--- a/common/simulation/spi.cpp
+++ b/common/simulation/spi.cpp
@@ -22,11 +22,16 @@ void sim_spi::SimTMC2130Spi::transmit_receive(
     uint8_t reg = control & ~write_mask;
 
     if (control & write_mask) {
+        // This is a write command.
         register_map[reg] = data;
+    } else {
+        // A read command will return the data from the previous read command.
+        auto out_iter = receive.begin();
+        out_iter =
+            bit_utils::int_to_bytes(read_register, out_iter, receive.end());
+        out_iter = bit_utils::int_to_bytes(register_map[read_register],
+                                           out_iter, receive.end());
+        // For the next read.
+        read_register = reg;
     }
-
-    auto out_iter = receive.begin();
-    out_iter = bit_utils::int_to_bytes(reg, out_iter, receive.end());
-    out_iter =
-        bit_utils::int_to_bytes(register_map[reg], out_iter, receive.end());
 }

--- a/common/tests/test_spi.cpp
+++ b/common/tests/test_spi.cpp
@@ -46,6 +46,7 @@ SCENARIO("simulator works") {
             spi::TMC2130Spi::build_command(
                 transmit, spi::TMC2130Spi::Mode::READ, 0x01, 0);
             subject.transmit_receive(transmit, receive);
+            subject.transmit_receive(transmit, receive);
             THEN("the data is what was written") {
                 REQUIRE(receive[1] == 0xBE);
                 REQUIRE(receive[2] == 0xEF);
@@ -63,6 +64,7 @@ SCENARIO("simulator works") {
             spi::TMC2130Spi::build_command(
                 transmit, spi::TMC2130Spi::Mode::READ, 0x01, 0);
             subject.transmit_receive(transmit, receive);
+            subject.transmit_receive(transmit, receive);
             THEN("the data is was in the register map") {
                 REQUIRE(receive[1] == 0x0);
                 REQUIRE(receive[2] == 0x0);
@@ -72,6 +74,7 @@ SCENARIO("simulator works") {
 
             spi::TMC2130Spi::build_command(
                 transmit, spi::TMC2130Spi::Mode::READ, 0x02, 0);
+            subject.transmit_receive(transmit, receive);
             subject.transmit_receive(transmit, receive);
             THEN("the data is was in the register map") {
                 REQUIRE(receive[1] == 0x0);

--- a/common/tests/test_spi.cpp
+++ b/common/tests/test_spi.cpp
@@ -46,7 +46,6 @@ SCENARIO("simulator works") {
             spi::TMC2130Spi::build_command(
                 transmit, spi::TMC2130Spi::Mode::READ, 0x01, 0);
             subject.transmit_receive(transmit, receive);
-            subject.transmit_receive(transmit, receive);
             THEN("the data is what was written") {
                 REQUIRE(receive[1] == 0xBE);
                 REQUIRE(receive[2] == 0xEF);

--- a/include/common/simulation/spi.hpp
+++ b/include/common/simulation/spi.hpp
@@ -31,6 +31,8 @@ class SimTMC2130Spi : public spi::TMC2130Spi {
   private:
     RegisterMap register_map;
     uint8_t read_register{0};
+    // This status byte is unused currently but may have some use in the future.
+    uint8_t status{0};
 };
 
 }  // namespace sim_spi

--- a/include/common/simulation/spi.hpp
+++ b/include/common/simulation/spi.hpp
@@ -30,6 +30,7 @@ class SimTMC2130Spi : public spi::TMC2130Spi {
 
   private:
     RegisterMap register_map;
+    uint8_t read_register{0};
 };
 
 }  // namespace sim_spi

--- a/include/motor-control/core/motor_driver.hpp
+++ b/include/motor-control/core/motor_driver.hpp
@@ -33,6 +33,9 @@ class MotorDriver {
         auto txBuffer = spi::TMC2130Spi::BufferType{};
         spi::TMC2130Spi::build_command(txBuffer, spi::TMC2130Spi::Mode::READ,
                                        motor_reg, command_data);
+        // A read requires two transmissions. The second returns the data in the
+        // register from the first transmission.
+        spi_comms.transmit_receive(txBuffer, rxBuffer);
         spi_comms.transmit_receive(txBuffer, rxBuffer);
 
         // Extract data bytes after the address.


### PR DESCRIPTION
As @fsinapi pointed out a read command to the TMC2130 will return the data in the register specified in the previous command.

This PR simulates that behavior in the simulator and fixes the driver.