### PR TITLE
fix(bootloader): can messaging related fixes

### DIFF
--- a/bootloader/firmware/main.c
+++ b/bootloader/firmware/main.c
@@ -57,21 +57,23 @@ static void initialize_can(FDCAN_HandleTypeDef * can_handle) {
     filter_def.FilterIndex = 0;
     filter_def.FilterType = filter_type_to_hal(mask),
     filter_def.FilterConfig = filter_config_to_hal(to_fifo0),
-    filter_def.FilterID1 = arb_mask.id,
-    filter_def.FilterID2 = arb_filter.id;
+    filter_def.FilterID1 = arb_filter.id,
+    filter_def.FilterID2 = arb_mask.id;
     HAL_FDCAN_ConfigFilter(can_handle, &filter_def);
 
-    // Create filter to accept broadcast messages
+    // Create filter to accept broadcast DeviceInfoRequest messages
     arb_mask.id = 0;
     arb_mask.parts.node_id = -1;
+    arb_mask.parts.message_id = -1;
     arb_filter.id = 0;
     arb_filter.parts.node_id = can_nodeid_broadcast;
+    arb_filter.parts.message_id = can_messageid_device_info_request;
 
     filter_def.FilterIndex = 1;
     filter_def.FilterType = filter_type_to_hal(mask),
     filter_def.FilterConfig = filter_config_to_hal(to_fifo0),
-    filter_def.FilterID1 = arb_mask.id,
-    filter_def.FilterID2 = arb_filter.id;
+    filter_def.FilterID1 = arb_filter.id,
+    filter_def.FilterID2 = arb_mask.id;
     HAL_FDCAN_ConfigFilter(can_handle, &filter_def);
 
     // Reject everything else

--- a/bootloader/firmware/main.c
+++ b/bootloader/firmware/main.c
@@ -4,6 +4,8 @@
 #include "can/firmware/utils.h"
 #include "bootloader/core/message_handler.h"
 #include "bootloader/core/node_id.h"
+#include "common/firmware/clocking.h"
+#include "bootloader/firmware/system.h"
 
 /**
  * The CAN handle.
@@ -83,6 +85,9 @@ static void initialize_can(FDCAN_HandleTypeDef * can_handle) {
 
 
 int main() {
+    HardwareInit();
+    RCC_Peripheral_Clock_Select();
+
     initialize_can(&hcan1);
 
     tx_header.IdType = FDCAN_EXTENDED_ID;

--- a/bootloader/firmware/stm32G4/can.c
+++ b/bootloader/firmware/stm32G4/can.c
@@ -52,11 +52,6 @@ void HAL_FDCAN_MspInit(FDCAN_HandleTypeDef* hfdcan) {
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF9_FDCAN1;
         HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
-        // Priority is 0-15 (highest to lowest). Use lowest priority until we
-        // believe it is too low.
-        HAL_NVIC_SetPriority(FDCAN1_IT0_IRQn, 15, 15);
-        HAL_NVIC_EnableIRQ(FDCAN1_IT0_IRQn);
     }
 }
 

--- a/bootloader/firmware/stm32G4/stm32g4xx_it.c
+++ b/bootloader/firmware/stm32G4/stm32g4xx_it.c
@@ -57,6 +57,7 @@ DMA_HandleTypeDef hdma_spi1_rx;
  */
 void NMI_Handler(void) {}
 
+
 /**
  * @brief  This function handles Hard Fault exception.
  * @param  None
@@ -143,5 +144,11 @@ void DMA1_Channel3_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_spi1_tx); }
  * @brief This function handles TIM7 global interrupt.
  */
 //void TIM7_IRQHandler(void) { HAL_TIM_IRQHandler(&htim7); }
+
+/** Interrupt handlers that are typically routed to FreeRTOS. No FreeRTOS on Bootloader. */
+void SVC_Handler(void) {}
+void PendSV_Handler(void) {}
+void SysTick_Handler(void) {}
+
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/bootloader/firmware/stm32L5/can.c
+++ b/bootloader/firmware/stm32L5/can.c
@@ -52,12 +52,6 @@ void HAL_FDCAN_MspInit(FDCAN_HandleTypeDef* hfdcan) {
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF9_FDCAN1;
         HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
-        // Priority is 0-15 (highest to lowest). Use lowest priority until we
-        // believe it is too low.
-
-        HAL_NVIC_SetPriority(FDCAN1_IT0_IRQn, 15, 15);
-        HAL_NVIC_EnableIRQ(FDCAN1_IT0_IRQn);
     }
 }
 

--- a/bootloader/firmware/stm32L5/stm32l5xx_it.c
+++ b/bootloader/firmware/stm32L5/stm32l5xx_it.c
@@ -147,4 +147,10 @@ void TIM7_IRQHandler(void) {  }
  * @}
  */
 
+/** Interrupt handlers that are typically routed to FreeRTOS. No FreeRTOS on Bootloader. */
+void SVC_Handler(void) {}
+void PendSV_Handler(void) {}
+void SysTick_Handler(void) {}
+
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/include/bootloader/firmware/system.h
+++ b/include/bootloader/firmware/system.h
@@ -1,6 +1,6 @@
-#ifndef OT3FIRMWARE_SYSTEM_H
-#define OT3FIRMWARE_SYSTEM_H
+#pragma once
 
+/**
+ * Initialize hardware and clocks. Defined in system_stmXXXX.c.
+ */
 void HardwareInit(void);
-
-#endif  // OT3FIRMWARE_SYSTEM_H

--- a/include/bootloader/firmware/system.h
+++ b/include/bootloader/firmware/system.h
@@ -1,0 +1,6 @@
+#ifndef OT3FIRMWARE_SYSTEM_H
+#define OT3FIRMWARE_SYSTEM_H
+
+void HardwareInit(void);
+
+#endif  // OT3FIRMWARE_SYSTEM_H


### PR DESCRIPTION
- Start the HAL
- Add interrupt handlers typically handled by FreeRTOS
- Fix CAN filters.