### PR TITLE
feat: enable IWDG in all applications

### DIFF
--- a/common/firmware/system/iwdg.c
+++ b/common/firmware/system/iwdg.c
@@ -1,0 +1,27 @@
+#include "platform_specific_hal_conf.h"
+#include "common/firmware/errors.h"
+#include "common/firmware/iwdg.h"
+
+
+static IWDG_HandleTypeDef hiwdg;
+
+
+void MX_IWDG_Init(void) {
+    /* USER CODE END IWDG_Init 1 */
+    hiwdg.Instance = IWDG;
+    hiwdg.Init.Prescaler = IWDG_PRESCALER_32;
+    hiwdg.Init.Window = IWDG_WINDOW_DISABLE;
+    hiwdg.Init.Reload = IWDG_INTERVAL_MS;
+    if (HAL_IWDG_Init(&hiwdg) != HAL_OK)
+    {
+        Error_Handler();
+    }
+}
+
+
+void iwdg_refresh(void) {
+    if (HAL_IWDG_Refresh(&hiwdg) != HAL_OK) {
+        /* Refresh Error */
+        Error_Handler();
+    }
+}

--- a/common/firmware/system/iwdg.cpp
+++ b/common/firmware/system/iwdg.cpp
@@ -6,14 +6,15 @@
 auto SLEEP_TIME = ((IWDG_INTERVAL_MS - 50) * portTICK_PERIOD_MS);
 
 void iwdg::TaskEntry::operator()() {
-    MX_IWDG_Init();
     for (;;) {
         iwdg_refresh();
         vTaskDelay(SLEEP_TIME);
     }
 }
 
-iwdg::IndependentWatchDog::IndependentWatchDog() : task{te} {}
+iwdg::IndependentWatchDog::IndependentWatchDog() : task{te} {
+    MX_IWDG_Init();
+}
 
 void iwdg::IndependentWatchDog::start(uint32_t priority) {
     task.start(priority, "iwdg");

--- a/common/firmware/system/iwdg.cpp
+++ b/common/firmware/system/iwdg.cpp
@@ -1,0 +1,20 @@
+#include "common/firmware/iwdg.h"
+
+#include "common/firmware/iwdg.hpp"
+
+/** How long to sleep between refreshes of watchdog */
+auto SLEEP_TIME = ((IWDG_INTERVAL_MS - 50) * portTICK_PERIOD_MS);
+
+void iwdg::TaskEntry::operator()() {
+    MX_IWDG_Init();
+    for (;;) {
+        iwdg_refresh();
+        vTaskDelay(SLEEP_TIME);
+    }
+}
+
+iwdg::IndependentWatchDog::IndependentWatchDog() : task{te} {}
+
+void iwdg::IndependentWatchDog::start(uint32_t priority) {
+    task.start(priority, "iwdg");
+}

--- a/common/firmware/system/iwdg.cpp
+++ b/common/firmware/system/iwdg.cpp
@@ -12,9 +12,7 @@ void iwdg::TaskEntry::operator()() {
     }
 }
 
