### PR TITLE
chore(sim): USE_SOCKETCAN env var

### DIFF
--- a/bootloader/simulator/CMakeLists.txt
+++ b/bootloader/simulator/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(
         ${BOOTLOADER_SIMULATOR_SRC}
 )
 
-if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
     target_compile_definitions(bootloader-simulator PUBLIC USE_SOCKETCAN)
 endif()
 

--- a/can/simulator/CMakeLists.txt
+++ b/can/simulator/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(
 
 target_can_simlib(can-simulator)
 
-if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
     target_compile_definitions(can-simulator PUBLIC USE_SOCKETCAN)
 endif()
 

--- a/gantry/simulator/CMakeLists.txt
+++ b/gantry/simulator/CMakeLists.txt
@@ -42,7 +42,7 @@ add_executable(
         ${GANTRY_SIMULATOR_SRC}
 )
 
-if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
     target_compile_definitions(gantry-x-simulator PUBLIC USE_SOCKETCAN)
     target_compile_definitions(gantry-y-simulator PUBLIC USE_SOCKETCAN)
 endif()

--- a/head/simulator/CMakeLists.txt
+++ b/head/simulator/CMakeLists.txt
@@ -33,7 +33,7 @@ add_executable(
         ${HEAD-CORE-SRC}
 )
 
-if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
     target_compile_definitions(head-simulator PUBLIC USE_SOCKETCAN)
 endif()
 

--- a/pipettes/simulator/CMakeLists.txt
+++ b/pipettes/simulator/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(
         ${PIPETTES_SIMULATOR_SRC}
 )
 
-if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
     target_compile_definitions(pipettes-simulator PUBLIC USE_SOCKETCAN)
 endif()
 


### PR DESCRIPTION
simulators will use SocketCAN only if building on linux and USE_SOCKETCAN is defined in an env variable.