### PR TITLE
feat(python,bootloader): expand code generation to support c

### DIFF
--- a/bootloader/CMakeLists.txt
+++ b/bootloader/CMakeLists.txt
@@ -1,5 +1,7 @@
 # bootloader source tree
 
+add_subdirectory(core)
+
 if (${CMAKE_CROSSCOMPILING})
     add_subdirectory(firmware)
 else ()

--- a/bootloader/core/CMakeLists.txt
+++ b/bootloader/core/CMakeLists.txt
@@ -1,0 +1,25 @@
+# This CMakeLists.txt handles everything that is compiled only when
+# cross-compiling, like the board support packages and special options.
+
+# generate the constants header that will provide node and message ids
+set(IDS_HPP_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../include/bootloader/core)
+set(IDS_HPP ${IDS_HPP_DIR}/ids.h)
+
+# while in theory we added the python sources to opentrons_generate_header
+# as INTERFACE sources and that should be transitive to the add_custom_command,
+# that doesn't actually work - maybe it would if this was a library? - so instead
+# we can just pull the list off the target props and explicitly depend on it here
+get_property(generator_sources TARGET opentrons_generate_header PROPERTY INTERFACE_SOURCES)
+
+add_custom_command(
+        OUTPUT ${IDS_HPP}
+        COMMAND opentrons_generate_header ${IDS_HPP} --language c
+        DEPENDS opentrons_generate_header ${generator_sources}
+)
+
+add_library(bootloader-core STATIC can.c ${IDS_HPP})
+
+target_include_directories(bootloader-core
+        PUBLIC
+        ${CMAKE_BINARY_DIR}/include
+        ${CMAKE_CURRENT_LIST_DIR}/../../include)

--- a/bootloader/core/can.c
+++ b/bootloader/core/can.c
@@ -1,0 +1,1 @@
+#include "bootloader/core/ids.h"