-iwdg::IndependentWatchDog::IndependentWatchDog() : task{te} {
-    MX_IWDG_Init();
-}
+iwdg::IndependentWatchDog::IndependentWatchDog() : task{te} { MX_IWDG_Init(); }
 
 void iwdg::IndependentWatchDog::start(uint32_t priority) {
     task.start(priority, "iwdg");

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -14,6 +14,7 @@ set(GANTRY_FW_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
         ${COMMON_EXECUTABLE_DIR}/spi/spi_comms.cpp
+        ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
         ${CAN_FW_DIR}/hal_can_bus.cpp
         ${CAN_FW_DIR}/utils.c
         ${CAN_FW_DIR}/hal_can.c
@@ -29,6 +30,7 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
         ${COMMON_EXECUTABLE_DIR}/system/app_update.c
+        ${COMMON_EXECUTABLE_DIR}/system/iwdg.c
         )
 
 add_executable(gantry-x

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -3,6 +3,7 @@
 #include "can/firmware/hal_can.h"
 #include "can/firmware/hal_can_bus.hpp"
 #include "common/core/freertos_message_queue.hpp"
+#include "common/firmware/iwdg.hpp"
 #include "common/firmware/spi_comms.hpp"
 #include "gantry/core/axis_type.h"
 #include "gantry/core/interfaces.hpp"
@@ -17,10 +18,12 @@
 #include "motor_hardware.h"
 #pragma GCC diagnostic pop
 
+static auto iWatchdog = iwdg::IndependentWatchDog{};
+
 /**
  * The SPI configuration.
  */
-spi::SPI_interface SPI_intf = {
+static spi::SPI_interface SPI_intf = {
     .SPI_handle = &hspi2,
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
     .GPIO_handle = GPIOB,
@@ -155,6 +158,8 @@ void interfaces::initialize() {
 
     // Start the can bus
     can_start();
+
+    iWatchdog.start(6);
 }
 
 auto interfaces::get_can_bus() -> can_bus::CanBus& { return canbus; }

--- a/gantry/firmware/main.cpp
+++ b/gantry/firmware/main.cpp
@@ -9,11 +9,10 @@
 // clang-format on
 
 #include "common/core/app_update.h"
-#include "gantry/core/interfaces.hpp"
-#include "gantry/core/tasks.hpp"
-
 #include "common/firmware/clocking.h"
 #include "common/firmware/utility_gpio.h"
+#include "gantry/core/interfaces.hpp"
+#include "gantry/core/tasks.hpp"
 
 auto main() -> int {
     HardwareInit();

--- a/gantry/firmware/main.cpp
+++ b/gantry/firmware/main.cpp
@@ -12,13 +12,8 @@
 #include "gantry/core/interfaces.hpp"
 #include "gantry/core/tasks.hpp"
 
-#pragma GCC diagnostic push
-// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
-#pragma GCC diagnostic ignored "-Wvolatile"
 #include "common/firmware/clocking.h"
 #include "common/firmware/utility_gpio.h"
-
-#pragma GCC diagnostic pop
 
 auto main() -> int {
     HardwareInit();

--- a/gantry/firmware/utility_gpio.c
+++ b/gantry/firmware/utility_gpio.c
@@ -1,4 +1,6 @@
 #include "common/firmware/utility_gpio.h"
+#include "platform_specific_hal_conf.h"
+
 
 /**
  * @brief Limit Switch GPIO Initialization Function

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEAD_FW_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/adc/adc_comms.cpp
         ${COMMON_EXECUTABLE_DIR}/spi/spi_comms.cpp
+        ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
         ${CAN_FW_DIR}/hal_can.c
         ${CAN_FW_DIR}/hal_can_bus.cpp
         ${CAN_FW_DIR}/utils.c
@@ -29,7 +30,9 @@ set(HEAD_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/utility_hardware.c
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
-        ${COMMON_EXECUTABLE_DIR}/system/app_update.c)
+        ${COMMON_EXECUTABLE_DIR}/system/app_update.c
+        ${COMMON_EXECUTABLE_DIR}/system/iwdg.c
+        )
 
 add_executable(head
         ${HEAD_FW_LINTABLE_SRCS}

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -8,6 +8,7 @@
 #include "system_stm32g4xx.h"
 #include "common/firmware/errors.h"
 #include "common/core/app_update.h"
+#include "common/firmware/iwdg.hpp"
 // clang-format on
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
@@ -29,6 +30,8 @@
 #include "motor-control/core/motor_driver_config.hpp"
 #include "motor-control/core/motor_interrupt_handler.hpp"
 #include "motor-control/firmware/motor_hardware.hpp"
+
+static auto iWatchdog = iwdg::IndependentWatchDog{};
 
 static auto can_bus_1 = hal_can_bus::HalCanBus(can_get_device_handle());
 
@@ -218,6 +221,8 @@ auto main() -> int {
                             motor_right.driver, psd);
 
     timer_for_notifier.start();
+
+    iWatchdog.start(6);
 
     vTaskStartScheduler();
 }

--- a/include/common/firmware/iwdg.h
+++ b/include/common/firmware/iwdg.h
@@ -1,0 +1,8 @@
+//
+// Created by amit lissack on 2/28/22.
+//
+
+#ifndef OT3FIRMWARE_IWDG_H
+#define OT3FIRMWARE_IWDG_H
+
+#endif //OT3FIRMWARE_IWDG_H

--- a/include/common/firmware/iwdg.h
+++ b/include/common/firmware/iwdg.h
@@ -1,8 +1,24 @@
-//
-// Created by amit lissack on 2/28/22.
-//
+#pragma once
 
-#ifndef OT3FIRMWARE_IWDG_H
-#define OT3FIRMWARE_IWDG_H
 
-#endif //OT3FIRMWARE_IWDG_H
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#define IWDG_INTERVAL_MS 1000
+
+/**
+ * Initialize the independent watch odg.
+ */
+void MX_IWDG_Init(void);
+
+/**
+ * Refresh the independent watch dog
+ * @param handle
+ */
+void iwdg_refresh(void);
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/include/common/firmware/iwdg.hpp
+++ b/include/common/firmware/iwdg.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "common/core/freertos_task.hpp"
+#include "common/firmware/iwdg.h"
+
+namespace iwdg {
+
+struct TaskEntry {
+    void operator()();
+};
+
+class IndependentWatchDog {
+  public:
+    IndependentWatchDog();
+
+    /**
+     * Start the task.
+     * @param priority
+     */
+    void start(uint32_t priority);
+
+  private:
+    TaskEntry te{};
+    freertos_task::FreeRTOSTask<128, TaskEntry> task;
+};
+
+}  // namespace iwdg

--- a/include/common/firmware/iwdg.hpp
+++ b/include/common/firmware/iwdg.hpp
@@ -12,6 +12,12 @@ struct TaskEntry {
 class IndependentWatchDog {
   public:
     IndependentWatchDog();
+    IndependentWatchDog(const IndependentWatchDog&) = delete;
+    IndependentWatchDog(const IndependentWatchDog&&) = delete;
+    auto operator=(const IndependentWatchDog&) -> IndependentWatchDog& = delete;
+    auto operator=(const IndependentWatchDog&&)
+        -> IndependentWatchDog& = delete;
+    ~IndependentWatchDog() = default;
 
     /**
      * Start the task.

--- a/include/common/firmware/utility_gpio.h
+++ b/include/common/firmware/utility_gpio.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "platform_specific_hal_conf.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PIPETTE_FW_LINTABLE_SRCS
     ${COMMON_EXECUTABLE_DIR}/spi/spi_comms.cpp
     ${COMMON_EXECUTABLE_DIR}/i2c/i2c_comms.cpp
     ${COMMON_EXECUTABLE_DIR}/i2c/i2c.c
+    ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
     ${CAN_FW_DIR}/hal_can.c
     ${CAN_FW_DIR}/hal_can_bus.cpp
     ${CAN_FW_DIR}/utils.c)
@@ -32,7 +33,8 @@ set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/mount_detect_hardware.c
     ${COMMON_EXECUTABLE_DIR}/errors/errors.c
     ${COMMON_EXECUTABLE_DIR}/spi/spi.c
-    ${COMMON_EXECUTABLE_DIR}/system/app_update.c)
+    ${COMMON_EXECUTABLE_DIR}/system/app_update.c
+    ${COMMON_EXECUTABLE_DIR}/system/iwdg.c)
 
 add_executable(pipettes
         ${PIPETTE_FW_LINTABLE_SRCS}

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -11,6 +11,7 @@
 #include "common/firmware/clocking.h"
 #include "common/firmware/errors.h"
 #include "common/firmware/i2c_comms.hpp"
+#include "common/firmware/iwdg.hpp"
 #include "common/firmware/spi_comms.hpp"
 #include "common/firmware/utility_gpio.h"
 #include "motor-control/core/linear_motion_system.hpp"
@@ -27,6 +28,8 @@
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "motor_hardware.h"
 #pragma GCC diagnostic pop
+
+static auto iWatchdog = iwdg::IndependentWatchDog{};
 
 static auto can_bus_1 = hal_can_bus::HalCanBus(can_get_device_handle());
 
@@ -134,6 +137,8 @@ auto main() -> int {
 
     pipettes_tasks::start_tasks(can_bus_1, pipette_motor.motion_controller,
                                 pipette_motor.driver, i2c_comms, id);
+
+    iWatchdog.start(6);
 
     vTaskStartScheduler();
 }

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -1,4 +1,6 @@
 #include "common/firmware/utility_gpio.h"
+#include "platform_specific_hal_conf.h"
+
 
 /**
  * @brief Limit Switch GPIO Initialization Function


### PR DESCRIPTION
This PR enables the IWDG. It expires after 1 second. When the watchdog expires the system will be reset.

A task is introduced that will refresh the watchdog timer every 950ms.

The bootloader detects when a restart occurred because of IWDG and does not automatically jump to the main application. 