### PR TITLE
fix(i2c): create I2CWriter globally.

### DIFF
--- a/common/simulation/i2c_sim.cpp
+++ b/common/simulation/i2c_sim.cpp
@@ -1,4 +1,3 @@
-
 #include "common/simulation/i2c_sim.hpp"
 
 auto sim_i2c::SimI2C::central_transmit(uint8_t *data, uint16_t size,

--- a/include/pipettes/core/tasks/eeprom_task.hpp
+++ b/include/pipettes/core/tasks/eeprom_task.hpp
@@ -55,7 +55,7 @@ class EEPromMessageHandler {
     }
 
     void visit(can_messages::ReadFromEEPromRequest &m) {
-        LOG("Received request to read serial number");
+        LOG("Received request to read serial number\n");
         writer.read(DEVICE_ADDRESS, callback);
     }
 

--- a/python/opentrons_ot3_firmware/messages/payloads.py
+++ b/python/opentrons_ot3_firmware/messages/payloads.py
@@ -48,7 +48,7 @@ class GetSpeedResponsePayload(utils.BinarySerializable):
 class WriteToEEPromRequestPayload(utils.BinarySerializable):
     """Write to eeprom request."""
 
-    serial_number: utils.UInt8Field
+    serial_number: utils.UInt16Field
 
 
 @dataclass


### PR DESCRIPTION
Fixing a little bug found in simulation. `I2CWriter` was allocated on the stack causing eeprom communication to fail.