### PR TITLE
feat(sim): socket simulators use hostname instead of ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,15 @@ For more information on interacting with simulation see [this readme](https://gi
 ### Running
 
 Each simulator is an executable binary using the pattern `build-host/{PROJ}/simulator/{PROJ}-simulator`
+
+### Environment Variables
+
+The simulators can be customized using environment variables.
+
+#### Socket CAN
+`CAN_CHANNEL` - is the SocketCAN channel to use.
+
+#### Opentrons Socket
+`CAN_SERVER_HOST` - Host name of opentrons can socket server
+
+`CAN_PORT` - Port of opentrons can socket server

--- a/can/simlib/transport.cpp
+++ b/can/simlib/transport.cpp
@@ -22,20 +22,20 @@ auto can_transport::create()
     auto transport = std::make_shared<socketcan_transport::SocketCanTransport<
         freertos_synchronization::FreeRTOSCriticalSection>>(channel);
 #else
-    auto constexpr ServerIpEnvironmentVariableName = "CAN_SERVER_IP";
-    auto constexpr DefaultServerIp = "127.0.0.1";
+    auto constexpr ServerHostEnvironmentVariableName = "CAN_SERVER_HOST";
+    auto constexpr DefaultServerHost = "localhost";
     auto constexpr PortEnvironmentVariableName = "CAN_PORT";
     auto constexpr DefaultPort = 9898;
 
-    const char* env_server_ip_val =
-        std::getenv(ServerIpEnvironmentVariableName);
-    auto ip = env_server_ip_val ? env_server_ip_val : DefaultServerIp;
+    const char* env_server_host_val =
+        std::getenv(ServerHostEnvironmentVariableName);
+    auto host = env_server_host_val ? env_server_host_val : DefaultServerHost;
     const char* env_port_val = std::getenv(PortEnvironmentVariableName);
     auto port =
         env_port_val ? std::strtoul(env_port_val, nullptr, 10) : DefaultPort;
 
     auto transport = std::make_shared<socket_transport::SocketTransport<
-        freertos_synchronization::FreeRTOSCriticalSection>>(ip, port);
+        freertos_synchronization::FreeRTOSCriticalSection>>(host, port);
 
 #endif
     return transport;

--- a/include/can/simlib/socket_transport.hpp
+++ b/include/can/simlib/socket_transport.hpp
@@ -48,15 +48,18 @@ auto SocketTransport<CriticalSection>::open() -> bool {
     struct sockaddr_in addr;
     int s = 0;
 
-    LOG("Trying to connect to %s:%d\n", host.c_str(), port);
+    LOG("Creating connection to %s:%d\n", host.c_str(), port);
 
     if ((s = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         return false;
     }
 
+    auto ip = host_to_ip(host);
+    LOG("Trying to connect to %s:%d\n", ip.c_str(), port);
+
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
-    ::inet_aton(host_to_ip(host).c_str(), &addr.sin_addr);
+    ::inet_aton(ip.c_str(), &addr.sin_addr);
 
     if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
         return false;


### PR DESCRIPTION
Very stubbornly not using boost for some reason. 
