### PR TITLE
feat(head): tolerate unknown tool ids

### DIFF
--- a/common/core/tool_detection.cpp
+++ b/common/core/tool_detection.cpp
@@ -6,10 +6,10 @@
 using namespace tool_detection;
 
 constexpr static auto pipette_384_chan_z_bounds =
-    ToolCheckBounds{.upper = 1883, .lower = 1851};
+    ToolCheckBounds{.upper = 1883, .lower = 1850};
 
 constexpr static auto pipette_96_chan_z_bounds =
-    ToolCheckBounds{.upper = 1434, .lower = 1400};
+    ToolCheckBounds{.upper = 1417, .lower = 1400};
 
 constexpr static auto pipette_single_chan_z_bounds =
     ToolCheckBounds{.upper = 460, .lower = 444};
@@ -21,13 +21,13 @@ constexpr static auto pipette_single_chan_a_bounds =
     ToolCheckBounds{.upper = 2389, .lower = 2362};
 
 constexpr static auto pipette_multiple_chan_a_bounds =
-    ToolCheckBounds{.upper = 2860, .lower = 2844};
+    ToolCheckBounds{.upper = 2859, .lower = 2844};
 
 constexpr static auto nothing_connected_z_bounds =
     ToolCheckBounds{.upper = 3, .lower = 1};
 
 constexpr static auto nothing_connected_a_bounds =
-    ToolCheckBounds{.upper = 54, .lower = 16};
+    ToolCheckBounds{.upper = 52, .lower = 15};
 
 // revisit these, not sure if EE has a calculation for gripper carrier bounds
 constexpr static auto nothing_connected_gripper_bounds =

