### PR TITLE
fix(sensors): specify the correct register to read from in initalization

### DIFF
--- a/include/sensors/core/hdc2080.hpp
+++ b/include/sensors/core/hdc2080.hpp
@@ -31,6 +31,7 @@ static constexpr uint16_t DEVICE_ID = 0x07D0;
 static constexpr uint8_t INTERRUPT_REGISTER = 0x07;
 static constexpr uint8_t DRDY_CONFIG = 0x0E;
 static const uint8_t MEASURE_REGISTER = 0x0F;
+static const uint8_t DEVICE_ID_REGISTER = 0xFE;
 // Low configurations for both temperature and humidity
 // this records the status when a reading goes below
 // a certain threshold.

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -82,7 +82,7 @@ class EnvironmentSensorMessageHandler {
 
     void initialize() {
         writer.write(DEVICE_ID, ADDRESS);
-        writer.read(ADDRESS, internal_callback);
+        writer.read(ADDRESS, internal_callback, DEVICE_ID);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
         // holding off for this PR.

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -81,8 +81,8 @@ class EnvironmentSensorMessageHandler {
     ~EnvironmentSensorMessageHandler() = default;
 
     void initialize() {
-        writer.write(DEVICE_ID, ADDRESS);
-        writer.read(ADDRESS, internal_callback, DEVICE_ID);
+        writer.write(DEVICE_ID_REGISTER, ADDRESS);
+        writer.read(ADDRESS, internal_callback, DEVICE_ID_REGISTER);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
         // holding off for this PR.


### PR DESCRIPTION
## Overview

Actually read from the `DEVICE_ID` register in the initialization function of the environment sensor