### PR TITLE
feat(can): Node IDs for left and right pipette

### DIFF
--- a/bootloader/firmware/node_id.c
+++ b/bootloader/firmware/node_id.c
@@ -5,8 +5,9 @@
  * @return Node id.
  */
 CANNodeId get_node_id(void) {
-#if defined node_id_pipette
-    return can_nodeid_pipette_bootloader;
+#if defined node_id_pipette_left
+    // TODO make this decision based on the mount sense voltage
+    return can_nodeid_pipette_left_bootloader;
 #elif defined node_id_head
     return can_nodeid_head_bootloader;
 #elif defined node_id_gantry_x

--- a/bootloader/firmware/stm32L5/CMakeLists.txt
+++ b/bootloader/firmware/stm32L5/CMakeLists.txt
@@ -95,7 +95,7 @@ add_executable(bootloader-pipettes
         ${BOOTLOADER_FW_NON_LINTABLE_SRCS}
         ${BOOTLOADER_L5_FW_NON_LINTABLE_SRCS})
 
-target_compile_definitions(bootloader-pipettes PUBLIC node_id_pipette)
+target_compile_definitions(bootloader-pipettes PUBLIC node_id_pipette_left)
 
 target_stm32L5(bootloader-pipettes)
 

--- a/bootloader/tests/test_message_handler.cpp
+++ b/bootloader/tests/test_message_handler.cpp
@@ -8,7 +8,7 @@
 #include "catch2/catch.hpp"
 
 /** Stub out get node id. */
-CANNodeId get_node_id(void) { return can_nodeid_pipette_bootloader; }
+CANNodeId get_node_id(void) { return can_nodeid_pipette_left_bootloader; }
 
 /** Stub out get version. */
 uint32_t get_version(void) { return 0xDEADBEEF; }

--- a/can/tests/test_arbitration_id.cpp
+++ b/can/tests/test_arbitration_id.cpp
@@ -49,8 +49,8 @@ SCENARIO("Arbitration ID") {
             subject.message_id(MessageId::get_move_group_request);
             subject.originating_node_id(NodeId::broadcast);
             subject.originating_node_id(NodeId::gantry_x);
-            subject.originating_node_id(NodeId::pipette);
-            subject.node_id(NodeId::pipette);
+            subject.originating_node_id(NodeId::pipette_right);
+            subject.node_id(NodeId::pipette_left);
             subject.node_id(NodeId::gantry_x);
             subject.node_id(NodeId::broadcast);
 
@@ -58,7 +58,7 @@ SCENARIO("Arbitration ID") {
                 REQUIRE(subject.message_id() ==
                         MessageId::get_move_group_request);
                 REQUIRE(subject.node_id() == NodeId::broadcast);
-                REQUIRE(subject.originating_node_id() == NodeId::pipette);
+                REQUIRE(subject.originating_node_id() == NodeId::pipette_right);
             }
         }
     }

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -21,7 +21,6 @@ class MessageWriter {
 
     explicit MessageWriter(can_ids::NodeId node_id) : node_id(node_id) {}
 
-
     /**
      * Write a message to the can bus
      *

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -21,6 +21,7 @@ class MessageWriter {
 
     explicit MessageWriter(can_ids::NodeId node_id) : node_id(node_id) {}
 
+
     /**
      * Write a message to the can bus
      *
@@ -44,9 +45,9 @@ class MessageWriter {
     }
 
     void set_queue(QueueType* q) { queue = q; }
+    can_ids::NodeId node_id;
 
   private:
     QueueType* queue{nullptr};
-    can_ids::NodeId node_id;
 };
 }  // namespace can_message_writer

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -44,9 +44,10 @@ class MessageWriter {
     }
 
     void set_queue(QueueType* q) { queue = q; }
-    can_ids::NodeId node_id;
+    void set_node_id(can_ids::NodeId id) { node_id = id; }
 
   private:
+    can_ids::NodeId node_id;
     QueueType* queue{nullptr};
 };
 }  // namespace can_message_writer

--- a/include/pipettes/core/can_task.hpp
+++ b/include/pipettes/core/can_task.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "can/core/can_bus.hpp"
-#include "can/core/ids.hpp"
 #include "can/core/can_writer_task.hpp"
+#include "can/core/ids.hpp"
 #include "common/core/freertos_message_queue.hpp"
 
 namespace can_bus {
@@ -13,8 +13,9 @@ namespace can_task {
 
 struct CanMessageReaderTask {
     [[noreturn]] void operator()(can_bus::CanBus* can_bus);
-    // For value injection; this object is created at static-ctor time but we wont
-    // know the value until we get to runtime, so we have to defer it like this
+    // For value injection; this object is created at static-ctor time but we
+    // wont know the value until we get to runtime, so we have to defer it like
+    // this
     can_ids::NodeId listen_id;
 };
 
@@ -24,7 +25,8 @@ struct CanMessageReaderTask {
  * @param canbus reference to the can bus
  * @return The task.
  */
-auto start_reader(can_bus::CanBus& canbus, can_ids::NodeId id) -> CanMessageReaderTask&;
+auto start_reader(can_bus::CanBus& canbus, can_ids::NodeId id)
+    -> CanMessageReaderTask&;
 
 using CanMessageWriterTask = message_writer_task::MessageWriterTask<
     freertos_message_queue::FreeRTOSMessageQueue>;

--- a/include/pipettes/core/can_task.hpp
+++ b/include/pipettes/core/can_task.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "can/core/can_bus.hpp"
+#include "can/core/ids.hpp"
 #include "can/core/can_writer_task.hpp"
 #include "common/core/freertos_message_queue.hpp"
 
@@ -12,6 +13,9 @@ namespace can_task {
 
 struct CanMessageReaderTask {
     [[noreturn]] void operator()(can_bus::CanBus* can_bus);
+    // For value injection; this object is created at static-ctor time but we wont
+    // know the value until we get to runtime, so we have to defer it like this
+    can_ids::NodeId listen_id;
 };
 
 /**
@@ -20,7 +24,7 @@ struct CanMessageReaderTask {
  * @param canbus reference to the can bus
  * @return The task.
  */
-auto start_reader(can_bus::CanBus& canbus) -> CanMessageReaderTask&;
+auto start_reader(can_bus::CanBus& canbus, can_ids::NodeId id) -> CanMessageReaderTask&;
 
 using CanMessageWriterTask = message_writer_task::MessageWriterTask<
     freertos_message_queue::FreeRTOSMessageQueue>;

--- a/include/pipettes/core/tasks.hpp
+++ b/include/pipettes/core/tasks.hpp
@@ -19,8 +19,7 @@ void start_tasks(can_bus::CanBus& can_bus,
                  motion_controller::MotionController<lms::LeadScrewConfig>&
                      motion_controller,
                  motor_driver::MotorDriver& motor_driver,
-                 i2c::I2CDeviceBase& i2c,
-                 can_ids::NodeId id);
+                 i2c::I2CDeviceBase& i2c, can_ids::NodeId id);
 
 /**
  * Access to all the message queues in the system.

--- a/include/pipettes/core/tasks.hpp
+++ b/include/pipettes/core/tasks.hpp
@@ -19,7 +19,8 @@ void start_tasks(can_bus::CanBus& can_bus,
                  motion_controller::MotionController<lms::LeadScrewConfig>&
                      motion_controller,
                  motor_driver::MotorDriver& motor_driver,
-                 i2c::I2CDeviceBase& i2c);
+                 i2c::I2CDeviceBase& i2c,
+                 can_ids::NodeId id);
 
 /**
  * Access to all the message queues in the system.

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -92,7 +92,8 @@ void callback(void* cb_data, uint32_t identifier, uint8_t* data,
 [[noreturn]] void can_task::CanMessageReaderTask::operator()(
     can_bus::CanBus* can_bus) {
     can_bus->set_incoming_message_callback(nullptr, callback);
-    can_bus->setup_node_id_filter(can_ids::NodeId::pipette);
+    can_bus->setup_node_id_filter(can_ids::NodeId::pipette_left);
+
     auto poller = freertos_can_dispatch::FreeRTOSCanBufferPoller(
         read_can_message_buffer, dispatcher);
     poller();

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -92,6 +92,7 @@ void callback(void* cb_data, uint32_t identifier, uint8_t* data,
 [[noreturn]] void can_task::CanMessageReaderTask::operator()(
     can_bus::CanBus* can_bus) {
     can_bus->set_incoming_message_callback(nullptr, callback);
+    // TODO: Set this based on tool attach value
     can_bus->setup_node_id_filter(can_ids::NodeId::pipette_left);
 
     auto poller = freertos_can_dispatch::FreeRTOSCanBufferPoller(

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -1,8 +1,8 @@
 #include "pipettes/core/can_task.hpp"
 
-#include "can/core/ids.hpp"
 #include "can/core/dispatch.hpp"
 #include "can/core/freertos_can_dispatch.hpp"
+#include "can/core/ids.hpp"
 #include "can/core/message_handlers/device_info.hpp"
 #include "can/core/message_handlers/motion.hpp"
 #include "can/core/message_handlers/motor.hpp"
@@ -100,7 +100,8 @@ void callback(void* cb_data, uint32_t identifier, uint8_t* data,
     poller();
 }
 
-auto static reader_task = can_task::CanMessageReaderTask{can_ids::NodeId::pipette_left};
+auto static reader_task =
+    can_task::CanMessageReaderTask{can_ids::NodeId::pipette_left};
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -1,5 +1,6 @@
 #include "pipettes/core/can_task.hpp"
 
+#include "can/core/ids.hpp"
 #include "can/core/dispatch.hpp"
 #include "can/core/freertos_can_dispatch.hpp"
 #include "can/core/message_handlers/device_info.hpp"
@@ -92,15 +93,14 @@ void callback(void* cb_data, uint32_t identifier, uint8_t* data,
 [[noreturn]] void can_task::CanMessageReaderTask::operator()(
     can_bus::CanBus* can_bus) {
     can_bus->set_incoming_message_callback(nullptr, callback);
-    // TODO: Set this based on tool attach value
-    can_bus->setup_node_id_filter(can_ids::NodeId::pipette_left);
+    can_bus->setup_node_id_filter(listen_id);
 
     auto poller = freertos_can_dispatch::FreeRTOSCanBufferPoller(
         read_can_message_buffer, dispatcher);
     poller();
 }
 
-auto static reader_task = can_task::CanMessageReaderTask{};
+auto static reader_task = can_task::CanMessageReaderTask{can_ids::NodeId::pipette_left};
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =
@@ -110,8 +110,9 @@ auto static writer_task_control =
     freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask,
                                 can_bus::CanBus>{writer_task};
 
-auto can_task::start_reader(can_bus::CanBus& canbus)
+auto can_task::start_reader(can_bus::CanBus& canbus, can_ids::NodeId id)
     -> can_task::CanMessageReaderTask& {
+    reader_task.listen_id = id;
     reader_task_control.start(5, "can reader task", &canbus);
     return reader_task;
 }

--- a/pipettes/core/tasks.cpp
+++ b/pipettes/core/tasks.cpp
@@ -34,7 +34,7 @@ void pipettes_tasks::start_tasks(
         motion_controller,
     motor_driver::MotorDriver& motor_driver, i2c::I2CDeviceBase& i2c,
     can_ids::NodeId id) {
-    queue_client.node_id = id;
+    queue_client.set_node_id(id);
     auto& queues = pipettes_tasks::get_queues();
     auto& tasks = pipettes_tasks::get_tasks();
 

--- a/pipettes/core/tasks.cpp
+++ b/pipettes/core/tasks.cpp
@@ -1,12 +1,12 @@
 #include "pipettes/core/tasks.hpp"
 
+#include "can/core/ids.hpp"
 #include "motor-control/core/tasks/motion_controller_task_starter.hpp"
 #include "motor-control/core/tasks/motor_driver_task_starter.hpp"
 #include "motor-control/core/tasks/move_group_task_starter.hpp"
 #include "motor-control/core/tasks/move_status_reporter_task_starter.hpp"
 #include "pipettes/core/can_task.hpp"
 #include "pipettes/core/tasks/eeprom_task_starter.hpp"
-#include "can/core/ids.hpp"
 
 static auto tasks = pipettes_tasks::AllTask{};
 static auto queue_client = pipettes_tasks::QueueClient{};
@@ -63,8 +63,8 @@ void pipettes_tasks::start_tasks(
 }
 
 pipettes_tasks::QueueClient::QueueClient()
-    // This gets overridden in start_tasks, needs to be static here since this is
-    // free-store allocated
+    // This gets overridden in start_tasks, needs to be static here since this
+    // is free-store allocated
     : can_message_writer::MessageWriter{can_ids::NodeId::pipette_left} {}
 
 void pipettes_tasks::QueueClient::send_motion_controller_queue(

--- a/pipettes/core/tasks.cpp
+++ b/pipettes/core/tasks.cpp
@@ -59,8 +59,9 @@ void pipettes_tasks::start_tasks(
     queues.eeprom_queue = &eeprom_task.get_queue();
 }
 
+// TODO: Make this decision based on which voltage is on the attach pin
 pipettes_tasks::QueueClient::QueueClient()
-    : can_message_writer::MessageWriter{can_ids::NodeId::pipette} {}
+    : can_message_writer::MessageWriter{can_ids::NodeId::pipette_left} {}
 
 void pipettes_tasks::QueueClient::send_motion_controller_queue(
     const motion_controller_task::TaskMessage& m) {

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -9,6 +9,7 @@
 
 // clang-format on
 
+#include "can/core/ids.hpp"
 #include "can/firmware/hal_can_bus.hpp"
 #include "common/firmware/clocking.h"
 #include "common/firmware/errors.h"
@@ -116,7 +117,9 @@ auto main() -> int {
     can_start();
 
     pipettes_tasks::start_tasks(can_bus_1, pipette_motor.motion_controller,
-                                pipette_motor.driver, i2c_comms);
+                                pipette_motor.driver, i2c_comms,
+                                // TODO: Load from mount interface
+                                can_ids::NodeId::pipette_left);
 
     vTaskStartScheduler();
 }

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -1,19 +1,19 @@
+#include <cstdlib>
+#include <cstring>
+
 #include "FreeRTOS.h"
 #include "can/core/ids.hpp"
 #include "can/simlib/sim_canbus.hpp"
 #include "can/simlib/transport.hpp"
 #include "common/core/freertos_message_queue.hpp"
+#include "common/core/logging.hpp"
 #include "common/simulation/eeprom.hpp"
 #include "common/simulation/spi.hpp"
 #include "motor-control/core/motor.hpp"
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
 #include "pipettes/core/tasks.hpp"
-#include "common/core/logging.hpp"
 #include "task.h"
-
-#include <cstdlib>
-#include <cstring>
 
 static auto can_bus_1 = sim_canbus::SimCANBus{can_transport::create()};
 

--- a/python/opentrons_ot3_firmware/constants.py
+++ b/python/opentrons_ot3_firmware/constants.py
@@ -8,13 +8,15 @@ class NodeId(int, Enum):
 
     broadcast = 0x00
     host = 0x10
-    pipette = 0x20
+    pipette_left = 0x60
+    pipette_right = 0x70
     gantry_x = 0x30
     gantry_y = 0x40
     head = 0x50
     head_l = 0x51
     head_r = 0x52
-    pipette_bootloader = pipette | 0xF
+    pipette_left_bootloader = pipette_left | 0xF
+    pipette_right_bootloader = pipette_right | 0xF
     gantry_x_bootloader = gantry_x | 0xF
     gantry_y_bootloader = gantry_y | 0xF
     head_bootloader = head | 0xF

--- a/python/opentrons_ot3_firmware/constants.py
+++ b/python/opentrons_ot3_firmware/constants.py
@@ -89,6 +89,7 @@ class MessageId(int, Enum):
     limit_sw_request = 0x08
     limit_sw_response = 0x09
 
+
 @unique
 class ErrorCode(int, Enum):
     """Common error codes."""

--- a/python/opentrons_ot3_firmware/messages/message_definitions.py
+++ b/python/opentrons_ot3_firmware/messages/message_definitions.py
@@ -278,6 +278,7 @@ class ReadLimitSwitchRequest:  # noqa: D101
     payload_type: Type[BinarySerializable] = payloads.EmptyPayload
     message_id: Literal[MessageId.limit_sw_request] = MessageId.limit_sw_request
 
+
 @dataclass
 class ReadLimitSwitchResponse:  # noqa: D101
     payload: payloads.GetLimitSwitchResponse

--- a/python/opentrons_ot3_firmware/scripts/generate_header.py
+++ b/python/opentrons_ot3_firmware/scripts/generate_header.py
@@ -87,7 +87,9 @@ def write_enum_c(e: Type[Enum], output: io.StringIO, prefix: str) -> None:
     """Generate constants from enumeration."""
     output.write(f"/** {e.__doc__} */\n")
     with block(
-        output=output, start="typedef enum {\n", terminate=f"}} {prefix}{e.__name__};\n\n"
+        output=output,
+        start="typedef enum {\n",
+        terminate=f"}} {prefix}{e.__name__};\n\n",
     ):
         for i in e:
             name = "_".join(("can", e.__name__, i.name)).lower()


### PR DESCRIPTION
When there are two pipettes attached, they need to have different node
IDs so they can both talk on the bus. The thing that makes them
different from each other is which mount they're on. We therefore can
use a different node id depending on the mount, which can be sensed from
a voltage expressed by a resistor net split between pipette and head
boards.

This commit only creates the new IDs and switches to using them. The pipette
application firmware and bootloader listen to left, arbitrarily.

The next step is to bring up the ADC to sense the voltage on the
resistor net and store its value so we know who we are.