### PR TITLE
refactor(motor-driver): update tmc2130 communications

### DIFF
--- a/common/firmware/spi/spi.c
+++ b/common/firmware/spi/spi.c
@@ -1,17 +1,19 @@
 #include "spi.h"
-#include "common/firmware/errors.h"
 
+#include "common/firmware/errors.h"
 #include "platform_specific_hal_conf.h"
 
+void Set_CS_Pin(GPIO_TypeDef* GPIO_instance, uint32_t pin) {
+    HAL_GPIO_WritePin(GPIO_instance, pin, GPIO_PIN_SET);
+}
 
-
-void Set_CS_Pin(GPIO_TypeDef *  GPIO_instance, uint32_t pin) { HAL_GPIO_WritePin(GPIO_instance, pin, GPIO_PIN_SET); }
-
-void Reset_CS_Pin(GPIO_TypeDef *  GPIO_instance, uint32_t pin) {
+void Reset_CS_Pin(GPIO_TypeDef* GPIO_instance, uint32_t pin) {
     HAL_GPIO_WritePin(GPIO_instance, pin, GPIO_PIN_RESET);
 }
 
-void hal_transmit_receive(uint8_t* transmit, uint8_t* receive,
-                          uint16_t buff_size, uint32_t timeout, SPI_HandleTypeDef* handle){
-    HAL_SPI_TransmitReceive(handle, transmit, receive, buff_size, timeout);
+HAL_StatusTypeDef hal_transmit_receive(uint8_t* transmit, uint8_t* receive,
+                                       uint16_t buff_size, uint32_t timeout,
+                                       SPI_HandleTypeDef* handle) {
+    return HAL_SPI_TransmitReceive(handle, transmit, receive, buff_size,
+                                   timeout);
 }

--- a/common/firmware/spi/spi.h
+++ b/common/firmware/spi/spi.h
@@ -7,11 +7,11 @@
 extern "C" {
 #endif  // __cplusplus
 
-
-void Set_CS_Pin(GPIO_TypeDef * GPIO_instance, uint32_t pin);
-void Reset_CS_Pin(GPIO_TypeDef *  GPIO_instance, uint32_t pin);
-void hal_transmit_receive(uint8_t* transmit, uint8_t* receive,
-                          uint16_t buff_size, uint32_t timeout, SPI_HandleTypeDef* handle) ;
+void Set_CS_Pin(GPIO_TypeDef* GPIO_instance, uint32_t pin);
+void Reset_CS_Pin(GPIO_TypeDef* GPIO_instance, uint32_t pin);
+HAL_StatusTypeDef hal_transmit_receive(uint8_t* transmit, uint8_t* receive,
+                                       uint16_t buff_size, uint32_t timeout,
+                                       SPI_HandleTypeDef* handle);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/common/firmware/spi/spi_comms.cpp
+++ b/common/firmware/spi/spi_comms.cpp
@@ -28,12 +28,14 @@ using namespace spi;
 
 Spi::Spi(SPI_interface SPI_intf_instance) : SPI_intf(SPI_intf_instance) {}
 
-void Spi::transmit_receive(const BufferType& transmit, BufferType& receive) {
+bool Spi::transmit_receive(const BufferType& transmit, BufferType& receive) {
+    HAL_StatusTypeDef response;
     Reset_CS_Pin(SPI_intf.GPIO_handle, SPI_intf.pin);
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    hal_transmit_receive(const_cast<uint8_t*>(transmit.data()), receive.data(),
-                         spi::TMC2130Spi::BufferSize, TIMEOUT,
-                         this->SPI_intf.SPI_handle);
+    response = hal_transmit_receive(const_cast<uint8_t*>(transmit.data()),
+                                    receive.data(), spi::TMC2130Spi::BufferSize,
+                                    TIMEOUT, this->SPI_intf.SPI_handle);
 
     Set_CS_Pin(SPI_intf.GPIO_handle, SPI_intf.pin);
+    return response == HAL_OK;
 }

--- a/common/firmware/spi/spi_comms.cpp
+++ b/common/firmware/spi/spi_comms.cpp
@@ -34,7 +34,7 @@ auto Spi::transmit_receive(const BufferType& transmit, BufferType& receive)
     auto response = hal_transmit_receive(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         const_cast<uint8_t*>(transmit.data()), receive.data(),
-        spi::TMC2130Spi::BufferSize, TIMEOUT, this->SPI_intf.SPI_handle);
+        spi::SpiDeviceBase::BufferSize, TIMEOUT, this->SPI_intf.SPI_handle);
 
     Set_CS_Pin(SPI_intf.GPIO_handle, SPI_intf.pin);
     return response == HAL_OK;

--- a/common/firmware/spi/spi_comms.cpp
+++ b/common/firmware/spi/spi_comms.cpp
@@ -28,13 +28,13 @@ using namespace spi;
 
 Spi::Spi(SPI_interface SPI_intf_instance) : SPI_intf(SPI_intf_instance) {}
 
-bool Spi::transmit_receive(const BufferType& transmit, BufferType& receive) {
-    HAL_StatusTypeDef response;
+auto Spi::transmit_receive(const BufferType& transmit, BufferType& receive)
+    -> bool {
     Reset_CS_Pin(SPI_intf.GPIO_handle, SPI_intf.pin);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    response = hal_transmit_receive(const_cast<uint8_t*>(transmit.data()),
-                                    receive.data(), spi::TMC2130Spi::BufferSize,
-                                    TIMEOUT, this->SPI_intf.SPI_handle);
+    auto response = hal_transmit_receive(
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        const_cast<uint8_t*>(transmit.data()), receive.data(),
+        spi::TMC2130Spi::BufferSize, TIMEOUT, this->SPI_intf.SPI_handle);
 
     Set_CS_Pin(SPI_intf.GPIO_handle, SPI_intf.pin);
     return response == HAL_OK;

--- a/common/simulation/spi.cpp
+++ b/common/simulation/spi.cpp
@@ -3,7 +3,7 @@
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.hpp"
 
-void sim_spi::SimTMC2130Spi::transmit_receive(
+bool sim_spi::SimTMC2130Spi::transmit_receive(
     const spi::TMC2130Spi::BufferType& transmit,
     spi::TMC2130Spi::BufferType& receive) {
     uint8_t control = 0;
@@ -35,4 +35,5 @@ void sim_spi::SimTMC2130Spi::transmit_receive(
     }
     // The register is cached for the next read operation.
     read_register = reg;
+    return true;
 }

--- a/common/simulation/spi.cpp
+++ b/common/simulation/spi.cpp
@@ -3,9 +3,9 @@
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.hpp"
 
-bool sim_spi::SimTMC2130Spi::transmit_receive(
-    const spi::TMC2130Spi::BufferType& transmit,
-    spi::TMC2130Spi::BufferType& receive) {
+bool sim_spi::SimSpiDeviceBase::transmit_receive(
+    const spi::SpiDeviceBase::BufferType& transmit,
+    spi::SpiDeviceBase::BufferType& receive) {
     uint8_t control = 0;
     uint32_t data = 0;
 
@@ -17,7 +17,7 @@ bool sim_spi::SimTMC2130Spi::transmit_receive(
     LOG("transmit_receive: control=%d, data=%d\n", control, data);
 
     constexpr uint8_t write_mask =
-        static_cast<uint8_t>(spi::TMC2130Spi::Mode::WRITE);
+        static_cast<uint8_t>(spi::SpiDeviceBase::Mode::WRITE);
 
     auto out_iter = receive.begin();
     // Write status byte into buffer.

--- a/common/tests/test_spi.cpp
+++ b/common/tests/test_spi.cpp
@@ -4,11 +4,11 @@
 #include "common/simulation/spi.hpp"
 
 SCENARIO("build_command works") {
-    auto arr = spi::TMC2130Spi::BufferType{};
+    auto arr = spi::SpiDeviceBase::BufferType{};
     GIVEN("a message buffer") {
         WHEN("called with write mode") {
-            spi::TMC2130Spi::build_command(arr, spi::TMC2130Spi::Mode::WRITE,
-                                           0x12, 0x01020304);
+            spi::SpiDeviceBase::build_command(
+                arr, spi::SpiDeviceBase::Mode::WRITE, 0x12, 0x01020304);
             THEN("the write bit is set") { REQUIRE(arr[0] == 0x92); }
             THEN("the data is correct.") {
                 REQUIRE(arr[1] == 0x1);
@@ -19,8 +19,8 @@ SCENARIO("build_command works") {
         }
 
         WHEN("called read write mode") {
-            spi::TMC2130Spi::build_command(arr, spi::TMC2130Spi::Mode::READ,
-                                           0x12, 0xDEADBEEF);
+            spi::SpiDeviceBase::build_command(
+                arr, spi::SpiDeviceBase::Mode::READ, 0x12, 0xDEADBEEF);
             THEN("the write bit is not set") { REQUIRE(arr[0] == 0x12); }
             THEN("the data is correct.") {
                 REQUIRE(arr[1] == 0xDE);
@@ -33,18 +33,18 @@ SCENARIO("build_command works") {
 }
 
 SCENARIO("simulator works") {
-    auto transmit = spi::TMC2130Spi::BufferType{};
-    auto receive = spi::TMC2130Spi::BufferType{};
+    auto transmit = spi::SpiDeviceBase::BufferType{};
+    auto receive = spi::SpiDeviceBase::BufferType{};
 
     GIVEN("a register write command") {
-        auto subject = sim_spi::SimTMC2130Spi{};
-        subject.build_command(transmit, spi::TMC2130Spi::Mode::WRITE, 0x01,
+        auto subject = sim_spi::SimSpiDeviceBase{};
+        subject.build_command(transmit, spi::SpiDeviceBase::Mode::WRITE, 0x01,
                               0xBEEFDEAD);
         subject.transmit_receive(transmit, receive);
 
         WHEN("called with a read command") {
-            spi::TMC2130Spi::build_command(
-                transmit, spi::TMC2130Spi::Mode::READ, 0x01, 0);
+            spi::SpiDeviceBase::build_command(
+                transmit, spi::SpiDeviceBase::Mode::READ, 0x01, 0);
             subject.transmit_receive(transmit, receive);
             THEN("the data is what was written") {
                 REQUIRE(receive[1] == 0xBE);
@@ -56,12 +56,13 @@ SCENARIO("simulator works") {
     }
 
     GIVEN("a registter map") {
-        auto register_map = sim_spi::SimTMC2130Spi::RegisterMap{{1, 2}, {2, 3}};
-        auto subject = sim_spi::SimTMC2130Spi{register_map};
+        auto register_map =
+            sim_spi::SimSpiDeviceBase::RegisterMap{{1, 2}, {2, 3}};
+        auto subject = sim_spi::SimSpiDeviceBase{register_map};
 
         WHEN("called with a read command") {
-            spi::TMC2130Spi::build_command(
-                transmit, spi::TMC2130Spi::Mode::READ, 0x01, 0);
+            spi::SpiDeviceBase::build_command(
+                transmit, spi::SpiDeviceBase::Mode::READ, 0x01, 0);
             subject.transmit_receive(transmit, receive);
             subject.transmit_receive(transmit, receive);
             THEN("the data is was in the register map") {
@@ -71,8 +72,8 @@ SCENARIO("simulator works") {
                 REQUIRE(receive[4] == 0x2);
             }
 
-            spi::TMC2130Spi::build_command(
-                transmit, spi::TMC2130Spi::Mode::READ, 0x02, 0);
+            spi::SpiDeviceBase::build_command(
+                transmit, spi::SpiDeviceBase::Mode::READ, 0x02, 0);
             subject.transmit_receive(transmit, receive);
             subject.transmit_receive(transmit, receive);
             THEN("the data is was in the register map") {

--- a/gantry/core/utils.cpp
+++ b/gantry/core/utils.cpp
@@ -26,12 +26,12 @@ auto utils::register_config_by_axis(enum GantryAxisType which)
                                .run_current = 0x10,
                                .hold_current_delay = 0x7},
                 .thigh = {.threshold = 0xFFFFF},
-                .chopconf = {.toff = 0b101,
-                             .hstrt = 0b101,
-                             .hend = 0b11,
-                             .tbl = 0b10,
-                             .mres = 0b100},
-                .coolconf = {.sgt = 0b110}};
+                .chopconf = {.toff = 0x5,
+                             .hstrt = 0x5,
+                             .hend = 0x3,
+                             .tbl = 0x2,
+                             .mres = 0x4},
+                .coolconf = {.sgt = 0x6}};
 
         case GantryAxisType::gantry_y:
             return tmc2130::TMC2130RegisterMap{

--- a/gantry/core/utils.cpp
+++ b/gantry/core/utils.cpp
@@ -17,25 +17,41 @@ auto utils::get_node_id() -> can_ids::NodeId {
 }
 
 auto utils::register_config_by_axis(enum GantryAxisType which)
-    -> motor_driver_config::RegisterConfig {
+    -> tmc2130::TMC2130RegisterMap {
     switch (which) {
         case GantryAxisType::gantry_x:
-            return motor_driver_config::RegisterConfig{.gconf = 0x04,
-                                                       .ihold_irun = 0x71002,
-                                                       .chopconf = 0x40101D5,
-                                                       .thigh = 0xFFFFF,
-                                                       .coolconf = 0x60000};
+            return tmc2130::TMC2130RegisterMap{
+                .gconfig = {.en_pwm_mode = 1},
+                .ihold_irun = {.hold_current = 0x2,
+                               .run_current = 0x10,
+                               .hold_current_delay = 0x7},
+                .thigh = {.threshold = 0xFFFFF},
+                .chopconf = {.toff = 0b101,
+                             .hstrt = 0b101,
+                             .hend = 0b11,
+                             .tbl = 0b10,
+                             .mres = 0b100},
+                .coolconf = {.sgt = 0b110}};
 
         case GantryAxisType::gantry_y:
-            return motor_driver_config::RegisterConfig{.gconf = 0x04,
-                                                       .ihold_irun = 0x71002,
-                                                       .chopconf = 0x40101D5,
-                                                       .thigh = 0xFFFFF,
-                                                       .coolconf = 0x60000};
+            return tmc2130::TMC2130RegisterMap{
+                .gconfig = {.en_pwm_mode = 1},
+                .ihold_irun = {.hold_current = 0x2,
+                               .run_current = 0x10,
+                               .hold_current_delay = 0x7},
+                .tpowerdown = {},
+                .tcoolthrs = {.threshold = 0},
+                .thigh = {.threshold = 0xFFFFF},
+                .chopconf = {.toff = 0x5,
+                             .hstrt = 0x5,
+                             .hend = 0x3,
+                             .tbl = 0x2,
+                             .mres = 0x4},
+                .coolconf = {.sgt = 0b110}};
     }
     std::abort();
 }
 
-auto utils::register_config() -> motor_driver_config::RegisterConfig {
+auto utils::register_config() -> tmc2130::TMC2130RegisterMap {
     return register_config_by_axis(get_axis_type());
 }

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -159,7 +159,7 @@ void interfaces::initialize() {
 
 auto interfaces::get_can_bus() -> can_bus::CanBus& { return canbus; }
 
-auto interfaces::get_spi() -> spi::TMC2130Spi& { return spi_comms; }
+auto interfaces::get_spi() -> spi::SpiDeviceBase& { return spi_comms; }
 
 auto interfaces::get_motor_hardware_iface()
     -> motor_hardware::MotorHardwareIface& {

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -17,7 +17,7 @@ static auto canbus = sim_canbus::SimCANBus(can_transport::create());
 /**
  * The SPI bus.
  */
-static auto spi_comms = sim_spi::SimTMC2130Spi();
+static auto spi_comms = sim_spi::SimSpiDeviceBase();
 
 /**
  * The motor interface.
@@ -61,7 +61,7 @@ void interfaces::initialize() {}
 
 auto interfaces::get_can_bus() -> can_bus::CanBus& { return canbus; }
 
-auto interfaces::get_spi() -> spi::TMC2130Spi& { return spi_comms; }
+auto interfaces::get_spi() -> spi::SpiDeviceBase& { return spi_comms; }
 
 auto interfaces::get_motor_hardware_iface()
     -> motor_hardware::MotorHardwareIface& {

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -136,7 +136,7 @@ static tmc2130::TMC2130RegisterMap MotorDriverConfigurations{
     .thigh = {.threshold = 0xFFFFF},
     .chopconf =
         {.toff = 0x5, .hstrt = 0x5, .hend = 0x3, .tbl = 0x2, .mres = 0x4},
-    .coolconf = {.sgt = 0b110}};
+    .coolconf = {.sgt = 0x6}};
 
 /**
  * TODO: This motor class is only used in motor handler and should be

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -28,6 +28,7 @@
 #include "motor-control/core/motor.hpp"
 #include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/motor_interrupt_handler.hpp"
+#include "motor-control/core/tmc2130_registers.hpp"
 #include "motor-control/firmware/motor_hardware.hpp"
 
 static auto can_bus_1 = hal_can_bus::HalCanBus(can_get_device_handle());
@@ -125,12 +126,17 @@ struct motor_hardware::HardwareConfig pin_configurations_right {
         .active_setting = GPIO_PIN_RESET},
 };
 
-motor_driver_config::RegisterConfig MotorDriverConfigurations{
-    .gconf = 0x04,
-    .ihold_irun = 0x71002,
-    .chopconf = 0x40101D5,
-    .thigh = 0xFFFFF,
-    .coolconf = 0x60000};
+static tmc2130::TMC2130RegisterMap MotorDriverConfigurations{
+    .gconfig = {.en_pwm_mode = 1},
+    .ihold_irun = {.hold_current = 0x2,
+                   .run_current = 0x10,
+                   .hold_current_delay = 0x7},
+    .tpowerdown = {},
+    .tcoolthrs = {.threshold = 0},
+    .thigh = {.threshold = 0xFFFFF},
+    .chopconf =
+        {.toff = 0x5, .hstrt = 0x5, .hend = 0x3, .tbl = 0x2, .mres = 0x4},
+    .coolconf = {.sgt = 0b110}};
 
 /**
  * TODO: This motor class is only used in motor handler and should be

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -19,8 +19,8 @@ static auto canbus = sim_canbus::SimCANBus(can_transport::create());
 /**
  * The SPI busses.
  */
-static auto spi_comms_right = sim_spi::SimTMC2130Spi();
-static auto spi_comms_left = sim_spi::SimTMC2130Spi();
+static auto spi_comms_right = sim_spi::SimSpiDeviceBase();
+static auto spi_comms_left = sim_spi::SimSpiDeviceBase();
 
 /**
  * The motor interfaces.

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -6,6 +6,7 @@
 #include "head/simulation/adc.hpp"
 #include "motor-control/core/motor.hpp"
 #include "motor-control/core/motor_interrupt_handler.hpp"
+#include "motor-control/core/tmc2130.hpp"
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
 #include "task.h"
@@ -34,12 +35,17 @@ static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
 static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
     motor_queue_left("Motor Queue Left");
 
-motor_driver_config::RegisterConfig MotorDriverConfigurations{
-    .gconf = 0x04,
-    .ihold_irun = 0x70202,
-    .chopconf = 0x40101D5,
-    .thigh = 0xFFFFF,
-    .coolconf = 0x60000};
+static tmc2130::TMC2130RegisterMap MotorDriverConfigurations{
+    .gconfig = {.en_pwm_mode = 1},
+    .ihold_irun = {.hold_current = 0x2,
+                   .run_current = 0x10,
+                   .hold_current_delay = 0x7},
+    .tpowerdown = {},
+    .tcoolthrs = {.threshold = 0},
+    .thigh = {.threshold = 0xFFFFF},
+    .chopconf =
+        {.toff = 0x5, .hstrt = 0x5, .hend = 0x3, .tbl = 0x2, .mres = 0x4},
+    .coolconf = {.sgt = 0b110}};
 
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_interface_right);

--- a/include/common/core/spi.hpp
+++ b/include/common/core/spi.hpp
@@ -11,14 +11,14 @@ namespace spi {
  * Abstract SPI driver base class.
  */
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
-class TMC2130Spi {
+class SpiDeviceBase {
   public:
     static constexpr size_t BufferSize = 5;
     using BufferType = std::array<uint8_t, BufferSize>;
 
     enum class Mode : uint8_t { WRITE = 0x80, READ = 0x0 };
 
-    virtual ~TMC2130Spi() = default;
+    virtual ~SpiDeviceBase() = default;
 
     /**
      * Transmit and receive.
@@ -26,8 +26,9 @@ class TMC2130Spi {
      * @param transmit The transmit buffer.
      * @param receive The receive buffer.
      */
-    virtual auto transmit_receive(const TMC2130Spi::BufferType& transmit,
-                                  TMC2130Spi::BufferType& receive) -> bool= 0;
+    virtual auto transmit_receive(const SpiDeviceBase::BufferType& transmit,
+                                  SpiDeviceBase::BufferType& receive)
+        -> bool = 0;
 
     /**
      * Fill a buffer with a command.
@@ -37,8 +38,8 @@ class TMC2130Spi {
      * @param address The register's address
      * @param data The 32-bit data wor
      */
-    static void build_command(TMC2130Spi::BufferType& buffer,
-                              TMC2130Spi::Mode mode, uint8_t address,
+    static void build_command(SpiDeviceBase::BufferType& buffer,
+                              SpiDeviceBase::Mode mode, uint8_t address,
                               uint32_t data) {
         auto* iter = buffer.begin();
         // Address is ored with the mode.

--- a/include/common/core/spi.hpp
+++ b/include/common/core/spi.hpp
@@ -26,8 +26,8 @@ class TMC2130Spi {
      * @param transmit The transmit buffer.
      * @param receive The receive buffer.
      */
-    virtual void transmit_receive(const TMC2130Spi::BufferType& transmit,
-                                  TMC2130Spi::BufferType& receive) = 0;
+    virtual bool transmit_receive(const TMC2130Spi::BufferType& transmit,
+                                  TMC2130Spi::BufferType& receive);
 
     /**
      * Fill a buffer with a command.

--- a/include/common/core/spi.hpp
+++ b/include/common/core/spi.hpp
@@ -27,7 +27,7 @@ class TMC2130Spi {
      * @param receive The receive buffer.
      */
     virtual auto transmit_receive(const TMC2130Spi::BufferType& transmit,
-                                  TMC2130Spi::BufferType& receive) -> bool;
+                                  TMC2130Spi::BufferType& receive) -> bool= 0;
 
     /**
      * Fill a buffer with a command.

--- a/include/common/core/spi.hpp
+++ b/include/common/core/spi.hpp
@@ -26,8 +26,8 @@ class TMC2130Spi {
      * @param transmit The transmit buffer.
      * @param receive The receive buffer.
      */
-    virtual bool transmit_receive(const TMC2130Spi::BufferType& transmit,
-                                  TMC2130Spi::BufferType& receive);
+    virtual auto transmit_receive(const TMC2130Spi::BufferType& transmit,
+                                  TMC2130Spi::BufferType& receive) -> bool;
 
     /**
      * Fill a buffer with a command.

--- a/include/common/firmware/spi_comms.hpp
+++ b/include/common/firmware/spi_comms.hpp
@@ -19,8 +19,8 @@ struct SPI_interface {
 class Spi : public TMC2130Spi {
   public:
     explicit Spi(SPI_interface SPI_int);
-    bool transmit_receive(const TMC2130Spi::BufferType& transmit,
-                          TMC2130Spi::BufferType& receive) final;
+    auto transmit_receive(const TMC2130Spi::BufferType& transmit,
+                          TMC2130Spi::BufferType& receive) -> bool final;
 
   private:
     static constexpr uint32_t TIMEOUT = 0xFFFF;

--- a/include/common/firmware/spi_comms.hpp
+++ b/include/common/firmware/spi_comms.hpp
@@ -16,11 +16,11 @@ struct SPI_interface {
     uint32_t pin;
 };
 
-class Spi : public TMC2130Spi {
+class Spi : public SpiDeviceBase {
   public:
     explicit Spi(SPI_interface SPI_int);
-    auto transmit_receive(const TMC2130Spi::BufferType& transmit,
-                          TMC2130Spi::BufferType& receive) -> bool final;
+    auto transmit_receive(const SpiDeviceBase::BufferType& transmit,
+                          SpiDeviceBase::BufferType& receive) -> bool final;
 
   private:
     static constexpr uint32_t TIMEOUT = 0xFFFF;

--- a/include/common/firmware/spi_comms.hpp
+++ b/include/common/firmware/spi_comms.hpp
@@ -19,7 +19,7 @@ struct SPI_interface {
 class Spi : public TMC2130Spi {
   public:
     explicit Spi(SPI_interface SPI_int);
-    void transmit_receive(const TMC2130Spi::BufferType& transmit,
+    bool transmit_receive(const TMC2130Spi::BufferType& transmit,
                           TMC2130Spi::BufferType& receive) final;
 
   private:

--- a/include/common/simulation/spi.hpp
+++ b/include/common/simulation/spi.hpp
@@ -7,26 +7,26 @@
 namespace sim_spi {
 
 /**
- * Implementation of TMC2130Spi protocol for simulation purposes.
+ * Implementation of SpiDeviceBase protocol for simulation purposes.
  */
-class SimTMC2130Spi : public spi::TMC2130Spi {
+class SimSpiDeviceBase : public spi::SpiDeviceBase {
   public:
     using RegisterMap = std::map<uint8_t, uint32_t>;
 
     /**
      * Constructor.
      */
-    SimTMC2130Spi(void) : register_map{} {}
+    SimSpiDeviceBase(void) : register_map{} {}
 
     /**
      * Construct with a register map.
      * @param register_map map of register to value
      */
-    SimTMC2130Spi(const RegisterMap& register_map)
+    SimSpiDeviceBase(const RegisterMap& register_map)
         : register_map{register_map} {}
 
-    bool transmit_receive(const spi::TMC2130Spi::BufferType& transmit,
-                          spi::TMC2130Spi::BufferType& receive) final;
+    bool transmit_receive(const spi::SpiDeviceBase::BufferType& transmit,
+                          spi::SpiDeviceBase::BufferType& receive) final;
 
   private:
     RegisterMap register_map;

--- a/include/common/simulation/spi.hpp
+++ b/include/common/simulation/spi.hpp
@@ -25,7 +25,7 @@ class SimTMC2130Spi : public spi::TMC2130Spi {
     SimTMC2130Spi(const RegisterMap& register_map)
         : register_map{register_map} {}
 
-    void transmit_receive(const spi::TMC2130Spi::BufferType& transmit,
+    bool transmit_receive(const spi::TMC2130Spi::BufferType& transmit,
                           spi::TMC2130Spi::BufferType& receive) final;
 
   private:

--- a/include/gantry/core/interfaces.hpp
+++ b/include/gantry/core/interfaces.hpp
@@ -22,7 +22,7 @@ auto get_can_bus() -> can_bus::CanBus &;
  * Get the SPI interface
  * @return the SPI interface
  */
-auto get_spi() -> spi::TMC2130Spi &;
+auto get_spi() -> spi::SpiDeviceBase &;
 
 /**
  * Get the motor hardware interface

--- a/include/gantry/core/utils.hpp
+++ b/include/gantry/core/utils.hpp
@@ -2,7 +2,7 @@
 
 #include "can/core/ids.hpp"
 #include "gantry/core/axis_type.h"
-#include "motor-control/core/motor_driver_config.hpp"
+#include "motor-control/core/tmc2130_registers.hpp"
 
 namespace utils {
 
@@ -11,8 +11,8 @@ auto get_node_id_by_axis(enum GantryAxisType which) -> can_ids::NodeId;
 auto get_node_id() -> can_ids::NodeId;
 
 auto register_config_by_axis(enum GantryAxisType which)
-    -> motor_driver_config::RegisterConfig;
+    -> tmc2130::TMC2130RegisterMap;
 
-auto register_config() -> motor_driver_config::RegisterConfig;
+auto register_config() -> tmc2130::TMC2130RegisterMap;
 
 }  // namespace utils

--- a/include/motor-control/core/motor.hpp
+++ b/include/motor-control/core/motor.hpp
@@ -36,7 +36,7 @@ struct Motor {
      * @param queue Input message queue containing motion commands.
      * commands.
      */
-    Motor(spi::TMC2130Spi& spi,
+    Motor(spi::SpiDeviceBase& spi,
           lms::LinearMotionSystemConfig<MEConfig> lms_config,
           motor_hardware::MotorHardwareIface& hardware_iface,
           MotionConstraints constraints,

--- a/include/motor-control/core/motor.hpp
+++ b/include/motor-control/core/motor.hpp
@@ -9,6 +9,7 @@
 #include "motor_driver.hpp"
 #include "motor_driver_config.hpp"
 #include "motor_messages.hpp"
+#include "tmc2130.hpp"
 
 namespace motor_hardware {
 class MotorHardwareIface;
@@ -38,8 +39,8 @@ struct Motor {
     Motor(spi::TMC2130Spi& spi,
           lms::LinearMotionSystemConfig<MEConfig> lms_config,
           motor_hardware::MotorHardwareIface& hardware_iface,
-          MotionConstraints constraints, RegisterConfig driver_config,
-          GenericQueue& queue)
+          MotionConstraints constraints,
+          tmc2130::TMC2130RegisterMap driver_config, GenericQueue& queue)
 
         : pending_move_queue(queue),
           driver{spi, driver_config},

--- a/include/motor-control/core/motor_driver.hpp
+++ b/include/motor-control/core/motor_driver.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "common/core/bit_utils.hpp"
 #include "common/core/spi.hpp"
 #include "motor_driver_config.hpp"
+#include "tmc2130.hpp"
 
 namespace motor_driver {
 
@@ -16,48 +16,21 @@ class MotorDriver {
   public:
     spi::TMC2130Spi::BufferType rxBuffer{0};
 
-    explicit MotorDriver(spi::TMC2130Spi& spi, RegisterConfig conf)
-        : spi_comms(spi), register_config(conf) {}
+    explicit MotorDriver(spi::TMC2130Spi& spi, tmc2130::TMC2130RegisterMap conf)
+        : tmc2130{conf, spi} {}
 
-    void setup() {
-        write(DriverRegisters::Addresses::GCONF, register_config.gconf);
-        write(DriverRegisters::Addresses::IHOLD_IRUN,
-              register_config.ihold_irun);
-        write(DriverRegisters::Addresses::CHOPCONF, register_config.chopconf);
-        write(DriverRegisters::Addresses::THIGH, register_config.thigh);
-        write(DriverRegisters::Addresses::COOLCONF, register_config.coolconf);
+    void setup() { tmc2130.write_config(); }
+
+    auto read(tmc2130::Registers motor_reg, uint32_t command_data) -> uint32_t {
+        return tmc2130.read(motor_reg, command_data);
     }
 
-    auto read(DriverRegisters::Addresses motor_reg, uint32_t command_data)
-        -> uint32_t {
-        auto txBuffer = spi::TMC2130Spi::BufferType{};
-        spi::TMC2130Spi::build_command(txBuffer, spi::TMC2130Spi::Mode::READ,
-                                       motor_reg, command_data);
-        // A read requires two transmissions. The second returns the data in the
-        // register from the first transmission.
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
-
-        // Extract data bytes after the address.
-        uint32_t response = 0;
-        const auto* iter = rxBuffer.cbegin();                      // NOLINT
-        iter = bit_utils::bytes_to_int(iter + 1, rxBuffer.cend(),  // NOLINT
-                                       response);
-        return response;
-    }
-
-    auto write(DriverRegisters::Addresses motor_reg, uint32_t command_data)
-        -> spi::TMC2130Spi::BufferType {
-        auto txBuffer = spi::TMC2130Spi::BufferType{};
-        spi::TMC2130Spi::build_command(txBuffer, spi::TMC2130Spi::Mode::WRITE,
-                                       motor_reg, command_data);
-        spi_comms.transmit_receive(txBuffer, rxBuffer);
-        return txBuffer;
+    auto write(tmc2130::Registers motor_reg, uint32_t command_data) -> bool {
+        return tmc2130.write(motor_reg, command_data);
     }
 
   private:
-    spi::TMC2130Spi& spi_comms;
-    RegisterConfig register_config;
+    tmc2130::TMC2130 tmc2130;
 };
 
 }  // namespace motor_driver

--- a/include/motor-control/core/motor_driver.hpp
+++ b/include/motor-control/core/motor_driver.hpp
@@ -14,9 +14,10 @@ using namespace motor_driver_config;
  */
 class MotorDriver {
   public:
-    spi::TMC2130Spi::BufferType rxBuffer{0};
+    spi::SpiDeviceBase::BufferType rxBuffer{0};
 
-    explicit MotorDriver(spi::TMC2130Spi& spi, tmc2130::TMC2130RegisterMap conf)
+    explicit MotorDriver(spi::SpiDeviceBase& spi,
+                         tmc2130::TMC2130RegisterMap conf)
         : tmc2130{conf, spi} {}
 
     void setup() { tmc2130.write_config(); }

--- a/include/motor-control/core/motor_driver.hpp
+++ b/include/motor-control/core/motor_driver.hpp
@@ -29,7 +29,6 @@ class MotorDriver {
         return tmc2130.write(motor_reg, command_data);
     }
 
-  private:
     tmc2130::TMC2130 tmc2130;
 };
 

--- a/include/motor-control/core/tasks/motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/motor_driver_task.hpp
@@ -9,6 +9,7 @@
 #include "motor-control/core/motor_driver.hpp"
 #include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/tasks/messages.hpp"
+#include "motor-control/core/tmc2130_registers.hpp"
 
 namespace motor_driver_task {
 
@@ -50,9 +51,7 @@ class MotorDriverMessageHandler {
             m.reg_address, m.data);
         if (motor_driver_config::DriverRegisters::is_valid_address(
                 m.reg_address)) {
-            driver.write(
-                motor_driver_config::DriverRegisters::Addresses(m.reg_address),
-                m.data);
+            driver.write(tmc2130::Registers(m.reg_address), m.data);
         }
     }
 
@@ -61,9 +60,7 @@ class MotorDriverMessageHandler {
         uint32_t data = 0;
         if (motor_driver_config::DriverRegisters::is_valid_address(
                 m.reg_address)) {
-            data = driver.read(
-                motor_driver_config::DriverRegisters::Addresses(m.reg_address),
-                data);
+            data = driver.read(tmc2130::Registers(m.reg_address), data);
         }
         can_messages::ReadMotorDriverRegisterResponse response_msg{
             .reg_address = m.reg_address,

--- a/include/motor-control/core/tmc2130.hpp
+++ b/include/motor-control/core/tmc2130.hpp
@@ -21,10 +21,10 @@ class TMC2130 {
     static constexpr size_t MESSAGE_LEN = 5;
     // The type of a single TMC2130 message.
     using MessageT = std::array<uint8_t, MESSAGE_LEN>;
-    spi::TMC2130Spi::BufferType rxBuffer{0};
+    spi::SpiDeviceBase::BufferType rxBuffer{0};
 
     TMC2130() = delete;
-    TMC2130(const TMC2130RegisterMap& registers, spi::TMC2130Spi& spi)
+    TMC2130(const TMC2130RegisterMap& registers, spi::SpiDeviceBase& spi)
         : _registers(registers), _spi_comms(spi), _initialized(false) {}
 
     /**
@@ -35,7 +35,7 @@ class TMC2130 {
      * @return An array with the contents of the message, or nothing if
      * there was an error
      */
-    static auto build_message(Registers addr, spi::TMC2130Spi::Mode mode,
+    static auto build_message(Registers addr, spi::SpiDeviceBase::Mode mode,
                               RegisterSerializedType val) -> MessageT {
         MessageT buffer = {0};
         auto* iter = buffer.begin();
@@ -51,7 +51,7 @@ class TMC2130 {
 
     auto read(Registers addr, uint32_t command_data) -> uint32_t {
         auto txBuffer =
-            build_message(addr, spi::TMC2130Spi::Mode::READ, command_data);
+            build_message(addr, spi::SpiDeviceBase::Mode::READ, command_data);
         // A read requires two transmissions. The second returns the data in the
         // register from the first transmission.
         _spi_comms.transmit_receive(txBuffer, rxBuffer);
@@ -67,7 +67,7 @@ class TMC2130 {
 
     auto write(Registers addr, uint32_t command_data) -> bool {
         auto txBuffer =
-            build_message(addr, spi::TMC2130Spi::Mode::WRITE, command_data);
+            build_message(addr, spi::SpiDeviceBase::Mode::WRITE, command_data);
         auto response = _spi_comms.transmit_receive(txBuffer, rxBuffer);
         return response;
     }
@@ -340,7 +340,7 @@ class TMC2130 {
     }
 
     TMC2130RegisterMap _registers = {};
-    spi::TMC2130Spi& _spi_comms;
+    spi::SpiDeviceBase& _spi_comms;
     bool _initialized;
 };
 }  // namespace tmc2130

--- a/include/motor-control/core/tmc2130.hpp
+++ b/include/motor-control/core/tmc2130.hpp
@@ -43,6 +43,9 @@ class TMC2130 {
         addr_byte |= static_cast<uint8_t>(mode);
         iter = bit_utils::int_to_bytes(addr_byte, iter, buffer.end());
         iter = bit_utils::int_to_bytes(val, iter, buffer.end());
+        if (iter != buffer.end()) {
+            return MessageT();
+        }
         return buffer;
     }
 
@@ -333,7 +336,6 @@ class TMC2130 {
         // Ignore the typical linter warning because we're only using
         // this on __packed structures that mimic hardware registers
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-
         return RG(*reinterpret_cast<Reg*>(&ret.value()));
     }
 

--- a/include/motor-control/core/tmc2130.hpp
+++ b/include/motor-control/core/tmc2130.hpp
@@ -1,0 +1,344 @@
+/**
+ * @file tmc2130.hpp
+ * @brief Interface to control a TMC2130 IC
+ */
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+#include "common/core/bit_utils.hpp"
+#include "tmc2130_registers.hpp"
+
+namespace tmc2130 {
+
+// using namespace tmc2130_registers;
+
+class TMC2130 {
+  public:
+    static constexpr size_t MESSAGE_LEN = 5;
+    // The type of a single TMC2130 message.
+    using MessageT = std::array<uint8_t, MESSAGE_LEN>;
+    spi::TMC2130Spi::BufferType rxBuffer{0};
+
+    TMC2130() = delete;
+    TMC2130(const TMC2130RegisterMap& registers, spi::TMC2130Spi& spi)
+        : _registers(registers), _spi_comms(spi), _initialized(false) {}
+
+    /**
+     * @brief Build a message to send over SPI
+     * @param[in] addr The address to write to
+     * @param[in] mode The mode to use, either WRITE or READ
+     * @param[in] val The contents to write to the address (0 if this is a read)
+     * @return An array with the contents of the message, or nothing if
+     * there was an error
+     */
+    static auto build_message(Registers addr, spi::TMC2130Spi::Mode mode,
+                              RegisterSerializedType val) -> MessageT {
+        MessageT buffer = {0};
+        auto* iter = buffer.begin();
+        auto addr_byte = static_cast<uint8_t>(addr);
+        addr_byte |= static_cast<uint8_t>(mode);
+        iter = bit_utils::int_to_bytes(addr_byte, iter, buffer.end());
+        iter = bit_utils::int_to_bytes(val, iter, buffer.end());
+        return buffer;
+    }
+
+    auto read(Registers addr, uint32_t command_data) -> uint32_t {
+        auto txBuffer =
+            build_message(addr, spi::TMC2130Spi::Mode::READ, command_data);
+        // A read requires two transmissions. The second returns the data in the
+        // register from the first transmission.
+        _spi_comms.transmit_receive(txBuffer, rxBuffer);
+        _spi_comms.transmit_receive(txBuffer, rxBuffer);
+
+        // Extract data bytes after the address.
+        uint32_t response = 0;
+        const auto* iter = rxBuffer.cbegin();                      // NOLINT
+        iter = bit_utils::bytes_to_int(iter + 1, rxBuffer.cend(),  // NOLINT
+                                       response);
+        return response;
+    }
+
+    auto write(Registers addr, uint32_t command_data) -> bool {
+        auto txBuffer =
+            build_message(addr, spi::TMC2130Spi::Mode::WRITE, command_data);
+        auto response = _spi_comms.transmit_receive(txBuffer, rxBuffer);
+        return response;
+    }
+
+    auto write_config() -> bool {
+        if (!set_gconf(_registers.gconfig)) {
+            return false;
+        }
+        if (!set_current_control(_registers.ihold_irun)) {
+            return false;
+        }
+        if (!set_power_down_delay(
+                PowerDownDelay::reg_to_seconds(_registers.tpowerdown.time))) {
+            return false;
+        }
+        if (!set_cool_threshold(_registers.tcoolthrs)) {
+            return false;
+        }
+        if (!set_thigh(_registers.thigh)) {
+            return false;
+        }
+        if (!set_chop_config(_registers.chopconf)) {
+            return false;
+        }
+        if (!set_cool_config(_registers.coolconf)) {
+            return false;
+        }
+        _initialized = true;
+        return true;
+    }
+
+    auto write_config(const TMC2130RegisterMap& registers) -> bool {
+        if (!set_gconf(registers.gconfig)) {
+            return false;
+        }
+        if (!set_current_control(registers.ihold_irun)) {
+            return false;
+        }
+        if (!set_power_down_delay(
+                PowerDownDelay::reg_to_seconds(registers.tpowerdown.time))) {
+            return false;
+        }
+        if (!set_cool_threshold(registers.tcoolthrs)) {
+            return false;
+        }
+        if (!set_thigh(registers.thigh)) {
+            return false;
+        }
+        if (!set_chop_config(registers.chopconf)) {
+            return false;
+        }
+        if (!set_cool_config(registers.coolconf)) {
+            return false;
+        }
+        _initialized = true;
+        return true;
+    }
+
+    /**
+     * @brief Check if the TMC2130 has been initialized.
+     * @return true if the registers have been written at least once,
+     * false otherwise.
+     */
+    [[nodiscard]] auto initialized() const -> bool { return _initialized; }
+
+    // FUNCTIONS TO SET INDIVIDUAL REGISTERS
+
+    /**
+     * @brief Update GCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_gconf(GConfig reg) -> bool {
+        reg.enc_commutation = 0;
+        reg.test_mode = 0;
+        if (set_register(reg)) {
+            _registers.gconfig = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update IHOLDIRUN register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_current_control(CurrentControl reg) -> bool {
+        reg.bit_padding_1 = 0;
+        reg.bit_padding_2 = 0;
+        if (set_register(reg)) {
+            _registers.ihold_irun = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Update TPOWERDOWN register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_power_down_delay(double time) -> bool {
+        PowerDownDelay temp_reg = {.time =
+                                       PowerDownDelay::seconds_to_reg(time)};
+        if (set_register(temp_reg)) {
+            _registers.tpowerdown = temp_reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update TCOOLTHRSH register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_cool_threshold(TCoolThreshold reg) -> bool {
+        if (set_register(reg)) {
+            _registers.tcoolthrs = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Update THIGH register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_thigh(THigh reg) -> bool {
+        if (set_register(reg)) {
+            _registers.thigh = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update CHOPCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_chop_config(ChopConfig reg) -> bool {
+        if (set_register(reg)) {
+            _registers.chopconf = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update COOLCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_cool_config(CoolConfig reg) -> bool {
+        // Assert that bits that MUST be 0 are actually 0
+        reg.padding_1 = 0;
+        reg.padding_2 = 0;
+        reg.padding_3 = 0;
+        reg.padding_4 = 0;
+        if (set_register(reg)) {
+            _registers.coolconf = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Get the current GCONF register status. This register can
+     * be read, so this function gets it from the actual device.
+     */
+    [[nodiscard]] auto get_gconf() -> std::optional<GConfig> {
+        auto ret = read_register<GConfig>();
+        if (ret.has_value()) {
+            _registers.gconfig = ret.value();
+        }
+        return ret;
+    }
+    /**
+     * @brief Get the general status register
+     */
+    [[nodiscard]] auto get_gstatus() -> GStatus {
+        auto ret = read_register<GStatus>();
+        if (ret.has_value()) {
+            return ret.value();
+        }
+        return GStatus{.driver_error = 1};
+    }
+    /**
+     * @brief Get the current CHOPCONF register status. This register can
+     * be read, so this function gets it from the actual device.
+     */
+    [[nodiscard]] auto get_chop_config() -> std::optional<ChopConfig> {
+        auto ret = read_register<ChopConfig>();
+        if (ret.has_value()) {
+            _registers.chopconf = ret.value();
+        }
+        return ret;
+    }
+
+    /**
+     * @brief Get the current DRV_STATUS register reading. Contains
+     * information on the current error & stallguard status of the IC.
+     * @return The register, or nothing if the register couldn't be read.
+     */
+    [[nodiscard]] auto get_driver_status() -> std::optional<DriveStatus> {
+        return read_register<DriveStatus>();
+    }
+
+    /**
+     * @brief Get the register map
+     */
+    [[nodiscard]] auto get_register_map() -> TMC2130RegisterMap& {
+        return _registers;
+    }
+
+  private:
+    /**
+     * @brief Set a register on the TMC2130
+     *
+     * @tparam Reg The type of register to set
+     * @tparam Policy Abstraction class for actual writing
+     * @param[in] policy Instance of the abstraction policy to use
+     * @param[in] reg The register to write
+     * @return True if the register could be written, false otherwise.
+     * Attempts to write to an unwirteable register will throw a static
+     * assertion.
+     */
+    template <TMC2130Register Reg>
+    requires WritableRegister<Reg>
+    auto set_register(Reg reg) -> bool {
+        // Ignore the typical linter warning because we're only using
+        // this on __packed structures that mimic hardware registers
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto value = *reinterpret_cast<RegisterSerializedTypeA*>(&reg);
+        value &= Reg::value_mask;
+        return write(Reg::address, value);
+    }
+    /**
+     * @brief Read a register on the TMC2130
+     *
+     * @tparam Reg The type of register to read
+     * @tparam Policy Abstraction class for actual writing
+     * @param[in] policy Instance of the abstraction policy to use
+     * @return The contents of the register, or nothing if the register
+     * can't be read.
+     */
+    template <TMC2130Register Reg>
+    requires ReadableRegister<Reg>
+    auto read_register() -> std::optional<Reg> {
+        using RT = std::optional<RegisterSerializedType>;
+        using RG = std::optional<Reg>;
+
+        uint32_t data{0};
+        auto ret = RT(read(Reg::address, data));
+        if (!ret.has_value()) {
+            return RG();
+        }
+        // Ignore the typical linter warning because we're only using
+        // this on __packed structures that mimic hardware registers
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+
+        return RG(*reinterpret_cast<Reg*>(&ret.value()));
+    }
+
+    TMC2130RegisterMap _registers = {};
+    spi::TMC2130Spi& _spi_comms;
+    bool _initialized;
+};
+}  // namespace tmc2130

--- a/include/motor-control/core/tmc2130_registers.hpp
+++ b/include/motor-control/core/tmc2130_registers.hpp
@@ -1,0 +1,419 @@
+/**
+ * @file tmc2130_registers.hpp
+ * @brief Contains register mapping information for the TMC2130 motor
+ * driver IC.
+ *
+ */
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+
+namespace tmc2130 {
+
+// Register mapping
+
+enum class Registers : uint8_t {
+    GCONF = 0x00,
+    GSTAT = 0x01,
+    IOIN = 0x04,
+    IHOLD_IRUN = 0x10,
+    TPOWERDOWN = 0x11,
+    TSTEP = 0x12,
+    TPWMTHRS = 0x13,
+    TCOOLTHRS = 0x14,
+    THIGH = 0x15,
+    XDIRECT = 0x2D,
+    VDCMIN = 0x33,
+    CHOPCONF = 0x6C,
+    COOLCONF = 0x6D,
+    DCCTRL = 0x6E,
+    DRVSTATUS = 0x6F,
+    PWMCONF = 0x70,
+    ENCM_CTRL = 0x72,
+    MSLUT_0 = 0x60,
+    MSLUT_1 = 0x61,
+    MSLUT_2 = 0x62,
+    MSLUT_3 = 0x63,
+    MSLUT_4 = 0x64,
+    MSLUT_5 = 0x65,
+    MSLUT_6 = 0x66,
+    MSLUT_7 = 0x67,
+    MSLUTSEL = 0x68,
+    MSLUTSTART = 0x69,
+    MSCNT = 0x6A,
+    MSCURACT = 0x6B,
+    PWM_SCALE = 0x71,
+    LOST_STEPS = 0x73,
+};
+
+/** Template concept to constrain what structures encapsulate registers.*/
+template <typename Reg>
+concept TMC2130Register = requires(Reg& r, uint64_t value) {
+    // Struct has a valid register address
+    std::same_as<decltype(Reg::address), Registers&>;
+    // Struct has an integer with the total number of bits in a register.
+    // This is used to mask the 64-bit value before writing to the IC.
+    std::integral<decltype(Reg::value_mask)>;
+};
+
+template <typename Reg>
+concept WritableRegister = requires() {
+    {Reg::writable};
+};
+
+template <typename Reg>
+concept ReadableRegister = requires() {
+    {Reg::readable};
+};
+
+struct __attribute__((packed, __may_alias__)) GConfig {
+    static constexpr Registers address = Registers::GCONF;
+    static constexpr bool readable = true;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 17) - 1;
+
+    uint32_t i_scale_analog : 1 = 0;
+    uint32_t internal_rsense : 1 = 0;
+    uint32_t en_pwm_mode : 1 = 0;
+    uint32_t enc_commutation : 1 = 0;  // MUST be 0
+    uint32_t shaft : 1 = 0;
+    uint32_t diag0_error : 1 = 0;
+    uint32_t diag0_otpw : 1 = 0;
+    uint32_t diag0_stall : 1 = 0;
+    uint32_t diag1_stall : 1 = 0;
+    uint32_t diag1_index : 1 = 0;
+    uint32_t diag1_onstate : 1 = 0;
+    uint32_t diag1_steps_skipped : 1 = 0;
+    uint32_t diag0_int_pushpull : 1 = 0;
+    uint32_t diag1_pushpull : 1 = 0;
+    uint32_t small_hysteresis : 1 = 0;
+    uint32_t stop_enable : 1 = 0;
+    uint32_t direct_mode : 1 = 0;
+    uint32_t test_mode : 1 = 0;  // MUST be 0
+};
+
+struct __attribute__((packed, __may_alias__)) GStatus {
+    static constexpr Registers address = Registers::GSTAT;
+    static constexpr bool readable = true;
+    static constexpr uint32_t value_mask = (1 << 3) - 1;
+
+    uint32_t undervoltage_error : 1 = 0;
+    uint32_t driver_error : 1 = 0;
+    uint32_t reset : 1 = 0;
+};
+
+/**
+ * This register sets the control current for holding and running.
+ */
+struct __attribute__((packed, __may_alias__)) CurrentControl {
+    static constexpr Registers address = Registers::IHOLD_IRUN;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 20) - 1;
+
+    // Arbitrary scale from 0-31
+    uint32_t hold_current : 5 = 0;
+    uint32_t bit_padding_1 : 3 = 0;
+    // Arbitrary scale from 0-31
+    uint32_t run_current : 5 = 0;
+    uint32_t bit_padding_2 : 3 = 0;
+    // Motor powers down after (hold_current_delay * (2^18)) clock cycles
+    uint32_t hold_current_delay : 4 = 0;
+};
+
+/**
+ * This is the time to delay between ending a movement and moving to power-down
+ * current. Scale goes up to "about 4 seconds"
+ */
+struct __attribute__((packed, __may_alias__)) PowerDownDelay {
+    static constexpr Registers address = Registers::TPOWERDOWN;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 8) - 1;
+
+    static constexpr double max_time = 4.0F;
+    static constexpr uint32_t max_val = 0xFF;
+
+    [[nodiscard]] static auto reg_to_seconds(uint8_t reg) -> double {
+        return (static_cast<double>(reg) / static_cast<double>(max_val)) *
+               max_time;
+    }
+    static auto seconds_to_reg(double seconds) -> uint8_t {
+        if (seconds > max_time) {
+            return max_val;
+        }
+        return static_cast<uint32_t>((seconds / max_time) *
+                                     static_cast<double>(max_val));
+    }
+
+    uint32_t time : 8 = 0;
+};
+
+/**
+ * This is the threshold velocity for switching on smart energy coolStep
+ * and stallGuard.
+ */
+struct __attribute__((packed, __may_alias__)) TCoolThreshold {
+    static constexpr Registers address = Registers::TCOOLTHRS;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 20) - 1;
+
+    uint32_t threshold : 20 = 0;
+};
+
+/**
+ * This is the velocity threshold at which the controller will automatically
+ * move into a different chopper mode w/ fullstepping to maximize torque,
+ * applied whenever TSTEP < THIGH
+ */
+struct __attribute__((packed, __may_alias__)) THigh {
+    static constexpr Registers address = Registers::THIGH;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 20) - 1;
+
+    uint32_t threshold : 20 = 0;
+};
+
+/**
+ * The CHOPCONFIG register contains a number of configuration options for the
+ * Chopper control.
+ */
+struct __attribute__((packed, __may_alias__)) ChopConfig {
+    static constexpr Registers address = Registers::CHOPCONF;
+    static constexpr bool readable = true;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = 0x7FFFFFFF;
+
+    /** 0 = Driver disable
+     *  1 = "use only with TBL >= 2"
+     *  2...15 sets duration of slow decay phase:
+     * Nclk = 12 + 32 * TOFF
+     */
+    uint32_t toff : 4 = 0;
+    /**
+     * CHM = 0: sets hysteresis start value added to HEND
+     *  - Add 1,2,...,8 to hysteresis low value HEND
+     *
+     * CHM = 1: sets fast decay time, TFD :
+     *  - Nclk = 32*HSTRT
+     */
+    uint32_t hstrt : 3 = 0;
+    /**
+     * CHM = 0: Hysteresis is -3, -2, -1, ... 12. This is the hysteresis
+     * value used for the hysteresis chopper
+     *
+     * CHM = 1: Sine wave offset. 1/512 of the val gets added to abs of each
+     * sine wave entry
+     */
+    uint32_t hend : 4 = 0;
+    /**
+     * CHM = 1: MSB of fast decay time setting TFD
+     */
+    uint32_t fd3 : 1 = 0;
+    /**
+     * CHM = 1: Fast decay mode. Set to 1 to disable current comparator
+     * usage for termination of fast decay cycle.
+     */
+    uint32_t disfdcc : 1 = 0;
+    /**
+     * 0 = chopper OFF time fixed as set by TOFF (aka hstrt and fd3)
+     *
+     * 1 = Random mode, TOFF is modulated by [-12,3] clocks
+     */
+    uint32_t rndtf : 1 = 0;
+    /**
+     * Chopper mode. 0 = standard mode, 1 = constant off-time with fast decay.
+     */
+    uint32_t chm : 1 = 0;
+    /**
+     * Blank Time Select. Sets comparator blank time to 16,24,36,54
+     */
+    uint32_t tbl : 2 = 2;
+    /**
+     * 0 = low sensitivity, high sense resistor voltage
+     *
+     * 1 = high sensitivity, low sense resistor voltage
+     */
+    uint32_t vsense : 1 = 0;
+    /**
+     * High velocity fullstep selection: Enables switching to fullstep when
+     * VHIGH is exceeded. Only switches at 45º position.
+     */
+    uint32_t vhighfs : 1 = 0;
+    /**
+     * High Velocity Chopper Mode: Enables switching to chm=1 and fd=0 when
+     * VHIGH is exceeded. If set, the TOFF setting automatically becomes
+     * doubled during high velocity operation.
+     */
+    uint32_t vhighchm : 1 = 0;
+    /**
+     * SYNC PWM synchronization clock: Allows synchroniation of the chopper
+     * for both phases of a two phase motor to avoid occurrence of a beat.
+     * Automatically switched off above VHIGH
+     *
+     * 0 = disabled
+     *
+     * 1...15 = synchronized with fsync = fclk/(sync*64)
+     */
+    uint32_t sync : 4 = 0;
+    /**
+     * Microstep resolution:
+     *
+     * 0 = native 256 microstep setting
+     *
+     * 0b1...0b1000 = 128,64,32,16,8,4,2,FULLSTEP
+     *
+     * Reduced microstep resolution for STEP/DIR operation. Resolution gives
+     * the number of microstep entries per sine quarter wave.
+     */
+    uint32_t mres : 4 = 0;
+    /**
+     * Interpolation to 256 microsteps: If set, the actual MRES becomes
+     * extrapolated to 256 usteps for smoothest motor operation
+     */
+    uint32_t intpol : 1 = 0;
+    /**
+     * Enable double edge step pulses: If set, enable step impulse at each
+     * step edge to reduce step frequency requirement
+     */
+    uint32_t dedge : 1 = 0;
+    /**
+     * Short to GND protectino disable:
+     *
+     * 0 = short to gnd protection on
+     *
+     * 1 = short to gnd protection disabled
+     */
+    uint32_t diss2g : 1 = 0;
+};
+
+/**
+ * COOLCONF contains information to configure the Coolstep and Smartguard (SG)
+ * features in the TMC2130
+ */
+struct __attribute__((packed, __may_alias__)) CoolConfig {
+    static constexpr Registers address = Registers::COOLCONF;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 25) - 1;
+
+    /**
+     * Minimum SG value for smart current control & smart current enable.
+     *
+     * If SG result falls below SEMIN*32, motor current increases to
+     * reduce motor load angle.
+     *
+     * 0 = smart current control coolStep OFF
+     *
+     * 1..15 = set threshold value
+     */
+    uint32_t semin : 4 = 0;
+    uint32_t padding_1 : 1 = 0;
+    /**
+     * Current up step width: Current increment steps per measured SG value:
+     *
+     * 1,2,4,8
+     */
+    uint32_t seup : 2 = 0;
+    uint32_t padding_2 : 1 = 0;
+    /**
+     * If the SG result is >= (SEMIN+SEMAX+1)*32, motor current decreases
+     * to save energy.
+     */
+    uint32_t semax : 4 = 0;
+    uint32_t padding_3 : 1 = 0;
+    /**
+     * Current down step speed:
+     *
+     * 0: for each 32 SG values, decrease by one
+     *
+     * 1: for each 8 SG values, decrease by one
+     *
+     * 2: for each 2 SG values, decrease by one
+     *
+     * 3: for each SG value, decrease by one
+     */
+    uint32_t sedn : 2 = 0;
+    /**
+     * Minimum current for smart current control:
+     *
+     * 0 = 1/2 of current setting in IRUN
+     *
+     * 1 = 1/4 of current setting in IRUN
+     */
+    uint32_t seimin : 1 = 0;
+    /**
+     * SG Threshold Value: This signed value controlls SG level for stall
+     * output and sets optimum measurement range for readout. A lower val
+     * gives a higher sensitivity. Zero is starting value working with most
+     * motors.
+     *
+     * -64 to +63: Higher value makes SG less sensitive and requires more
+     * torque to indicate a stall
+     */
+    int32_t sgt : 7 = 0;
+    uint32_t padding_4 : 1 = 0;
+    /**
+     * SG filter enable:
+     *
+     * 0 = standard mode, high time res for SG
+     *
+     * 1 = filtered mode, SG signal updated for each 4 full steps
+     */
+    uint32_t sfilt : 1 = 0;
+};
+
+/**
+ * Holds error & stallguard information. Read only.
+ */
+struct __attribute__((packed, __may_alias__)) DriveStatus {
+    static constexpr Registers address = Registers::DRVSTATUS;
+    static constexpr bool readable = true;
+    static constexpr uint32_t value_mask = 0xFFFFFFFF;
+
+    // Stallguard2 Result, represents mechanical load.
+    // 0 is max load, 0x3FF is the max load.
+    uint32_t sg_result : 10 = 0;
+    // Reserved padding
+    uint32_t padding_0 : 5 = 0;
+    // Fullstep-active indicator
+    uint32_t fsactive : 1 = 0;
+    // Actual motor current/ smart energy current.
+    // For monitoring function of automatic current scaling.
+    uint32_t cs_actual : 5 = 0;
+    // Rserved padding
+    uint32_t padding_1 : 3 = 0;
+    // Motor stall detected (sg_result = 0), or DcStep stall
+    // in DcStep mode.
+    uint32_t stallguard : 1 = 0;
+    // If 1, overtemp detected and driver is shut down.
+    uint32_t overtemp_flag : 1 = 0;
+    // If 1, pre-warning threshold for overtemp is exceeded.
+    uint32_t overtemp_prewarning_flag : 1 = 0;
+    // Short to ground in phase A
+    uint32_t s2ga : 1 = 0;
+    // Short to ground in phase B
+    uint32_t s2gb : 1 = 0;
+    // Open load in phase A
+    uint32_t ola : 1 = 0;
+    // Open load in phase B
+    uint32_t olb : 1 = 0;
+    // Standstill indicator. Occurs 2^20 clocks after last step.
+    uint32_t stst : 1 = 0;
+};
+
+// Encapsulates all of the registers that should be configured by software
+struct TMC2130RegisterMap {
+    GConfig gconfig = {};
+    CurrentControl ihold_irun = {};
+    PowerDownDelay tpowerdown = {};
+    TCoolThreshold tcoolthrs = {};
+    THigh thigh = {};
+    ChopConfig chopconf = {};
+    CoolConfig coolconf = {};
+};
+
+// Registers are all 32 bits
+using RegisterSerializedType = uint32_t;
+// Type definition to allow type aliasing for pointer dereferencing
+using RegisterSerializedTypeA = __attribute__((__may_alias__)) uint32_t;
+
+}  // namespace tmc2130

--- a/include/pipettes/tests/test_motor_control.hpp
+++ b/include/pipettes/tests/test_motor_control.hpp
@@ -28,7 +28,7 @@ enum class MotorRegisters : uint8_t {
 static constexpr auto BUFFER_SIZE = 5;
 using BufferType = std::array<uint8_t, BUFFER_SIZE>;
 
-template <spi::TMC2130Spi SpiDriver>
+template <spi::SpiDeviceBase SpiDriver>
 class TestMotorDriver {
   public:
     TestMotorDriver(SpiDriver& spi) : spi_comms(spi) {}
@@ -60,7 +60,7 @@ class TestMotorDriver {
     void reset_status() { status = 0; }
 };
 
-template <spi::TMC2130Spi SpiDriver, template <class> class QueueImpl>
+template <spi::SpiDeviceBase SpiDriver, template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Move>, Move>
 class TestMotionController {
   public:
@@ -86,7 +86,7 @@ class TestMotionController {
     GenericQueue& queue;
 };
 
-template <spi::TMC2130Spi SpiDriver, template <class> class QueueImpl>
+template <spi::SpiDeviceBase SpiDriver, template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<Move>, Move>
 struct TestMotor {
     using GenericQueue = QueueImpl<Move>;

--- a/motor-control/tests/test_motor_driver.cpp
+++ b/motor-control/tests/test_motor_driver.cpp
@@ -2,33 +2,53 @@
 #include "common/simulation/spi.hpp"
 #include "motor-control/core/motor_driver.hpp"
 #include "motor-control/core/motor_driver_config.hpp"
+#include "motor-control/core/tmc2130_registers.hpp"
 
 using namespace motor_driver_config;
 
 TEST_CASE("Setup") {
     auto spi = sim_spi::SimTMC2130Spi{};
-    auto register_config = RegisterConfig{};
-    register_config.gconf = 1;
-    register_config.ihold_irun = 2;
-    register_config.chopconf = 3;
-    register_config.coolconf = 4;
-    register_config.thigh = 5;
+    tmc2130::TMC2130RegisterMap register_config{
+        .gconfig = {.en_pwm_mode = 1},
+        .ihold_irun = {.hold_current = 0x2,
+                       .run_current = 0x2,
+                       .hold_current_delay = 0x7},
+        .tpowerdown = {},
+        .tcoolthrs = {.threshold = 0},
+        .thigh = {.threshold = 0xFFFFF},
+        .chopconf =
+            {.toff = 0x5, .hstrt = 0x5, .hend = 0x3, .tbl = 0x2, .mres = 0x3},
+        .coolconf = {.sgt = 0b110}};
+
     auto subject = motor_driver::MotorDriver{spi, register_config};
 
     GIVEN("Driver") {
         WHEN("Setup is called") {
             subject.setup();
             THEN("Registers have the configured values.") {
-                REQUIRE(subject.read(DriverRegisters::Addresses::GCONF, 0) ==
-                        register_config.gconf);
-                REQUIRE(subject.read(DriverRegisters::Addresses::IHOLD_IRUN,
-                                     0) == register_config.ihold_irun);
-                REQUIRE(subject.read(DriverRegisters::Addresses::CHOPCONF, 0) ==
-                        register_config.chopconf);
-                REQUIRE(subject.read(DriverRegisters::Addresses::THIGH, 0) ==
-                        register_config.thigh);
-                REQUIRE(subject.read(DriverRegisters::Addresses::COOLCONF, 0) ==
-                        register_config.coolconf);
+                REQUIRE(subject.tmc2130.get_gconf().value().en_pwm_mode ==
+                        register_config.gconfig.en_pwm_mode);
+                REQUIRE(subject.tmc2130.get_register_map()
+                            .ihold_irun.hold_current ==
+                        register_config.ihold_irun.hold_current);
+                REQUIRE(
+                    subject.tmc2130.get_register_map().ihold_irun.run_current ==
+                    register_config.ihold_irun.run_current);
+                REQUIRE(subject.tmc2130.get_register_map()
+                            .ihold_irun.hold_current_delay ==
+                        register_config.ihold_irun.hold_current_delay);
+                REQUIRE(subject.tmc2130.get_chop_config().value().toff ==
+                        register_config.chopconf.toff);
+                REQUIRE(subject.tmc2130.get_chop_config().value().hstrt ==
+                        register_config.chopconf.hstrt);
+                REQUIRE(subject.tmc2130.get_chop_config().value().hend ==
+                        register_config.chopconf.hend);
+                REQUIRE(subject.tmc2130.get_chop_config().value().tbl ==
+                        register_config.chopconf.tbl);
+                REQUIRE(subject.tmc2130.get_chop_config().value().mres ==
+                        register_config.chopconf.mres);
+                REQUIRE(subject.tmc2130.get_register_map().coolconf.sgt ==
+                        register_config.coolconf.sgt);
             }
         }
     }

--- a/motor-control/tests/test_motor_driver.cpp
+++ b/motor-control/tests/test_motor_driver.cpp
@@ -7,7 +7,7 @@
 using namespace motor_driver_config;
 
 TEST_CASE("Setup") {
-    auto spi = sim_spi::SimTMC2130Spi{};
+    auto spi = sim_spi::SimSpiDeviceBase{};
     tmc2130::TMC2130RegisterMap register_config{
         .gconfig = {.en_pwm_mode = 1},
         .ihold_irun = {.hold_current = 0x2,

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -82,14 +82,14 @@ static motor_handler::MotorInterruptHandler plunger_interrupt(
 static tmc2130::TMC2130RegisterMap MotorDriverConfigurations{
     .gconfig = {.en_pwm_mode = 1},
     .ihold_irun = {.hold_current = 0x2,
-                   .run_current = 0x2,
+                   .run_current = 0x10,
                    .hold_current_delay = 0x7},
     .tpowerdown = {},
     .tcoolthrs = {.threshold = 0},
     .thigh = {.threshold = 0xFFFFF},
     .chopconf =
         {.toff = 0x5, .hstrt = 0x5, .hend = 0x3, .tbl = 0x2, .mres = 0x3},
-    .coolconf = {.sgt = 0b110}};
+    .coolconf = {.sgt = 0x6}};
 
 /**
  * TODO: This motor class is only used in motor handler and should be

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -18,6 +18,7 @@
 #include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/motor_interrupt_handler.hpp"
 #include "motor-control/core/motor_messages.hpp"
+#include "motor-control/core/tmc2130_registers.hpp"
 #include "motor-control/firmware/motor_hardware.hpp"
 #include "mount_detection.hpp"
 #include "pipettes/core/tasks.hpp"
@@ -78,12 +79,17 @@ static motor_handler::MotorInterruptHandler plunger_interrupt(
     motor_queue, pipettes_tasks::get_queues(), plunger_hw);
 
 // microstepping is currently set to 32 μsteps.
-static motor_driver_config::RegisterConfig MotorDriverConfigurations{
-    .gconf = 0x04,
-    .ihold_irun = 0x70202,
-    .chopconf = 0x30101D5,
-    .thigh = 0xFFFFF,
-    .coolconf = 0x60000};
+static tmc2130::TMC2130RegisterMap MotorDriverConfigurations{
+    .gconfig = {.en_pwm_mode = 1},
+    .ihold_irun = {.hold_current = 0x2,
+                   .run_current = 0x2,
+                   .hold_current_delay = 0x7},
+    .tpowerdown = {},
+    .tcoolthrs = {.threshold = 0},
+    .thigh = {.threshold = 0xFFFFF},
+    .chopconf =
+        {.toff = 0x5, .hstrt = 0x5, .hend = 0x3, .tbl = 0x2, .mres = 0x3},
+    .coolconf = {.sgt = 0b110}};
 
 /**
  * TODO: This motor class is only used in motor handler and should be

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -10,6 +10,7 @@
 #include "common/simulation/i2c_sim.hpp"
 #include "common/simulation/spi.hpp"
 #include "motor-control/core/motor.hpp"
+#include "motor-control/core/tmc2130.hpp"
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
 #include "pipettes/core/tasks.hpp"
@@ -34,12 +35,17 @@ static motor_interrupt_driver::MotorInterruptDriver sim_interrupt(
     motor_queue, plunger_interrupt);
 
 // microstepping is currently set to 32 μsteps.
-static motor_driver_config::RegisterConfig MotorDriverConfigurations{
-    .gconf = 0x04,
-    .ihold_irun = 0x70202,
-    .chopconf = 0x30101D5,
-    .thigh = 0xFFFFF,
-    .coolconf = 0x60000};
+static tmc2130::TMC2130RegisterMap MotorDriverConfigurations{
+    .gconfig = {.en_pwm_mode = 1},
+    .ihold_irun = {.hold_current = 0x2,
+                   .run_current = 0x2,
+                   .hold_current_delay = 0x7},
+    .tpowerdown = {},
+    .tcoolthrs = {.threshold = 0},
+    .thigh = {.threshold = 0xFFFFF},
+    .chopconf =
+        {.toff = 0x5, .hstrt = 0x5, .hend = 0x3, .tbl = 0x2, .mres = 0x3},
+    .coolconf = {.sgt = 0b110}};
 
 static auto hdcsensor = hdc2080_simulator::HDC2080{};
 static auto eeprom = eeprom_simulator::EEProm{};

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -24,7 +24,7 @@ static auto can_bus_1 = sim_canbus::SimCANBus{can_transport::create()};
 static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
     motor_queue("Motor Queue");
 
-static sim_spi::SimTMC2130Spi spi_comms{};
+static sim_spi::SimSpiDeviceBase spi_comms{};
 
 static sim_motor_hardware_iface::SimMotorHardwareIface plunger_hw{};
 


### PR DESCRIPTION
This copies @fsinapi's TMC2130 implementation in [opentrons-modules](https://github.com/Opentrons/opentrons-modules/pull/232) for the OT3. We now have a nice `TMC2130RegisterMap` so the driver configuration is more readable and can be modified easily. We're keeping the way SPI works in the OT3 for now, and we should think about doing refactor there and make SPI its own task. 