### PR TITLE
fix(head): Missing motor configs

### DIFF
--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -95,7 +95,7 @@ struct motor_hardware::HardwareConfig pin_configurations_right {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         .port = GPIOB,
         .pin = GPIO_PIN_11,
-        .active_setting = GPIO_PIN_SET},
+        .active_setting = GPIO_PIN_RESET},
 };
 
 motor_driver_config::RegisterConfig MotorDriverConfigurations{

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -34,7 +34,8 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
         HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0, GPIO_PIN_RESET);
         HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_RESET);
 
-        GPIO_InitStruct.Pin = GPIO_PIN_6;
+        // A motor step and direction
+        GPIO_InitStruct.Pin = GPIO_PIN_6 | GPIO_PIN_7;
         GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
         HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
                       &GPIO_InitStruct);


### PR DESCRIPTION
A couple other things that were missed - flip the Z motor activation
setting and initialize the direction pin.