--- a/bootloader/firmware/stm32G4/CMakeLists.txt
+++ b/bootloader/firmware/stm32G4/CMakeLists.txt
@@ -15,7 +15,8 @@ macro(target_stm32G4 TARGET)
     ## todo: The bootloader project should have its own linker files. It cannot share the other subproject's
     target_link_libraries(${TARGET}
             PUBLIC STM32G491RETx
-            STM32G4xx_Drivers_Bootloader)
+            STM32G4xx_Drivers_Bootloader
+            bootloader-core)
 
     set_target_properties(${TARGET}
             PROPERTIES CXX_STANDARD 20
@@ -108,7 +109,6 @@ add_executable(bootloader-gantry-y
         ${BOOTLOADER_G4FW_NON_LINTABLE_SRCS})
 
 target_stm32G4(bootloader-gantry-y)
-
 
 target_include_directories(STM32G4xx_Drivers_Bootloader
         PUBLIC .)

--- a/bootloader/firmware/stm32L5/CMakeLists.txt
+++ b/bootloader/firmware/stm32L5/CMakeLists.txt
@@ -16,7 +16,8 @@ macro(target_stm32L5 TARGET)
     ## todo: The bootloader project should have its own linker files. It cannot share the other subproject's
     target_link_libraries(${TARGET}
             PUBLIC STM32L562RETx
-            STM32L5xx_Drivers_Bootloader)
+            STM32L5xx_Drivers_Bootloader
+            bootloader-core)
 
     set_target_properties(${TARGET}
             PROPERTIES CXX_STANDARD 20

--- a/python/opentrons_ot3_firmware/arbitration_id.py
+++ b/python/opentrons_ot3_firmware/arbitration_id.py
@@ -1,7 +1,11 @@
 """Can bus arbitration id."""
 from __future__ import annotations
 import ctypes
-from .constants import MESSAGE_ID_BITS, NODE_ID_BITS, FUNCTION_CODE_BITS
+from typing_extensions import Final
+
+NODE_ID_BITS: Final[int] = 7
+FUNCTION_CODE_BITS: Final[int] = 4
+MESSAGE_ID_BITS: Final[int] = 11
 
 
 class ArbitrationIdParts(ctypes.Structure):

--- a/python/opentrons_ot3_firmware/constants.py
+++ b/python/opentrons_ot3_firmware/constants.py
@@ -1,11 +1,5 @@
 """Constants for can bus."""
 from enum import Enum
-from typing_extensions import Final
-
-
-NODE_ID_BITS: Final[int] = 7
-FUNCTION_CODE_BITS: Final[int] = 4
-MESSAGE_ID_BITS: Final[int] = 11
 
 
 class NodeId(int, Enum):

--- a/python/opentrons_ot3_firmware/constants.py
+++ b/python/opentrons_ot3_firmware/constants.py
@@ -76,3 +76,12 @@ class MessageId(int, Enum):
     fw_update_data_ack = 0x62
     fw_update_complete = 0x63
     fw_update_complete_ack = 0x64
+
+
+
+class ErrorCode(int, Enum):
+    """Common error codes."""
+
+    ok = 0x00
+    invalid_length = 0x01
+    bad_checksum = 0x02

--- a/python/opentrons_ot3_firmware/messages/message_definitions.py
+++ b/python/opentrons_ot3_firmware/messages/message_definitions.py
@@ -238,53 +238,35 @@ class ReadPresenceSensingVoltageResponse:  # noqa: D101
 @dataclass
 class FirmwareUpdateInitiate:  # noqa: D101
     payload: payloads.EmptyPayload
-    payload_type: Type[
-        BinarySerializable
-    ] = payloads.EmptyPayload
-    message_id: Literal[
-        MessageId.fw_update_initiate
-    ] = MessageId.fw_update_initiate
+    payload_type: Type[BinarySerializable] = payloads.EmptyPayload
+    message_id: Literal[MessageId.fw_update_initiate] = MessageId.fw_update_initiate
 
 
 @dataclass
 class FirmwareUpdateData:  # noqa: D101
     payload: payloads.FirmwareUpdateData
-    payload_type: Type[
-        BinarySerializable
-    ] = payloads.FirmwareUpdateData
-    message_id: Literal[
-        MessageId.fw_update_data
-    ] = MessageId.fw_update_data
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateData
+    message_id: Literal[MessageId.fw_update_data] = MessageId.fw_update_data
 
 
 @dataclass
 class FirmwareUpdateDataAcknowledge:  # noqa: D101
     payload: payloads.FirmwareUpdateDataAcknowledge
-    payload_type: Type[
-        BinarySerializable
-    ] = payloads.FirmwareUpdateDataAcknowledge
-    message_id: Literal[
-        MessageId.fw_update_data_ack
-    ] = MessageId.fw_update_data_ack
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateDataAcknowledge
+    message_id: Literal[MessageId.fw_update_data_ack] = MessageId.fw_update_data_ack
 
 
 @dataclass
 class FirmwareUpdateComplete:  # noqa: D101
     payload: payloads.FirmwareUpdateComplete
-    payload_type: Type[
-        BinarySerializable
-    ] = payloads.FirmwareUpdateComplete
-    message_id: Literal[
-        MessageId.fw_update_complete
-    ] = MessageId.fw_update_complete
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateComplete
+    message_id: Literal[MessageId.fw_update_complete] = MessageId.fw_update_complete
 
 
 @dataclass
 class FirmwareUpdateCompleteAcknowledge:  # noqa: D101
     payload: payloads.FirmwareUpdateCompleteAcknowledge
-    payload_type: Type[
-        BinarySerializable
-    ] = payloads.FirmwareUpdateCompleteAcknowledge
+    payload_type: Type[BinarySerializable] = payloads.FirmwareUpdateCompleteAcknowledge
     message_id: Literal[
         MessageId.fw_update_complete_ack
     ] = MessageId.fw_update_complete_ack

--- a/python/opentrons_ot3_firmware/messages/payloads.py
+++ b/python/opentrons_ot3_firmware/messages/payloads.py
@@ -160,6 +160,7 @@ class FirmwareUpdateWithAddress(utils.BinarySerializable):
 
 class FirmwareUpdateDataField(utils.BinaryFieldBase[bytes]):
     """The data field of FirmwareUpdateData."""
+
     NUM_BYTES = 56
     FORMAT = f"{NUM_BYTES}s"
 
@@ -177,8 +178,10 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
         """Post init processing."""
         data_length = len(self.data.value)
         if data_length > FirmwareUpdateDataField.NUM_BYTES:
-            raise ValueError(f"Data cannot be more than"
-                             f" {FirmwareUpdateDataField.NUM_BYTES} bytes.")
+            raise ValueError(
+                f"Data cannot be more than"
+                f" {FirmwareUpdateDataField.NUM_BYTES} bytes."
+            )
 
 
 @dataclass

--- a/python/opentrons_ot3_firmware/scripts/generate_header.py
+++ b/python/opentrons_ot3_firmware/scripts/generate_header.py
@@ -69,6 +69,7 @@ def write_enum_cpp(e: Type[Enum], output: io.StringIO) -> None:
         for i in e:
             output.write(f"  {i.name} = 0x{i.value:x},\n")
 
+
 def generate_c(output: io.StringIO) -> None:
     """Generate source code into output."""
     generate_file_comment(output)
@@ -117,7 +118,7 @@ def main() -> None:
     )
 
     parser.add_argument(
-        "language",
+        "--language",
         metavar="language",
         type=Languge,
         default=Languge.CPP,

--- a/python/opentrons_ot3_firmware/scripts/generate_header.py
+++ b/python/opentrons_ot3_firmware/scripts/generate_header.py
@@ -84,7 +84,7 @@ def write_enum_c(e: Type[Enum], output: io.StringIO) -> None:
     output.write(f"/** {e.__doc__} */\n")
     for i in e:
         name = "_".join(("can", e.__name__, i.name)).upper()
-        output.write(f"#define {name} = 0x{i.value:x},\n")
+        output.write(f"#define {name} = 0x{i.value:x}\n")
 
 
 def write_arbitration_id_c(output: io.StringIO) -> None:

--- a/python/opentrons_ot3_firmware/scripts/generate_header.py
+++ b/python/opentrons_ot3_firmware/scripts/generate_header.py
@@ -10,6 +10,7 @@ from opentrons_ot3_firmware.constants import (
     MessageId,
     FunctionCode,
     NodeId,
+    ErrorCode,
 )
 from opentrons_ot3_firmware.arbitration_id import ArbitrationIdParts
 
@@ -58,6 +59,7 @@ def generate_cpp(output: io.StringIO) -> None:
         write_enum_cpp(FunctionCode, output)
         write_enum_cpp(MessageId, output)
         write_enum_cpp(NodeId, output)
+        write_enum_cpp(ErrorCode, output)
 
 
 def write_enum_cpp(e: Type[Enum], output: io.StringIO) -> None:
@@ -76,15 +78,19 @@ def generate_c(output: io.StringIO) -> None:
     write_enum_c(FunctionCode, output)
     write_enum_c(MessageId, output)
     write_enum_c(NodeId, output)
+    write_enum_c(ErrorCode, output)
     write_arbitration_id_c(output)
 
 
 def write_enum_c(e: Type[Enum], output: io.StringIO) -> None:
     """Generate constants from enumeration."""
     output.write(f"/** {e.__doc__} */\n")
-    for i in e:
-        name = "_".join(("can", e.__name__, i.name)).upper()
-        output.write(f"#define {name} = 0x{i.value:x}\n")
+    with block(
+        output=output, start=f"enum {e.__name__} {{\n", terminate="};\n\n"
+    ):
+        for i in e:
+            name = "_".join(("can", e.__name__, i.name)).lower()
+            output.write(f"  {name} = 0x{i.value:x},\n")
 
 
 def write_arbitration_id_c(output: io.StringIO) -> None:

--- a/python/opentrons_ot3_firmware/scripts/generate_header.py
+++ b/python/opentrons_ot3_firmware/scripts/generate_header.py
@@ -11,7 +11,7 @@ from opentrons_ot3_firmware.constants import (
     FunctionCode,
     NodeId,
 )
-from opentrons_ot3_firmware.arbitration_id import ArbitrationId, ArbitrationIdParts
+from opentrons_ot3_firmware.arbitration_id import ArbitrationIdParts
 
 
 class block:
@@ -91,13 +91,17 @@ def write_arbitration_id_c(output: io.StringIO) -> None:
     """Generate C arbitration id code."""
     output.write(f"/** {ArbitrationIdParts.__doc__} */\n")
     with block(
-        output=output, start=f"struct {ArbitrationIdParts.__name__} {{\n", terminate="};\n\n"
+        output=output,
+        start=f"struct {ArbitrationIdParts.__name__} {{\n",
+        terminate="};\n\n",
     ):
         for i in ArbitrationIdParts._fields_:
             output.write(f"  unsigned int {i[0]}: {i[2]};\n")
 
 
 class Languge(str, Enum):
+    """Langauge enum."""
+
     C = "c"
     CPP = "c++"
     CPP_alt = "cpp"

--- a/python/opentrons_ot3_firmware/scripts/generate_header.py
+++ b/python/opentrons_ot3_firmware/scripts/generate_header.py
@@ -11,6 +11,7 @@ from opentrons_ot3_firmware.constants import (
     FunctionCode,
     NodeId,
 )
+from opentrons_ot3_firmware.arbitration_id import ArbitrationId, ArbitrationIdParts
 
 
 class block:
@@ -38,23 +39,28 @@ class block:
         self._output.write(self._terminate)
 
 
-def generate(output: io.StringIO) -> None:
-    """Generate source code into output."""
+def generate_file_comment(output: io.StringIO) -> None:
+    """Generate the header file comment."""
     output.write("/********************************************\n")
     output.write("* This is a generated file. Do not modify.  *\n")
     output.write("********************************************/\n")
     output.write("#pragma once\n\n")
+
+
+def generate_cpp(output: io.StringIO) -> None:
+    """Generate source code into output."""
+    generate_file_comment(output)
     with block(
         output=output,
         start="namespace can_ids {\n\n",
         terminate="} // namespace can_ids\n\n",
     ):
-        write_enum(FunctionCode, output)
-        write_enum(MessageId, output)
-        write_enum(NodeId, output)
+        write_enum_cpp(FunctionCode, output)
+        write_enum_cpp(MessageId, output)
+        write_enum_cpp(NodeId, output)
 
 
-def write_enum(e: Type[Enum], output: io.StringIO) -> None:
+def write_enum_cpp(e: Type[Enum], output: io.StringIO) -> None:
     """Generate enum class from enumeration."""
     output.write(f"/** {e.__doc__} */\n")
     with block(
@@ -63,11 +69,43 @@ def write_enum(e: Type[Enum], output: io.StringIO) -> None:
         for i in e:
             output.write(f"  {i.name} = 0x{i.value:x},\n")
 
+def generate_c(output: io.StringIO) -> None:
+    """Generate source code into output."""
+    generate_file_comment(output)
+    write_enum_c(FunctionCode, output)
+    write_enum_c(MessageId, output)
+    write_enum_c(NodeId, output)
+    write_arbitration_id_c(output)
+
+
+def write_enum_c(e: Type[Enum], output: io.StringIO) -> None:
+    """Generate constants from enumeration."""
+    output.write(f"/** {e.__doc__} */\n")
+    for i in e:
+        name = "_".join(("can", e.__name__, i.name)).upper()
+        output.write(f"#define {name} = 0x{i.value:x},\n")
+
+
+def write_arbitration_id_c(output: io.StringIO) -> None:
+    """Generate C arbitration id code."""
+    output.write(f"/** {ArbitrationIdParts.__doc__} */\n")
+    with block(
+        output=output, start=f"struct {ArbitrationIdParts.__name__} {{\n", terminate="};\n\n"
+    ):
+        for i in ArbitrationIdParts._fields_:
+            output.write(f"  unsigned int {i[0]}: {i[2]};\n")
+
+
+class Languge(str, Enum):
+    C = "c"
+    CPP = "c++"
+    CPP_alt = "cpp"
+
 
 def main() -> None:
     """Entry point."""
     parser = argparse.ArgumentParser(
-        description="Generate a C++ header file defining CANBUS constants."
+        description="Generate a C or C++ header files defining CANBUS constants."
     )
     parser.add_argument(
         "target",
@@ -78,9 +116,22 @@ def main() -> None:
         help="path of header file to generate; use - or do not specify for stdout",
     )
 
+    parser.add_argument(
+        "language",
+        metavar="language",
+        type=Languge,
+        default=Languge.CPP,
+        choices=Languge,
+        nargs="?",
+        help=f"language to use. can be one of {','.join(l.value for l in Languge)}",
+    )
+
     args = parser.parse_args()
 
-    generate(args.target)
+    if args.language in {Languge.CPP, Languge.CPP_alt}:
+        generate_cpp(args.target)
+    if args.language in {Languge.C}:
+        generate_c(args.target)
 
 
 if __name__ == "__main__":

--- a/python/tests/opentrons_ot3_firmware/test_constants.py
+++ b/python/tests/opentrons_ot3_firmware/test_constants.py
@@ -4,14 +4,19 @@ from typing import Iterable
 import pytest
 
 from opentrons_ot3_firmware import constants
+from opentrons_ot3_firmware.arbitration_id import (
+    NODE_ID_BITS,
+    MESSAGE_ID_BITS,
+    FUNCTION_CODE_BITS,
+)
 
 
 @pytest.mark.parametrize(
     argnames=["subject", "bit_width"],
     argvalues=[
-        [constants.NodeId, constants.NODE_ID_BITS],
-        [constants.MessageId, constants.MESSAGE_ID_BITS],
-        [constants.FunctionCode, constants.FUNCTION_CODE_BITS],
+        [constants.NodeId, NODE_ID_BITS],
+        [constants.MessageId, MESSAGE_ID_BITS],
+        [constants.FunctionCode, FUNCTION_CODE_BITS],
     ],
 )
 def test_range(subject: Iterable[int], bit_width: int) -> None:


### PR DESCRIPTION
The bootloader will be written in C and will need to know about CAN arbitration ids. 

This PR adds ability to specify which language to target in the `generate_header` script. Additionally, the `generate_header` script spits out a bit field for C implementation.

The C++ generation is unchanged.

The generated C is like so 

```
/********************************************
* This is a generated file. Do not modify.  *
********************************************/
#pragma once

/** Can bus arbitration id function code. */
enum FunctionCode {
  can_functioncode_network_management = 0x0,
  can_functioncode_sync = 0x1,
  can_functioncode_error = 0x2,
  can_functioncode_command = 0x3,
  can_functioncode_status = 0x4,
  can_functioncode_parameters = 0x5,
  can_functioncode_bootloader = 0x6,
  can_functioncode_heartbeat = 0x7,
};

/** Can bus arbitration id message id. */
enum MessageId {
  can_messageid_heartbeat_request = 0x3ff,
  can_messageid_heartbeat_response = 0x3fe,
  can_messageid_device_info_request = 0x302,
  can_messageid_device_info_response = 0x303,
  can_messageid_stop_request = 0x0,
  can_messageid_get_status_request = 0x1,
  can_messageid_get_status_response = 0x5,
  can_messageid_enable_motor_request = 0x6,
  can_messageid_disable_motor_request = 0x7,
  can_messageid_move_request = 0x10,
  can_messageid_setup_request = 0x2,
  can_messageid_write_eeprom = 0x201,
  can_messageid_read_eeprom_request = 0x202,
  can_messageid_read_eeprom_response = 0x203,
  can_messageid_add_move_request = 0x15,
  can_messageid_get_move_group_request = 0x16,
  can_messageid_get_move_group_response = 0x17,
  can_messageid_execute_move_group_request = 0x18,
  can_messageid_clear_all_move_groups_request = 0x19,
  can_messageid_move_completed = 0x13,
  can_messageid_set_motion_constraints = 0x101,
  can_messageid_get_motion_constraints_request = 0x102,
  can_messageid_get_motion_constraints_response = 0x103,
  can_messageid_write_motor_driver_register_request = 0x30,
  can_messageid_read_motor_driver_register_request = 0x31,
  can_messageid_read_motor_driver_register_response = 0x32,
  can_messageid_read_presence_sensing_voltage_request = 0x600,
  can_messageid_read_presence_sensing_voltage_response = 0x601,
  can_messageid_fw_update_initiate = 0x60,
  can_messageid_fw_update_data = 0x61,
  can_messageid_fw_update_data_ack = 0x62,
  can_messageid_fw_update_complete = 0x63,
  can_messageid_fw_update_complete_ack = 0x64,
};

/** Can bus arbitration id node id. */
enum NodeId {
  can_nodeid_broadcast = 0x0,
  can_nodeid_host = 0x10,
  can_nodeid_pipette = 0x20,
  can_nodeid_gantry_x = 0x30,
  can_nodeid_gantry_y = 0x40,
  can_nodeid_head = 0x50,
  can_nodeid_head_l = 0x51,
  can_nodeid_head_r = 0x52,
};

/** Common error codes. */
enum ErrorCode {
  can_errorcode_ok = 0x0,
  can_errorcode_invalid_length = 0x1,
  can_errorcode_bad_checksum = 0x2,
};

/** A bit field of the arbitration id parts. */
struct ArbitrationIdParts {
  unsigned int function_code: 4;
  unsigned int node_id: 7;
  unsigned int originating_node_id: 7;
  unsigned int message_id: 11;
  unsigned int padding: 3;
};

```