### PR TITLE
feat(sensors): add threshold configuration messages to CAN

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -439,7 +439,7 @@ struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
 
 struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
     can_ids::SensorType sensor{};
-    uint32_t sensor_data;
+    uint32_t sensor_data = 0;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
@@ -449,6 +449,41 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
         return iter - body;
     }
     auto operator==(const ReadFromSensorResponse& other) const
+        -> bool = default;
+};
+
+struct SetSensorThresholdRequest
+    : BaseMessage<MessageId::set_sensor_threshold_request> {
+    uint8_t sensor;
+    uint32_t threshold;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> SetSensorThresholdRequest {
+        uint8_t sensor = 0;
+        uint8_t threshold = 0;
+        body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, threshold);
+        return SetSensorThresholdRequest{.sensor = sensor,
+                                         .threshold = threshold};
+    }
+
+    auto operator==(const SetSensorThresholdRequest& other) const
+        -> bool = default;
+};
+
+struct SensorThresholdResponse
+    : BaseMessage<MessageId::set_sensor_threshold_response> {
+    can_ids::SensorType sensor{};
+    uint32_t threshold = 0;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter =
+            bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
+        iter = bit_utils::int_to_bytes(threshold, body, limit);
+        return iter - body;
+    }
+    auto operator==(const SensorThresholdResponse& other) const
         -> bool = default;
 };
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -496,6 +496,7 @@ using ResponseMessageType =
                  ReadMotorDriverRegisterResponse, ReadFromEEPromResponse,
                  MoveCompleted, ReadPresenceSensingVoltageResponse,
                  PushToolsDetectedNotification, ReadLimitSwitchResponse,
-                 ReadFromSensorResponse, FirmwareUpdateStatusResponse>;
+                 ReadFromSensorResponse, FirmwareUpdateStatusResponse,
+                 SensorThresholdResponse>;
 
 }  // namespace can_messages

