### PR TITLE
fix(codegen): "Namespace" C enums.

### DIFF
--- a/bootloader/core/message_handler.c
+++ b/bootloader/core/message_handler.c
@@ -69,7 +69,7 @@ HandleMessageReturn handle_initiate_fw_update(const Message* request, Message* r
 
 HandleMessageReturn handle_fw_update_data(const Message* request, Message* response) {
     UpdateData data;
-    ErrorCode e = parse_update_data(request->data, request->size, &data);
+    CANErrorCode e = parse_update_data(request->data, request->size, &data);
 
     if (e == can_errorcode_ok) {
         // All is good. Pass on to updater.
@@ -97,7 +97,7 @@ HandleMessageReturn handle_fw_update_data(const Message* request, Message* respo
 
 HandleMessageReturn handle_fw_update_complete(const Message* request, Message* response) {
     UpdateComplete complete;
-    ErrorCode e = parse_update_complete(request->data, request->size, &complete);
+    CANErrorCode e = parse_update_complete(request->data, request->size, &complete);
 
     if (e == can_errorcode_ok) {
         FwUpdateReturn updater_return = fw_update_complete(

--- a/bootloader/core/messages.c
+++ b/bootloader/core/messages.c
@@ -8,7 +8,7 @@
  * @param result Pointer to UpdateData struct to populate
  * @return result code
  */
-ErrorCode parse_update_data(
+CANErrorCode parse_update_data(
     const uint8_t * buffer,
     uint32_t size,
     UpdateData * result) {
@@ -55,7 +55,7 @@ ErrorCode parse_update_data(
  * @param result Pointer to UpdateComplete struct to populate
  * @return result code
  */
-ErrorCode parse_update_complete(
+CANErrorCode parse_update_complete(
     const uint8_t * buffer,
     uint32_t size,
     UpdateComplete * result) {

--- a/bootloader/firmware/main.c
+++ b/bootloader/firmware/main.c
@@ -33,8 +33,8 @@ static void initialize_can(FDCAN_HandleTypeDef * can_handle) {
         Error_Handler();
     }
 
-    ArbitrationId arb_mask;
-    ArbitrationId arb_filter;
+    CANArbitrationId arb_mask;
+    CANArbitrationId arb_filter;
 
     FDCAN_FilterTypeDef filter_def = {
         .IdType = FDCAN_EXTENDED_ID,

--- a/bootloader/firmware/node_id.c
+++ b/bootloader/firmware/node_id.c
@@ -4,7 +4,7 @@
  * Get the node id this bootloader is installed on
  * @return Node id.
  */
-NodeId get_node_id(void) {
+CANNodeId get_node_id(void) {
 #if defined node_id_pipette
     return can_nodeid_pipette_bootloader;
 #elif defined node_id_head

--- a/bootloader/tests/test_message_handler.cpp
+++ b/bootloader/tests/test_message_handler.cpp
@@ -8,7 +8,7 @@
 #include "catch2/catch.hpp"
 
 /** Stub out get node id. */
-NodeId get_node_id(void) { return can_nodeid_pipette_bootloader; }
+CANNodeId get_node_id(void) { return can_nodeid_pipette_bootloader; }
 
 /** Stub out get version. */
 uint32_t get_version(void) { return 0xDEADBEEF; }

--- a/include/bootloader/core/message_handler.h
+++ b/include/bootloader/core/message_handler.h
@@ -13,15 +13,15 @@ extern "C" {
  * Arbitration ID type.
  */
 typedef union {
-    ArbitrationIdParts parts;
+    CANArbitrationIdParts parts;
     uint32_t id;
-} ArbitrationId;
+} CANArbitrationId;
 
 /**
  * Message definition.
  */
 typedef struct {
-    ArbitrationId arbitration_id;
+    CANArbitrationId arbitration_id;
     uint8_t size;
     uint8_t data[64];
 } Message;

--- a/include/bootloader/core/messages.h
+++ b/include/bootloader/core/messages.h
@@ -39,7 +39,7 @@ typedef struct {
  * @param result Pointer to UpdateData struct to populate
  * @return result code
  */
-ErrorCode parse_update_data(
+CANErrorCode parse_update_data(
     const uint8_t * buffer,
     uint32_t size,
     UpdateData * result);
@@ -52,7 +52,7 @@ ErrorCode parse_update_data(
  * @param result Pointer to UpdateComplete struct to populate
  * @return result code
  */
-ErrorCode parse_update_complete(
+CANErrorCode parse_update_complete(
     const uint8_t * buffer,
     uint32_t size,
     UpdateComplete * result);

--- a/include/bootloader/core/node_id.h
+++ b/include/bootloader/core/node_id.h
@@ -11,7 +11,7 @@ extern "C" {
  * not implemented in core lib. Must be implemented in executables.
  * @return Node id.
  */
-NodeId get_node_id(void);
+CANNodeId get_node_id(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/python/opentrons_ot3_firmware/scripts/generate_header.py
+++ b/python/opentrons_ot3_firmware/scripts/generate_header.py
@@ -75,31 +75,32 @@ def write_enum_cpp(e: Type[Enum], output: io.StringIO) -> None:
 def generate_c(output: io.StringIO) -> None:
     """Generate source code into output."""
     generate_file_comment(output)
-    write_enum_c(FunctionCode, output)
-    write_enum_c(MessageId, output)
-    write_enum_c(NodeId, output)
-    write_enum_c(ErrorCode, output)
-    write_arbitration_id_c(output)
+    can = "CAN"
+    write_enum_c(FunctionCode, output, can)
+    write_enum_c(MessageId, output, can)
+    write_enum_c(NodeId, output, can)
+    write_enum_c(ErrorCode, output, can)
+    write_arbitration_id_c(output, can)
 
 
-def write_enum_c(e: Type[Enum], output: io.StringIO) -> None:
+def write_enum_c(e: Type[Enum], output: io.StringIO, prefix: str) -> None:
     """Generate constants from enumeration."""
     output.write(f"/** {e.__doc__} */\n")
     with block(
-        output=output, start="typedef enum {\n", terminate=f"}} {e.__name__};\n\n"
+        output=output, start="typedef enum {\n", terminate=f"}} {prefix}{e.__name__};\n\n"
     ):
         for i in e:
             name = "_".join(("can", e.__name__, i.name)).lower()
             output.write(f"  {name} = 0x{i.value:x},\n")
 
 
-def write_arbitration_id_c(output: io.StringIO) -> None:
+def write_arbitration_id_c(output: io.StringIO, prefix: str) -> None:
     """Generate C arbitration id code."""
     output.write(f"/** {ArbitrationIdParts.__doc__} */\n")
     with block(
         output=output,
         start="typedef struct {\n",
-        terminate=f"}} {ArbitrationIdParts.__name__};\n\n",
+        terminate=f"}} {prefix}{ArbitrationIdParts.__name__};\n\n",
     ):
         for i in ArbitrationIdParts._fields_:
             output.write(f"  unsigned int {i[0]}: {i[2]};\n")


### PR DESCRIPTION
Prefix generated C enums with CAN to avoid clashes with C++. More consistent with C-style.

This is an issue for bootloader simulator as it uses both C++ and C generated types. 



