### PR TITLE
feat(can): crc 32 checksum of entire fw update

### DIFF
--- a/bootloader/core/message_handler.c
+++ b/bootloader/core/message_handler.c
@@ -115,8 +115,7 @@ HandleMessageReturn handle_fw_update_complete(const Message* request, Message* r
         FwUpdateReturn updater_return = fw_update_complete(
             get_update_state(),
             complete.num_messages,
-            // TODO (amit, 2022-02-01) - Provide checksum or crc32.
-            0);
+            complete.crc32);
         switch (updater_return) {
             case fw_update_error:
                 e = can_errorcode_hardware;

--- a/bootloader/core/messages.c
+++ b/bootloader/core/messages.c
@@ -69,7 +69,8 @@ CANErrorCode parse_update_complete(
         return can_errorcode_invalid_size;
     }
 
-    to_uint32(buffer, &result->num_messages);
+    buffer = to_uint32(buffer, &result->num_messages);
+    to_uint32(buffer, &result->crc32);
 
     return can_errorcode_ok;
 }

--- a/bootloader/firmware/CMakeLists.txt
+++ b/bootloader/firmware/CMakeLists.txt
@@ -15,6 +15,7 @@ set(BOOTLOADER_FW_NON_LINTABLE_SRCS
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
         ${COMMON_EXECUTABLE_DIR}/system/app_update.c
         ${CAN_EXECUTABLE_DIR}/utils.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/crc32.c
         )
 
 if (${ARM_ARCH_TYPE} STREQUAL "cortex-m4")

--- a/bootloader/firmware/crc32.c
+++ b/bootloader/firmware/crc32.c
@@ -2,6 +2,10 @@
 #include "platform_specific_hal_conf.h"
 #include "common/firmware/errors.h"
 