--- a/include/sensors/core/message_handlers/sensors.hpp
+++ b/include/sensors/core/message_handlers/sensors.hpp
@@ -25,6 +25,10 @@ class SensorHandler {
 
     void visit(std::monostate &m) {}
 
+    void visit(can_messages::SetSensorThresholdRequest &m) {
+        send_to_queue(can_ids::SensorType(m.sensor), m);
+    }
+
     void visit(can_messages::BaselineSensorRequest &m) {
         send_to_queue(can_ids::SensorType(m.sensor), m);
     }

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -104,6 +104,8 @@ class EnvironmentSensorMessageHandler {
 
     void visit(can_messages::BaselineSensorRequest &m) {}
 
+    void visit(can_messages::SetSensorThresholdRequest &m) {}
+
     void visit(can_messages::WriteToSensorRequest &m) {
         LOG("Received request to write data %d to %d sensor\n", m.data,
             m.sensor);

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -6,7 +6,8 @@ namespace sensor_task_utils {
 using TaskMessage =
     std::variant<std::monostate, can_messages::ReadFromSensorRequest,
                  can_messages::WriteToSensorRequest,
-                 can_messages::BaselineSensorRequest>;
+                 can_messages::BaselineSensorRequest,
+                 can_messages::SetSensorThresholdRequest>;
 
 /**
  * Concept describing a class that can message this task.

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -70,8 +70,8 @@ static auto system_dispatch_target = can_dispatch::DispatchParseTarget<
 
 static auto sensor_dispatch_target = can_dispatch::DispatchParseTarget<
     decltype(sensor_handler), can_messages::ReadFromSensorRequest,
-    can_messages::WriteToSensorRequest, can_messages::BaselineSensorRequest>{
-    sensor_handler};
+    can_messages::WriteToSensorRequest, can_messages::BaselineSensorRequest,
+    can_messages::SetSensorThresholdRequest>{sensor_handler};
 
 /** Dispatcher to the various handlers */
 static auto dispatcher = can_dispatch::Dispatcher(

--- a/python/opentrons_ot3_firmware/constants.py
+++ b/python/opentrons_ot3_firmware/constants.py
@@ -98,6 +98,8 @@ class MessageId(int, Enum):
     write_sensor_request = 0x83
     baseline_sensor_request = 0x84
     read_sensor_response = 0x85
+    set_sensor_threshold_request = 0x86
+    set_sensor_threshold_response = 0x87
 
 
 @unique

--- a/python/opentrons_ot3_firmware/messages/message_definitions.py
+++ b/python/opentrons_ot3_firmware/messages/message_definitions.py
@@ -350,3 +350,21 @@ class ReadFromSensorResponse:  # noqa: D101
     payload: payloads.ReadFromSensorResponse
     payload_type: Type[BinarySerializable] = payloads.ReadFromSensorResponse
     message_id: Literal[MessageId.read_sensor_response] = MessageId.read_sensor_response
+
+
+@dataclass
+class SetSensorThresholdRequest:  # noqa: D101
+    payload: payloads.SetSensorThresholdRequest
+    payload_type: Type[BinarySerializable] = payloads.SetSensorThresholdRequest
+    message_id: Literal[
+        MessageId.set_sensor_threshold_request
+    ] = MessageId.set_sensor_threshold_request
+
+
+@dataclass
+class SensorThresholdResponse:  # noqa: D101
+    payload: payloads.SensorThresholdResponse
+    payload_type: Type[BinarySerializable] = payloads.SensorThresholdResponse
+    message_id: Literal[
+        MessageId.set_sensor_threshold_response
+    ] = MessageId.set_sensor_threshold_response

--- a/python/opentrons_ot3_firmware/messages/messages.py
+++ b/python/opentrons_ot3_firmware/messages/messages.py
@@ -47,6 +47,12 @@ MessageDefinition = Union[
     defs.FirmwareUpdateStatusResponse,
     defs.ReadLimitSwitchRequest,
     defs.ReadLimitSwitchResponse,
+    defs.ReadFromSensorRequest,
+    defs.WriteToSensorRequest,
+    defs.BaselineSensorRequest,
+    defs.SetSensorThresholdRequest,
+    defs.ReadFromSensorResponse,
+    defs.SensorThresholdResponse,
 ]
 
 

--- a/python/opentrons_ot3_firmware/messages/payloads.py
+++ b/python/opentrons_ot3_firmware/messages/payloads.py
@@ -278,3 +278,19 @@ class ReadFromSensorResponse(utils.BinarySerializable):
 
     sensor: constants.SensorType
     sensor_data: utils.UInt32Field
+
+
+@dataclass
+class SetSensorThresholdRequest(utils.BinarySerializable):
+    """A request to set the threshold value of a sensor."""
+
+    sensor: constants.SensorType
+    threshold: utils.UInt32Field
+
+
+@dataclass
+class SensorThresholdResponse(utils.BinarySerializable):
+    """A response that sends back the current threshold value of the sensor."""
+
+    sensor: constants.SensorType
+    threshold: utils.UInt32Field

--- a/python/opentrons_ot3_firmware/messages/payloads.py
+++ b/python/opentrons_ot3_firmware/messages/payloads.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass
 
 from .. import utils
-from opentrons_ot3_firmware import constants
 
 
 @dataclass

--- a/python/opentrons_ot3_firmware/messages/payloads.py
+++ b/python/opentrons_ot3_firmware/messages/payloads.py
@@ -276,7 +276,7 @@ class BaselineSensorRequest(utils.BinarySerializable):
 class ReadFromSensorResponse(utils.BinarySerializable):
     """A response for either a single reading or an averaged reading of a sensor."""
 
-    sensor: constants.SensorType
+    sensor: utils.UInt8Field
     sensor_data: utils.UInt32Field
 
 
@@ -284,7 +284,7 @@ class ReadFromSensorResponse(utils.BinarySerializable):
 class SetSensorThresholdRequest(utils.BinarySerializable):
     """A request to set the threshold value of a sensor."""
 
-    sensor: constants.SensorType
+    sensor: utils.UInt8Field
     threshold: utils.UInt32Field
 
 
@@ -292,5 +292,5 @@ class SetSensorThresholdRequest(utils.BinarySerializable):
 class SensorThresholdResponse(utils.BinarySerializable):
     """A response that sends back the current threshold value of the sensor."""
 
-    sensor: constants.SensorType
+    sensor: utils.UInt8Field
     threshold: utils.UInt32Field


### PR DESCRIPTION
## Overview

Add CAN messages to set and receive the threshold value for a given sensor.