### PR TITLE
feat(python): add fw update message definitions.

### DIFF
--- a/python/opentrons_ot3_firmware/constants.py
+++ b/python/opentrons_ot3_firmware/constants.py
@@ -76,3 +76,9 @@ class MessageId(int, Enum):
 
     read_presence_sensing_voltage_request = 0x600
     read_presence_sensing_voltage_response = 0x601
+
+    fw_update_initiate = 0x60
+    fw_update_data = 0x61
+    fw_update_data_ack = 0x62
+    fw_update_complete = 0x63
+    fw_update_complete_ack = 0x64

--- a/python/opentrons_ot3_firmware/messages/message_definitions.py
+++ b/python/opentrons_ot3_firmware/messages/message_definitions.py
@@ -233,3 +233,58 @@ class ReadPresenceSensingVoltageResponse:  # noqa: D101
     message_id: Literal[
         MessageId.read_presence_sensing_voltage_response
     ] = MessageId.read_presence_sensing_voltage_response
+
+
+@dataclass
+class FirmwareUpdateInitiate:  # noqa: D101
+    payload: payloads.EmptyPayload
+    payload_type: Type[
+        BinarySerializable
+    ] = payloads.EmptyPayload
+    message_id: Literal[
+        MessageId.fw_update_initiate
+    ] = MessageId.fw_update_initiate
+
+
+@dataclass
+class FirmwareUpdateData:  # noqa: D101
+    payload: payloads.FirmwareUpdateData
+    payload_type: Type[
+        BinarySerializable
+    ] = payloads.FirmwareUpdateData
+    message_id: Literal[
+        MessageId.fw_update_data
+    ] = MessageId.fw_update_data
+
+
+@dataclass
+class FirmwareUpdateDataAcknowledge:  # noqa: D101
+    payload: payloads.FirmwareUpdateDataAcknowledge
+    payload_type: Type[
+        BinarySerializable
+    ] = payloads.FirmwareUpdateDataAcknowledge
+    message_id: Literal[
+        MessageId.fw_update_data_ack
+    ] = MessageId.fw_update_data_ack
+
+
+@dataclass
+class FirmwareUpdateComplete:  # noqa: D101
+    payload: payloads.FirmwareUpdateComplete
+    payload_type: Type[
+        BinarySerializable
+    ] = payloads.FirmwareUpdateComplete
+    message_id: Literal[
+        MessageId.fw_update_complete
+    ] = MessageId.fw_update_complete
+
+
+@dataclass
+class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
+    payload: payloads.FirmwareUpdateCompleteAcknowledge
+    payload_type: Type[
+        BinarySerializable
+    ] = payloads.FirmwareUpdateCompleteAcknowledge
+    message_id: Literal[
+        MessageId.fw_update_complete_ack
+    ] = MessageId.fw_update_complete_ack

--- a/python/opentrons_ot3_firmware/messages/messages.py
+++ b/python/opentrons_ot3_firmware/messages/messages.py
@@ -36,6 +36,8 @@ MessageDefinition = Union[
     defs.ReadMotorDriverResponse,
     defs.ReadPresenceSensingVoltageRequest,
     defs.ReadPresenceSensingVoltageResponse,
+    defs.FirmwareUpdateDataAcknowledge,
+    defs.FirmwareUpdateCompleteAcknowledge,
 ]
 
 

--- a/python/opentrons_ot3_firmware/messages/payloads.py
+++ b/python/opentrons_ot3_firmware/messages/payloads.py
@@ -149,3 +149,54 @@ class ReadPresenceSensingVoltageResponsePayload(utils.BinarySerializable):
     z_motor: utils.UInt16Field
     a_motor: utils.UInt16Field
     gripper: utils.UInt16Field
+
+
+@dataclass
+class FirmwareUpdateWithAddress(utils.BinarySerializable):
+    """A FW update payload with an address."""
+
+    address: utils.UInt32Field
+
+
+class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
+    """The data field of FirmwareUpdateData."""
+    NUM_BYTES = 56
+    FORMAT = f"{NUM_BYTES}s"
+
+
+@dataclass
+class FirmwareUpdateData(FirmwareUpdateWithAddress):
+    """A FW update data payload."""
+
+    num_bytes: utils.UInt8Field
+    reserved: utils.UInt8Field
+    data: FirmwareUpdateDataField
+    checksum: utils.UInt16Field
+
+    def __post_init__(self) -> None:
+        """Post init processing."""
+        data_length = len(self.data.value)
+        if data_length > FirmwareUpdateDataField.NUM_BYTES:
+            raise ValueError(f"Data cannot be more than"
+                             f" {FirmwareUpdateDataField.NUM_BYTES} bytes.")
+
+
+@dataclass
+class FirmwareUpdateDataAcknowledge(FirmwareUpdateWithAddress):
+    """A FW update data acknowledge payload."""
+
+    error_code: utils.UInt16Field
+
+
+@dataclass
+class FirmwareUpdateComplete(utils.BinarySerializable):
+    """All data messages have been transmitted."""
+
+    num_messages: utils.UInt32Field
+
+
+@dataclass
+class FirmwareUpdateCompleteAcknowledge(utils.BinarySerializable):
+    """A response to the FirmwareUpdateComplete message."""
+
+    error_code: utils.UInt16Field

--- a/python/opentrons_ot3_firmware/utils/binary_serializable.py
+++ b/python/opentrons_ot3_firmware/utils/binary_serializable.py
@@ -64,49 +64,49 @@ class BinaryFieldBase(Generic[T]):
 
 
 class UInt64Field(BinaryFieldBase[int]):
-    """Unsigned 64 bit integer field."""
+    """Unsigned 64-bit integer field."""
 
     FORMAT = "Q"
 
 
 class Int64Field(BinaryFieldBase[int]):
-    """Signed 64 bit integer field."""
+    """Signed 64-bit integer field."""
 
     FORMAT = "q"
 
 
 class UInt32Field(BinaryFieldBase[int]):
-    """Unsigned 32 bit integer field."""
+    """Unsigned 32-bit integer field."""
 
     FORMAT = "L"
 
 
 class Int32Field(BinaryFieldBase[int]):
-    """Signed 32 bit integer field."""
+    """Signed 32-bit integer field."""
 
     FORMAT = "l"
 
 
 class UInt16Field(BinaryFieldBase[int]):
-    """Unsigned 16 bit integer field."""
+    """Unsigned 16-bit integer field."""
 
     FORMAT = "H"
 
 
 class Int16Field(BinaryFieldBase[int]):
-    """Signed 16 bit integer field."""
+    """Signed 16-bit integer field."""
 
     FORMAT = "h"
 
 
 class UInt8Field(BinaryFieldBase[int]):
-    """Unsigned 8 bit integer field."""
+    """Unsigned 8-bit integer field."""
 
     FORMAT = "B"
 
 
 class Int8Field(BinaryFieldBase[int]):
-    """Signed 8 bit integer field."""
+    """Signed 8-bit integer field."""
 
     FORMAT = "b"
 


### PR DESCRIPTION
This adds python message definitions to support FW update over CANFD.

There's a preliminary doc on the FW update plan. 

These messages assume that each data message sent will require an acknowledgement from the FW. That is not the ideal as it might be too slow. I'd rather have some flow control from the FW side based on the CAN FIFO level.

But it gets us to where we can download data to FW.