### PR TITLE
feat(pipettes): add capacitive sensor support

### DIFF
--- a/common/simulation/i2c_sim.cpp
+++ b/common/simulation/i2c_sim.cpp
@@ -1,4 +1,3 @@
-
 #include "common/simulation/i2c_sim.hpp"
 
 #include "common/core/bit_utils.hpp"
@@ -7,10 +6,13 @@ auto sim_i2c::SimI2C::central_transmit(uint8_t *data, uint16_t size,
                                        uint16_t dev_address, uint32_t timeout)
     -> bool {
     uint8_t reg = data[0];
-    uint16_t store_in_register = 0;
-    auto *iter = data + 1;
-    iter = bit_utils::bytes_to_int(iter, data + size, store_in_register);
-    sensor_map[dev_address].REGISTER_MAP[reg] = store_in_register;
+    uint8_t write_bit = data[1];
+    if (write_bit == 1) {
+        uint16_t store_in_register = 0;
+        auto *iter = data + 1;
+        iter = bit_utils::bytes_to_int(iter, data + size, store_in_register);
+        sensor_map[dev_address].REGISTER_MAP[reg] = store_in_register;
+    }
     return true;
 }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -392,7 +392,7 @@ struct FirmwareUpdateStatusResponse
 };
 
 struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
-    uint8_t sensor;
+    uint8_t sensor = 0;
     uint8_t offset_reading = 0;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -425,8 +425,8 @@ struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
 };
 
 struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
-    uint8_t sensor;
-    uint8_t sample_rate;
+    uint8_t sensor = 0;
+    uint8_t sample_rate = 1;
     uint8_t offset_update = 0;
 
     template <bit_utils::ByteIterator Input, typename Limit>

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -393,12 +393,15 @@ struct FirmwareUpdateStatusResponse
 
 struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
     uint8_t sensor;
+    uint8_t offset_reading = 0;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> ReadFromSensorRequest {
         uint8_t sensor = 0;
+        uint8_t offset_reading = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
-        return ReadFromSensorRequest{.sensor = sensor};
+        body = bit_utils::bytes_to_int(body, limit, offset_reading);
+        return ReadFromSensorRequest{.sensor = sensor, .offset_reading = offset_reading};
     }
 
     auto operator==(const ReadFromSensorRequest& other) const -> bool = default;
@@ -423,15 +426,19 @@ struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
 struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
     uint8_t sensor;
     uint8_t sample_rate;
+    uint8_t offset_update = 0;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> BaselineSensorRequest {
         uint8_t sensor = 0;
         uint8_t sample_rate = 0;
+        uint8_t offset_update = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, sample_rate);
+        body = bit_utils::bytes_to_int(body, limit, offset_update);
         return BaselineSensorRequest{.sensor = sensor,
-                                     .sample_rate = sample_rate};
+                                     .sample_rate = sample_rate,
+                                     .offset_update = offset_update};
     }
 
     auto operator==(const BaselineSensorRequest& other) const -> bool = default;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -401,7 +401,8 @@ struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
         uint8_t offset_reading = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, offset_reading);
-        return ReadFromSensorRequest{.sensor = sensor, .offset_reading = offset_reading};
+        return ReadFromSensorRequest{.sensor = sensor,
+                                     .offset_reading = offset_reading};
     }
 
     auto operator==(const ReadFromSensorRequest& other) const -> bool = default;

--- a/include/common/tests/mock_queue_client.hpp
+++ b/include/common/tests/mock_queue_client.hpp
@@ -17,6 +17,8 @@ struct QueueClient
     test_mocks::MockMessageQueue<eeprom_task::TaskMessage>* eeprom_queue;
     test_mocks::MockMessageQueue<sensor_task_utils::TaskMessage>*
         environment_sensor_queue;
+    test_mocks::MockMessageQueue<sensor_task_utils::TaskMessage>*
+        capacitive_sensor_queue;
 
     void send_eeprom_queue(const eeprom_task::TaskMessage& m) {
         eeprom_queue->try_write(m);
@@ -25,6 +27,11 @@ struct QueueClient
     void send_environment_sensor_queue(
         const sensor_task_utils::TaskMessage& m) {
         environment_sensor_queue->try_write(m);
+    }
+
+    void send_capacitive_sensor_queue(
+        const sensor_task_utils::TaskMessage& m) {
+        capacitve_sensor_queue->try_write(m);
     }
 };
 }  // namespace mock_client

--- a/include/common/tests/mock_queue_client.hpp
+++ b/include/common/tests/mock_queue_client.hpp
@@ -29,9 +29,8 @@ struct QueueClient
         environment_sensor_queue->try_write(m);
     }
 
-    void send_capacitive_sensor_queue(
-        const sensor_task_utils::TaskMessage& m) {
-        capacitve_sensor_queue->try_write(m);
+    void send_capacitive_sensor_queue(const sensor_task_utils::TaskMessage& m) {
+        capacitive_sensor_queue->try_write(m);
     }
 };
 }  // namespace mock_client

--- a/include/motor-control/core/utils.hpp
+++ b/include/motor-control/core/utils.hpp
@@ -14,3 +14,5 @@ auto convert_to_fixed_point_64_bit(float value, int to_radix) -> sq31_31;
 auto fixed_point_multiply(sq0_31 a, sq0_31 b) -> sq0_31;
 
 auto fixed_point_multiply(sq31_31 a, sq0_31 b) -> sq0_31;
+
+auto fixed_point_to_float(uint32_t data, int to_radix) -> float;

--- a/include/pipettes/core/i2c_writer.hpp
+++ b/include/pipettes/core/i2c_writer.hpp
@@ -41,7 +41,7 @@ class I2CWriter {
         queue->try_write(write_msg);
     }
 
-    /*
+    /**
      * A single read to the i2c bus.
      *
      * @param device_address: device address on the i2c bus
@@ -68,7 +68,7 @@ class I2CWriter {
         queue->try_write(read_msg);
     }
 
-    /*
+    /**
      * Single Register Poll.
      *
      * This function will poll the results of a single register.
@@ -104,7 +104,7 @@ class I2CWriter {
         queue->try_write(read_msg);
     }
 
-    /*
+    /**
      * Multi Register Poll.
      *
      * This function will poll the results of two registers. Typically this is
@@ -138,11 +138,11 @@ class I2CWriter {
         pipette_messages::MultiRegisterPollReadFromI2C read_msg{
             .address = device_address,
             .polling = number_reads,
+            .delay_ms = delay,
             .register_buffer_1 = buffer_1,
             .register_buffer_2 = buffer_2,
             .client_callback = std::move(client_callback),
-            .handle_buffer = std::move(handle_callback),
-            .delay_ms = delay};
+            .handle_buffer = std::move(handle_callback)};
         queue->try_write(read_msg);
     }
 

--- a/include/pipettes/core/i2c_writer.hpp
+++ b/include/pipettes/core/i2c_writer.hpp
@@ -12,6 +12,7 @@
 namespace i2c_writer {
 
 using namespace pipette_messages;
+using namespace sensor_callbacks;
 
 using TaskMessage =
     std::variant<std::monostate, WriteToI2C, ReadFromI2C,
@@ -40,51 +41,98 @@ class I2CWriter {
         queue->try_write(write_msg);
     }
 
-    void read(uint16_t device_address,
-              sensor_callbacks::SingleRegisterCallback* callback,
-              uint8_t reg = 0x0) {
-        // We want to copy the callback every time as opposed to passing a
-        // reference to it from the eeprom task.
-        std::array<uint8_t, MAX_SIZE> max_buffer{reg};
-        pipette_messages::ReadFromI2C read_msg{.address = device_address,
-                                               .buffer = max_buffer,
-                                               .client_callback = callback};
-        queue->try_write(read_msg);
-    }
-
     /*
-     * This function will poll the results of a single register.
+     * A single read to the i2c bus.
+     *
+     * @param device_address: device address on the i2c bus
+     * @param client_callback: the function that will write a CAN return message
+     * to the client queue.
+     * @param handle_callback: the function that will handle any data
+     * manipulation required for the specific task using the i2c bus. Takes in
+     * two buffers.
+     * @param reg: the register to read from, if relevant.
      *
      * A poll function automatically initiates a read/write to the specified
      * register on the i2c bus.
      */
-    void single_register_poll(
-        uint16_t device_address, uint8_t number_reads, uint16_t delay,
-        sensor_callbacks::SingleRegisterCallback* callback, uint8_t reg = 0x0) {
+    void read(uint16_t device_address, SingleBufferTypeDef handle_callback,
+              SendToCanFunctionTypeDef client_callback, uint8_t reg = 0x0) {
+        // We want to copy the callback every time as opposed to passing a
+        // reference to it from the eeprom task.
+        std::array<uint8_t, MAX_SIZE> max_buffer{reg};
+        pipette_messages::ReadFromI2C read_msg{
+            .address = device_address,
+            .buffer = max_buffer,
+            .handle_buffer = handle_callback,
+            .client_callback = client_callback};
+        queue->try_write(read_msg);
+    }
+
+    /*
+     * Single Register Poll.
+     *
+     * This function will poll the results of a single register.
+     *
+     * @param device_address: device address on the i2c bus
+     * @param number_reads: how many data points to take from the sensor
+     * @param delay: the frequency to send the read/writes to the register
+     * provided.
+     * @param client_callback: the function that will write a CAN return message
+     * to the client queue.
+     * @param single_callback: the function that will handle any data
+     * manipulation required for the specific task using the i2c bus.
+     * @param reg: the register to read from, if relevant.
+     *
+     * A poll function automatically initiates a read/write to the specified
+     * register on the i2c bus.
+     */
+    void single_register_poll(uint16_t device_address, uint8_t number_reads,
+                              uint16_t delay,
+                              SendToCanFunctionTypeDef client_callback,
+                              SingleBufferTypeDef handle_callback,
+                              uint8_t reg = 0x0) {
         // We want to copy the callback every time as opposed to passing a
         // reference to it from the eeprom task.
         std::array<uint8_t, MAX_SIZE> max_buffer{reg};
         pipette_messages::SingleRegisterPollReadFromI2C read_msg{
             .address = device_address,
             .polling = number_reads,
+            .delay_ms = delay,
             .buffer = max_buffer,
-            .client_callback = callback,
-            .delay_ms = delay};
+            .client_callback = client_callback,
+            .handle_buffer = handle_callback};
         queue->try_write(read_msg);
     }
 
     /*
+     * Multi Register Poll.
+     *
      * This function will poll the results of two registers. Typically this is
      * relevant when data is stored in two separate registers.
      *
+     * @param device_address: device address on the i2c bus
+     * @param number_reads: how many data points to take from the sensor
+     * @param delay: the frequency to send the read/writes to the register
+     * provided.
+     * @param client_callback: the function that will write a CAN return message
+     * to the client queue.
+     * @param multi_callback: the function that will handle any data
+     * manipulation required for the specific task using the i2c bus. Takes in
+     * two buffers.
+     * @param register_1: the register to read from, if relevant.
+     * @param register_2: the register to read from, if relevant.
+     *
+     * Registers will be written to/read from in the order they are listed. This
+     * means that `register_1` will always be read from before `register_2`.
+     *
      * A poll function automatically initiates a read/write to the specified
-     * registers on the i2c bus.
+     * register on the i2c bus.
      */