--- a/head/firmware/adc/adc_comms.cpp
+++ b/head/firmware/adc/adc_comms.cpp
@@ -16,7 +16,7 @@ auto ADCChannel::get_reading() -> uint16_t {
 ADC::ADC(ADC_HandleTypeDef* ADC_intf_instance1,
          ADC_HandleTypeDef* ADC_intf_instance2)
     : a_channel(ADC_intf_instance2, ADC_CHANNEL_12),
-      z_channel(ADC_intf_instance2, ADC_CHANNEL_12),
+      z_channel(ADC_intf_instance2, ADC_CHANNEL_11),
       gripper_channel(ADC_intf_instance1, ADC_CHANNEL_12) {
     adc_setup(ADC_intf_instance1, ADC_intf_instance2);
 }

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -13,6 +13,7 @@
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
 #pragma GCC diagnostic ignored "-Wvolatile"
+#include "head/firmware/adc.h"
 #include "motor_hardware.h"
 #include "stm32g4xx_hal.h"
 #include "stm32g4xx_hal_conf.h"
@@ -199,7 +200,7 @@ extern "C" void motor_callback_glue() {
     motor_interrupt_right.run_interrupt();
 }
 
-static auto ADC_comms = adc::ADC(&adc1, &adc2);
+static auto ADC_comms = adc::ADC(get_adc1_handle(), get_adc2_handle());
 
 static auto psd = presence_sensing_driver::PresenceSensingDriver{ADC_comms};
 

--- a/head/tests/test_presence_sensing_driver.cpp
+++ b/head/tests/test_presence_sensing_driver.cpp
@@ -1,3 +1,5 @@
+#include <tuple>
+
 #include "catch2/catch.hpp"
 #include "common/core/tool_detection.hpp"
 #include "head/core/presence_sensing_driver.hpp"
@@ -18,27 +20,51 @@ SCENARIO("get_tool called on presence sensing driver") {
         */
 
         WHEN("get_tool func is called and raw ADC readings are within bounds") {
-            static auto adc_comms = adc::MockADC(2332, 3548, 666);
+            auto adc_comms = adc::MockADC(2332, 3548, 666);
             auto ps = presence_sensing_driver::PresenceSensingDriver(adc_comms);
-            auto tools = attached_tools::AttachedTools(
-                ps.get_readings(), tool_detection::lookup_table());
-
+            attached_tools::AttachedTools tools;
+            bool updated;
+            std::tie(updated, tools) = ps.update_tools();
             THEN("Tools mapped to voltage reading") {
+                REQUIRE(updated);
                 REQUIRE(tools.gripper == can_ids::ToolType::gripper);
                 REQUIRE(tools.a_motor == can_ids::ToolType::pipette_multi_chan);
                 REQUIRE(tools.z_motor == can_ids::ToolType::pipette_384_chan);
+                AND_WHEN("Tools switch to invalid voltages") {
+                    adc_comms.get_z_channel().mock_set_reading(9999);
+                    std::tie(updated, tools) = ps.update_tools();
+                    THEN("The invalid reading is ignored") {
+                        REQUIRE(!updated);
+                        REQUIRE(tools.z_motor ==
+                                can_ids::ToolType::pipette_384_chan);
+                    }
+                }
             }
         }
         WHEN("get_tool func is called and raw ADC readings are out of bounds") {
-            static auto adc_comms = adc::MockADC(9999, 9999, 9999);
+            auto adc_comms = adc::MockADC(9999, 9999, 9999);
             auto ps = presence_sensing_driver::PresenceSensingDriver(adc_comms);
-            auto tools = attached_tools::AttachedTools(
-                ps.get_readings(), tool_detection::lookup_table());
-
-            THEN("Tools mapped to voltage reading") {
+            attached_tools::AttachedTools tools;
+            bool updated;
+            std::tie(updated, tools) = ps.update_tools();
+            THEN("Tools remain invalid mapped to voltage reading") {
+                REQUIRE(!updated);
                 REQUIRE(tools.gripper == can_ids::ToolType::undefined_tool);
                 REQUIRE(tools.a_motor == can_ids::ToolType::undefined_tool);
                 REQUIRE(tools.z_motor == can_ids::ToolType::undefined_tool);
+                AND_WHEN("tools switch to valid voltages") {
+                    adc_comms.get_a_channel().mock_set_reading(3548);
+                    std::tie(updated, tools) = ps.update_tools();
+                    THEN("the valid tool is read out") {
+                        REQUIRE(updated);
+                        REQUIRE(tools.a_motor ==
+                                can_ids::ToolType::pipette_multi_chan);
+                        REQUIRE(tools.z_motor ==
+                                can_ids::ToolType::undefined_tool);
+                        REQUIRE(tools.gripper ==
+                                can_ids::ToolType::undefined_tool);
+                    }
+                }
             }
         }
         WHEN(
@@ -46,10 +72,12 @@ SCENARIO("get_tool called on presence sensing driver") {
             "attached") {
             static auto adc_comms = adc::MockADC(2, 20, 20);
             auto ps = presence_sensing_driver::PresenceSensingDriver(adc_comms);
-            auto tools = attached_tools::AttachedTools(
-                ps.get_readings(), tool_detection::lookup_table());
+            attached_tools::AttachedTools tools;
+            bool updated;
+            std::tie(updated, tools) = ps.update_tools();
 
             THEN("Tools mapped to voltage reading") {
+                REQUIRE(updated);
                 REQUIRE(tools.gripper == can_ids::ToolType::nothing_attached);
                 REQUIRE(tools.a_motor == can_ids::ToolType::nothing_attached);
                 REQUIRE(tools.z_motor == can_ids::ToolType::nothing_attached);

--- a/head/tests/test_presence_sensing_driver.cpp
+++ b/head/tests/test_presence_sensing_driver.cpp
@@ -20,7 +20,7 @@ SCENARIO("get_tool called on presence sensing driver") {
         */
 
         WHEN("get_tool func is called and raw ADC readings are within bounds") {
-            auto adc_comms = adc::MockADC(2332, 3548, 666);
+            auto adc_comms = adc::MockADC(1855, 2850, 666);
             auto ps = presence_sensing_driver::PresenceSensingDriver(adc_comms);
             attached_tools::AttachedTools tools;
             bool updated;
@@ -31,7 +31,7 @@ SCENARIO("get_tool called on presence sensing driver") {
                 REQUIRE(tools.a_motor == can_ids::ToolType::pipette_multi_chan);
                 REQUIRE(tools.z_motor == can_ids::ToolType::pipette_384_chan);
                 AND_WHEN("Tools switch to invalid voltages") {
-                    adc_comms.get_z_channel().mock_set_reading(9999);
+                    adc_comms.get_z_channel().mock_set_reading_by_voltage(3300);
                     std::tie(updated, tools) = ps.update_tools();
                     THEN("The invalid reading is ignored") {
                         REQUIRE(!updated);
@@ -42,7 +42,7 @@ SCENARIO("get_tool called on presence sensing driver") {
             }
         }
         WHEN("get_tool func is called and raw ADC readings are out of bounds") {
-            auto adc_comms = adc::MockADC(9999, 9999, 9999);
+            auto adc_comms = adc::MockADC(5000, 4000, 3400);
             auto ps = presence_sensing_driver::PresenceSensingDriver(adc_comms);
             attached_tools::AttachedTools tools;
             bool updated;
@@ -53,7 +53,7 @@ SCENARIO("get_tool called on presence sensing driver") {
                 REQUIRE(tools.a_motor == can_ids::ToolType::undefined_tool);
                 REQUIRE(tools.z_motor == can_ids::ToolType::undefined_tool);
                 AND_WHEN("tools switch to valid voltages") {
-                    adc_comms.get_a_channel().mock_set_reading(3548);
+                    adc_comms.get_a_channel().mock_set_reading_by_voltage(2850);
                     std::tie(updated, tools) = ps.update_tools();
                     THEN("the valid tool is read out") {
                         REQUIRE(updated);

--- a/head/tests/test_voltage_conversion.cpp
+++ b/head/tests/test_voltage_conversion.cpp
@@ -4,7 +4,10 @@
 
 SCENARIO("Raw ADC readings to voltage conversions") {
     GIVEN("Raw readings and an ADC instance") {
-        static auto adc_comms = adc::MockADC{666, 333, 999};
+        auto adc_comms = adc::MockADC{666, 333, 999};
+        adc_comms.get_z_channel().mock_set_reading(666);
+        adc_comms.get_a_channel().mock_set_reading(333);
+        adc_comms.get_gripper_channel().mock_set_reading(999);
         WHEN("get_readings function is called") {
             auto voltage_readings = adc_comms.get_voltages();
 

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -29,7 +29,7 @@ class MessageWriter {
      * @param message The message to send
      */
     template <message_core::CanResponseMessage ResponseMessage>
-    void send_can_message(can_ids::NodeId node, ResponseMessage& message) {
+    void send_can_message(can_ids::NodeId node, ResponseMessage&& message) {
         auto arbitration_id = can_arbitration_id::ArbitrationId{};
         auto task_message = message_writer_task::TaskMessage{};
 

--- a/include/common/tests/mock_adc_channel.hpp
+++ b/include/common/tests/mock_adc_channel.hpp
@@ -3,12 +3,22 @@
 #include "common/core/adc_channel.hpp"
 
 namespace adc {
-template <int FULLSCALE_VOLTAGE = 1, int FULLSCALE_READING = 1>
+template <int FULLSCALE_VOLTAGE, int FULLSCALE_READING>
 class MockADCChannel
     : public BaseADCChannel<FULLSCALE_VOLTAGE, FULLSCALE_READING> {
   public:
-    explicit MockADCChannel(uint16_t initial_value) : _value(initial_value) {}
+    MockADCChannel(uint16_t initial_mv)
+        : _value(value_from_voltage(initial_mv)) {}
     auto mock_set_reading(uint16_t new_value) -> void { _value = new_value; }
+    auto mock_set_reading_by_voltage(uint16_t new_mv) -> void {
+        _value = value_from_voltage(new_mv);
+    }
+    [[nodiscard]] constexpr auto value_from_voltage(uint16_t voltage)
+        -> uint16_t {
+        return static_cast<uint16_t>(static_cast<float>(voltage) *
+                                     static_cast<float>(FULLSCALE_READING) /
+                                     static_cast<float>(FULLSCALE_VOLTAGE));
+    }
     auto get_reading() -> uint16_t override final { return _value; }
     uint16_t _value;
 };

--- a/include/common/tests/mock_message_writer.hpp
+++ b/include/common/tests/mock_message_writer.hpp
@@ -25,7 +25,7 @@ class MockMessageWriter {
      * @param message The message to send
      */
     template <message_core::CanResponseMessage ResponseMessage>
-    void send_can_message(can_ids::NodeId node, ResponseMessage& message) {
+    void send_can_message(can_ids::NodeId node, ResponseMessage&& message) {
         TaskMessage task_msg{.arbitration_id = 0x1, .message = message};
         queue->try_write(task_msg);
     }

--- a/include/head/core/attached_tools.hpp
+++ b/include/head/core/attached_tools.hpp
@@ -30,6 +30,10 @@ struct AttachedTools {
           gripper(tooltype_from_reading(reading.gripper, arr)) {
         {}
     }
+    constexpr AttachedTools(can_ids::ToolType z_motor_in,
+                            can_ids::ToolType a_motor_in,
+                            can_ids::ToolType gripper_in)
+        : z_motor(z_motor_in), a_motor(a_motor_in), gripper(gripper_in) {}
 };
 
 }  // namespace attached_tools

--- a/include/head/core/presence_sensing_driver.hpp
+++ b/include/head/core/presence_sensing_driver.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <utility>
 
 #include "can/core/ids.hpp"
 #include "common/core/bit_utils.hpp"
@@ -28,7 +29,67 @@ class PresenceSensingDriver {
         this->current_tools = tools;
     }
 
+    /**
+     * Determine if two attached tool structs are different enough from each
+     * other that upstream should be notified of a change.
+     *
+     * In some cases, hardware tolerances can be slightly incorrect, so readings
+     * can bounce between some valid reading and one of the holes in the ranges.
+     * This causes extreme canbus loading and bad behavior because upstream
+     * keeps getting notified that things break.
+     *
+     * To prevent this, we can suppress notifications for when we see a change
+     * from a valid setting to an unknown value.
+     *
+     * This function therefore returns a (bool, AttachedTools) tuple. The bool
+     * is true if the new value is different from what was previously cached.
+     *
+     * After the call, the internal tool cache will be the same as what is
+     * returned.
+     */
+
+    [[nodiscard]] auto update_tools()
+        -> std::pair<bool, attached_tools::AttachedTools> {
+        auto new_tools = attached_tools::AttachedTools(get_readings());
+
+        auto ret = std::make_pair(should_update(current_tools, new_tools),
+                                  update_tools(current_tools, new_tools));
+        if (ret.first) {
+            current_tools = ret.second;
+        }
+        return ret;
+    }
+
   private:
+    [[nodiscard]] constexpr static auto should_use_new_value(
+        can_ids::ToolType old_tool, can_ids::ToolType new_tool) -> bool {
+        return (old_tool != new_tool) &&
+               (new_tool != can_ids::ToolType::undefined_tool);
+    }
+
+    [[nodiscard]] constexpr static auto should_update(
+        const attached_tools::AttachedTools& old_tools,
+        const attached_tools::AttachedTools& new_tools) -> bool {
+        return should_use_new_value(old_tools.z_motor, new_tools.z_motor) ||
+               should_use_new_value(old_tools.a_motor, new_tools.a_motor) ||
+               should_use_new_value(old_tools.gripper, new_tools.gripper);
+    }
+    [[nodiscard]] constexpr static auto update_tool(can_ids::ToolType old_tool,
+                                                    can_ids::ToolType new_tool)
+        -> can_ids::ToolType {
+        return (new_tool == can_ids::ToolType::undefined_tool) ? old_tool
+                                                               : new_tool;
+    }
+    [[nodiscard]] constexpr static auto update_tools(
+        const attached_tools::AttachedTools& old_tools,
+        const attached_tools::AttachedTools& new_tools)
+        -> attached_tools::AttachedTools {
+        return attached_tools::AttachedTools(
+            update_tool(old_tools.z_motor, new_tools.z_motor),
+            update_tool(old_tools.a_motor, new_tools.a_motor),
+            update_tool(old_tools.gripper, new_tools.gripper));
+    }
+
     adc::BaseADC& adc_comms;
     attached_tools::AttachedTools current_tools;
 };

--- a/include/head/firmware/adc.h
+++ b/include/head/firmware/adc.h
@@ -7,12 +7,9 @@
 extern "C" {
 #endif  // __cplusplus
 
-extern ADC_HandleTypeDef adc1;
-extern ADC_HandleTypeDef adc2;
 
-void MX_ADC1_Init(ADC_HandleTypeDef* adc1);
-void MX_ADC2_Init(ADC_HandleTypeDef* adc2);
-void ADC_set_chan(uint32_t chan, ADC_HandleTypeDef* handle);
+ADC_HandleTypeDef* get_adc1_handle(void);
+ADC_HandleTypeDef* get_adc2_handle(void);
 void adc_setup(ADC_HandleTypeDef* adc1, ADC_HandleTypeDef* adc2);
 uint32_t adc_read(ADC_HandleTypeDef* adc_handle, uint32_t adc_channel);
 

--- a/include/head/tests/mock_adc.hpp
+++ b/include/head/tests/mock_adc.hpp
@@ -16,7 +16,6 @@ class MockADC : public adc::BaseADC {
           a_channel(a_reading),
           gripper_channel(gripper_reading) {}
 
-  protected:
     auto get_gripper_channel() -> MockChannelType& override {
         return gripper_channel;
     }

--- a/include/head/tests/mock_adc.hpp
+++ b/include/head/tests/mock_adc.hpp
@@ -11,10 +11,8 @@ class MockADC : public adc::BaseADC {
 
   public:
     MockADC() = default;
-    MockADC(uint16_t z_reading, uint16_t a_reading, uint16_t gripper_reading)
-        : z_channel(z_reading),
-          a_channel(a_reading),
-          gripper_channel(gripper_reading) {}
+    MockADC(uint16_t z_mv, uint16_t a_mv, uint16_t gripper_mv)
+        : z_channel(z_mv), a_channel(a_mv), gripper_channel(gripper_mv) {}
 
     auto get_gripper_channel() -> MockChannelType& override {
         return gripper_channel;

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -64,7 +64,9 @@ class CapacitiveMessageHandler {
         capdac_offset = capacitance_handler.get_offset();
         if (bool(m.offset_reading)) {
             auto message = can_messages::ReadFromSensorResponse{
-                {}, SensorType::capacitive, static_cast<uint32_t>(capdac_offset)};
+                {},
+                SensorType::capacitive,
+                static_cast<uint32_t>(capdac_offset)};
             can_client.send_can_message(can_ids::NodeId::host, message);
         } else {
             capacitance_handler.reset();


### PR DESCRIPTION
The tool identification voltage ranges will sometimes not quite be
right, and the values coming out of the ADC can bounce around slightly.
This can combine to have the head spam the canbus with tool detection
notification change messages bouncing between some normal value and
undefined_tool. In practice, if these values bounce around like this,
it's not reflecting anything physical - so let's filter it out by
latching away undefined_tool, and not allowing the state to go from
valid->invalid since undefined_tool is just an artifact of the way we
categorize things.

We also weren't reading the ADC quite correctly; we need to handle some busy states and also set the right channel.

## Testing
Put this on a head and monitor on can_mon; you should now see correct notifications when attaching and removing pipettes from either interface.