### PR TITLE
feat(can): add freertos task info request/response

### DIFF
--- a/head/core/can_task.cpp
+++ b/head/core/can_task.cpp
@@ -38,7 +38,7 @@ using MotionControllerDispatchTarget = can_dispatch::DispatchParseTarget<
 using SystemDispatchTarget = can_dispatch::DispatchParseTarget<
     system_handler::SystemMessageHandler<head_tasks::HeadQueueClient>,
     can_messages::DeviceInfoRequest, can_messages::InitiateFirmwareUpdate,
-    can_messages::FirmwareUpdateStatusRequest>;
+    can_messages::FirmwareUpdateStatusRequest, can_messages::TaskInfoRequest>;
 using PresenceSensingDispatchTarget = can_dispatch::DispatchParseTarget<
     presence_sensing_message_handler::PresenceSensingHandler<
         head_tasks::HeadQueueClient>,

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -21,6 +21,8 @@ typedef enum {
   can_messageid_heartbeat_response = 0x3fe,
   can_messageid_device_info_request = 0x302,
   can_messageid_device_info_response = 0x303,
+  can_messageid_task_info_request = 0x304,
+  can_messageid_task_info_response = 0x305,
   can_messageid_stop_request = 0x0,
   can_messageid_get_status_request = 0x1,
   can_messageid_get_status_response = 0x5,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -1,6 +1,6 @@
 /********************************************
- * This is a generated file. Do not modify.  *
- ********************************************/
+* This is a generated file. Do not modify.  *
+********************************************/
 #pragma once
 
 namespace can_ids {
@@ -23,6 +23,8 @@ enum class MessageId {
     heartbeat_response = 0x3fe,
     device_info_request = 0x302,
     device_info_response = 0x303,
+    task_info_request = 0x304,
+    task_info_response = 0x305,
     stop_request = 0x0,
     get_status_request = 0x1,
     get_status_response = 0x5,
@@ -116,3 +118,4 @@ enum class SensorType {
 };
 
 }  // namespace can_ids
+

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -1,6 +1,6 @@
 /********************************************
-* This is a generated file. Do not modify.  *
-********************************************/
+ * This is a generated file. Do not modify.  *
+ ********************************************/
 #pragma once
 
 namespace can_ids {
@@ -118,4 +118,3 @@ enum class SensorType {
 };
 
 }  // namespace can_ids
-

--- a/include/can/core/message_handlers/system.hpp
+++ b/include/can/core/message_handlers/system.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstring>
+
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
@@ -62,9 +63,10 @@ class SystemMessageHandler {
         writer.send_can_message(can_ids::NodeId::host, status_response);
     }
 
-    void visit(TaskInfoRequest& m) {
+    void visit(TaskInfoRequest &m) {
         auto tasks = std::array<TaskStatus_t, 20>{};
-        auto num_tasks = uxTaskGetSystemState(tasks.data(), tasks.size(), nullptr);
+        auto num_tasks =
+            uxTaskGetSystemState(tasks.data(), tasks.size(), nullptr);
         for (UBaseType_t i = 0; i < num_tasks; i++) {
             auto r = TaskInfoResponse{};
             ::memcpy(r.name, tasks[i].pcTaskName, sizeof(r.name));

--- a/include/can/core/message_handlers/system.hpp
+++ b/include/can/core/message_handlers/system.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstring>
-
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
@@ -69,7 +67,7 @@ class SystemMessageHandler {
             uxTaskGetSystemState(tasks.data(), tasks.size(), nullptr);
         for (UBaseType_t i = 0; i < num_tasks; i++) {
             auto r = TaskInfoResponse{};
-            ::memcpy(r.name, tasks[i].pcTaskName, sizeof(r.name));
+            std::copy_n(tasks[i].pcTaskName, r.name.size(), r.name.begin());
             r.runtime_counter = tasks[i].ulRunTimeCounter;
             r.stack_high_water_mark = tasks[i].usStackHighWaterMark;
             r.state = tasks[i].eCurrentState;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -81,7 +81,6 @@ struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
     auto operator==(const DeviceInfoResponse& other) const -> bool = default;
 };
 
-
 using TaskInfoRequest = Empty<MessageId::task_info_request>;
 
 struct TaskInfoResponse : BaseMessage<MessageId::task_info_response> {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -81,6 +81,29 @@ struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
     auto operator==(const DeviceInfoResponse& other) const -> bool = default;
 };
 
+
+using TaskInfoRequest = Empty<MessageId::task_info_request>;
+
+struct TaskInfoResponse : BaseMessage<MessageId::task_info_response> {
+    char name[12];
+    uint32_t runtime_counter;
+    uint32_t stack_high_water_mark;
+    uint16_t state;
+    uint16_t priority;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = std::copy(name, name + sizeof(name), body);
+        iter = bit_utils::int_to_bytes(runtime_counter, iter, limit);
+        iter = bit_utils::int_to_bytes(stack_high_water_mark, iter, limit);
+        iter = bit_utils::int_to_bytes(state, iter, limit);
+        iter = bit_utils::int_to_bytes(priority, iter, limit);
+        return iter - body;
+    }
+
+    auto operator==(const TaskInfoResponse& other) const -> bool = default;
+};
+
 using StopRequest = Empty<MessageId::stop_request>;
 
 using EnableMotorRequest = Empty<MessageId::enable_motor_request>;
@@ -526,5 +549,5 @@ using ResponseMessageType =
                  MoveCompleted, ReadPresenceSensingVoltageResponse,
                  PushToolsDetectedNotification, ReadLimitSwitchResponse,
                  ReadFromSensorResponse, FirmwareUpdateStatusResponse,
-                 SensorThresholdResponse>;
+                 SensorThresholdResponse, TaskInfoResponse>;
 }  // namespace can_messages

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -84,7 +84,7 @@ struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
 using TaskInfoRequest = Empty<MessageId::task_info_request>;
 
 struct TaskInfoResponse : BaseMessage<MessageId::task_info_response> {
-    char name[12];
+    std::array<char, 12> name{};
     uint32_t runtime_counter;
     uint32_t stack_high_water_mark;
     uint16_t state;
@@ -92,7 +92,7 @@ struct TaskInfoResponse : BaseMessage<MessageId::task_info_response> {
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = std::copy(name, name + sizeof(name), body);
+        auto iter = std::copy(name.cbegin(), name.cend(), body);
         iter = bit_utils::int_to_bytes(runtime_counter, iter, limit);
         iter = bit_utils::int_to_bytes(stack_high_water_mark, iter, limit);
         iter = bit_utils::int_to_bytes(state, iter, limit);

--- a/include/gantry/core/can_task.hpp
+++ b/include/gantry/core/can_task.hpp
@@ -34,7 +34,7 @@ using MotionControllerDispatchTarget = can_dispatch::DispatchParseTarget<
 using SystemDispatchTarget = can_dispatch::DispatchParseTarget<
     system_handler::SystemMessageHandler<gantry_tasks::QueueClient>,
     can_messages::DeviceInfoRequest, can_messages::InitiateFirmwareUpdate,
-    can_messages::FirmwareUpdateStatusRequest>;
+    can_messages::FirmwareUpdateStatusRequest, can_messages::TaskInfoRequest>;
 
 using GantryDispatcherType =
     can_dispatch::Dispatcher<MotorDispatchTarget, MoveGroupDispatchTarget,

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -66,7 +66,8 @@ static auto eeprom_dispatch_target =
 static auto system_dispatch_target = can_dispatch::DispatchParseTarget<
     decltype(system_message_handler), can_messages::DeviceInfoRequest,
     can_messages::InitiateFirmwareUpdate,
-    can_messages::FirmwareUpdateStatusRequest>{system_message_handler};
+    can_messages::FirmwareUpdateStatusRequest, can_messages::TaskInfoRequest>{
+    system_message_handler};
 
 static auto sensor_dispatch_target = can_dispatch::DispatchParseTarget<
     decltype(sensor_handler), can_messages::ReadFromSensorRequest,


### PR DESCRIPTION
Add request to read FreeRTOS task info. The request results in a sequence of responses; one for each running task.

Using the https://freertos.org/uxTaskGetSystemState.html function we return each tasks:
- name
- current priority
- run time counter
- stack high water mark
- current state

This could be useful in fine tuning stack sizes, balancing priorites, etc.