-    void multi_register_poll(uint16_t device_address, uint8_t number_reads,
-                             uint16_t delay,
-                             sensor_callbacks::MultiRegisterCallback* callback,
-                             uint8_t register_1 = 0x0,
-                             uint8_t register_2 = 0x0) {
+    void multi_register_poll(
+        uint16_t device_address, uint8_t number_reads, uint16_t delay,
+        sensor_callbacks::SendToCanFunctionTypeDef client_callback,
+        sensor_callbacks::MultiBufferTypeDef handle_callback,
+        uint8_t register_1 = 0x0, uint8_t register_2 = 0x0) {
         std::array<uint8_t, MAX_SIZE> buffer_1{register_1};
         std::array<uint8_t, MAX_SIZE> buffer_2{register_2};
         pipette_messages::MultiRegisterPollReadFromI2C read_msg{
@@ -92,7 +140,8 @@ class I2CWriter {
             .polling = number_reads,
             .register_buffer_1 = buffer_1,
             .register_buffer_2 = buffer_2,
-            .client_callback = callback,
+            .client_callback = client_callback,
+            .handle_buffer = handle_callback,
             .delay_ms = delay};
         queue->try_write(read_msg);
     }

--- a/include/pipettes/core/i2c_writer.hpp
+++ b/include/pipettes/core/i2c_writer.hpp
@@ -13,7 +13,7 @@ namespace i2c_writer {
 using namespace pipette_messages;
 
 using TaskMessage =
-    std::variant<std::monostate, WriteToI2C, ReadFromI2C, PollReadFromI2C>;
+    std::variant<std::monostate, WriteToI2C, ReadFromI2C, SingleRegisterPollReadFromI2C>;
 
 template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
@@ -39,7 +39,7 @@ class I2CWriter {
     }
 
     void read(uint16_t device_address,
-              const Callback
+              const SingleRegisterCallback
                   callback,  // NOLINT (performance-unnecessary-value-param)
               uint8_t reg = 0x0) {
         // We want to copy the callback every time as opposed to passing a
@@ -51,19 +51,53 @@ class I2CWriter {
         queue->try_write(read_msg);
     }
 
-    void poll_read(
+    /*
+     * This function will poll the results of a single register.
+     *
+     * A poll function automatically initiates a read/write to the specified
+     * register on the i2c bus.
+     */
+    void single_register_poll(
         uint16_t device_address, uint8_t number_reads, uint16_t delay,
-        const Callback
+        const SingleRegisterCallback
             callback,  // NOLINT (performance-unnecessary-value-param)
         uint8_t reg = 0x0) {
         // We want to copy the callback every time as opposed to passing a
         // reference to it from the eeprom task.
         std::array<uint8_t, MAX_SIZE> max_buffer{reg};
-        pipette_messages::PollReadFromI2C read_msg{.address = device_address,
-                                                   .polling = number_reads,
-                                                   .buffer = max_buffer,
-                                                   .client_callback = callback,
-                                                   .delay_ms = delay};
+        pipette_messages::SingleRegisterPollReadFromI2C read_msg{
+            .address = device_address,
+            .polling = number_reads,
+            .buffer = max_buffer,
+            .client_callback = callback,
+            .delay_ms = delay};
+        queue->try_write(read_msg);
+    }
+
+    /*
+     * This function will poll the results of two registers. Typically this is
+     * relevant when data is stored in two separate registers.
+     *
+     * A poll function automatically initiates a read/write to the specified
+     * registers on the i2c bus.
+     */
+    void multi_register_poll(
+        uint16_t device_address, uint8_t number_reads, uint16_t delay,
+        const MultiRegisterCallback
+        callback,  // NOLINT (performance-unnecessary-value-param)
+        uint8_t register_1 = 0x0,
+        uint8_t register_2 = 0x0) {
+        // We want to copy the callback every time as opposed to passing a
+        // reference to it from the eeprom task.
+        std::array<uint8_t, MAX_SIZE> buffer_1{register_1};
+        std::array<uint8_t, MAX_SIZE> buffer_2{register_2};
+        pipette_messages::MultiRegisterPollReadFromI2C read_msg{
+            .address = device_address,
+            .polling = number_reads,
+            .register_buffer_1 = buffer_1,
+            .register_buffer_2 = buffer_2,
+            .client_callback = callback,
+            .delay_ms = delay};
         queue->try_write(read_msg);
     }
 

--- a/include/pipettes/core/i2c_writer.hpp
+++ b/include/pipettes/core/i2c_writer.hpp
@@ -63,8 +63,8 @@ class I2CWriter {
         pipette_messages::ReadFromI2C read_msg{
             .address = device_address,
             .buffer = max_buffer,
-            .handle_buffer = handle_callback,
-            .client_callback = client_callback};
+            .handle_buffer = std::move(handle_callback),
+            .client_callback = std::move(client_callback)};
         queue->try_write(read_msg);
     }
 
@@ -99,8 +99,8 @@ class I2CWriter {
             .polling = number_reads,
             .delay_ms = delay,
             .buffer = max_buffer,
-            .client_callback = client_callback,
-            .handle_buffer = handle_callback};
+            .client_callback = std::move(client_callback),
+            .handle_buffer = std::move(handle_callback)};
         queue->try_write(read_msg);
     }
 
@@ -140,8 +140,8 @@ class I2CWriter {
             .polling = number_reads,
             .register_buffer_1 = buffer_1,
             .register_buffer_2 = buffer_2,
-            .client_callback = client_callback,
-            .handle_buffer = handle_callback,
+            .client_callback = std::move(client_callback),
+            .handle_buffer = std::move(handle_callback),
             .delay_ms = delay};
         queue->try_write(read_msg);
     }

--- a/include/pipettes/core/i2c_writer.hpp
+++ b/include/pipettes/core/i2c_writer.hpp
@@ -55,16 +55,14 @@ class I2CWriter {
      * A poll function automatically initiates a read/write to the specified
      * register on the i2c bus.
      */
-    void read(uint16_t device_address, SingleBufferTypeDef handle_callback,
-              SendToCanFunctionTypeDef client_callback, uint8_t reg = 0x0) {
-        // We want to copy the callback every time as opposed to passing a
-        // reference to it from the eeprom task.
+    void read(uint16_t device_address, SendToCanFunctionTypeDef client_callback,
+              SingleBufferTypeDef handle_callback, uint8_t reg = 0x0) {
         std::array<uint8_t, MAX_SIZE> max_buffer{reg};
         pipette_messages::ReadFromI2C read_msg{
             .address = device_address,
             .buffer = max_buffer,
-            .handle_buffer = std::move(handle_callback),
-            .client_callback = std::move(client_callback)};
+            .client_callback = std::move(client_callback),
+            .handle_buffer = std::move(handle_callback)};
         queue->try_write(read_msg);
     }
 
@@ -86,13 +84,11 @@ class I2CWriter {
      * A poll function automatically initiates a read/write to the specified
      * register on the i2c bus.
      */
-    void single_register_poll(uint16_t device_address, uint8_t number_reads,
+    void single_register_poll(uint16_t device_address, uint16_t number_reads,
                               uint16_t delay,
                               SendToCanFunctionTypeDef client_callback,
                               SingleBufferTypeDef handle_callback,
                               uint8_t reg = 0x0) {
-        // We want to copy the callback every time as opposed to passing a
-        // reference to it from the eeprom task.
         std::array<uint8_t, MAX_SIZE> max_buffer{reg};
         pipette_messages::SingleRegisterPollReadFromI2C read_msg{
             .address = device_address,
@@ -129,7 +125,7 @@ class I2CWriter {
      * register on the i2c bus.
      */
     void multi_register_poll(
-        uint16_t device_address, uint8_t number_reads, uint16_t delay,
+        uint16_t device_address, uint16_t number_reads, uint16_t delay,
         sensor_callbacks::SendToCanFunctionTypeDef client_callback,
         sensor_callbacks::MultiBufferTypeDef handle_callback,
         uint8_t register_1 = 0x0, uint8_t register_2 = 0x0) {

--- a/include/pipettes/core/messages.hpp
+++ b/include/pipettes/core/messages.hpp
@@ -29,11 +29,11 @@ struct SingleRegisterPollReadFromI2C {
 struct MultiRegisterPollReadFromI2C {
     uint16_t address;
     int polling;
+    int delay_ms;
     sensor_callbacks::MaxMessageBuffer register_buffer_1;
     sensor_callbacks::MaxMessageBuffer register_buffer_2;
     sensor_callbacks::SendToCanFunctionTypeDef client_callback;
     sensor_callbacks::MultiBufferTypeDef handle_buffer;
-    int delay_ms;
 };
 
 }  // namespace pipette_messages

--- a/include/pipettes/core/messages.hpp
+++ b/include/pipettes/core/messages.hpp
@@ -7,7 +7,8 @@
 namespace pipette_messages {
 
 using MaxMessageBuffer = std::array<uint8_t, 5>;
-using Callback = std::function<void(const MaxMessageBuffer&)>;
+using SingleRegisterCallback = std::function<void(const MaxMessageBuffer&)>;
+using MultiRegisterCallback = std::function<void(const MaxMessageBuffer&, const MaxMessageBuffer&, bool)>;
 
 struct WriteToI2C {
     uint16_t address;
@@ -17,14 +18,23 @@ struct WriteToI2C {
 struct ReadFromI2C {
     uint16_t address;
     MaxMessageBuffer buffer;
-    Callback client_callback;
+    SingleRegisterCallback client_callback;
 };
 
-struct PollReadFromI2C {
+struct SingleRegisterPollReadFromI2C {
     uint16_t address;
     int polling;
     MaxMessageBuffer buffer;
-    Callback client_callback;
+    SingleRegisterCallback client_callback;
+    int delay_ms;
+};
+
+struct MultiRegisterPollReadFromI2C {
+    uint16_t address;
+    int polling;
+    MaxMessageBuffer register_buffer_1;
+    MaxMessageBuffer register_buffer_2;
+    MultiRegisterCallback client_callback;
     int delay_ms;
 };
 

--- a/include/pipettes/core/messages.hpp
+++ b/include/pipettes/core/messages.hpp
@@ -13,15 +13,17 @@ struct WriteToI2C {
 struct ReadFromI2C {
     uint16_t address;
     sensor_callbacks::MaxMessageBuffer buffer;
-    sensor_callbacks::SingleRegisterCallback* client_callback;
+    sensor_callbacks::SingleBufferTypeDef handle_buffer;
+    sensor_callbacks::SendToCanFunctionTypeDef client_callback;
 };
 
 struct SingleRegisterPollReadFromI2C {
     uint16_t address;
     int polling;
-    sensor_callbacks::MaxMessageBuffer buffer;
-    sensor_callbacks::SingleRegisterCallback* client_callback;
     int delay_ms;
+    sensor_callbacks::MaxMessageBuffer buffer;
+    sensor_callbacks::SendToCanFunctionTypeDef client_callback;
+    sensor_callbacks::SingleBufferTypeDef handle_buffer;
 };
 
 struct MultiRegisterPollReadFromI2C {
@@ -29,7 +31,8 @@ struct MultiRegisterPollReadFromI2C {
     int polling;
     sensor_callbacks::MaxMessageBuffer register_buffer_1;
     sensor_callbacks::MaxMessageBuffer register_buffer_2;
-    sensor_callbacks::MultiRegisterCallback* client_callback;
+    sensor_callbacks::SendToCanFunctionTypeDef client_callback;
+    sensor_callbacks::MultiBufferTypeDef handle_buffer;
     int delay_ms;
 };
 

--- a/include/pipettes/core/messages.hpp
+++ b/include/pipettes/core/messages.hpp
@@ -1,40 +1,35 @@
 #pragma once
 
-#include <functional>
-
 #include "common/core/i2c.hpp"
+#include "sensors/core/callback_types.hpp"
 
 namespace pipette_messages {
 
-using MaxMessageBuffer = std::array<uint8_t, 5>;
-using SingleRegisterCallback = std::function<void(const MaxMessageBuffer&)>;
-using MultiRegisterCallback = std::function<void(const MaxMessageBuffer&, const MaxMessageBuffer&, bool)>;
-
 struct WriteToI2C {
     uint16_t address;
-    MaxMessageBuffer buffer;
+    sensor_callbacks::MaxMessageBuffer buffer;
 };
 
 struct ReadFromI2C {
     uint16_t address;
-    MaxMessageBuffer buffer;
-    SingleRegisterCallback client_callback;
+    sensor_callbacks::MaxMessageBuffer buffer;
+    sensor_callbacks::SingleRegisterCallback* client_callback;
 };
 
 struct SingleRegisterPollReadFromI2C {
     uint16_t address;
     int polling;
-    MaxMessageBuffer buffer;
-    SingleRegisterCallback client_callback;
+    sensor_callbacks::MaxMessageBuffer buffer;
+    sensor_callbacks::SingleRegisterCallback* client_callback;
     int delay_ms;
 };
 
 struct MultiRegisterPollReadFromI2C {
     uint16_t address;
     int polling;
-    MaxMessageBuffer register_buffer_1;
-    MaxMessageBuffer register_buffer_2;
-    MultiRegisterCallback client_callback;
+    sensor_callbacks::MaxMessageBuffer register_buffer_1;
+    sensor_callbacks::MaxMessageBuffer register_buffer_2;
+    sensor_callbacks::MultiRegisterCallback* client_callback;
     int delay_ms;
 };
 

--- a/include/pipettes/core/messages.hpp
+++ b/include/pipettes/core/messages.hpp
@@ -13,8 +13,8 @@ struct WriteToI2C {
 struct ReadFromI2C {
     uint16_t address;
     sensor_callbacks::MaxMessageBuffer buffer;
-    sensor_callbacks::SingleBufferTypeDef handle_buffer;
     sensor_callbacks::SendToCanFunctionTypeDef client_callback;
+    sensor_callbacks::SingleBufferTypeDef handle_buffer;
 };
 
 struct SingleRegisterPollReadFromI2C {

--- a/include/pipettes/core/tasks.hpp
+++ b/include/pipettes/core/tasks.hpp
@@ -12,6 +12,7 @@
 #include "pipettes/core/tasks/eeprom_task.hpp"
 #include "pipettes/core/tasks/i2c_task.hpp"
 #include "sensors/core/tasks/environmental_sensor_task.hpp"
+#include "sensors/core/tasks/capacitive_sensor_task.hpp"
 
 namespace pipettes_tasks {
 
@@ -44,6 +45,8 @@ struct QueueClient : can_message_writer::MessageWriter {
 
     void send_environment_sensor_queue(const sensor_task_utils::TaskMessage& m);
 
+    void send_capacitive_sensor_queue(const sensor_task_utils::TaskMessage& m);
+
     freertos_message_queue::FreeRTOSMessageQueue<
         motion_controller_task::TaskMessage>* motion_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<
@@ -57,6 +60,8 @@ struct QueueClient : can_message_writer::MessageWriter {
         eeprom_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<
         sensor_task_utils::TaskMessage>* environment_sensor_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<
+        sensor_task_utils::TaskMessage>* capacitive_sensor_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<i2c_task::TaskMessage>*
         i2c_queue{nullptr};
 };
@@ -90,6 +95,10 @@ struct AllTask {
         freertos_message_queue::FreeRTOSMessageQueue,
         i2c_writer::I2CWriter<freertos_message_queue::FreeRTOSMessageQueue>,
         QueueClient>* environment_sensor_task{nullptr};
+    capacitive_sensor_task::CapacitiveSensorTask<
+        freertos_message_queue::FreeRTOSMessageQueue,
+        i2c_writer::I2CWriter<freertos_message_queue::FreeRTOSMessageQueue>,
+        QueueClient>* capacitive_sensor_task{nullptr};
 };
 
 /**

--- a/include/pipettes/core/tasks.hpp
+++ b/include/pipettes/core/tasks.hpp
@@ -11,8 +11,8 @@
 #include "pipettes/core/i2c_writer.hpp"
 #include "pipettes/core/tasks/eeprom_task.hpp"
 #include "pipettes/core/tasks/i2c_task.hpp"
-#include "sensors/core/tasks/environmental_sensor_task.hpp"
 #include "sensors/core/tasks/capacitive_sensor_task.hpp"
+#include "sensors/core/tasks/environmental_sensor_task.hpp"
 
 namespace pipettes_tasks {
 

--- a/include/pipettes/core/tasks/eeprom_task.hpp
+++ b/include/pipettes/core/tasks/eeprom_task.hpp
@@ -65,9 +65,8 @@ class EEPromMessageHandler {
     void visit(can_messages::ReadFromEEPromRequest &m) {
         LOG("Received request to read serial number\n");
         writer.read(
-            DEVICE_ADDRESS,
-            [this]() {handler.send_to_can();},
-            [this](auto message_a) {handler.handle_data(message_a);});
+            DEVICE_ADDRESS, [this]() { handler.send_to_can(); },
+            [this](auto message_a) { handler.handle_data(message_a); });
     }
 
     static constexpr uint16_t DEVICE_ADDRESS = 0x1;

--- a/include/pipettes/core/tasks/i2c_task.hpp
+++ b/include/pipettes/core/tasks/i2c_task.hpp
@@ -33,7 +33,8 @@ class I2CMessageHandler {
     void visit(ReadFromI2C &m) {
         i2c_device.central_receive(m.buffer.data(), m.buffer.size(), m.address,
                                    TIMEOUT);
-        m.client_callback->operator()(m.buffer);
+        m.handle_buffer(m.buffer);
+        m.client_callback();
     }
 
     void visit(SingleRegisterPollReadFromI2C &m) {
@@ -43,11 +44,11 @@ class I2CMessageHandler {
                                         m.address, TIMEOUT);
             i2c_device.central_receive(m.buffer.data(), m.buffer.size(),
                                        m.address, TIMEOUT);
-            m.client_callback->operator()(m.buffer);
+            m.handle_buffer(m.buffer);
             m.buffer = empty_array;
             i2c_device.wait_during_poll(m.delay_ms);
         }
-        m.client_callback->operator()();
+        m.client_callback();
     }
 
     void visit(MultiRegisterPollReadFromI2C &m) {
@@ -66,13 +67,12 @@ class I2CMessageHandler {
             i2c_device.central_receive(m.register_buffer_2.data(),
                                        m.register_buffer_2.size(), m.address,
                                        TIMEOUT);
-            m.client_callback->operator()(m.register_buffer_1,
-                                          m.register_buffer_2);
+            m.handle_buffer(m.register_buffer_1, m.register_buffer_2);
             m.register_buffer_1 = empty_array_reg_1;
             m.register_buffer_2 = empty_array_reg_2;
             i2c_device.wait_during_poll(m.delay_ms);
         }
-        m.client_callback->operator()();
+        m.client_callback();
     }
 
     i2c::I2CDeviceBase &i2c_device;

--- a/include/pipettes/core/tasks/i2c_task.hpp
+++ b/include/pipettes/core/tasks/i2c_task.hpp
@@ -41,6 +41,7 @@ class I2CMessageHandler {
         // TODO (lc, 03-01-2022): see about making this non-blocking
         // TODO (lc, 03-01-2022): we should try to consolidate polling to
         // support any number of registers potentially.
+        // TODO (lc, 03-01-2022): put in timer interrupt
         auto empty_array = m.buffer;
         for (int i = 0; i < m.polling; i++) {
             i2c_device.central_transmit(m.buffer.data(), m.buffer.size(),
@@ -58,6 +59,7 @@ class I2CMessageHandler {
         // TODO (lc, 03-01-2022): see about making this non-blocking
         // TODO (lc, 03-01-2022): we should try to consolidate polling to
         // support any number of registers potentially.
+        // TODO (lc, 03-01-2022): put in timer interrupt
         auto empty_array_reg_1 = m.register_buffer_1;
         auto empty_array_reg_2 = m.register_buffer_2;
         for (int i = 0; i < m.polling; i++) {
@@ -76,6 +78,8 @@ class I2CMessageHandler {
             m.handle_buffer(m.register_buffer_1, m.register_buffer_2);
             m.register_buffer_1 = empty_array_reg_1;
             m.register_buffer_2 = empty_array_reg_2;
+            // not fully correct mapping of frequency. See related github comment:
+            // https://github.com/Opentrons/ot3-firmware/pull/261#discussion_r816862421
             i2c_device.wait_during_poll(m.delay_ms);
         }
         m.client_callback();

--- a/include/pipettes/core/tasks/i2c_task.hpp
+++ b/include/pipettes/core/tasks/i2c_task.hpp
@@ -38,6 +38,9 @@ class I2CMessageHandler {
     }
 
     void visit(SingleRegisterPollReadFromI2C &m) {
+        // TODO (lc, 03-01-2022): see about making this non-blocking
+        // TODO (lc, 03-01-2022): we should try to consolidate polling to
+        // support any number of registers potentially.
         auto empty_array = m.buffer;
         for (int i = 0; i < m.polling; i++) {
             i2c_device.central_transmit(m.buffer.data(), m.buffer.size(),
@@ -52,6 +55,9 @@ class I2CMessageHandler {
     }
 
     void visit(MultiRegisterPollReadFromI2C &m) {
+        // TODO (lc, 03-01-2022): see about making this non-blocking
+        // TODO (lc, 03-01-2022): we should try to consolidate polling to
+        // support any number of registers potentially.
         auto empty_array_reg_1 = m.register_buffer_1;
         auto empty_array_reg_2 = m.register_buffer_2;
         for (int i = 0; i < m.polling; i++) {

--- a/include/pipettes/core/tasks/i2c_task.hpp
+++ b/include/pipettes/core/tasks/i2c_task.hpp
@@ -78,7 +78,8 @@ class I2CMessageHandler {
             m.handle_buffer(m.register_buffer_1, m.register_buffer_2);
             m.register_buffer_1 = empty_array_reg_1;
             m.register_buffer_2 = empty_array_reg_2;
-            // not fully correct mapping of frequency. See related github comment:
+            // not fully correct mapping of frequency. See related github
+            // comment:
             // https://github.com/Opentrons/ot3-firmware/pull/261#discussion_r816862421
             i2c_device.wait_during_poll(m.delay_ms);
         }

--- a/include/pipettes/core/tasks/i2c_task.hpp
+++ b/include/pipettes/core/tasks/i2c_task.hpp
@@ -33,45 +33,47 @@ class I2CMessageHandler {
     void visit(ReadFromI2C &m) {
         i2c_device.central_receive(m.buffer.data(), m.buffer.size(), m.address,
                                    TIMEOUT);
-        m.client_callback(m.buffer);
+        m.client_callback->operator()(m.buffer);
     }
 
     void visit(SingleRegisterPollReadFromI2C &m) {
         auto empty_array = m.buffer;
         for (int i = 0; i < m.polling; i++) {
-            i2c_device.central_transmit(m.buffer.data(), m.buffer.size(), m.address,
-                                        TIMEOUT);
+            i2c_device.central_transmit(m.buffer.data(), m.buffer.size(),
+                                        m.address, TIMEOUT);
             i2c_device.central_receive(m.buffer.data(), m.buffer.size(),
                                        m.address, TIMEOUT);
+            m.client_callback->operator()(m.buffer);
             m.buffer = empty_array;
             i2c_device.wait_during_poll(m.delay_ms);
         }
-        m.client_callback(m.buffer);
+        m.client_callback->operator()();
     }
 
     void visit(MultiRegisterPollReadFromI2C &m) {
         auto empty_array_reg_1 = m.register_buffer_1;
         auto empty_array_reg_2 = m.register_buffer_2;
-        bool final_read = false;
         for (int i = 0; i < m.polling; i++) {
-            if (i == m.polling -1) {
-                final_read = true;
-            }
-            i2c_device.central_transmit(m.register_buffer_1.data(), m.register_buffer_1.size(), m.address,
+            i2c_device.central_transmit(m.register_buffer_1.data(),
+                                        m.register_buffer_1.size(), m.address,
                                         TIMEOUT);
-            i2c_device.central_receive(m.register_buffer_1.data(), m.register_buffer_1.size(),
-                                       m.address, TIMEOUT);
-            i2c_device.central_transmit(m.register_buffer_2.data(), m.register_buffer_2.size(), m.address,
+            i2c_device.central_receive(m.register_buffer_1.data(),
+                                       m.register_buffer_1.size(), m.address,
+                                       TIMEOUT);
+            i2c_device.central_transmit(m.register_buffer_2.data(),
+                                        m.register_buffer_2.size(), m.address,
                                         TIMEOUT);
-            i2c_device.central_receive(m.register_buffer_2.data(), m.register_buffer_2.size(),
-                                       m.address, TIMEOUT);
-            m.client_callback(m.register_buffer_1, m.register_buffer_2, final_read);
+            i2c_device.central_receive(m.register_buffer_2.data(),
+                                       m.register_buffer_2.size(), m.address,
+                                       TIMEOUT);
+            m.client_callback->operator()(m.register_buffer_1,
+                                          m.register_buffer_2);
             m.register_buffer_1 = empty_array_reg_1;
             m.register_buffer_2 = empty_array_reg_2;
             i2c_device.wait_during_poll(m.delay_ms);
         }
+        m.client_callback->operator()();
     }
-
 
     i2c::I2CDeviceBase &i2c_device;
 

--- a/include/sensors/core/callback_types.hpp
+++ b/include/sensors/core/callback_types.hpp
@@ -1,23 +1,74 @@
 #pragma once
 
+#include <functional>
+
 namespace sensor_callbacks {
+/*
+ * Generic types for callbacks used in sensor types.
+ *
+ * SingleRegister Concept - accepts a single buffer to convert the given
+ * data to a fixed point value.
+ * MultiRegister Concept - accepts two buffers to convert the given data to
+ * a fixed point value.
+ *
+ * SingleRegisterCallback - wrappers around the callback structs in
+ * the sensor tasks. Mostly to work around the fact that we can't use
+ * templates with `std::variant`.
+ *
+ * MultiRegisterCallback - wrappers around the callback structs in
+ * the sensor tasks. Mostly to work around the fact that we can't use
+ * templates with `std::variant`.
+ *
+ * TODO (lc 02-27-2022): We should think about how to genericise these
+ * concepts to take in any number of buffers, but not required at the moment.
+ */
+// Max sized buffer for data we'll ever need is ~40 bits.
 using MaxMessageBuffer = std::array<uint8_t, 5>;
 
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
-class SingleRegisterCallback {
-  public:
-    virtual void operator()(const MaxMessageBuffer &buffer) = 0;
-    virtual void operator()() = 0;
-    virtual ~SingleRegisterCallback() = default;
+
+template<typename Callback>
+concept SingleRegister = requires(Callback cb, const MaxMessageBuffer &buffer) {
+    {cb.handle_data(buffer)};
+    {cb.send_to_can()};
 };
 
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
-class MultiRegisterCallback {
-  public:
-    virtual auto operator()(const MaxMessageBuffer &buffer_a,
-                            const MaxMessageBuffer &buffer_b) -> void = 0;
-    virtual auto operator()() -> void = 0;
-    virtual ~MultiRegisterCallback() = default;
+template<typename Callback>
+concept MultiRegister = requires(Callback cb, const MaxMessageBuffer &buffer) {
+    {cb.handle_data(buffer, buffer)};
+    {cb.send_to_can()};
 };
+
+template<SingleRegister scb>
+struct SingleRegisterCallback {
+    SingleRegisterCallback(scb& callback) : callback{callback} {}
+    scb& callback;
+
+    void operator()(const MaxMessageBuffer &buffer) {
+        callback.handle_data(buffer);
+    }
+
+    void operator()() {
+        callback.send_to_can();
+    }
+};
+
+template<MultiRegister mcb>
+struct MultiRegisterCallback {
+    MultiRegisterCallback(mcb& callback) : callback{callback} {}
+    mcb& callback;
+
+    void operator()(const MaxMessageBuffer &buffer_a, const MaxMessageBuffer &buffer_b) {
+        callback.handle_data(buffer_a, buffer_b);
+    }
+
+    void operator()() {
+        callback.send_to_can();
+    }
+};
+
+// Types representing the possible callback signatures
+using SendToCanFunctionTypeDef = std::function<void()>;
+using SingleBufferTypeDef = std::function<void(const MaxMessageBuffer&)>;
+using MultiBufferTypeDef = std::function<void(const MaxMessageBuffer&, const MaxMessageBuffer&)>;
 
 }  // namespace sensor_callbacks

--- a/include/sensors/core/callback_types.hpp
+++ b/include/sensors/core/callback_types.hpp
@@ -25,50 +25,47 @@ namespace sensor_callbacks {
 // Max sized buffer for data we'll ever need is ~40 bits.
 using MaxMessageBuffer = std::array<uint8_t, 5>;
 
-
-template<typename Callback>
+template <typename Callback>
 concept SingleRegister = requires(Callback cb, const MaxMessageBuffer &buffer) {
     {cb.handle_data(buffer)};
     {cb.send_to_can()};
 };
 
-template<typename Callback>
+template <typename Callback>
 concept MultiRegister = requires(Callback cb, const MaxMessageBuffer &buffer) {
     {cb.handle_data(buffer, buffer)};
     {cb.send_to_can()};
 };
 
-template<SingleRegister scb>
+template <SingleRegister scb>
 struct SingleRegisterCallback {
-    SingleRegisterCallback(scb& callback) : callback{callback} {}
-    scb& callback;
+    SingleRegisterCallback(scb &callback) : callback{callback} {}
+    scb &callback;
 
     void operator()(const MaxMessageBuffer &buffer) {
         callback.handle_data(buffer);
     }
 
-    void operator()() {
-        callback.send_to_can();
-    }
+    void operator()() { callback.send_to_can(); }
 };
 
-template<MultiRegister mcb>
+template <MultiRegister mcb>
 struct MultiRegisterCallback {
-    MultiRegisterCallback(mcb& callback) : callback{callback} {}
-    mcb& callback;
+    MultiRegisterCallback(mcb &callback) : callback{callback} {}
+    mcb &callback;
 
-    void operator()(const MaxMessageBuffer &buffer_a, const MaxMessageBuffer &buffer_b) {
+    void operator()(const MaxMessageBuffer &buffer_a,
+                    const MaxMessageBuffer &buffer_b) {
         callback.handle_data(buffer_a, buffer_b);
     }
 
-    void operator()() {
-        callback.send_to_can();
-    }
+    void operator()() { callback.send_to_can(); }
 };
 
 // Types representing the possible callback signatures
 using SendToCanFunctionTypeDef = std::function<void()>;
-using SingleBufferTypeDef = std::function<void(const MaxMessageBuffer&)>;
-using MultiBufferTypeDef = std::function<void(const MaxMessageBuffer&, const MaxMessageBuffer&)>;
+using SingleBufferTypeDef = std::function<void(const MaxMessageBuffer &)>;
+using MultiBufferTypeDef =
+    std::function<void(const MaxMessageBuffer &, const MaxMessageBuffer &)>;
 
 }  // namespace sensor_callbacks

--- a/include/sensors/core/callback_types.hpp
+++ b/include/sensors/core/callback_types.hpp
@@ -25,43 +25,6 @@ namespace sensor_callbacks {
 // Max sized buffer for data we'll ever need is ~40 bits.
 using MaxMessageBuffer = std::array<uint8_t, 5>;
 
-template <typename Callback>
-concept SingleRegister = requires(Callback cb, const MaxMessageBuffer &buffer) {
-    {cb.handle_data(buffer)};
-    {cb.send_to_can()};
-};
-
-template <typename Callback>
-concept MultiRegister = requires(Callback cb, const MaxMessageBuffer &buffer) {
-    {cb.handle_data(buffer, buffer)};
-    {cb.send_to_can()};
-};
-
-template <SingleRegister scb>
-struct SingleRegisterCallback {
-    SingleRegisterCallback(scb &callback) : callback{callback} {}
-    scb &callback;
-
-    void operator()(const MaxMessageBuffer &buffer) {
-        callback.handle_data(buffer);
-    }
-
-    void operator()() { callback.send_to_can(); }
-};
-
-template <MultiRegister mcb>
-struct MultiRegisterCallback {
-    MultiRegisterCallback(mcb &callback) : callback{callback} {}
-    mcb &callback;
-
-    void operator()(const MaxMessageBuffer &buffer_a,
-                    const MaxMessageBuffer &buffer_b) {
-        callback.handle_data(buffer_a, buffer_b);
-    }
-
-    void operator()() { callback.send_to_can(); }
-};
-
 // Types representing the possible callback signatures
 using SendToCanFunctionTypeDef = std::function<void()>;
 using SingleBufferTypeDef = std::function<void(const MaxMessageBuffer &)>;

--- a/include/sensors/core/callback_types.hpp
+++ b/include/sensors/core/callback_types.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace sensor_callbacks {
+using MaxMessageBuffer = std::array<uint8_t, 5>;
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+class SingleRegisterCallback {
+  public:
+    virtual void operator()(const MaxMessageBuffer &buffer) = 0;
+    virtual void operator()() = 0;
+    virtual ~SingleRegisterCallback() = default;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+class MultiRegisterCallback {
+  public:
+    virtual auto operator()(const MaxMessageBuffer &buffer_a,
+                            const MaxMessageBuffer &buffer_b) -> void = 0;
+    virtual auto operator()() -> void = 0;
+    virtual ~MultiRegisterCallback() = default;
+};
+
+}  // namespace sensor_callbacks

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -75,9 +75,8 @@ inline auto update_capdac(uint16_t capacitance, float current_offset)
     return new_capdac;
 }
 
-inline auto get_offset_pf(uint16_t unitless_capdac) -> uint16_t {
-    float offset = static_cast<float>(unitless_capdac) * CAPDAC_OFFSET;
-    return convert_to_fixed_point(offset, 7);
+inline auto get_offset_pf(uint16_t unitless_capdac) -> float {
+    return static_cast<float>(unitless_capdac) * CAPDAC_OFFSET;
 }
 
 }  // namespace fdc1004_utils

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -20,58 +20,54 @@
  */
 
 namespace fdc1004_utils {
-static auto convert(uint32_t measurement, uint16_t accumulation,
-                    float current_offset) -> sq14_15;
-static auto calculate_capdac(uint16_t measurement, uint16_t accumulation,
-                             float current_offset) -> uint16_t;
 
 // Capacitance Sensor Address and Registers
-static constexpr uint16_t ADDRESS = 0x50 << 1;
-static constexpr uint8_t MSB_MEASUREMENT_1 = 0x00;
-static constexpr uint8_t LSB_MEASUREMENT_1 = 0x01;
-static constexpr uint8_t CONFIGURATION_MEASUREMENT = 0x08;
-static constexpr uint8_t FDC_CONFIGURATION = 0x0C;
-static constexpr uint8_t DEVICE_ID_REGISTER = 0xFF;
+constexpr uint16_t ADDRESS = 0x50 << 1;
+constexpr uint8_t MSB_MEASUREMENT_1 = 0x00;
+constexpr uint8_t LSB_MEASUREMENT_1 = 0x01;
+constexpr uint8_t CONFIGURATION_MEASUREMENT = 0x08;
+constexpr uint8_t FDC_CONFIGURATION = 0x0C;
+constexpr uint8_t DEVICE_ID_REGISTER = 0xFF;
 
 // configurations
-static constexpr uint16_t DEVICE_CONFIGURATION =
+constexpr uint16_t DEVICE_CONFIGURATION =
     0x0 << 13 |  // CHA = CIN1 (U.FL Connector)
     0x4 << 10;   // CHB = CAPDAC
-static constexpr uint16_t SAMPLE_RATE = 1 << 10 |  // 100S/s
+constexpr uint16_t SAMPLE_RATE = 1 << 10 |  // 100S/s
                                         1 << 8 |   // Repeat enabled
                                         1 << 7;    // Measurement 1 enabled
 
-static constexpr uint16_t DEVICE_ID = 0x1004;
+constexpr uint16_t DEVICE_ID = 0x1004;
 
 // Constants
-static constexpr int MAX_CAPDAC_RESOLUTION = 5;
-static constexpr int MSB_SHIFT = 16;
-static constexpr uint16_t MAX_CAPDAC_OFFSET = 0x1F << MAX_CAPDAC_RESOLUTION;
-static constexpr float MAX_MEASUREMENT = 524288.0;
+constexpr int MAX_CAPDAC_RESOLUTION = 5;
+constexpr int MSB_SHIFT = 16;
+constexpr float MAX_CAPDAC_OFFSET = 0x1F << MAX_CAPDAC_RESOLUTION;
+constexpr float MAX_MEASUREMENT = 524288.0;
 // single ended capdac offset measurement in pF
-static constexpr float CAPDAC_OFFSET = 3.125;
+constexpr float CAPDAC_OFFSET = 3.125;
 
-[[maybe_unused]] static auto convert(uint32_t measurement,
-                                     uint16_t accumulation,
-                                     float current_offset) -> sq14_15 {
-    // shift the 32 bit value number down to 24 bits
+inline auto convert(uint32_t measurement,
+                    uint16_t read_count,
+                    float current_offset) -> sq14_15 {
     auto average =
-        static_cast<float>(measurement >> 8) / static_cast<float>(accumulation);
+        static_cast<float>(measurement) / static_cast<float>(read_count);
     float capacitance = average / MAX_MEASUREMENT + current_offset;
     return convert_to_fixed_point(capacitance, 15);
 }
 
-[[maybe_unused]] static auto calculate_capdac(uint16_t measurement,
-                                              uint16_t accumulation,
-                                              float current_offset)
+inline auto calculate_capdac(uint16_t measurement,
+                             uint16_t read_count,
+                             float current_offset)
     -> uint16_t {
     float average =
-        static_cast<float>(measurement) / static_cast<float>(accumulation);
+        static_cast<float>(measurement) / static_cast<float>(read_count);
     float offset = (average + current_offset) / CAPDAC_OFFSET;
-    uint16_t new_offset = static_cast<uint8_t>(offset) << MAX_CAPDAC_RESOLUTION;
-    if (new_offset > MAX_CAPDAC_OFFSET) {
-        new_offset = MAX_CAPDAC_OFFSET;
+    if (offset > MAX_CAPDAC_OFFSET) {
+        offset = MAX_CAPDAC_OFFSET;
     }
+    uint16_t new_offset = static_cast<uint8_t>(offset) << MAX_CAPDAC_RESOLUTION;
+
     return new_offset;
 }
 

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -35,8 +35,8 @@ constexpr uint16_t POSITIVE_INPUT_CHANNEL = 0x0;
 constexpr uint16_t NEGATIVE_INPUT_CHANNEL = 0x4 << 10;
 // configurations
 constexpr uint16_t DEVICE_CONFIGURATION =
-    0x0 << 13 |  // CHA = CIN1 (U.FL Connector)
-    0x4 << 10;   // CHB = CAPDAC
+    0x0 << 13 |                             // CHA = CIN1 (U.FL Connector)
+    0x4 << 10;                              // CHB = CAPDAC
 constexpr uint16_t SAMPLE_RATE = 1 << 10 |  // 100S/s
                                  1 << 8 |   // Repeat enabled
                                  1 << 7;    // Measurement 1 enabled
@@ -51,8 +51,7 @@ constexpr float MAX_MEASUREMENT = 524288.0;
 // single ended capdac offset measurement in pF
 constexpr float CAPDAC_OFFSET = 3.125;
 
-inline auto convert_capacitance(uint32_t capacitance,
-                                uint16_t read_count,
+inline auto convert_capacitance(uint32_t capacitance, uint16_t read_count,
                                 float current_offset) -> sq14_15 {
     auto average =
         static_cast<float>(capacitance) / static_cast<float>(read_count);
@@ -66,7 +65,8 @@ inline auto update_capdac(uint16_t capacitance, float current_offset)
      * CAPDAC is a unitless offset. To calculate the capacitive offset,
      * you would multiply CAPDAC (unitless) * CAPDAC_OFFSET (pF)
      */
-    float capdac = (static_cast<float>(capacitance)  + current_offset) / CAPDAC_OFFSET;
+    float capdac =
+        (static_cast<float>(capacitance) + current_offset) / CAPDAC_OFFSET;
     if (capdac > MAX_CAPDAC_OFFSET) {
         capdac = MAX_CAPDAC_OFFSET;
     }

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -75,4 +75,9 @@ inline auto update_capdac(uint16_t capacitance, float current_offset)
     return new_capdac;
 }
 
+inline auto get_offset_pf(uint16_t unitless_capdac) -> uint16_t {
+    float offset = static_cast<float>(unitless_capdac) * CAPDAC_OFFSET;
+    return convert_to_fixed_point(offset, 7);
+}
+
 }  // namespace fdc1004_utils

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+/*
+ * FDC1004 Capacitive Sensor
+ *
+ * Datasheet: https://www.ti.com/lit/ds/symlink/fdc1004.pdf?ts=1645556558559&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FFDC1004
+ *
+ * The configuration of the sensor is always in single-ended measurement mode. We are currently only using
+ * 1 out of the 4 measurement channels.
+ *
+ * By default, CAPDAC is enabled. The max resolution of the capdac is 5 bits.
+ *
+ * Capacitance measurement is a total of 24 bits long. You must do consecutive reads of
+ * the MSB and LSB registers to get the data.
+ */
+
+namespace fdc1004_utils {
+    static auto convert(uint32_t measurement, uint16_t accumulation, float current_offset) -> sq14_15;
+    static auto calculate_capdac(uint16_t measurement, uint16_t accumulation, float current_offset)-> uint16_t;
+
+    // Capacitance Sensor Address and Registers
+    static constexpr uint16_t ADDRESS = 0x50 << 1;
+    static constexpr uint8_t MSB_MEASUREMENT_1 = 0x00;
+    static constexpr uint8_t LSB_MEASUREMENT_1 = 0x01;
+    static constexpr uint8_t CONFIGURATION_MEASUREMENT = 0x08;
+    static constexpr uint8_t FDC_CONFIGURATION = 0x0C;
+    static constexpr uint8_t DEVICE_ID_REGISTER = 0xFF;
+
+    //configurations
+    static constexpr uint16_t DEVICE_CONFIGURATION = 0x0 << 13 |  // CHA = CIN1 (U.FL Connector)
+                                                     0x4 << 10;   // CHB = CAPDAC
+    static constexpr uint16_t SAMPLE_RATE = 1 << 10 |  // 100S/s
+                                            1 << 8 |   // Repeat enabled
+                                            1 << 7;    // Measurement 1 enabled
+
+    static constexpr uint16_t DEVICE_ID = 0x1004;
+
+    // Constants
+    static constexpr int MAX_CAPDAC_RESOLUTION = 5;
+    static constexpr int MSB_SHIFT = 16;
+    static constexpr uint16_t MAX_CAPDAC_OFFSET = 0x1F << MAX_CAPDAC_RESOLUTION;
+    static constexpr float MAX_MEASUREMENT = 524288.0;
+    // single ended capdac offset measurement in pF
+    static constexpr float CAPDAC_OFFSET = 3.125;
+
+
+    [[maybe_unused]] static auto convert(uint32_t measurement, uint16_t accumulation, float current_offset) -> sq14_15 {
+        // shift the 32 bit value number down to 24 bits
+        auto average = static_cast<float>(measurement >> 8)/static_cast<float>(accumulation);
+        float capacitance = average/MAX_MEASUREMENT + current_offset;
+        return convert_to_fixed_point(capacitance, 15);
+    }
+
+    [[maybe_unused]] static auto calculate_capdac(uint16_t measurement, uint16_t accumulation, float current_offset) -> uint16_t {
+        float average = static_cast<float>(measurement)/static_cast<float>(accumulation);
+        float offset = (average + current_offset) / CAPDAC_OFFSET;
+        uint16_t new_offset = static_cast<uint8_t>(offset) << MAX_CAPDAC_RESOLUTION;
+        if (new_offset > MAX_CAPDAC_OFFSET) {
+            new_offset = MAX_CAPDAC_OFFSET;
+        }
+        return new_offset;
+    }
+
+} // namespace fdc1004_utils
+
+
+/*
+
+
+float fdc1004_set_capdac(I2C_HandleTypeDef *i2c, float pf_delta)
+{
+    static const float CAPDAC_PF_PER_COUNT = 3.125;
+    static const float CAPDAC_COUNTS_PER_PF = 0.32; // 1.0 counts / 3.125 pF
+    uint16_t temp;
+    i2c_read_reg_uint16(i2c, FDC1004_ADDR, FDC1004_CONF_MEAS1, &temp, I2C_MSB_FIRST);
+
+    // Calculate CAPDAC value
+    // Commands are relative to measurement, so include present offset
+    uint8_t offset = (uint8_t)((capacitance_offset + pf_delta) * CAPDAC_COUNTS_PER_PF);
+    if (offset > 0x1F) offset = 0x1F;
+    temp &= ~(0x1F << 5);
+    temp |= offset << 5;
+
+    // Set CHB to CAPDAC
+    temp &= ~(0x7 << 10);
+    temp |= 0x4 << 10;
+
+    i2c_write_reg_uint16(i2c, FDC1004_ADDR, FDC1004_CONF_MEAS1, temp, I2C_MSB_FIRST);
+    capacitance_offset = (float)offset * CAPDAC_PF_PER_COUNT;
+    return capacitance_offset;
+}
+
+ */

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -1,93 +1,78 @@
 #pragma once
 
+// TODO (lc 02-16-2022) We should refactor the fixed point
+// helper functions such that they live in a shared location.
+#include "motor-control/core/utils.hpp"
+
 /*
  * FDC1004 Capacitive Sensor
  *
- * Datasheet: https://www.ti.com/lit/ds/symlink/fdc1004.pdf?ts=1645556558559&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FFDC1004
+ * Datasheet:
+ * https://www.ti.com/lit/ds/symlink/fdc1004.pdf?ts=1645556558559&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FFDC1004
  *
- * The configuration of the sensor is always in single-ended measurement mode. We are currently only using
- * 1 out of the 4 measurement channels.
+ * The configuration of the sensor is always in single-ended measurement mode.
+ * We are currently only using 1 out of the 4 measurement channels.
  *
  * By default, CAPDAC is enabled. The max resolution of the capdac is 5 bits.
  *
- * Capacitance measurement is a total of 24 bits long. You must do consecutive reads of
- * the MSB and LSB registers to get the data.
+ * Capacitance measurement is a total of 24 bits long. You must do consecutive
+ * reads of the MSB and LSB registers to get the data.
  */
 
 namespace fdc1004_utils {
-    static auto convert(uint32_t measurement, uint16_t accumulation, float current_offset) -> sq14_15;
-    static auto calculate_capdac(uint16_t measurement, uint16_t accumulation, float current_offset)-> uint16_t;
+static auto convert(uint32_t measurement, uint16_t accumulation,
+                    float current_offset) -> sq14_15;
+static auto calculate_capdac(uint16_t measurement, uint16_t accumulation,
+                             float current_offset) -> uint16_t;
 
-    // Capacitance Sensor Address and Registers
-    static constexpr uint16_t ADDRESS = 0x50 << 1;
-    static constexpr uint8_t MSB_MEASUREMENT_1 = 0x00;
-    static constexpr uint8_t LSB_MEASUREMENT_1 = 0x01;
-    static constexpr uint8_t CONFIGURATION_MEASUREMENT = 0x08;
-    static constexpr uint8_t FDC_CONFIGURATION = 0x0C;
-    static constexpr uint8_t DEVICE_ID_REGISTER = 0xFF;
+// Capacitance Sensor Address and Registers
+static constexpr uint16_t ADDRESS = 0x50 << 1;
+static constexpr uint8_t MSB_MEASUREMENT_1 = 0x00;
+static constexpr uint8_t LSB_MEASUREMENT_1 = 0x01;
+static constexpr uint8_t CONFIGURATION_MEASUREMENT = 0x08;
+static constexpr uint8_t FDC_CONFIGURATION = 0x0C;
+static constexpr uint8_t DEVICE_ID_REGISTER = 0xFF;
 
-    //configurations
-    static constexpr uint16_t DEVICE_CONFIGURATION = 0x0 << 13 |  // CHA = CIN1 (U.FL Connector)
-                                                     0x4 << 10;   // CHB = CAPDAC
-    static constexpr uint16_t SAMPLE_RATE = 1 << 10 |  // 100S/s
-                                            1 << 8 |   // Repeat enabled
-                                            1 << 7;    // Measurement 1 enabled
+// configurations
+static constexpr uint16_t DEVICE_CONFIGURATION =
+    0x0 << 13 |  // CHA = CIN1 (U.FL Connector)
+    0x4 << 10;   // CHB = CAPDAC
+static constexpr uint16_t SAMPLE_RATE = 1 << 10 |  // 100S/s
+                                        1 << 8 |   // Repeat enabled
+                                        1 << 7;    // Measurement 1 enabled
 
-    static constexpr uint16_t DEVICE_ID = 0x1004;
+static constexpr uint16_t DEVICE_ID = 0x1004;
 
-    // Constants
-    static constexpr int MAX_CAPDAC_RESOLUTION = 5;
-    static constexpr int MSB_SHIFT = 16;
-    static constexpr uint16_t MAX_CAPDAC_OFFSET = 0x1F << MAX_CAPDAC_RESOLUTION;
-    static constexpr float MAX_MEASUREMENT = 524288.0;
-    // single ended capdac offset measurement in pF
-    static constexpr float CAPDAC_OFFSET = 3.125;
+// Constants
+static constexpr int MAX_CAPDAC_RESOLUTION = 5;
+static constexpr int MSB_SHIFT = 16;
+static constexpr uint16_t MAX_CAPDAC_OFFSET = 0x1F << MAX_CAPDAC_RESOLUTION;
+static constexpr float MAX_MEASUREMENT = 524288.0;
+// single ended capdac offset measurement in pF
+static constexpr float CAPDAC_OFFSET = 3.125;
 
-
-    [[maybe_unused]] static auto convert(uint32_t measurement, uint16_t accumulation, float current_offset) -> sq14_15 {
-        // shift the 32 bit value number down to 24 bits
-        auto average = static_cast<float>(measurement >> 8)/static_cast<float>(accumulation);
-        float capacitance = average/MAX_MEASUREMENT + current_offset;
-        return convert_to_fixed_point(capacitance, 15);
-    }
-
-    [[maybe_unused]] static auto calculate_capdac(uint16_t measurement, uint16_t accumulation, float current_offset) -> uint16_t {
-        float average = static_cast<float>(measurement)/static_cast<float>(accumulation);
-        float offset = (average + current_offset) / CAPDAC_OFFSET;
-        uint16_t new_offset = static_cast<uint8_t>(offset) << MAX_CAPDAC_RESOLUTION;
-        if (new_offset > MAX_CAPDAC_OFFSET) {
-            new_offset = MAX_CAPDAC_OFFSET;
-        }
-        return new_offset;
-    }
-
-} // namespace fdc1004_utils
-
-
-/*
-
-
-float fdc1004_set_capdac(I2C_HandleTypeDef *i2c, float pf_delta)
-{
-    static const float CAPDAC_PF_PER_COUNT = 3.125;
-    static const float CAPDAC_COUNTS_PER_PF = 0.32; // 1.0 counts / 3.125 pF
-    uint16_t temp;
-    i2c_read_reg_uint16(i2c, FDC1004_ADDR, FDC1004_CONF_MEAS1, &temp, I2C_MSB_FIRST);
-
-    // Calculate CAPDAC value
-    // Commands are relative to measurement, so include present offset
-    uint8_t offset = (uint8_t)((capacitance_offset + pf_delta) * CAPDAC_COUNTS_PER_PF);
-    if (offset > 0x1F) offset = 0x1F;
-    temp &= ~(0x1F << 5);
-    temp |= offset << 5;
-
-    // Set CHB to CAPDAC
-    temp &= ~(0x7 << 10);
-    temp |= 0x4 << 10;
-
-    i2c_write_reg_uint16(i2c, FDC1004_ADDR, FDC1004_CONF_MEAS1, temp, I2C_MSB_FIRST);
-    capacitance_offset = (float)offset * CAPDAC_PF_PER_COUNT;
-    return capacitance_offset;
+[[maybe_unused]] static auto convert(uint32_t measurement,
+                                     uint16_t accumulation,
+                                     float current_offset) -> sq14_15 {
+    // shift the 32 bit value number down to 24 bits
+    auto average =
+        static_cast<float>(measurement >> 8) / static_cast<float>(accumulation);
+    float capacitance = average / MAX_MEASUREMENT + current_offset;
+    return convert_to_fixed_point(capacitance, 15);
 }
 
- */
+[[maybe_unused]] static auto calculate_capdac(uint16_t measurement,
+                                              uint16_t accumulation,
+                                              float current_offset)
+    -> uint16_t {
+    float average =
+        static_cast<float>(measurement) / static_cast<float>(accumulation);
+    float offset = (average + current_offset) / CAPDAC_OFFSET;
+    uint16_t new_offset = static_cast<uint8_t>(offset) << MAX_CAPDAC_RESOLUTION;
+    if (new_offset > MAX_CAPDAC_OFFSET) {
+        new_offset = MAX_CAPDAC_OFFSET;
+    }
+    return new_offset;
+}
+
+}  // namespace fdc1004_utils

--- a/include/sensors/core/hdc2080.hpp
+++ b/include/sensors/core/hdc2080.hpp
@@ -45,8 +45,7 @@ constexpr uint8_t SAMPLE_RATE =
 constexpr uint8_t SET_DATARDY = 1 << 7;
 constexpr uint8_t BEGIN_MEASUREMENT_RECORDING = 1;
 
-inline auto convert(uint16_t data, can_ids::SensorType type)
-    -> sq14_15 {
+inline auto convert(uint16_t data, can_ids::SensorType type) -> sq14_15 {
     switch (type) {
         case can_ids::SensorType::humidity: {
             // returns humidity in relative humidity percentage

--- a/include/sensors/core/hdc2080.hpp
+++ b/include/sensors/core/hdc2080.hpp
@@ -14,40 +14,38 @@
 
 namespace hdc2080_utils {
 
-static auto convert(uint16_t data, can_ids::SensorType type) -> sq14_15;
-
 // constants
-static constexpr float TEMP_CONST_MULTIPLIER = 165.0;
-static constexpr float TEMP_CONST = 40.5;
-static constexpr float HUMIDITY_CONST = 100.0;
+constexpr float TEMP_CONST_MULTIPLIER = 165.0;
+constexpr float TEMP_CONST = 40.5;
+constexpr float HUMIDITY_CONST = 100.0;
 
 // max bits for regular sensor value reading is 2^16
-static constexpr float MAX_SIZE = 65536.0;
+constexpr float MAX_SIZE = 65536.0;
 
-static constexpr uint16_t ADDRESS = 0x41 << 1;
-static constexpr uint16_t DEVICE_ID = 0x07D0;
+constexpr uint16_t ADDRESS = 0x41 << 1;
+constexpr uint16_t DEVICE_ID = 0x07D0;
 
 // Registers to read from or write to
-static constexpr uint8_t INTERRUPT_REGISTER = 0x07;
-static constexpr uint8_t DRDY_CONFIG = 0x0E;
-static const uint8_t MEASURE_REGISTER = 0x0F;
-static const uint8_t DEVICE_ID_REGISTER = 0xFE;
+constexpr uint8_t INTERRUPT_REGISTER = 0x07;
+constexpr uint8_t DRDY_CONFIG = 0x0E;
+constexpr uint8_t MEASURE_REGISTER = 0x0F;
+constexpr uint8_t DEVICE_ID_REGISTER = 0xFE;
 // Low configurations for both temperature and humidity
 // this records the status when a reading goes below
 // a certain threshold.
-static constexpr uint8_t LSB_TEMPERATURE_REGISTER = 0x00;
-static constexpr uint8_t LSB_HUMIDITY_REGISTER = 0x02;
+constexpr uint8_t LSB_TEMPERATURE_REGISTER = 0x00;
+constexpr uint8_t LSB_HUMIDITY_REGISTER = 0x02;
 
-static constexpr uint8_t MSB_HUMIDITY_REGISTER = 0x01;
-static constexpr uint8_t MSB_TEMPERATURE_REGISTER = 0x03;
+constexpr uint8_t MSB_HUMIDITY_REGISTER = 0x01;
+constexpr uint8_t MSB_TEMPERATURE_REGISTER = 0x03;
 
 // humidity sensor configurations
-static constexpr uint8_t SAMPLE_RATE =
+constexpr uint8_t SAMPLE_RATE =
     (5 << 4) | (1 << 2) | (1 << 1);  // 1 sample/second, positive DRDY output
-static constexpr uint8_t SET_DATARDY = 1 << 7;
-static constexpr uint8_t BEGIN_MEASUREMENT_RECORDING = 1;
+constexpr uint8_t SET_DATARDY = 1 << 7;
+constexpr uint8_t BEGIN_MEASUREMENT_RECORDING = 1;
 
-[[maybe_unused]] static auto convert(uint16_t data, can_ids::SensorType type)
+inline auto convert(uint16_t data, can_ids::SensorType type)
     -> sq14_15 {
     switch (type) {
         case can_ids::SensorType::humidity: {

--- a/include/sensors/core/message_handlers/sensors.hpp
+++ b/include/sensors/core/message_handlers/sensors.hpp
@@ -51,6 +51,9 @@ class SensorHandler {
             case can_ids::SensorType::humidity: {
                 client.send_environment_sensor_queue(m);
             }
+            case can_ids::SensorType::capacitive: {
+                client.send_capacitive_sensor_queue(m);
+            }
             default:
                 break;
         }

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -23,9 +23,8 @@ struct ReadCapacitanceCallback {
     ReadCapacitanceCallback(CanClient &can_client, float current_offset)
         : can_client{can_client}, current_offset{current_offset} {}
 
-    void handle_data(
-        const sensor_callbacks::MaxMessageBuffer &MSB_buffer,
-        const sensor_callbacks::MaxMessageBuffer &LSB_buffer) {
+    void handle_data(const sensor_callbacks::MaxMessageBuffer &MSB_buffer,
+                     const sensor_callbacks::MaxMessageBuffer &LSB_buffer) {
         uint32_t msb_data = 0x0;
         uint32_t lsb_data = 0x0;
         const auto *MSB_iter = MSB_buffer.cbegin();
@@ -51,7 +50,7 @@ struct ReadCapacitanceCallback {
     }
 
     void set_number_of_reads(uint16_t number_of_reads) {
-        number_of_reads = number_of_reads;
+        this->number_of_reads = number_of_reads;
     }
 
     void set_offset(float new_offset) { current_offset = new_offset; }
@@ -97,7 +96,7 @@ struct ReadOffsetCallback {
     }
 
     void set_number_of_reads(uint16_t number_of_reads) {
-        number_of_reads = number_of_reads;
+        this->number_of_reads = number_of_reads;
     }
 
     void set_offset(float new_offset) { current_offset = new_offset; }

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -25,8 +25,8 @@ struct ReadCapacitanceCallback {
 
     void handle_data(const sensor_callbacks::MaxMessageBuffer &MSB_buffer,
                      const sensor_callbacks::MaxMessageBuffer &LSB_buffer) {
-        uint32_t msb_data = 0x0;
-        uint32_t lsb_data = 0x0;
+        uint16_t msb_data = 0x0;
+        uint16_t lsb_data = 0x0;
         const auto *MSB_iter = MSB_buffer.cbegin();
         MSB_iter =
             bit_utils::bytes_to_int(MSB_iter, MSB_buffer.cend(), msb_data);

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "can/core/can_writer_task.hpp"
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+#include "sensors/core/callback_types.hpp"
+#include "sensors/core/fdc1004.hpp"
+
+namespace capacitance_callbacks {
+using namespace fdc1004_utils;
+using namespace can_ids;
+
+template <message_writer_task::TaskClient CanClient>
+struct ReadCapacitanceCallback
+    : public sensor_callbacks::MultiRegisterCallback {
+  public:
+    ReadCapacitanceCallback(CanClient &can_client, float current_offset)
+        : can_client{can_client}, current_offset{current_offset} {}
+
+    void operator()(const sensor_callbacks::MaxMessageBuffer &MSB_buffer,
+                    const sensor_callbacks::MaxMessageBuffer &LSB_buffer) override {
+        uint32_t msb_data = 0x0;
+        uint32_t lsb_data = 0x0;
+        const auto *MSB_iter = MSB_buffer.cbegin();
+        MSB_iter =
+            bit_utils::bytes_to_int(MSB_iter, MSB_buffer.cend(), msb_data);
+        const auto *LSB_iter = LSB_buffer.cbegin();
+        LSB_iter =
+            bit_utils::bytes_to_int(LSB_iter, LSB_buffer.cend(), lsb_data);
+        measurement += (msb_data << MSB_SHIFT | lsb_data);
+    }
+
+    void operator()() override {
+        uint32_t capacitive =
+            convert(measurement, number_of_reads, current_offset);
+        auto message = can_messages::ReadFromSensorResponse{
+            {}, SensorType::capacitive, capacitive};
+        can_client.send_can_message(can_ids::NodeId::host, message);
+    }
+
+    void reset() {
+        number_of_reads = 1;
+        measurement = 0;
+    }
+
+    void set_number_of_reads(uint16_t number_of_reads) {
+        number_of_reads = number_of_reads;
+    }
+
+    void set_offset(float new_offset) { current_offset = new_offset; }
+
+  private:
+    CanClient &can_client;
+    float current_offset;
+    uint32_t measurement = 0;
+    uint16_t number_of_reads = 1;
+};
+
+template <message_writer_task::TaskClient CanClient>
+struct ReadOffsetCallback : public sensor_callbacks::SingleRegisterCallback {
+  public:
+    ReadOffsetCallback(CanClient &can_client, float current_offset)
+        : can_client{can_client}, current_offset{current_offset} {}
+
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) override {
+        uint16_t data = 0x0;
+        const auto *iter = buffer.cbegin();
+        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
+    }
+
+    void operator()() override {
+        uint32_t offset =
+            calculate_capdac(measurement, number_of_reads, current_offset);
+        auto message = can_messages::ReadFromSensorResponse{
+            {}, SensorType::capacitive, offset};
+        can_client.send_can_message(can_ids::NodeId::host, message);
+    }
+
+    void reset() {
+        measurement = 0;
+        number_of_reads = 1;
+    }
+
+    void set_number_of_reads(uint16_t number_of_reads) {
+        number_of_reads = number_of_reads;
+    }
+
+    void set_offset(float new_offset) { current_offset = new_offset; }
+
+  private:
+    CanClient &can_client;
+    float current_offset;
+    uint32_t measurement = 0;
+    uint16_t number_of_reads = 1;
+};
+
+// This struct should be used when the message handler
+// class receives information it should handle (i.e. the device info)
+struct InternalCallback : public sensor_callbacks::SingleRegisterCallback {
+    std::array<uint16_t, 1> storage{};
+
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) override {
+        uint16_t data = 0x0;
+        const auto *iter = buffer.cbegin();
+        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
+        storage[0] = data;
+    }
+
+    void operator()() override {}
+
+    auto get_storage() -> uint16_t { return storage[0]; }
+};
+};  // namespace capacitance_callbacks

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -22,7 +22,7 @@ template <message_writer_task::TaskClient CanClient, class I2CQueueWriter>
 struct ReadCapacitanceCallback {
   public:
     ReadCapacitanceCallback(CanClient &can_client, I2CQueueWriter &i2c_writer,
-                            uint32_t threshold, uint16_t current_offset)
+                            uint32_t threshold, float current_offset)
         : can_client{can_client},
           i2c_writer{i2c_writer},
           current_offset{current_offset},
@@ -53,7 +53,7 @@ struct ReadCapacitanceCallback {
             auto capdac = update_capdac(capacitance, current_offset);
             // convert back to pF
             current_offset = get_offset_pf(capdac);
-            LOG("Setting offset to %d \n", current_offset);
+            LOG("Setting offset to %d \n", static_cast<int>(current_offset));
             uint16_t update = CONFIGURATION_MEASUREMENT |
                               POSITIVE_INPUT_CHANNEL | NEGATIVE_INPUT_CHANNEL |
                               capdac;
@@ -75,7 +75,7 @@ struct ReadCapacitanceCallback {
   private:
     CanClient &can_client;
     I2CQueueWriter &i2c_writer;
-    uint16_t current_offset;
+    float current_offset;
     uint32_t zero_threshold;
     uint32_t measurement = 0;
     uint16_t number_of_reads = 1;

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -52,7 +52,7 @@ struct ReadCapacitanceCallback {
                 zero_threshold);
             auto capdac = update_capdac(capacitance, current_offset);
             // convert back to pF
-            current_offset = capdac * CAPDAC_OFFSET;
+            current_offset = get_offset_pf(capdac);
             LOG("Setting offset to %d \n", current_offset);
             uint16_t update = CONFIGURATION_MEASUREMENT |
                               POSITIVE_INPUT_CHANNEL | NEGATIVE_INPUT_CHANNEL |

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -17,8 +17,9 @@ struct ReadCapacitanceCallback
     ReadCapacitanceCallback(CanClient &can_client, float current_offset)
         : can_client{can_client}, current_offset{current_offset} {}
 
-    void operator()(const sensor_callbacks::MaxMessageBuffer &MSB_buffer,
-                    const sensor_callbacks::MaxMessageBuffer &LSB_buffer) override {
+    void operator()(
+        const sensor_callbacks::MaxMessageBuffer &MSB_buffer,
+        const sensor_callbacks::MaxMessageBuffer &LSB_buffer) override {
         uint32_t msb_data = 0x0;
         uint32_t lsb_data = 0x0;
         const auto *MSB_iter = MSB_buffer.cbegin();

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -1,0 +1,230 @@
+#pragma once
+
+#include "can/core/can_writer_task.hpp"
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+#include "common/core/bit_utils.hpp"
+#include "common/core/logging.hpp"
+#include "common/core/message_queue.hpp"
+#include "sensors/core/fdc1004.hpp"
+#include "sensors/core/utils.hpp"
+
+namespace capacitive_sensor_task {
+
+using namespace fdc1004_utils;
+using namespace can_ids;
+
+
+template <message_writer_task::TaskClient CanClient>
+struct ReadCapacitanceCallback {
+    CanClient &can_client;
+    float current_offset;
+    uint32_t measurement = 0;
+    uint16_t number_of_reads = 1;
+
+    void operator()(const pipette_messages::MaxMessageBuffer &MSB_buffer, const pipette_messages::MaxMessageBuffer &LSB_buffer, bool final_read) {
+        uint16_t msb_data = 0x0;
+        uint16_t lsb_data = 0x0;
+        const auto *MSB_iter = MSB_buffer.cbegin();
+        MSB_iter = bit_utils::bytes_to_int(MSB_iter, MSB_buffer.cend(), msb_data);
+        const auto *LSB_iter = LSB_buffer.cbegin();
+        LSB_iter = bit_utils::bytes_to_int(LSB_iter, LSB_buffer.cend(), lsb_data);
+        measurement += (msb_data << MSB_SHIFT | lsb_data);
+
+        if (final_read) {
+            auto capacitive = convert(measurement, number_of_reads, current_offset);
+            auto message = can_messages::ReadFromSensorResponse{{}, SensorType::capacitive, capacitive};
+            can_client.send_can_message(can_ids::NodeId::host, message);
+        }
+    }
+
+    void reset() {
+        number_of_reads = 1;
+        measurement = 0;
+    }
+
+    void set_number_of_reads(uint16_t number_of_reads) {
+        number_of_reads = number_of_reads;
+    }
+
+    void set_offset(float new_offset) {
+        current_offset = new_offset;
+    }
+};
+
+template <message_writer_task::TaskClient CanClient>
+struct ReadOffsetCallback {
+    CanClient &can_client;
+    float current_offset;
+    uint32_t measurement = 0;
+    uint16_t number_of_reads = 1;
+
+    void operator()(const pipette_messages::MaxMessageBuffer &buffer, bool final_read) {
+        uint16_t data = 0x0;
+        const auto *iter = buffer.cbegin();
+        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
+
+        if (final_read) {
+            auto offset = calculate_capdac(measurement, number_of_reads, current_offset);
+            auto message = can_messages::ReadFromSensorResponse{{}, SensorType::capacitive, offset};
+            can_client.send_can_message(can_ids::NodeId::host, message);
+        }
+    }
+
+    void reset() {
+        measurement = 0;
+        number_of_reads = 1;
+    }
+
+    void set_number_of_reads(uint16_t number_of_reads) {
+        number_of_reads = number_of_reads;
+    }
+
+    void set_offset(float new_offset) {
+        current_offset = new_offset;
+    }
+};
+
+// This struct should be used when the message handler
+// class receives information it should handle (i.e. the device info)
+struct InternalCallback {
+    std::array<uint16_t, 1> storage{};
+
+    void operator()(const pipette_messages::MaxMessageBuffer &buffer) {
+        uint16_t data = 0x0;
+        const auto *iter = buffer.cbegin();
+        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
+        storage[0] = data;
+    }
+
+    uint16_t get_storage() {
+        return storage[0];
+    }
+};
+
+template <class I2CQueueWriter, message_writer_task::TaskClient CanClient>
+class CapacitiveMessageHandler {
+  public:
+    explicit CapacitiveMessageHandler(I2CQueueWriter &i2c_writer,
+                                      CanClient &can_client)
+        : writer{i2c_writer}, can_client{can_client}, capacitance_callback{can_client, CAPDAC_OFFSET}, capdac_callback{can_client, CAPDAC_OFFSET} {}
+    CapacitiveMessageHandler(const CapacitiveMessageHandler &) = delete;
+    CapacitiveMessageHandler(const CapacitiveMessageHandler &&) = delete;
+    auto operator=(const CapacitiveMessageHandler &)
+    -> CapacitiveMessageHandler & = delete;
+    auto operator=(const CapacitiveMessageHandler &&)
+    -> CapacitiveMessageHandler && = delete;
+    ~CapacitiveMessageHandler() = default;
+
+    void handle_message(sensor_task_utils::TaskMessage &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+    void initialize() {
+        writer.write(DEVICE_ID, ADDRESS);
+        writer.read(ADDRESS, internal_callback, DEVICE_ID);
+        // We should send a message that the sensor is in a ready state,
+        // not sure if we should have a separate can message to do that
+        // holding off for this PR.
+        uint16_t configuration_data = CONFIGURATION_MEASUREMENT << 8 | DEVICE_CONFIGURATION;
+        writer.write(configuration_data, ADDRESS);
+        configuration_data = FDC_CONFIGURATION << 8 | SAMPLE_RATE;
+        writer.write(configuration_data, ADDRESS);
+    }
+
+  private:
+
+    void visit(can_messages::ReadFromSensorRequest &m) {
+        LOG("Received request to read from %d sensor\n", m.sensor);
+        if (m.offset_reading) {
+            capdac_callback.reset();
+            capdac_callback.set_offset(CAPDAC_OFFSET);
+            writer.write(CONFIGURATION_MEASUREMENT, ADDRESS);
+            writer.read(ADDRESS, capdac_callback, CONFIGURATION_MEASUREMENT);
+        } else {
+            capacitance_callback.reset();
+            capacitance_callback.set_offset(CAPDAC_OFFSET);
+            writer.multi_register_poll(ADDRESS, 1, capacitance_callback, MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
+        }
+
+    }
+
+    void visit(can_messages::WriteToSensorRequest &m) {
+        LOG("Received request to write data %d to %d sensor\n", m.data,
+            m.sensor);
+        writer.write(m.data, ADDRESS);
+    }
+
+    void visit(can_messages::BaselineSensorRequest &m) {
+        LOG("Received request to read from %d sensor\n", m.sensor);
+        if (m.offset_update) {
+            capdac_callback.reset();
+            capdac_callback.set_number_of_reads(m.sample_rate);
+            capdac_callback.set_offset(CAPDAC_OFFSET);
+            writer.single_register_poll(ADDRESS, m.sample_rate, capdac_callback, CONFIGURATION_MEASUREMENT);
+        } else {
+            capacitance_callback.reset();
+            capacitance_callback.set_number_of_reads(m.sample_rate);
+            capacitance_callback.set_offset(CAPDAC_OFFSET);
+            writer.multi_register_poll(ADDRESS, m.sample_rate, capacitance_callback, MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
+        }
+    }
+
+    void visit(can_messages::SetSensorThresholdRequest &m) {
+        LOG("Received request to set threshold to %d from %d sensor\n", m.threshold, m.sensor);
+        THRESHOLD = m.threshold;
+        auto message = can_messages::SensorThresholdResponse{{}, THRESHOLD};
+        can_client.send_can_message(can_ids::NodeId::host, message);
+    }
+
+    InternalCallback internal_callback{};
+    sensor_task_utils::BitMode mode = sensor_task_utils::BitMode::MSB;
+    // 8 pF
+    uint32_t THRESHOLD = 0x8;
+    float CAPDAC_OFFSET = 0x0;
+    I2CQueueWriter &writer;
+    CanClient &can_client;
+    ReadCapacitanceCallback<CanClient> capacitance_callback;
+    ReadOffsetCallback<CanClient> capdac_callback;
+};
+
+/**
+ * The task type.
+ */
+template <template <class> class QueueImpl, class I2CQueueWriter,
+    message_writer_task::TaskClient CanClient>
+requires MessageQueue<QueueImpl<sensor_task_utils::TaskMessage>, sensor_task_utils::TaskMessage>
+class CapacitiveSensorTask {
+  public:
+    using QueueType = QueueImpl<sensor_task_utils::TaskMessage>;
+    CapacitiveSensorTask(QueueType &queue) : queue{queue} {}
+    CapacitiveSensorTask(const CapacitiveSensorTask &c) = delete;
+    CapacitiveSensorTask(const CapacitiveSensorTask &&c) = delete;
+    auto operator=(const CapacitiveSensorTask &c) = delete;
+    auto operator=(const CapacitiveSensorTask &&c) = delete;
+    ~CapacitiveSensorTask() = default;
+
+    /**
+     * Task entry point.
+     */
+    [[noreturn]] void operator()(I2CQueueWriter *writer,
+                                 CanClient *can_client) {
+        auto handler = CapacitiveMessageHandler{*writer, *can_client};
+        handler.initialize();
+        sensor_task_utils::TaskMessage message{};
+        for (;;) {
+            if (queue.try_read(&message, queue.max_delay)) {
+                handler.handle_message(message);
+            }
+        }
+    }
+
+    [[nodiscard]] auto get_queue() const -> QueueType & { return queue; }
+
+  private:
+    QueueType &queue;
+};
+
+
+}  // namespace capacitive_sensor_task

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -33,7 +33,8 @@ class CapacitiveMessageHandler {
 
     void initialize() {
         writer.write(DEVICE_ID_REGISTER, ADDRESS);
-        writer.read(ADDRESS, &internal_callback, DEVICE_ID_REGISTER);
+        sensor_callbacks::SingleRegisterCallback callback{internal_callback};
+        writer.read(ADDRESS, callback, callback, DEVICE_ID_REGISTER);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
         // holding off for this PR.
@@ -53,11 +54,13 @@ class CapacitiveMessageHandler {
             capdac_callback.reset();
             capdac_callback.set_offset(CAPDAC_OFFSET);
             writer.write(CONFIGURATION_MEASUREMENT, ADDRESS);
-            writer.read(ADDRESS, &capdac_callback, CONFIGURATION_MEASUREMENT);
+            sensor_callbacks::SingleRegisterCallback callback{capdac_callback};
+            writer.read(ADDRESS, callback, callback, CONFIGURATION_MEASUREMENT);
         } else {
             capacitance_callback.reset();
             capacitance_callback.set_offset(CAPDAC_OFFSET);
-            writer.multi_register_poll(ADDRESS, 1, DELAY, &capacitance_callback,
+            sensor_callbacks::MultiRegisterCallback callback{capacitance_callback};
+            writer.multi_register_poll(ADDRESS, 1, DELAY, callback, callback,
                                        MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
         }
     }
@@ -74,15 +77,17 @@ class CapacitiveMessageHandler {
             capdac_callback.reset();
             capdac_callback.set_number_of_reads(m.sample_rate);
             capdac_callback.set_offset(CAPDAC_OFFSET);
+            sensor_callbacks::SingleRegisterCallback callback{capdac_callback};
             writer.single_register_poll(ADDRESS, m.sample_rate, DELAY,
-                                        &capdac_callback,
+                                        callback, callback,
                                         CONFIGURATION_MEASUREMENT);
         } else {
             capacitance_callback.reset();
             capacitance_callback.set_number_of_reads(m.sample_rate);
             capacitance_callback.set_offset(CAPDAC_OFFSET);
+            sensor_callbacks::MultiRegisterCallback callback{capacitance_callback};
             writer.multi_register_poll(ADDRESS, m.sample_rate, DELAY,
-                                       &capacitance_callback, MSB_MEASUREMENT_1,
+                                       callback, callback, MSB_MEASUREMENT_1,
                                        LSB_MEASUREMENT_1);
         }
     }

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -64,7 +64,7 @@ class CapacitiveMessageHandler {
         capdac_offset = capacitance_handler.get_offset();
         if (bool(m.offset_reading)) {
             auto message = can_messages::ReadFromSensorResponse{
-                {}, SensorType::capacitive, capdac_offset};
+                {}, SensorType::capacitive, static_cast<uint32_t>(capdac_offset)};
             can_client.send_can_message(can_ids::NodeId::host, message);
         } else {
             capacitance_handler.reset();
@@ -111,7 +111,8 @@ class CapacitiveMessageHandler {
     sensor_task_utils::BitMode mode = sensor_task_utils::BitMode::MSB;
     // 3 pF
     uint32_t zero_threshold = 0x3;
-    uint16_t capdac_offset = 0x0;
+    // 0 pF
+    float capdac_offset = 0x0;
     static constexpr uint16_t DELAY = 20;
     I2CQueueWriter &writer;
     CanClient &can_client;

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -17,7 +17,8 @@ class CapacitiveMessageHandler {
                                       CanClient &can_client)
         : writer{i2c_writer},
           can_client{can_client},
-          capacitance_handler{can_client, writer, zero_threshold, capdac_offset} {}
+          capacitance_handler{can_client, writer, zero_threshold,
+                              capdac_offset} {}
     CapacitiveMessageHandler(const CapacitiveMessageHandler &) = delete;
     CapacitiveMessageHandler(const CapacitiveMessageHandler &&) = delete;
     auto operator=(const CapacitiveMessageHandler &)
@@ -33,9 +34,10 @@ class CapacitiveMessageHandler {
     void initialize() {
         writer.write(DEVICE_ID_REGISTER, ADDRESS);
         writer.read(
-            ADDRESS,
-            [this]() {internal_callback.send_to_can();},
-            [this](auto message_a) {internal_callback.handle_data(message_a);},
+            ADDRESS, [this]() { internal_callback.send_to_can(); },
+            [this](auto message_a) {
+                internal_callback.handle_data(message_a);
+            },
             DEVICE_ID_REGISTER);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
@@ -60,9 +62,7 @@ class CapacitiveMessageHandler {
          */
         LOG("Received request to read from %d sensor\n", m.sensor);
         capdac_offset = capacitance_handler.get_offset();
-        std::cout << "capdac  " << static_cast<int>(capdac_offset) << "\n";
         if (bool(m.offset_reading)) {
-            std::cout << "offset reading  " << "\n";
             auto message = can_messages::ReadFromSensorResponse{
                 {}, SensorType::capacitive, capdac_offset};
             can_client.send_can_message(can_ids::NodeId::host, message);
@@ -70,8 +70,10 @@ class CapacitiveMessageHandler {
             capacitance_handler.reset();
             writer.multi_register_poll(
                 ADDRESS, 1, DELAY,
-                [this]() {capacitance_handler.send_to_can();},
-                [this](auto message_a, auto message_b) {capacitance_handler.handle_data(message_a, message_b);},
+                [this]() { capacitance_handler.send_to_can(); },
+                [this](auto message_a, auto message_b) {
+                    capacitance_handler.handle_data(message_a, message_b);
+                },
                 MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
         }
     }
@@ -89,8 +91,10 @@ class CapacitiveMessageHandler {
         capacitance_handler.set_number_of_reads(m.sample_rate);
         writer.multi_register_poll(
             ADDRESS, m.sample_rate, DELAY,
-            [this]() {capacitance_handler.send_to_can();},
-            [this](auto message_a, auto message_b) {capacitance_handler.handle_data(message_a, message_b);},
+            [this]() { capacitance_handler.send_to_can(); },
+            [this](auto message_a, auto message_b) {
+                capacitance_handler.handle_data(message_a, message_b);
+            },
             MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
     }
 

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -1,120 +1,30 @@
 #pragma once
 
-#include "can/core/can_writer_task.hpp"
-#include "can/core/ids.hpp"
-#include "can/core/messages.hpp"
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.hpp"
 #include "common/core/message_queue.hpp"
-#include "sensors/core/fdc1004.hpp"
+#include "sensors/core/tasks/capacitive_sensor_callbacks.hpp"
 #include "sensors/core/utils.hpp"
 
 namespace capacitive_sensor_task {
 
-using namespace fdc1004_utils;
-using namespace can_ids;
-
-
-template <message_writer_task::TaskClient CanClient>
-struct ReadCapacitanceCallback {
-    CanClient &can_client;
-    float current_offset;
-    uint32_t measurement = 0;
-    uint16_t number_of_reads = 1;
-
-    void operator()(const pipette_messages::MaxMessageBuffer &MSB_buffer, const pipette_messages::MaxMessageBuffer &LSB_buffer, bool final_read) {
-        uint16_t msb_data = 0x0;
-        uint16_t lsb_data = 0x0;
-        const auto *MSB_iter = MSB_buffer.cbegin();
-        MSB_iter = bit_utils::bytes_to_int(MSB_iter, MSB_buffer.cend(), msb_data);
-        const auto *LSB_iter = LSB_buffer.cbegin();
-        LSB_iter = bit_utils::bytes_to_int(LSB_iter, LSB_buffer.cend(), lsb_data);
-        measurement += (msb_data << MSB_SHIFT | lsb_data);
-
-        if (final_read) {
-            auto capacitive = convert(measurement, number_of_reads, current_offset);
-            auto message = can_messages::ReadFromSensorResponse{{}, SensorType::capacitive, capacitive};
-            can_client.send_can_message(can_ids::NodeId::host, message);
-        }
-    }
-
-    void reset() {
-        number_of_reads = 1;
-        measurement = 0;
-    }
-
-    void set_number_of_reads(uint16_t number_of_reads) {
-        number_of_reads = number_of_reads;
-    }
-
-    void set_offset(float new_offset) {
-        current_offset = new_offset;
-    }
-};
-
-template <message_writer_task::TaskClient CanClient>
-struct ReadOffsetCallback {
-    CanClient &can_client;
-    float current_offset;
-    uint32_t measurement = 0;
-    uint16_t number_of_reads = 1;
-
-    void operator()(const pipette_messages::MaxMessageBuffer &buffer, bool final_read) {
-        uint16_t data = 0x0;
-        const auto *iter = buffer.cbegin();
-        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
-
-        if (final_read) {
-            auto offset = calculate_capdac(measurement, number_of_reads, current_offset);
-            auto message = can_messages::ReadFromSensorResponse{{}, SensorType::capacitive, offset};
-            can_client.send_can_message(can_ids::NodeId::host, message);
-        }
-    }
-
-    void reset() {
-        measurement = 0;
-        number_of_reads = 1;
-    }
-
-    void set_number_of_reads(uint16_t number_of_reads) {
-        number_of_reads = number_of_reads;
-    }
-
-    void set_offset(float new_offset) {
-        current_offset = new_offset;
-    }
-};
-
-// This struct should be used when the message handler
-// class receives information it should handle (i.e. the device info)
-struct InternalCallback {
-    std::array<uint16_t, 1> storage{};
-
-    void operator()(const pipette_messages::MaxMessageBuffer &buffer) {
-        uint16_t data = 0x0;
-        const auto *iter = buffer.cbegin();
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
-        storage[0] = data;
-    }
-
-    uint16_t get_storage() {
-        return storage[0];
-    }
-};
+using namespace capacitance_callbacks;
 
 template <class I2CQueueWriter, message_writer_task::TaskClient CanClient>
 class CapacitiveMessageHandler {
   public:
     explicit CapacitiveMessageHandler(I2CQueueWriter &i2c_writer,
                                       CanClient &can_client)
-        : writer{i2c_writer}, can_client{can_client}, capacitance_callback{can_client, CAPDAC_OFFSET}, capdac_callback{can_client, CAPDAC_OFFSET} {}
+        : writer{i2c_writer},
+          can_client{can_client},
+          capacitance_callback{can_client, CAPDAC_OFFSET},
+          capdac_callback{can_client, CAPDAC_OFFSET} {}
     CapacitiveMessageHandler(const CapacitiveMessageHandler &) = delete;
     CapacitiveMessageHandler(const CapacitiveMessageHandler &&) = delete;
     auto operator=(const CapacitiveMessageHandler &)
-    -> CapacitiveMessageHandler & = delete;
+        -> CapacitiveMessageHandler & = delete;
     auto operator=(const CapacitiveMessageHandler &&)
-    -> CapacitiveMessageHandler && = delete;
+        -> CapacitiveMessageHandler && = delete;
     ~CapacitiveMessageHandler() = default;
 
     void handle_message(sensor_task_utils::TaskMessage &m) {
@@ -122,32 +32,34 @@ class CapacitiveMessageHandler {
     }
 
     void initialize() {
-        writer.write(DEVICE_ID, ADDRESS);
-        writer.read(ADDRESS, internal_callback, DEVICE_ID);
+        writer.write(DEVICE_ID_REGISTER, ADDRESS);
+        writer.read(ADDRESS, &internal_callback, DEVICE_ID_REGISTER);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
         // holding off for this PR.
-        uint16_t configuration_data = CONFIGURATION_MEASUREMENT << 8 | DEVICE_CONFIGURATION;
+        uint16_t configuration_data =
+            CONFIGURATION_MEASUREMENT << 8 | DEVICE_CONFIGURATION;
         writer.write(configuration_data, ADDRESS);
         configuration_data = FDC_CONFIGURATION << 8 | SAMPLE_RATE;
         writer.write(configuration_data, ADDRESS);
     }
 
   private:
+    void visit(std::monostate &m) {}
 
     void visit(can_messages::ReadFromSensorRequest &m) {
         LOG("Received request to read from %d sensor\n", m.sensor);
-        if (m.offset_reading) {
+        if (bool(m.offset_reading)) {
             capdac_callback.reset();
             capdac_callback.set_offset(CAPDAC_OFFSET);
             writer.write(CONFIGURATION_MEASUREMENT, ADDRESS);
-            writer.read(ADDRESS, capdac_callback, CONFIGURATION_MEASUREMENT);
+            writer.read(ADDRESS, &capdac_callback, CONFIGURATION_MEASUREMENT);
         } else {
             capacitance_callback.reset();
             capacitance_callback.set_offset(CAPDAC_OFFSET);
-            writer.multi_register_poll(ADDRESS, 1, capacitance_callback, MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
+            writer.multi_register_poll(ADDRESS, 1, DELAY, &capacitance_callback,
+                                       MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
         }
-
     }
 
     void visit(can_messages::WriteToSensorRequest &m) {
@@ -158,23 +70,29 @@ class CapacitiveMessageHandler {
 
     void visit(can_messages::BaselineSensorRequest &m) {
         LOG("Received request to read from %d sensor\n", m.sensor);
-        if (m.offset_update) {
+        if (bool(m.offset_update)) {
             capdac_callback.reset();
             capdac_callback.set_number_of_reads(m.sample_rate);
             capdac_callback.set_offset(CAPDAC_OFFSET);
-            writer.single_register_poll(ADDRESS, m.sample_rate, capdac_callback, CONFIGURATION_MEASUREMENT);
+            writer.single_register_poll(ADDRESS, m.sample_rate, DELAY,
+                                        &capdac_callback,
+                                        CONFIGURATION_MEASUREMENT);
         } else {
             capacitance_callback.reset();
             capacitance_callback.set_number_of_reads(m.sample_rate);
             capacitance_callback.set_offset(CAPDAC_OFFSET);
-            writer.multi_register_poll(ADDRESS, m.sample_rate, capacitance_callback, MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
+            writer.multi_register_poll(ADDRESS, m.sample_rate, DELAY,
+                                       &capacitance_callback, MSB_MEASUREMENT_1,
+                                       LSB_MEASUREMENT_1);
         }
     }
 
     void visit(can_messages::SetSensorThresholdRequest &m) {
-        LOG("Received request to set threshold to %d from %d sensor\n", m.threshold, m.sensor);
+        LOG("Received request to set threshold to %d from %d sensor\n",
+            m.threshold, m.sensor);
         THRESHOLD = m.threshold;
-        auto message = can_messages::SensorThresholdResponse{{}, THRESHOLD};
+        auto message = can_messages::SensorThresholdResponse{
+            {}, SensorType::capacitive, THRESHOLD};
         can_client.send_can_message(can_ids::NodeId::host, message);
     }
 
@@ -183,6 +101,7 @@ class CapacitiveMessageHandler {
     // 8 pF
     uint32_t THRESHOLD = 0x8;
     float CAPDAC_OFFSET = 0x0;
+    uint16_t DELAY = 20;
     I2CQueueWriter &writer;
     CanClient &can_client;
     ReadCapacitanceCallback<CanClient> capacitance_callback;
@@ -193,8 +112,9 @@ class CapacitiveMessageHandler {
  * The task type.
  */
 template <template <class> class QueueImpl, class I2CQueueWriter,
-    message_writer_task::TaskClient CanClient>
-requires MessageQueue<QueueImpl<sensor_task_utils::TaskMessage>, sensor_task_utils::TaskMessage>
+          message_writer_task::TaskClient CanClient>
+requires MessageQueue<QueueImpl<sensor_task_utils::TaskMessage>,
+                      sensor_task_utils::TaskMessage>
 class CapacitiveSensorTask {
   public:
     using QueueType = QueueImpl<sensor_task_utils::TaskMessage>;
@@ -225,6 +145,5 @@ class CapacitiveSensorTask {
   private:
     QueueType &queue;
 };
-
 
 }  // namespace capacitive_sensor_task

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -59,7 +59,8 @@ class CapacitiveMessageHandler {
         } else {
             capacitance_callback.reset();
             capacitance_callback.set_offset(CAPDAC_OFFSET);
-            sensor_callbacks::MultiRegisterCallback callback{capacitance_callback};
+            sensor_callbacks::MultiRegisterCallback callback{
+                capacitance_callback};
             writer.multi_register_poll(ADDRESS, 1, DELAY, callback, callback,
                                        MSB_MEASUREMENT_1, LSB_MEASUREMENT_1);
         }
@@ -78,16 +79,16 @@ class CapacitiveMessageHandler {
             capdac_callback.set_number_of_reads(m.sample_rate);
             capdac_callback.set_offset(CAPDAC_OFFSET);
             sensor_callbacks::SingleRegisterCallback callback{capdac_callback};
-            writer.single_register_poll(ADDRESS, m.sample_rate, DELAY,
-                                        callback, callback,
-                                        CONFIGURATION_MEASUREMENT);
+            writer.single_register_poll(ADDRESS, m.sample_rate, DELAY, callback,
+                                        callback, CONFIGURATION_MEASUREMENT);
         } else {
             capacitance_callback.reset();
             capacitance_callback.set_number_of_reads(m.sample_rate);
             capacitance_callback.set_offset(CAPDAC_OFFSET);
-            sensor_callbacks::MultiRegisterCallback callback{capacitance_callback};
-            writer.multi_register_poll(ADDRESS, m.sample_rate, DELAY,
-                                       callback, callback, MSB_MEASUREMENT_1,
+            sensor_callbacks::MultiRegisterCallback callback{
+                capacitance_callback};
+            writer.multi_register_poll(ADDRESS, m.sample_rate, DELAY, callback,
+                                       callback, MSB_MEASUREMENT_1,
                                        LSB_MEASUREMENT_1);
         }
     }

--- a/include/sensors/core/tasks/capacitive_sensor_task_starter.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task_starter.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "common/core/freertos_message_queue.hpp"
+#include "common/core/freertos_task.hpp"
+#include "pipettes/core/i2c_writer.hpp"
+#include "sensors/core/utils.hpp"
+
+namespace capacitive_sensor_task_starter {
+
+template <uint32_t StackDepth, message_writer_task::TaskClient CanClient>
+class TaskStarter {
+  public:
+    using I2CWriterType =
+    i2c_writer::I2CWriter<freertos_message_queue::FreeRTOSMessageQueue>;
+    using CapacitiveTaskType =
+    capacitive_task::CapacitiveTask<freertos_message_queue::FreeRTOSMessageQueue,
+        I2CWriterType, CanClient>;
+    using QueueType =
+    freertos_message_queue::FreeRTOSMessageQueue<sensor_task_utils::TaskMessage>;
+    using TaskType = freertos_task::FreeRTOSTask<StackDepth, CapacitiveTaskType,
+        I2CWriterType, CanClient>;
+
+    TaskStarter() : task_entry{queue}, task{task_entry} {}
+    TaskStarter(const TaskStarter& c) = delete;
+    TaskStarter(const TaskStarter&& c) = delete;
+    auto operator=(const TaskStarter& c) = delete;
+    auto operator=(const TaskStarter&& c) = delete;
+    ~TaskStarter() = default;
+
+    auto start(uint32_t priority, I2CWriterType& writer, CanClient& can_client)
+    -> CapacitiveTaskType& {
+        task.start(priority, "capacitive", &writer, &can_client);
+        return task_entry;
+    }
+
+  private:
+    QueueType queue{};
+    CapacitiveTaskType task_entry;
+    TaskType task;
+};
+
+}  // namespace capacitive_sensor_task_starter

--- a/include/sensors/core/tasks/capacitive_sensor_task_starter.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task_starter.hpp
@@ -3,6 +3,7 @@
 #include "common/core/freertos_message_queue.hpp"
 #include "common/core/freertos_task.hpp"
 #include "pipettes/core/i2c_writer.hpp"
+#include "sensors/core/tasks/capacitive_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
 
 namespace capacitive_sensor_task_starter {
@@ -11,14 +12,13 @@ template <uint32_t StackDepth, message_writer_task::TaskClient CanClient>
 class TaskStarter {
   public:
     using I2CWriterType =
-    i2c_writer::I2CWriter<freertos_message_queue::FreeRTOSMessageQueue>;
-    using CapacitiveTaskType =
-    capacitive_task::CapacitiveTask<freertos_message_queue::FreeRTOSMessageQueue,
-        I2CWriterType, CanClient>;
-    using QueueType =
-    freertos_message_queue::FreeRTOSMessageQueue<sensor_task_utils::TaskMessage>;
+        i2c_writer::I2CWriter<freertos_message_queue::FreeRTOSMessageQueue>;
+    using CapacitiveTaskType = capacitive_sensor_task::CapacitiveSensorTask<
+        freertos_message_queue::FreeRTOSMessageQueue, I2CWriterType, CanClient>;
+    using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
+        sensor_task_utils::TaskMessage>;
     using TaskType = freertos_task::FreeRTOSTask<StackDepth, CapacitiveTaskType,
-        I2CWriterType, CanClient>;
+                                                 I2CWriterType, CanClient>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;
@@ -28,7 +28,7 @@ class TaskStarter {
     ~TaskStarter() = default;
 
     auto start(uint32_t priority, I2CWriterType& writer, CanClient& can_client)
-    -> CapacitiveTaskType& {
+        -> CapacitiveTaskType& {
         task.start(priority, "capacitive", &writer, &can_client);
         return task_entry;
     }

--- a/include/sensors/core/tasks/environment_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/environment_sensor_callbacks.hpp
@@ -45,7 +45,6 @@ struct TemperatureReadingCallback {
         const auto *iter = buffer.cbegin();
         iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
         temperature = convert(data, SensorType::temperature);
-
     }
 
     void send_to_can() {

--- a/include/sensors/core/tasks/environment_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/environment_sensor_callbacks.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "can/core/can_writer_task.hpp"
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+#include "sensors/core/callback_types.hpp"
+#include "sensors/core/hdc2080.hpp"
+
+namespace environment_sensor_callbacks {
+using namespace hdc2080_utils;
+using namespace can_ids;
+
+template <message_writer_task::TaskClient CanClient>
+struct HumidityReadingCallback
+    : public sensor_callbacks::SingleRegisterCallback {
+  public:
+    HumidityReadingCallback(CanClient &can_client) : can_client{can_client} {}
+
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) override {
+        uint16_t data = 0x0;
+        const auto *iter = buffer.cbegin();
+        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
+        auto humidity = convert(data, SensorType::humidity);
+
+        auto message = can_messages::ReadFromSensorResponse{
+            {}, SensorType::humidity, static_cast<uint32_t>(humidity)};
+        can_client.send_can_message(can_ids::NodeId::host, message);
+    }
+
+    void operator()() override {}
+
+  private:
+    CanClient &can_client;
+};
+
+template <message_writer_task::TaskClient CanClient>
+struct TemperatureReadingCallback
+    : public sensor_callbacks::SingleRegisterCallback {
+  public:
+    TemperatureReadingCallback(CanClient &can_client)
+        : can_client{can_client} {}
+
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) override {
+        uint16_t data = 0x0;
+        const auto *iter = buffer.cbegin();
+        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
+        auto temperature = convert(data, SensorType::temperature);
+
+        auto message = can_messages::ReadFromSensorResponse{
+            {}, SensorType::temperature, static_cast<uint32_t>(temperature)};
+        can_client.send_can_message(can_ids::NodeId::host, message);
+    }
+
+    void operator()() override {}
+
+  private:
+    CanClient &can_client;
+};
+
+// TODO (lc: 02-24-2022 pull into its own shared file)
+// This struct should be used when the message handler
+// class receives information it should handle (i.e. the device info)
+struct InternalCallback : public sensor_callbacks::SingleRegisterCallback {
+    std::array<uint16_t, 1> storage{};
+
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) override {
+        uint16_t data = 0x0;
+        const auto *iter = buffer.cbegin();
+        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
+        storage[0] = data;
+    }
+
+    void operator()() override {}
+};
+
+}  // namespace environment_sensor_callbacks

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -6,60 +6,12 @@
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.hpp"
 #include "common/core/message_queue.hpp"
-#include "pipettes/core/messages.hpp"
-#include "sensors/core/hdc2080.hpp"
+#include "sensors/core/tasks/environment_sensor_callbacks.hpp"
 #include "sensors/core/utils.hpp"
 
 namespace environment_sensor_task {
 
-using namespace hdc2080_utils;
-using namespace can_ids;
-
-template <message_writer_task::TaskClient CanClient>
-struct HumidityReadingCallback {
-    CanClient &can_client;
-
-    void operator()(const pipette_messages::MaxMessageBuffer &buffer) {
-        uint16_t data = 0x0;
-        const auto *iter = buffer.cbegin();
-        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
-        auto humidity = convert(data, SensorType::humidity);
-
-        auto message = can_messages::ReadFromSensorResponse{
-            {}, SensorType::humidity, static_cast<uint32_t>(humidity)};
-        can_client.send_can_message(can_ids::NodeId::host, message);
-    }
-};
-
-template <message_writer_task::TaskClient CanClient>
-struct TemperatureReadingCallback {
-    CanClient &can_client;
-
-    void operator()(const pipette_messages::MaxMessageBuffer &buffer) {
-        uint16_t data = 0x0;
-        const auto *iter = buffer.cbegin();
-        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
-        auto temperature = convert(data, SensorType::temperature);
-
-        auto message = can_messages::ReadFromSensorResponse{
-            {}, SensorType::temperature, static_cast<uint32_t>(temperature)};
-        can_client.send_can_message(can_ids::NodeId::host, message);
-    }
-};
-
-// This struct should be used when the message handler
-// class receives information it should handle (i.e. the device info)
-struct InternalCallback {
-    std::array<uint16_t, 1> storage{};
-
-    void operator()(const pipette_messages::MaxMessageBuffer &buffer) {
-        uint16_t data = 0x0;
-        const auto *iter = buffer.cbegin();
-        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
-        storage[0] = data;
-    }
-};
+using namespace environment_sensor_callbacks;
 
 template <class I2CQueueWriter, message_writer_task::TaskClient CanClient>
 class EnvironmentSensorMessageHandler {
@@ -82,7 +34,7 @@ class EnvironmentSensorMessageHandler {
 
     void initialize() {
         writer.write(DEVICE_ID_REGISTER, ADDRESS);
-        writer.read(ADDRESS, internal_callback, DEVICE_ID_REGISTER);
+        writer.read(ADDRESS, &internal_callback, DEVICE_ID_REGISTER);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
         // holding off for this PR.
@@ -116,10 +68,10 @@ class EnvironmentSensorMessageHandler {
         LOG("Received request to read from %d sensor\n", m.sensor);
         if (SensorType(m.sensor) == SensorType::humidity) {
             writer.write(HUMIDITY_REGISTER, ADDRESS);
-            writer.read(ADDRESS, humidity_callback, HUMIDITY_REGISTER);
+            writer.read(ADDRESS, &humidity_callback, HUMIDITY_REGISTER);
         } else {
             writer.write(TEMPERATURE_REGISTER, ADDRESS);
-            writer.read(ADDRESS, temperature_callback, TEMPERATURE_REGISTER);
+            writer.read(ADDRESS, &temperature_callback, TEMPERATURE_REGISTER);
         }
     }
 

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -35,9 +35,8 @@ class EnvironmentSensorMessageHandler {
     void initialize() {
         writer.write(DEVICE_ID_REGISTER, ADDRESS);
         writer.read(
-            ADDRESS,
-            [this]() {internal_handler.send_to_can();},
-            [this](auto message_a) {internal_handler.handle_data(message_a);},
+            ADDRESS, [this]() { internal_handler.send_to_can(); },
+            [this](auto message_a) { internal_handler.handle_data(message_a); },
             DEVICE_ID_REGISTER);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
@@ -73,16 +72,18 @@ class EnvironmentSensorMessageHandler {
         if (SensorType(m.sensor) == SensorType::humidity) {
             writer.write(HUMIDITY_REGISTER, ADDRESS);
             writer.read(
-                ADDRESS,
-                [this]() {humidity_handler.send_to_can();},
-                [this](auto message_a) {humidity_handler.handle_data(message_a);},
+                ADDRESS, [this]() { humidity_handler.send_to_can(); },
+                [this](auto message_a) {
+                    humidity_handler.handle_data(message_a);
+                },
                 HUMIDITY_REGISTER);
         } else {
             writer.write(TEMPERATURE_REGISTER, ADDRESS);
             writer.read(
-                ADDRESS,
-                [this]() {temperature_handler.send_to_can();},
-                [this](auto message_a) {temperature_handler.handle_data(message_a);},
+                ADDRESS, [this]() { temperature_handler.send_to_can(); },
+                [this](auto message_a) {
+                    temperature_handler.handle_data(message_a);
+                },
                 TEMPERATURE_REGISTER);
         }
     }

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -34,7 +34,8 @@ class EnvironmentSensorMessageHandler {
 
     void initialize() {
         writer.write(DEVICE_ID_REGISTER, ADDRESS);
-        writer.read(ADDRESS, &internal_callback, DEVICE_ID_REGISTER);
+        sensor_callbacks::SingleRegisterCallback callback{internal_callback};
+        writer.read(ADDRESS, callback, callback, DEVICE_ID_REGISTER);
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
         // holding off for this PR.
@@ -68,10 +69,14 @@ class EnvironmentSensorMessageHandler {
         LOG("Received request to read from %d sensor\n", m.sensor);
         if (SensorType(m.sensor) == SensorType::humidity) {
             writer.write(HUMIDITY_REGISTER, ADDRESS);
-            writer.read(ADDRESS, &humidity_callback, HUMIDITY_REGISTER);
+            sensor_callbacks::SingleRegisterCallback callback{
+                humidity_callback};
+            writer.read(ADDRESS, callback, callback, HUMIDITY_REGISTER);
         } else {
             writer.write(TEMPERATURE_REGISTER, ADDRESS);
-            writer.read(ADDRESS, &temperature_callback, TEMPERATURE_REGISTER);
+            sensor_callbacks::SingleRegisterCallback callback{
+                temperature_callback};
+            writer.read(ADDRESS, callback, callback, TEMPERATURE_REGISTER);
         }
     }
 

--- a/include/sensors/core/tasks/environmental_sensor_task_starter.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task_starter.hpp
@@ -3,7 +3,7 @@
 #include "common/core/freertos_message_queue.hpp"
 #include "common/core/freertos_task.hpp"
 #include "pipettes/core/i2c_writer.hpp"
-#include "pipettes/core/tasks/eeprom_task.hpp"
+#include "sensors/core/tasks/environmental_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
 
 namespace environment_sensor_task_starter {

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -3,6 +3,7 @@
 #include "can/core/messages.hpp"
 
 namespace sensor_task_utils {
+
 using TaskMessage =
     std::variant<std::monostate, can_messages::ReadFromSensorRequest,
                  can_messages::WriteToSensorRequest,

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -16,6 +16,7 @@ using TaskMessage =
 template <typename Client>
 concept TaskClient = requires(Client client, const TaskMessage &m) {
     {client.send_environment_sensor_queue(m)};
+    {client.send_capacitive_sensor_queue(m)};
 };
 
 enum class BitMode : uint8_t { LSB = 0x0, MSB = 0x1 };

--- a/include/sensors/simulation/fdc1004.hpp
+++ b/include/sensors/simulation/fdc1004.hpp
@@ -12,7 +12,6 @@ class FDC1004 : public sensor_simulator::SensorType {
         REGISTER_MAP = {
             {fdc1004_utils::CONFIGURATION_MEASUREMENT, 0},
             {fdc1004_utils::FDC_CONFIGURATION, 0},
-            {fdc1004_utils::MEASURE_REGISTER, 0},
             {fdc1004_utils::MSB_MEASUREMENT_1, 5},
             {fdc1004_utils::LSB_MEASUREMENT_1, 2},
             {fdc1004_utils::DEVICE_ID_REGISTER, fdc1004_utils::DEVICE_ID}};

--- a/include/sensors/simulation/fdc1004.hpp
+++ b/include/sensors/simulation/fdc1004.hpp
@@ -9,12 +9,13 @@ class FDC1004 : public sensor_simulator::SensorType {
     FDC1004() {
         DEVICE_ID = fdc1004_utils::DEVICE_ID;
         ADDRESS = fdc1004_utils::ADDRESS;
-        REGISTER_MAP = {{fdc1004_utils::CONFIGURATION_MEASUREMENT, 0},
-                        {fdc1004_utils::FDC_CONFIGURATION, 0},
-                        {fdc1004_utils::MEASURE_REGISTER, 0},
-                        {fdc1004_utils::MSB_MEASUREMENT_1, 5},
-                        {fdc1004_utils::LSB_MEASUREMENT_1, 2},
-                        {fdc1004_utils::DEVICE_ID_REGISTER, fdc1004_utils::DEVICE_ID}};
+        REGISTER_MAP = {
+            {fdc1004_utils::CONFIGURATION_MEASUREMENT, 0},
+            {fdc1004_utils::FDC_CONFIGURATION, 0},
+            {fdc1004_utils::MEASURE_REGISTER, 0},
+            {fdc1004_utils::MSB_MEASUREMENT_1, 5},
+            {fdc1004_utils::LSB_MEASUREMENT_1, 2},
+            {fdc1004_utils::DEVICE_ID_REGISTER, fdc1004_utils::DEVICE_ID}};
     }
 };
 };  // namespace fdc1004_simulator

--- a/include/sensors/simulation/fdc1004.hpp
+++ b/include/sensors/simulation/fdc1004.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "sensors/core/fdc1004.hpp"
+#include "sensors/simulation/sensors.hpp"
+
+namespace fdc1004_simulator {
+class FDC1004 : public sensor_simulator::SensorType {
+  public:
+    FDC1004() {
+        DEVICE_ID = fdc1004_utils::DEVICE_ID;
+        ADDRESS = fdc1004_utils::ADDRESS;
+        REGISTER_MAP = {{fdc1004_utils::CONFIGURATION_MEASUREMENT, 0},
+                        {fdc1004_utils::FDC_CONFIGURATION, 0},
+                        {fdc1004_utils::MEASURE_REGISTER, 0},
+                        {fdc1004_utils::MSB_MEASUREMENT_1, 5},
+                        {fdc1004_utils::LSB_MEASUREMENT_1, 2},
+                        {fdc1004_utils::DEVICE_ID_REGISTER, fdc1004_utils::DEVICE_ID}};
+    }
+};
+};  // namespace fdc1004_simulator

--- a/include/sensors/tests/callbacks.hpp
+++ b/include/sensors/tests/callbacks.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "sensors/core/callback_types.hpp"
+
+namespace mock_callbacks {
+struct EmptyCallback : public sensor_callbacks::SingleRegisterCallback {
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) {}
+    void operator()() {}
+};
+
+struct UpdateCallback : public sensor_callbacks::SingleRegisterCallback {
+  public:
+    uint8_t update_value;
+
+    UpdateCallback() : update_value(0) {}
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) {
+        update_value += buffer[3];
+    }
+
+    void operator()() {}
+};
+
+struct MultiUpdateCallback : public sensor_callbacks::MultiRegisterCallback {
+  public:
+    uint8_t register_a_value;
+    uint8_t register_b_value;
+
+    MultiUpdateCallback() : register_a_value(0), register_b_value(0) {}
+    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer_a,
+                    const sensor_callbacks::MaxMessageBuffer &buffer_b) {
+        register_a_value += buffer_a[3];
+        register_b_value += buffer_b[3];
+    }
+
+    void operator()() {}
+};
+
+}  // namespace mock_callbacks

--- a/include/sensors/tests/callbacks.hpp
+++ b/include/sensors/tests/callbacks.hpp
@@ -19,9 +19,7 @@ struct UpdateCallback {
 
     void send_to_can() {}
 
-    void reset() {
-        update_value = 0;
-    }
+    void reset() { update_value = 0; }
 };
 
 struct MultiUpdateCallback {

--- a/include/sensors/tests/callbacks.hpp
+++ b/include/sensors/tests/callbacks.hpp
@@ -3,36 +3,45 @@
 #include "sensors/core/callback_types.hpp"
 
 namespace mock_callbacks {
-struct EmptyCallback : public sensor_callbacks::SingleRegisterCallback {
+struct EmptyCallback {
     void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) {}
     void operator()() {}
 };
 
-struct UpdateCallback : public sensor_callbacks::SingleRegisterCallback {
+struct UpdateCallback {
   public:
     uint8_t update_value;
 
     UpdateCallback() : update_value(0) {}
-    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer) {
+    void handle_data(const sensor_callbacks::MaxMessageBuffer &buffer) {
         update_value += buffer[3];
     }
 
-    void operator()() {}
+    void send_to_can() {}
+
+    void reset() {
+        update_value = 0;
+    }
 };
 
-struct MultiUpdateCallback : public sensor_callbacks::MultiRegisterCallback {
+struct MultiUpdateCallback {
   public:
     uint8_t register_a_value;
     uint8_t register_b_value;
 
     MultiUpdateCallback() : register_a_value(0), register_b_value(0) {}
-    void operator()(const sensor_callbacks::MaxMessageBuffer &buffer_a,
-                    const sensor_callbacks::MaxMessageBuffer &buffer_b) {
+    void handle_data(const sensor_callbacks::MaxMessageBuffer &buffer_a,
+                     const sensor_callbacks::MaxMessageBuffer &buffer_b) {
         register_a_value += buffer_a[3];
         register_b_value += buffer_b[3];
     }
 
-    void operator()() {}
+    void send_to_can() {}
+
+    void reset() {
+        register_a_value = 0;
+        register_b_value = 0;
+    }
 };
 
 }  // namespace mock_callbacks

--- a/motor-control/core/utils.cpp
+++ b/motor-control/core/utils.cpp
@@ -25,3 +25,8 @@ sq0_31 fixed_point_multiply(sq31_31 a, sq0_31 b) {
     int64_t result = a * static_cast<int64_t>(b);
     return static_cast<sq0_31>((result >> 31) & 0xFFFFFFFF);
 }
+
+float fixed_point_to_float(uint32_t data, int to_radix) {
+    const uint32_t power_of_two = 2 << to_radix;
+    return (1.0 * static_cast<float>(data)) / power_of_two;
+}

--- a/motor-control/core/utils.cpp
+++ b/motor-control/core/utils.cpp
@@ -27,6 +27,5 @@ sq0_31 fixed_point_multiply(sq31_31 a, sq0_31 b) {
 }
 
 float fixed_point_to_float(uint32_t data, int to_radix) {
-    const uint32_t power_of_two = 2 << to_radix;
-    return (1.0 * static_cast<float>(data)) / power_of_two;
+    return (1.0 * static_cast<float>(data)) / static_cast<float>(2 << to_radix);
 }

--- a/pipettes/core/tasks.cpp
+++ b/pipettes/core/tasks.cpp
@@ -9,6 +9,7 @@
 #include "pipettes/core/can_task.hpp"
 #include "pipettes/core/tasks/eeprom_task_starter.hpp"
 #include "pipettes/core/tasks/i2c_task_starter.hpp"
+#include "sensors/core/tasks/capacitive_sensor_task_starter.hpp"
 #include "sensors/core/tasks/environmental_sensor_task_starter.hpp"
 
 static auto tasks = pipettes_tasks::AllTask{};
@@ -33,6 +34,9 @@ static auto eeprom_task_builder =
 static auto environment_sensor_task_builder =
     environment_sensor_task_starter::TaskStarter<512,
                                                  pipettes_tasks::QueueClient>{};
+static auto capacitive_sensor_task_builder =
+    capacitive_sensor_task_starter::TaskStarter<512,
+                                                pipettes_tasks::QueueClient>{};
 
 static auto i2c_task_builder = i2c_task_starter::TaskStarter<512>{};
 
@@ -63,6 +67,8 @@ void pipettes_tasks::start_tasks(
     auto& eeprom_task = eeprom_task_builder.start(5, i2c_task_client, queues);
     auto& environment_sensor_task =
         environment_sensor_task_builder.start(5, i2c_task_client, queues);
+    auto& capacitive_sensor_task =
+        capacitive_sensor_task_builder.start(5, i2c_task_client, queues);
 
     tasks.can_writer = &can_writer;
     tasks.motion_controller = &motion;
@@ -71,6 +77,7 @@ void pipettes_tasks::start_tasks(
     tasks.move_status_reporter = &move_status_reporter;
     tasks.eeprom_task = &eeprom_task;
     tasks.environment_sensor_task = &environment_sensor_task;
+    tasks.capacitive_sensor_task = &capacitive_sensor_task;
     tasks.i2c_task = &i2c_task;
 
     queues.motion_queue = &motion.get_queue();
@@ -80,6 +87,7 @@ void pipettes_tasks::start_tasks(
     queues.move_status_report_queue = &move_status_reporter.get_queue();
     queues.eeprom_queue = &eeprom_task.get_queue();
     queues.environment_sensor_queue = &environment_sensor_task.get_queue();
+    queues.capacitive_sensor_queue = &capacitive_sensor_task.get_queue();
 
     queues.i2c_queue = &i2c_task.get_queue();
 }

--- a/pipettes/core/tasks.cpp
+++ b/pipettes/core/tasks.cpp
@@ -119,6 +119,11 @@ void pipettes_tasks::QueueClient::send_environment_sensor_queue(
     environment_sensor_queue->try_write(m);
 }
 
+void pipettes_tasks::QueueClient::send_capacitive_sensor_queue(
+    const sensor_task_utils::TaskMessage& m) {
+    capacitive_sensor_queue->try_write(m);
+}
+
 /**
  * Access to the tasks singleton
  * @return

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -45,7 +45,9 @@ static auto hdcsensor = hdc2080_simulator::HDC2080{};
 static auto capsensor = fdc1004_simulator::FDC1004{};
 static auto eeprom = eeprom_simulator::EEProm{};
 std::map<uint16_t, sensor_simulator::SensorType> sensor_map = {
-    {hdcsensor.ADDRESS, hdcsensor}, {eeprom.ADDRESS, eeprom}, {capsensor.ADDRESS, capsensor}};
+    {hdcsensor.ADDRESS, hdcsensor},
+    {eeprom.ADDRESS, eeprom},
+    {capsensor.ADDRESS, capsensor}};
 
 static auto i2c_comms = sim_i2c::SimI2C{sensor_map};
 

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -14,8 +14,8 @@
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
 #include "pipettes/core/tasks.hpp"
 #include "sensors/simulation/eeprom.hpp"
-#include "sensors/simulation/hdc2080.hpp"
 #include "sensors/simulation/fdc1004.hpp"
+#include "sensors/simulation/hdc2080.hpp"
 #include "sensors/simulation/sensors.hpp"
 #include "task.h"
 

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -15,6 +15,7 @@
 #include "pipettes/core/tasks.hpp"
 #include "sensors/simulation/eeprom.hpp"
 #include "sensors/simulation/hdc2080.hpp"
+#include "sensors/simulation/fdc1004.hpp"
 #include "sensors/simulation/sensors.hpp"
 #include "task.h"
 

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -42,9 +42,10 @@ static motor_driver_config::RegisterConfig MotorDriverConfigurations{
     .coolconf = 0x60000};
 
 static auto hdcsensor = hdc2080_simulator::HDC2080{};
+static auto capsensor = fdc1004_simulator::FDC1004{};
 static auto eeprom = eeprom_simulator::EEProm{};
 std::map<uint16_t, sensor_simulator::SensorType> sensor_map = {
-    {hdcsensor.ADDRESS, hdcsensor}, {eeprom.ADDRESS, eeprom}};
+    {hdcsensor.ADDRESS, hdcsensor}, {eeprom.ADDRESS, eeprom}, {capsensor.ADDRESS, capsensor}};
 
 static auto i2c_comms = sim_i2c::SimI2C{sensor_map};
 

--- a/pipettes/tests/CMakeLists.txt
+++ b/pipettes/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
         test_i2c_task.cpp
         test_mount_detection.cpp
         test_environment_sensor.cpp
+        test_capacitive_sensor.cpp
 )
 
 target_include_directories(pipettes PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -2,111 +2,93 @@
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
 #include "common/tests/mock_queue_client.hpp"
+#include "motor-control/core/utils.hpp"
 #include "pipettes/core/i2c_writer.hpp"
 #include "sensors/core/fdc1004.hpp"
 #include "sensors/core/tasks/capacitive_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
 
-float fixed_to_float(uint32_t data) {
-    constexpr uint32_t power_of_two = 2 << 15;
-    return (1.0 * static_cast<float>(data)) / power_of_two;
-}
-
-SCENARIO("read temperature and humidity values") {
+SCENARIO("read capacitance sensor values") {
     test_mocks::MockMessageQueue<i2c_writer::TaskMessage> i2c_queue{};
     test_mocks::MockMessageQueue<mock_message_writer::TaskMessage> can_queue{};
     test_mocks::MockMessageQueue<sensor_task_utils::TaskMessage>
         capacitive_queue{};
 
     i2c_writer::TaskMessage empty_msg{};
-    auto queue_client = mock_client::QueueClient{.capacitive_sensor_queue =
-    &capacitive_queue};
+    auto queue_client =
+        mock_client::QueueClient{.capacitive_sensor_queue = &capacitive_queue};
     auto writer = i2c_writer::I2CWriter<test_mocks::MockMessageQueue>{};
     queue_client.set_queue(&can_queue);
     writer.set_queue(&i2c_queue);
 
-    auto sensor = environment_sensor_task::CapacitiveSensorMessageHandler{
-        writer, queue_client};
+    auto sensor =
+        capacitive_sensor_task::CapacitiveMessageHandler{writer, queue_client};
     constexpr uint8_t capacitive_id = 0x1;
 
-    GIVEN("a request to take a single read of the sensor") {
+    GIVEN("a request to take a single read of the capacitive sensor") {
         auto single_read = sensor_task_utils::TaskMessage(
             can_messages::ReadFromSensorRequest({}, capacitive_id));
         sensor.handle_message(single_read);
-        WHEN("the handler function receives the message in LSB mode") {
+        WHEN("the handler function receives the message") {
             THEN("the i2c queue is populated with a write and read command") {
-                REQUIRE(i2c_queue.get_size() == 2);
+                REQUIRE(i2c_queue.get_size() == 1);
             }
             AND_WHEN("we read the messages from the queue") {
                 i2c_queue.try_read(&empty_msg);
                 auto read_message =
-                    std::get<i2c_writer::ReadFromI2C>(empty_msg);
-                i2c_queue.try_read(&empty_msg);
-                auto write_message =
-                    std::get<i2c_writer::WriteToI2C>(empty_msg);
+                    std::get<i2c_writer::MultiRegisterPollReadFromI2C>(
+                        empty_msg);
 
                 THEN("The write and read command addresses are correct") {
-                    REQUIRE(write_message.address == hdc2080_utils::ADDRESS);
-                    REQUIRE(write_message.buffer[0] ==
-                            hdc2080_utils::LSB_HUMIDITY_REGISTER);
-                    REQUIRE(read_message.address == hdc2080_utils::ADDRESS);
-                    REQUIRE(read_message.buffer[0] ==
-                            hdc2080_utils::LSB_HUMIDITY_REGISTER);
-                }
-                THEN(
-                    "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> my_buff = {250, 80, 0, 0, 0};
-                    read_message.client_callback(my_buff);
-                    mock_message_writer::TaskMessage can_msg{};
-
-                    can_queue.try_read(&can_msg);
-                    auto response_msg =
-                        std::get<can_messages::ReadFromSensorResponse>(
-                            can_msg.message);
-                    float check_data = fixed_to_float(response_msg.sensor_data);
-                    float expected = 48.88916;
-                    REQUIRE(check_data == Approx(expected).epsilon(1e-4));
+                    REQUIRE(read_message.address == fdc1004_utils::ADDRESS);
+                    REQUIRE(read_message.register_buffer_1[0] ==
+                            fdc1004_utils::MSB_MEASUREMENT_1);
+                    REQUIRE(read_message.register_buffer_2[0] ==
+                            fdc1004_utils::LSB_MEASUREMENT_1);
                 }
             }
         }
     }
-    GIVEN("a request to take a baseline reading of the sensor") {
+    GIVEN("a request to take a baseline reading of the capacitance sensor") {
         int NUM_READS = 30;
         auto multi_read = sensor_task_utils::TaskMessage(
             can_messages::BaselineSensorRequest({}, capacitive_id, NUM_READS));
         sensor.handle_message(multi_read);
         WHEN("the handler function receives the message in LSB mode") {
             THEN("the i2c queue is populated with a write and read command") {
-                REQUIRE(i2c_queue.get_size() == 2);
+                REQUIRE(i2c_queue.get_size() == 1);
             }
             AND_WHEN("we read the messages from the queue") {
                 i2c_queue.try_read(&empty_msg);
                 auto read_message =
-                    std::get<i2c_writer::ReadFromI2C>(empty_msg);
-                i2c_queue.try_read(&empty_msg);
-                auto write_message =
-                    std::get<i2c_writer::WriteToI2C>(empty_msg);
+                    std::get<i2c_writer::MultiRegisterPollReadFromI2C>(
+                        empty_msg);
 
                 THEN("The write and read command addresses are correct") {
-                    REQUIRE(write_message.address == hdc2080_utils::ADDRESS);
-                    REQUIRE(write_message.buffer[0] ==
-                            hdc2080_utils::LSB_TEMPERATURE_REGISTER);
-                    REQUIRE(read_message.address == hdc2080_utils::ADDRESS);
-                    REQUIRE(read_message.buffer[0] ==
-                            hdc2080_utils::LSB_TEMPERATURE_REGISTER);
+                    REQUIRE(read_message.address == fdc1004_utils::ADDRESS);
+                    REQUIRE(read_message.register_buffer_1[0] ==
+                            fdc1004_utils::MSB_MEASUREMENT_1);
+                    REQUIRE(read_message.register_buffer_2[0] ==
+                            fdc1004_utils::LSB_MEASUREMENT_1);
+                    REQUIRE(read_message.delay_ms == 20);
+                    REQUIRE(read_message.polling == NUM_READS);
                 }
                 THEN(
                     "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> my_buff = {200, 0, 0, 0, 0};
-                    read_message.client_callback(my_buff);
+                    std::array<uint8_t, 5> buffer_a = { 0, 0, 20, 80, 0};
+                    std::array<uint8_t, 5> buffer_b = {0, 0, 10, 10, 0};
+                    read_message.client_callback->operator()(buffer_a,
+                                                             buffer_b);
+                    read_message.client_callback->operator()();
                     mock_message_writer::TaskMessage can_msg{};
 
                     can_queue.try_read(&can_msg);
                     auto response_msg =
                         std::get<can_messages::ReadFromSensorResponse>(
                             can_msg.message);
-                    float check_data = fixed_to_float(response_msg.sensor_data);
-                    float expected = 44.20312;
+                    float check_data =
+                        fixed_point_to_float(response_msg.sensor_data, 15);
+                    float expected = 1.2695;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
             }

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -1,0 +1,115 @@
+#include "can/core/messages.hpp"
+#include "catch2/catch.hpp"
+#include "common/tests/mock_message_queue.hpp"
+#include "common/tests/mock_queue_client.hpp"
+#include "pipettes/core/i2c_writer.hpp"
+#include "sensors/core/fdc1004.hpp"
+#include "sensors/core/tasks/capacitive_sensor_task.hpp"
+#include "sensors/core/utils.hpp"
+
+float fixed_to_float(uint32_t data) {
+    constexpr uint32_t power_of_two = 2 << 15;
+    return (1.0 * static_cast<float>(data)) / power_of_two;
+}
+
+SCENARIO("read temperature and humidity values") {
+    test_mocks::MockMessageQueue<i2c_writer::TaskMessage> i2c_queue{};
+    test_mocks::MockMessageQueue<mock_message_writer::TaskMessage> can_queue{};
+    test_mocks::MockMessageQueue<sensor_task_utils::TaskMessage>
+        capacitive_queue{};
+
+    i2c_writer::TaskMessage empty_msg{};
+    auto queue_client = mock_client::QueueClient{.capacitive_sensor_queue =
+    &capacitive_queue};
+    auto writer = i2c_writer::I2CWriter<test_mocks::MockMessageQueue>{};
+    queue_client.set_queue(&can_queue);
+    writer.set_queue(&i2c_queue);
+
+    auto sensor = environment_sensor_task::CapacitiveSensorMessageHandler{
+        writer, queue_client};
+    constexpr uint8_t capacitive_id = 0x1;
+
+    GIVEN("a request to take a single read of the sensor") {
+        auto single_read = sensor_task_utils::TaskMessage(
+            can_messages::ReadFromSensorRequest({}, capacitive_id));
+        sensor.handle_message(single_read);
+        WHEN("the handler function receives the message in LSB mode") {
+            THEN("the i2c queue is populated with a write and read command") {
+                REQUIRE(i2c_queue.get_size() == 2);
+            }
+            AND_WHEN("we read the messages from the queue") {
+                i2c_queue.try_read(&empty_msg);
+                auto read_message =
+                    std::get<i2c_writer::ReadFromI2C>(empty_msg);
+                i2c_queue.try_read(&empty_msg);
+                auto write_message =
+                    std::get<i2c_writer::WriteToI2C>(empty_msg);
+
+                THEN("The write and read command addresses are correct") {
+                    REQUIRE(write_message.address == hdc2080_utils::ADDRESS);
+                    REQUIRE(write_message.buffer[0] ==
+                            hdc2080_utils::LSB_HUMIDITY_REGISTER);
+                    REQUIRE(read_message.address == hdc2080_utils::ADDRESS);
+                    REQUIRE(read_message.buffer[0] ==
+                            hdc2080_utils::LSB_HUMIDITY_REGISTER);
+                }
+                THEN(
+                    "using the callback with data returns the expected value") {
+                    std::array<uint8_t, 5> my_buff = {250, 80, 0, 0, 0};
+                    read_message.client_callback(my_buff);
+                    mock_message_writer::TaskMessage can_msg{};
+
+                    can_queue.try_read(&can_msg);
+                    auto response_msg =
+                        std::get<can_messages::ReadFromSensorResponse>(
+                            can_msg.message);
+                    float check_data = fixed_to_float(response_msg.sensor_data);
+                    float expected = 48.88916;
+                    REQUIRE(check_data == Approx(expected).epsilon(1e-4));
+                }
+            }
+        }
+    }
+    GIVEN("a request to take a baseline reading of the sensor") {
+        int NUM_READS = 30;
+        auto multi_read = sensor_task_utils::TaskMessage(
+            can_messages::BaselineSensorRequest({}, capacitive_id, NUM_READS));
+        sensor.handle_message(multi_read);
+        WHEN("the handler function receives the message in LSB mode") {
+            THEN("the i2c queue is populated with a write and read command") {
+                REQUIRE(i2c_queue.get_size() == 2);
+            }
+            AND_WHEN("we read the messages from the queue") {
+                i2c_queue.try_read(&empty_msg);
+                auto read_message =
+                    std::get<i2c_writer::ReadFromI2C>(empty_msg);
+                i2c_queue.try_read(&empty_msg);
+                auto write_message =
+                    std::get<i2c_writer::WriteToI2C>(empty_msg);
+
+                THEN("The write and read command addresses are correct") {
+                    REQUIRE(write_message.address == hdc2080_utils::ADDRESS);
+                    REQUIRE(write_message.buffer[0] ==
+                            hdc2080_utils::LSB_TEMPERATURE_REGISTER);
+                    REQUIRE(read_message.address == hdc2080_utils::ADDRESS);
+                    REQUIRE(read_message.buffer[0] ==
+                            hdc2080_utils::LSB_TEMPERATURE_REGISTER);
+                }
+                THEN(
+                    "using the callback with data returns the expected value") {
+                    std::array<uint8_t, 5> my_buff = {200, 0, 0, 0, 0};
+                    read_message.client_callback(my_buff);
+                    mock_message_writer::TaskMessage can_msg{};
+
+                    can_queue.try_read(&can_msg);
+                    auto response_msg =
+                        std::get<can_messages::ReadFromSensorResponse>(
+                            can_msg.message);
+                    float check_data = fixed_to_float(response_msg.sensor_data);
+                    float expected = 44.20312;
+                    REQUIRE(check_data == Approx(expected).epsilon(1e-4));
+                }
+            }
+        }
+    }
+}

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -120,7 +120,7 @@ SCENARIO("read capacitance sensor values") {
                 auto response_msg =
                     std::get<can_messages::ReadFromSensorResponse>(
                         can_msg.message);
-                float expected = 0.3418;
+                float expected = 0.75;
                 float check_data =
                     fixed_point_to_float(response_msg.sensor_data, 15);
                 REQUIRE(check_data == Approx(expected).epsilon(1e-4));

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -75,7 +75,7 @@ SCENARIO("read capacitance sensor values") {
                 }
                 THEN(
                     "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> buffer_a = { 0, 0, 20, 80, 0};
+                    std::array<uint8_t, 5> buffer_a = {0, 0, 20, 80, 0};
                     std::array<uint8_t, 5> buffer_b = {0, 0, 10, 10, 0};
                     read_message.client_callback->operator()(buffer_a,
                                                              buffer_b);

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -104,9 +104,8 @@ SCENARIO("read capacitance sensor values") {
             std::array<uint8_t, 5> buffer_b = {100, 10, 0, 0, 0};
             i2c_queue.try_read(&empty_msg);
             auto read_message =
-                std::get<i2c_writer::MultiRegisterPollReadFromI2C>(
-                    empty_msg);
-            for (int i=0; i<NUM_READS; i++) {
+                std::get<i2c_writer::MultiRegisterPollReadFromI2C>(empty_msg);
+            for (int i = 0; i < NUM_READS; i++) {
                 read_message.handle_buffer(buffer_a, buffer_b);
             }
             read_message.client_callback();
@@ -121,13 +120,11 @@ SCENARIO("read capacitance sensor values") {
                 auto response_msg =
                     std::get<can_messages::ReadFromSensorResponse>(
                         can_msg.message);
-                float expected = 0.10938;
+                float expected = 0.3418;
                 float check_data =
                     fixed_point_to_float(response_msg.sensor_data, 15);
                 REQUIRE(check_data == Approx(expected).epsilon(1e-4));
-
             }
         }
-
     }
 }

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -75,8 +75,8 @@ SCENARIO("read capacitance sensor values") {
                 }
                 THEN(
                     "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> buffer_a = {0, 0, 20, 80, 0};
-                    std::array<uint8_t, 5> buffer_b = {0, 0, 10, 10, 0};
+                    std::array<uint8_t, 5> buffer_a = {0, 0, 200, 80, 0};
+                    std::array<uint8_t, 5> buffer_b = {0, 0, 100, 10, 0};
                     read_message.handle_buffer(buffer_a, buffer_b);
                     read_message.client_callback();
                     mock_message_writer::TaskMessage can_msg{};
@@ -87,7 +87,7 @@ SCENARIO("read capacitance sensor values") {
                             can_msg.message);
                     float check_data =
                         fixed_point_to_float(response_msg.sensor_data, 15);
-                    float expected = 1.2695;
+                    float expected = 0.41731;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
             }

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -75,8 +75,8 @@ SCENARIO("read capacitance sensor values") {
                 }
                 THEN(
                     "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> buffer_a = {0, 0, 200, 80, 0};
-                    std::array<uint8_t, 5> buffer_b = {0, 0, 100, 10, 0};
+                    std::array<uint8_t, 5> buffer_a = {2, 8, 0, 0, 0};
+                    std::array<uint8_t, 5> buffer_b = {1, 1, 0, 0, 0};
                     read_message.handle_buffer(buffer_a, buffer_b);
                     read_message.client_callback();
                     mock_message_writer::TaskMessage can_msg{};
@@ -87,7 +87,7 @@ SCENARIO("read capacitance sensor values") {
                             can_msg.message);
                     float check_data =
                         fixed_point_to_float(response_msg.sensor_data, 15);
-                    float expected = 0.41731;
+                    float expected = 1.08333;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
             }

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -123,7 +123,7 @@ SCENARIO("read capacitance sensor values") {
                 float expected = 0.3418;
                 float check_data =
                     fixed_point_to_float(response_msg.sensor_data, 15);
-                REQUIRE(check_data == Approx(expected).epsilon(1e-4));
+                REQUIRE(check_data >= Approx(expected).epsilon(1e-4));
             }
         }
     }

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -120,7 +120,7 @@ SCENARIO("read capacitance sensor values") {
                 auto response_msg =
                     std::get<can_messages::ReadFromSensorResponse>(
                         can_msg.message);
-                float expected = 0.75;
+                float expected = 0.3418;
                 float check_data =
                     fixed_point_to_float(response_msg.sensor_data, 15);
                 REQUIRE(check_data == Approx(expected).epsilon(1e-4));

--- a/pipettes/tests/test_capacitive_sensor.cpp
+++ b/pipettes/tests/test_capacitive_sensor.cpp
@@ -77,9 +77,8 @@ SCENARIO("read capacitance sensor values") {
                     "using the callback with data returns the expected value") {
                     std::array<uint8_t, 5> buffer_a = {0, 0, 20, 80, 0};
                     std::array<uint8_t, 5> buffer_b = {0, 0, 10, 10, 0};
-                    read_message.client_callback->operator()(buffer_a,
-                                                             buffer_b);
-                    read_message.client_callback->operator()();
+                    read_message.handle_buffer(buffer_a, buffer_b);
+                    read_message.client_callback();
                     mock_message_writer::TaskMessage can_msg{};
 
                     can_queue.try_read(&can_msg);

--- a/pipettes/tests/test_environment_sensor.cpp
+++ b/pipettes/tests/test_environment_sensor.cpp
@@ -2,15 +2,11 @@
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
 #include "common/tests/mock_queue_client.hpp"
+#include "motor-control/core/utils.hpp"
 #include "pipettes/core/i2c_writer.hpp"
 #include "sensors/core/hdc2080.hpp"
 #include "sensors/core/tasks/environmental_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
-
-float fixed_to_float(uint32_t data) {
-    constexpr uint32_t power_of_two = 2 << 15;
-    return (1.0 * static_cast<float>(data)) / power_of_two;
-}
 
 SCENARIO("read temperature and humidity values") {
     test_mocks::MockMessageQueue<i2c_writer::TaskMessage> i2c_queue{};
@@ -57,14 +53,15 @@ SCENARIO("read temperature and humidity values") {
                 THEN(
                     "using the callback with data returns the expected value") {
                     std::array<uint8_t, 5> my_buff = {250, 80, 0, 0, 0};
-                    read_message.client_callback(my_buff);
+                    read_message.client_callback->operator()(my_buff);
                     mock_message_writer::TaskMessage can_msg{};
 
                     can_queue.try_read(&can_msg);
                     auto response_msg =
                         std::get<can_messages::ReadFromSensorResponse>(
                             can_msg.message);
-                    float check_data = fixed_to_float(response_msg.sensor_data);
+                    float check_data =
+                        fixed_point_to_float(response_msg.sensor_data, 15);
                     float expected = 48.88916;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
@@ -98,14 +95,15 @@ SCENARIO("read temperature and humidity values") {
                 THEN(
                     "using the callback with data returns the expected value") {
                     std::array<uint8_t, 5> my_buff = {200, 0, 0, 0, 0};
-                    read_message.client_callback(my_buff);
+                    read_message.client_callback->operator()(my_buff);
                     mock_message_writer::TaskMessage can_msg{};
 
                     can_queue.try_read(&can_msg);
                     auto response_msg =
                         std::get<can_messages::ReadFromSensorResponse>(
                             can_msg.message);
-                    float check_data = fixed_to_float(response_msg.sensor_data);
+                    float check_data =
+                        fixed_point_to_float(response_msg.sensor_data, 15);
                     float expected = 44.20312;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }

--- a/pipettes/tests/test_environment_sensor.cpp
+++ b/pipettes/tests/test_environment_sensor.cpp
@@ -53,7 +53,8 @@ SCENARIO("read temperature and humidity values") {
                 THEN(
                     "using the callback with data returns the expected value") {
                     std::array<uint8_t, 5> my_buff = {250, 80, 0, 0, 0};
-                    read_message.client_callback->operator()(my_buff);
+                    read_message.handle_buffer(my_buff);
+                    read_message.client_callback();
                     mock_message_writer::TaskMessage can_msg{};
 
                     can_queue.try_read(&can_msg);
@@ -95,7 +96,8 @@ SCENARIO("read temperature and humidity values") {
                 THEN(
                     "using the callback with data returns the expected value") {
                     std::array<uint8_t, 5> my_buff = {200, 0, 0, 0, 0};
-                    read_message.client_callback->operator()(my_buff);
+                    read_message.handle_buffer(my_buff);
+                    read_message.client_callback();
                     mock_message_writer::TaskMessage can_msg{};
 
                     can_queue.try_read(&can_msg);

--- a/pipettes/tests/test_i2c_task.cpp
+++ b/pipettes/tests/test_i2c_task.cpp
@@ -5,13 +5,14 @@
 #include "common/tests/mock_message_queue.hpp"
 #include "pipettes/core/tasks/i2c_task.hpp"
 #include "sensors/simulation/sensors.hpp"
+#include "sensors/tests/callbacks.hpp"
 
 class FakeSensor : public sensor_simulator::SensorType {
   public:
     FakeSensor() {
         ADDRESS = 0x1;
         DEVICE_ID = 0x2;
-        REGISTER_MAP = {{0x2, 0}};
+        REGISTER_MAP = {{0x2, 0x3}, {0x5, 0x4}};
     }
 };
 
@@ -30,13 +31,14 @@ SCENARIO("read and write data to the i2c task") {
     auto sim_i2c = sim_i2c::SimI2C{sensor_map};
 
     auto i2c = i2c_task::I2CMessageHandler{sim_i2c};
-    std::array<uint8_t, 5> five_byte_arr{0x2, 0x0, 0x0, 0x0, 0x0};
-    uint16_t two_byte_data = 514;
 
     GIVEN("write command") {
+        std::array<uint8_t, 5> five_byte_arr{0x2, 0x0, 0x0, 0x0, 0x0};
+        uint32_t write_data = 0x2010200;
+
         // make a copy of the two byte array before it's manipulated by
         // the i2c writer.
-        writer.write(two_byte_data, ADDRESS);
+        writer.write(write_data, ADDRESS);
         i2c_queue.try_read(&empty_msg);
         auto write_msg = std::get<i2c_writer::WriteToI2C>(empty_msg);
         auto converted_msg = i2c_writer::TaskMessage(write_msg);
@@ -44,39 +46,54 @@ SCENARIO("read and write data to the i2c task") {
 
         sim_i2c.central_receive(five_byte_arr.data(), five_byte_arr.size(),
                                 ADDRESS, 1);
-        REQUIRE(five_byte_arr[2] == 2);
+        REQUIRE(five_byte_arr[3] == 2);
     }
     GIVEN("read command") {
-        uint8_t update = 0x0;
-        auto callback = [&update](std::array<uint8_t, 5> value) -> void {
-            update = value[2];
-        };
-        std::array<uint8_t, 2> data_to_store = {0x2, 0x3};
-        sim_i2c.central_transmit(data_to_store.data(), 2, ADDRESS, 1);
+        auto callback = mock_callbacks::UpdateCallback{};
 
-        writer.read(ADDRESS, callback, 0x2);
+        writer.read(ADDRESS, &callback, 0x2);
         i2c_queue.try_read(&empty_msg);
         auto read_msg = std::get<i2c_writer::ReadFromI2C>(empty_msg);
         auto converted_msg = i2c_writer::TaskMessage(read_msg);
         i2c.handle_message(converted_msg);
-        REQUIRE(update == data_to_store[1]);
+        REQUIRE(callback.update_value == fakesensor.REGISTER_MAP[2]);
     }
-    GIVEN("poll read command") {
-        uint8_t update = 0x0;
+    GIVEN("poll one register command") {
         constexpr int NUM_READS = 10;
         constexpr int DELAY_MS = 1;
-        auto callback = [&update](std::array<uint8_t, 5> value) -> void {
-            update += value[2];
-        };
+        auto callback = mock_callbacks::UpdateCallback{};
         std::array<uint8_t, 2> data_to_store = {0x2, 0x3};
         sim_i2c.central_transmit(data_to_store.data(), 2, ADDRESS, 1);
 
-        writer.single_register_poll(ADDRESS, NUM_READS, DELAY_MS, callback, 0x2);
+        writer.single_register_poll(ADDRESS, NUM_READS, DELAY_MS, &callback,
+                                    0x2);
         i2c_queue.try_read(&empty_msg);
-        auto read_msg = std::get<i2c_writer::SingleRegisterPollReadFromI2C>(empty_msg);
+        auto read_msg =
+            std::get<i2c_writer::SingleRegisterPollReadFromI2C>(empty_msg);
         auto converted_msg = i2c_writer::TaskMessage(read_msg);
         i2c.handle_message(converted_msg);
-        uint8_t expected_accumulated_data = data_to_store[1] * NUM_READS;
-        REQUIRE(update == expected_accumulated_data);
+        uint8_t expected_accumulated_data =
+            fakesensor.REGISTER_MAP[2] * NUM_READS;
+        REQUIRE(callback.update_value == expected_accumulated_data);
+    }
+
+    GIVEN("poll two registers command") {
+        constexpr int NUM_READS = 10;
+        constexpr int DELAY_MS = 1;
+        auto callback = mock_callbacks::MultiUpdateCallback{};
+
+        writer.multi_register_poll(ADDRESS, NUM_READS, DELAY_MS, &callback, 0x2,
+                                   0x5);
+        i2c_queue.try_read(&empty_msg);
+        auto read_msg =
+            std::get<i2c_writer::MultiRegisterPollReadFromI2C>(empty_msg);
+        auto converted_msg = i2c_writer::TaskMessage(read_msg);
+        i2c.handle_message(converted_msg);
+        uint8_t expected_accumulated_data_reg_a =
+            fakesensor.REGISTER_MAP[2] * NUM_READS;
+        uint8_t expected_accumulated_data_reg_b =
+            fakesensor.REGISTER_MAP[5] * NUM_READS;
+        REQUIRE(callback.register_a_value == expected_accumulated_data_reg_a);
+        REQUIRE(callback.register_b_value == expected_accumulated_data_reg_b);
     }
 }

--- a/pipettes/tests/test_i2c_task.cpp
+++ b/pipettes/tests/test_i2c_task.cpp
@@ -66,8 +66,8 @@ SCENARIO("read and write data to the i2c task") {
         constexpr int DELAY_MS = 1;
         single_update.reset();
 
-        writer.single_register_poll(ADDRESS, NUM_READS, DELAY_MS, single_callback, single_callback,
-                                    0x2);
+        writer.single_register_poll(ADDRESS, NUM_READS, DELAY_MS,
+                                    single_callback, single_callback, 0x2);
         i2c_queue.try_read(&empty_msg);
         auto read_msg =
             std::get<i2c_writer::SingleRegisterPollReadFromI2C>(empty_msg);
@@ -82,8 +82,8 @@ SCENARIO("read and write data to the i2c task") {
         constexpr int NUM_READS = 10;
         constexpr int DELAY_MS = 1;
 
-        writer.multi_register_poll(ADDRESS, NUM_READS, DELAY_MS, multi_callback, multi_callback, 0x2,
-                                   0x5);
+        writer.multi_register_poll(ADDRESS, NUM_READS, DELAY_MS, multi_callback,
+                                   multi_callback, 0x2, 0x5);
         i2c_queue.try_read(&empty_msg);
         auto read_msg =
             std::get<i2c_writer::MultiRegisterPollReadFromI2C>(empty_msg);
@@ -93,7 +93,9 @@ SCENARIO("read and write data to the i2c task") {
             fakesensor.REGISTER_MAP[2] * NUM_READS;
         uint8_t expected_accumulated_data_reg_b =
             fakesensor.REGISTER_MAP[5] * NUM_READS;
-        REQUIRE(multi_update.register_a_value == expected_accumulated_data_reg_a);
-        REQUIRE(multi_update.register_b_value == expected_accumulated_data_reg_b);
+        REQUIRE(multi_update.register_a_value ==
+                expected_accumulated_data_reg_a);
+        REQUIRE(multi_update.register_b_value ==
+                expected_accumulated_data_reg_b);
     }
 }

--- a/pipettes/tests/test_i2c_task.cpp
+++ b/pipettes/tests/test_i2c_task.cpp
@@ -53,9 +53,10 @@ SCENARIO("read and write data to the i2c task") {
     GIVEN("read command") {
         single_update.reset();
         writer.read(
-            ADDRESS,
-            [&single_update]() {single_update.send_to_can();},
-            [&single_update](auto message_a) {single_update.handle_data(message_a);},
+            ADDRESS, [&single_update]() { single_update.send_to_can(); },
+            [&single_update](auto message_a) {
+                single_update.handle_data(message_a);
+            },
             0x2);
         i2c_queue.try_read(&empty_msg);
         auto read_msg = std::get<i2c_writer::ReadFromI2C>(empty_msg);
@@ -68,10 +69,13 @@ SCENARIO("read and write data to the i2c task") {
         constexpr int DELAY_MS = 1;
         single_update.reset();
 
-        writer.single_register_poll(ADDRESS, NUM_READS, DELAY_MS,
-                                    [&single_update]() {single_update.send_to_can();},
-                                    [&single_update](auto message_a) {single_update.handle_data(message_a);},
-                                    0x2);
+        writer.single_register_poll(
+            ADDRESS, NUM_READS, DELAY_MS,
+            [&single_update]() { single_update.send_to_can(); },
+            [&single_update](auto message_a) {
+                single_update.handle_data(message_a);
+            },
+            0x2);
         i2c_queue.try_read(&empty_msg);
         auto read_msg =
             std::get<i2c_writer::SingleRegisterPollReadFromI2C>(empty_msg);
@@ -88,8 +92,10 @@ SCENARIO("read and write data to the i2c task") {
 
         writer.multi_register_poll(
             ADDRESS, NUM_READS, DELAY_MS,
-            [&multi_update]() {multi_update.send_to_can();},
-            [&multi_update](auto message_a, auto message_b) {multi_update.handle_data(message_a, message_b);},
+            [&multi_update]() { multi_update.send_to_can(); },
+            [&multi_update](auto message_a, auto message_b) {
+                multi_update.handle_data(message_a, message_b);
+            },
             0x2, 0x5);
         i2c_queue.try_read(&empty_msg);
         auto read_msg =

--- a/pipettes/tests/test_i2c_task.cpp
+++ b/pipettes/tests/test_i2c_task.cpp
@@ -71,9 +71,9 @@ SCENARIO("read and write data to the i2c task") {
         std::array<uint8_t, 2> data_to_store = {0x2, 0x3};
         sim_i2c.central_transmit(data_to_store.data(), 2, ADDRESS, 1);
 
-        writer.poll_read(ADDRESS, NUM_READS, DELAY_MS, callback, 0x2);
+        writer.single_register_poll(ADDRESS, NUM_READS, DELAY_MS, callback, 0x2);
         i2c_queue.try_read(&empty_msg);
-        auto read_msg = std::get<i2c_writer::PollReadFromI2C>(empty_msg);
+        auto read_msg = std::get<i2c_writer::SingleRegisterPollReadFromI2C>(empty_msg);
         auto converted_msg = i2c_writer::TaskMessage(read_msg);
         i2c.handle_message(converted_msg);
         uint8_t expected_accumulated_data = data_to_store[1] * NUM_READS;

--- a/pipettes/tests/test_i2c_writer.cpp
+++ b/pipettes/tests/test_i2c_writer.cpp
@@ -43,8 +43,8 @@ SCENARIO("Test the i2c command queue writer") {
         }
         WHEN("we read messages") {
             auto callback = mock_callbacks::EmptyCallback{};
-            writer.read(ADDRESS, &callback);
-            writer.read(ADDRESS, &callback);
+            writer.read(ADDRESS, callback, callback);
+            writer.read(ADDRESS, callback, callback);
             THEN("the queue has properly formatted read messages") {
                 REQUIRE(queue.get_size() == 2);
 

--- a/pipettes/tests/test_i2c_writer.cpp
+++ b/pipettes/tests/test_i2c_writer.cpp
@@ -1,6 +1,7 @@
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
 #include "pipettes/core/i2c_writer.hpp"
+#include "sensors/tests/callbacks.hpp"
 
 SCENARIO("Test the i2c command queue writer") {
     test_mocks::MockMessageQueue<i2c_writer::TaskMessage> queue{};
@@ -16,8 +17,6 @@ SCENARIO("Test the i2c command queue writer") {
         // Test that different sized buffers can
         // be passed in
         constexpr uint16_t ADDRESS = 0x1;
-        using BufferType = std::array<uint8_t, 5>;
-        auto callback = [](BufferType) -> void {};
 
         WHEN("we write messages") {
             writer.write(two_byte_data, ADDRESS);
@@ -43,8 +42,9 @@ SCENARIO("Test the i2c command queue writer") {
             }
         }
         WHEN("we read messages") {
-            writer.read(ADDRESS, callback);
-            writer.read(ADDRESS, callback);
+            auto callback = mock_callbacks::EmptyCallback{};
+            writer.read(ADDRESS, &callback);
+            writer.read(ADDRESS, &callback);
             THEN("the queue has properly formatted read messages") {
                 REQUIRE(queue.get_size() == 2);
 


### PR DESCRIPTION
## Overview

Apologies for the PR being all over the place. I tried to split up the commits, at least, to make it more readable.

Overall, this PR adds support for the fdc1004 capacitive sensor. There is an ability to set an offset -- depending on the environment the sensor is in. The idea here for the offset specifically is that you would be able to get the new offset by sending a `BaselineSensorRequest`, and then you would send over a `WriteToSensor` request to update the current sensor offset on the capacitive sensor itself.

## Changelog
- Added in an `offset` parameter to the `Read/Baseline` requests which will determine whether you are taking a sensor read or an offset read (this is used for both the pressure and capacitive sensor)
- Added the ability to poll from multiple registers
- Modified polling so that it sends write/read requests to the i2c bus for a given register
- Created abstract base classes for the two callback types used for the sensor tasks
- overloaded the operator function of the callback so that you can send a final can message once the firmware has taken an average read for polling
- Added a test for the capacitive sensor

## Review Requests
Please let me know if anything is confusing!