### PR TITLE
fix(gantry): x direction inversion

### DIFF
--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -75,7 +75,6 @@ struct motion_controller::HardwareConfig motor_pins_y {
         .active_setting = GPIO_PIN_SET},
 };
 
-
 /**
  * The motor hardware interface.
  */

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -35,7 +35,27 @@ static spi::Spi spi_comms(SPI_intf);
 /**
  * Motor pin configuration.
  */
-struct motion_controller::HardwareConfig motor_pins {
+struct motion_controller::HardwareConfig motor_pins_x {
+    .direction =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOB,
+            .pin = GPIO_PIN_1,
+            .active_setting = GPIO_PIN_RESET},
+    .step =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOC,
+            .pin = GPIO_PIN_8,
+            .active_setting = GPIO_PIN_SET},
+    .enable = {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        .port = GPIOA,
+        .pin = GPIO_PIN_9,
+        .active_setting = GPIO_PIN_SET},
+};
+
+struct motion_controller::HardwareConfig motor_pins_y {
     .direction =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -55,10 +75,12 @@ struct motion_controller::HardwareConfig motor_pins {
         .active_setting = GPIO_PIN_SET},
 };
 
+
 /**
  * The motor hardware interface.
  */
-static motor_hardware::MotorHardware motor_hardware_iface(motor_pins, &htim7);
+static motor_hardware::MotorHardware motor_hardware_iface(
+    (get_axis_type() == gantry_x) ? motor_pins_x : motor_pins_y, &htim7);
 
 /**
  * The can bus.


### PR DESCRIPTION
X homes to the physical right of the robot, and since we want to keep
its positions positive and home to 0, that means that positive motion is
right to left. That means we need to invert the sense of the direction
pin, which is now different from Y, so we need separate settings.