+/**
+ * Used this to match results from python's zlib.crc32.
+ * https://m0agx.eu/2021/04/09/matching-stm32-hardware-crc-with-standard-crc-32/
+ */
 
 /**
  * Handle to CRC module.
@@ -28,7 +32,7 @@ void crc32_init() {
  * @return Computed CRC
  */
 uint32_t crc32_compute(const uint8_t* data, uint8_t length) {
-    return HAL_CRC_Calculate(&hcrc, (uint32_t*)data, length);
+    return ~HAL_CRC_Calculate(&hcrc, (uint32_t*)data, length);
 }
 
 /**
@@ -38,7 +42,7 @@ uint32_t crc32_compute(const uint8_t* data, uint8_t length) {
  * @return Accumulated CRC
  */
 uint32_t crc32_accumulate(const uint8_t* data, uint8_t length) {
-    return HAL_CRC_Accumulate(&hcrc, (uint32_t*)data, length);
+    return ~HAL_CRC_Accumulate(&hcrc, (uint32_t*)data, length);
 }
 
 /**
@@ -48,14 +52,15 @@ void crc32_reset_accumulator() {
     __HAL_CRC_DR_RESET(&hcrc);
 }
 
-
-void MX_CRC_Init(void)
-{
+/**
+ * Initialize the CRC unit.
+ */
+void MX_CRC_Init(void) {
     hcrc.Instance = CRC;
     hcrc.Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_ENABLE;
     hcrc.Init.DefaultInitValueUse = DEFAULT_INIT_VALUE_ENABLE;
-    hcrc.Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_NONE;
-    hcrc.Init.OutputDataInversionMode = CRC_OUTPUTDATA_INVERSION_DISABLE;
+    hcrc.Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_WORD;
+    hcrc.Init.OutputDataInversionMode = CRC_OUTPUTDATA_INVERSION_ENABLE;
     hcrc.InputDataFormat = CRC_INPUTDATA_FORMAT_BYTES;
     if (HAL_CRC_Init(&hcrc) != HAL_OK)
     {

--- a/bootloader/firmware/crc32.c
+++ b/bootloader/firmware/crc32.c
@@ -1,0 +1,64 @@
+#include "bootloader/firmware/crc32.h"
+#include "platform_specific_hal_conf.h"
+#include "common/firmware/errors.h"
+
+
+/**
+ * Handle to CRC module.
+ */
+static CRC_HandleTypeDef hcrc;
+
+/**
+ * Initialize CRC handle.
+ */
+static void MX_CRC_Init(void);
+
+
+/**
+ * Initialize crc module.
+ */
+void crc32_init() {
+    MX_CRC_Init();
+}
+
+/**
+ * Compute the CRC
+ * @param data Data
+ * @param length Length of data
+ * @return Computed CRC
+ */
+uint32_t crc32_compute(uint8_t* data, uint8_t length) {
+    return HAL_CRC_Calculate(&hcrc, (uint32_t*)data, length);
+}
+
+/**
+ * Continue accumulating CRC using provided data.
+ * @param data Data
+ * @param length Length of data
+ * @return Accumulated CRC
+ */
+uint32_t crc32_accumulate(uint8_t* data, uint8_t length) {
+    return HAL_CRC_Accumulate(&hcrc, (uint32_t*)data, length);
+}
+
+/**
+ * Reset the accumulated CRC value.
+ */
+void crc32_reset_accumulator() {
+    __HAL_CRC_DR_RESET(&hcrc);
+}
+
+
+void MX_CRC_Init(void)
+{
+    hcrc.Instance = CRC;
+    hcrc.Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_ENABLE;
+    hcrc.Init.DefaultInitValueUse = DEFAULT_INIT_VALUE_ENABLE;
+    hcrc.Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_NONE;
+    hcrc.Init.OutputDataInversionMode = CRC_OUTPUTDATA_INVERSION_DISABLE;
+    hcrc.InputDataFormat = CRC_INPUTDATA_FORMAT_BYTES;
+    if (HAL_CRC_Init(&hcrc) != HAL_OK)
+    {
+        Error_Handler();
+    }
+}

--- a/bootloader/firmware/crc32.c
+++ b/bootloader/firmware/crc32.c
@@ -27,7 +27,7 @@ void crc32_init() {
  * @param length Length of data
  * @return Computed CRC
  */
-uint32_t crc32_compute(uint8_t* data, uint8_t length) {
+uint32_t crc32_compute(const uint8_t* data, uint8_t length) {
     return HAL_CRC_Calculate(&hcrc, (uint32_t*)data, length);
 }
 
@@ -37,7 +37,7 @@ uint32_t crc32_compute(uint8_t* data, uint8_t length) {
  * @param length Length of data
  * @return Accumulated CRC
  */
-uint32_t crc32_accumulate(uint8_t* data, uint8_t length) {
+uint32_t crc32_accumulate(const uint8_t* data, uint8_t length) {
     return HAL_CRC_Accumulate(&hcrc, (uint32_t*)data, length);
 }
 

--- a/bootloader/firmware/crc32.c
+++ b/bootloader/firmware/crc32.c
@@ -59,7 +59,7 @@ void MX_CRC_Init(void) {
     hcrc.Instance = CRC;
     hcrc.Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_ENABLE;
     hcrc.Init.DefaultInitValueUse = DEFAULT_INIT_VALUE_ENABLE;
-    hcrc.Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_WORD;
+    hcrc.Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_BYTE;
     hcrc.Init.OutputDataInversionMode = CRC_OUTPUTDATA_INVERSION_ENABLE;
     hcrc.InputDataFormat = CRC_INPUTDATA_FORMAT_BYTES;
     if (HAL_CRC_Init(&hcrc) != HAL_OK)

--- a/bootloader/firmware/main.c
+++ b/bootloader/firmware/main.c
@@ -9,6 +9,7 @@
 #include "bootloader/core/node_id.h"
 #include "bootloader/core/updater.h"
 #include "bootloader/firmware/system.h"
+#include "bootloader/firmware/crc32.h"
 
 /**
  * The CAN handle.
@@ -74,6 +75,8 @@ int main() {
 
 
 void run_upgrade() {
+
+    crc32_init();
 
     initialize_can(&hcan1);
 

--- a/bootloader/firmware/stm32G4/system_stm32g4xx.c
+++ b/bootloader/firmware/stm32G4/system_stm32g4xx.c
@@ -353,16 +353,32 @@ void HardwareInit(void) {
     SystemCoreClockUpdate();
 }
 
-/**
- * @}
- */
 
 /**
- * @}
+* @brief CRC MSP Initialization
+* @param hcrc: CRC handle pointer
+* @retval None
  */
+void HAL_CRC_MspInit(CRC_HandleTypeDef* hcrc)
+{
+    if(hcrc->Instance==CRC)
+    {
+        __HAL_RCC_CRC_CLK_ENABLE();
+    }
+
+}
 
 /**
- * @}
+* @brief CRC MSP De-Initialization
+* @param hcrc: CRC handle pointer
+* @retval None
  */
+void HAL_CRC_MspDeInit(CRC_HandleTypeDef* hcrc)
+{
+    if(hcrc->Instance==CRC)
+    {
+        __HAL_RCC_CRC_CLK_DISABLE();
+    }
+}
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/bootloader/firmware/stm32L5/system_stm32l5xx.c
+++ b/bootloader/firmware/stm32L5/system_stm32l5xx.c
@@ -453,15 +453,30 @@ void HardwareInit(void) {
 }
 
 /**
-  * @}
-  */
+* @brief CRC MSP Initialization
+* @param hcrc: CRC handle pointer
+* @retval None
+ */
+void HAL_CRC_MspInit(CRC_HandleTypeDef* hcrc)
+{
+    if(hcrc->Instance==CRC)
+    {
+        __HAL_RCC_CRC_CLK_ENABLE();
+    }
+
+}
 
 /**
-  * @}
-  */
-
-/**
-  * @}
-  */
+* @brief CRC MSP De-Initialization
+* @param hcrc: CRC handle pointer
+* @retval None
+ */
+void HAL_CRC_MspDeInit(CRC_HandleTypeDef* hcrc)
+{
+    if(hcrc->Instance==CRC)
+    {
+        __HAL_RCC_CRC_CLK_DISABLE();
+    }
+}
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/bootloader/tests/test_messages.cpp
+++ b/bootloader/tests/test_messages.cpp
@@ -144,12 +144,10 @@ SCENARIO("update data errors") {
 
 SCENARIO("update data complete") {
     GIVEN("a message") {
-        auto arr = std::array<uint8_t, 8>{
-            // Count
-            0xfe, 0xdc, 0xba, 0x98,
-            // CRC32
-            0xff, 0xfe, 0xfd, 0xfc
-        };
+        auto arr = std::array<uint8_t, 8>{// Count
+                                          0xfe, 0xdc, 0xba, 0x98,
+                                          // CRC32
+                                          0xff, 0xfe, 0xfd, 0xfc};
         WHEN("parsed") {
             UpdateComplete result;
             auto error = parse_update_complete(arr.data(), arr.size(), &result);
@@ -174,7 +172,8 @@ SCENARIO("update data complete errors") {
     }
 
     GIVEN("a null pointer for result") {
-        auto arr = std::array<uint8_t, 8>{0xfe, 0xdc, 0xba, 0x98, 0xff, 0xfe, 0xfd, 0xfc};
+        auto arr = std::array<uint8_t, 8>{0xfe, 0xdc, 0xba, 0x98,
+                                          0xff, 0xfe, 0xfd, 0xfc};
         WHEN("parsed") {
             auto error = parse_update_complete(arr.data(), arr.size(), nullptr);
             THEN("it returns error") {
@@ -184,7 +183,8 @@ SCENARIO("update data complete errors") {
     }
 
     GIVEN("a message with incorrect size") {
-        auto arr = std::array<uint8_t, 8>{0xfe, 0xdc, 0xba, 0x98, 0xff, 0xfe, 0xfd, 0xfc};
+        auto arr = std::array<uint8_t, 8>{0xfe, 0xdc, 0xba, 0x98,
+                                          0xff, 0xfe, 0xfd, 0xfc};
         WHEN("parsed") {
             UpdateComplete result;
             auto error =

--- a/bootloader/tests/test_messages.cpp
+++ b/bootloader/tests/test_messages.cpp
@@ -144,14 +144,19 @@ SCENARIO("update data errors") {
 
 SCENARIO("update data complete") {
     GIVEN("a message") {
-        auto arr = std::array<uint8_t, 4>{// Count
-                                          0xfe, 0xdc, 0xba, 0x98};
+        auto arr = std::array<uint8_t, 8>{
+            // Count
+            0xfe, 0xdc, 0xba, 0x98,
+            // CRC32
+            0xff, 0xfe, 0xfd, 0xfc
+        };
         WHEN("parsed") {
             UpdateComplete result;
             auto error = parse_update_complete(arr.data(), arr.size(), &result);
             THEN("it returns ok") { REQUIRE(error == can_errorcode_ok); }
             THEN("its fields are populated") {
                 REQUIRE(result.num_messages == 0xfedcba98);
+                REQUIRE(result.crc32 == 0xfffefdfc);
             }
         }
     }
@@ -161,7 +166,7 @@ SCENARIO("update data complete errors") {
     GIVEN("a null pointer") {
         WHEN("parsed") {
             UpdateComplete result;
-            auto error = parse_update_complete(nullptr, 4, &result);
+            auto error = parse_update_complete(nullptr, 8, &result);
             THEN("it returns error") {
                 REQUIRE(error == can_errorcode_invalid_size);
             }
@@ -169,7 +174,7 @@ SCENARIO("update data complete errors") {
     }
 
     GIVEN("a null pointer for result") {
-        auto arr = std::array<uint8_t, 4>{0xfe, 0xdc, 0xba, 0x98};
+        auto arr = std::array<uint8_t, 8>{0xfe, 0xdc, 0xba, 0x98, 0xff, 0xfe, 0xfd, 0xfc};
         WHEN("parsed") {
             auto error = parse_update_complete(arr.data(), arr.size(), nullptr);
             THEN("it returns error") {
@@ -179,7 +184,7 @@ SCENARIO("update data complete errors") {
     }
 
     GIVEN("a message with incorrect size") {
-        auto arr = std::array<uint8_t, 4>{0xfe, 0xdc, 0xba, 0x98};
+        auto arr = std::array<uint8_t, 8>{0xfe, 0xdc, 0xba, 0x98, 0xff, 0xfe, 0xfd, 0xfc};
         WHEN("parsed") {
             UpdateComplete result;
             auto error =

--- a/include/bootloader/core/messages.h
+++ b/include/bootloader/core/messages.h
@@ -27,9 +27,10 @@ typedef struct {
  */
 typedef struct {
     uint32_t num_messages;
+    uint32_t crc32;
 } UpdateComplete;
 
-#define UPDATE_COMPLETE_MESSAGE_SIZE    4
+#define UPDATE_COMPLETE_MESSAGE_SIZE    8
 
 
 /**

--- a/include/bootloader/firmware/crc32.h
+++ b/include/bootloader/firmware/crc32.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <stdint.h>
+
+/**
+ * Initialize crc module.
+ */
+void crc32_init();
+
+/**
+ * Compute the CRC
+ * @param data Data
+ * @param length Length of data
+ * @return Computed CRC
+ */
+uint32_t crc32_compute(uint8_t* data, uint8_t length);
+
+/**
+ * Continue accumulating CRC using provided data.
+ * @param data Data
+ * @param length Length of data
+ * @return Accumulated CRC
+ */
+uint32_t crc32_accumulate(uint8_t* data, uint8_t length);
+
+/**
+ * Reset the accumulated CRC value.
+ */
+void crc32_reset_accumulator();

--- a/include/bootloader/firmware/crc32.h
+++ b/include/bootloader/firmware/crc32.h
@@ -12,7 +12,7 @@ void crc32_init();
  * @param length Length of data
  * @return Computed CRC
  */
-uint32_t crc32_compute(uint8_t* data, uint8_t length);
+uint32_t crc32_compute(const uint8_t* data, uint8_t length);
 
 /**
  * Continue accumulating CRC using provided data.
@@ -20,7 +20,7 @@ uint32_t crc32_compute(uint8_t* data, uint8_t length);
  * @param length Length of data
  * @return Accumulated CRC
  */
-uint32_t crc32_accumulate(uint8_t* data, uint8_t length);
+uint32_t crc32_accumulate(const uint8_t* data, uint8_t length);
 
 /**
  * Reset the accumulated CRC value.


### PR DESCRIPTION
The download complete message now includes a crc32 of the entire application data.  We are using the HAL crc module to compute the crc. 

The crc is generated by python's `binascii.crc32`. There was a bit of monkeying around to get the HAL CRC to match the python generated.  This makes me a little nervous and I'm kind of wondering whether we should use a plain old checksum.

Anyway. It works. Tested on G4.