### PR TITLE
refactor(bootloader):  use interrupt version of flash erase

### DIFF
--- a/bootloader/core/update_state.c
+++ b/bootloader/core/update_state.c
@@ -3,6 +3,7 @@
 static UpdateState update_state = {
     .num_messages_received=0,
     .error_detection=0,
+    .erase_state=erase_state_idle
 };
 
 
@@ -14,5 +15,6 @@ void reset_update_state(UpdateState * state) {
     if (state) {
         state->num_messages_received = 0;
         state->error_detection = 0;
+        state->erase_state = erase_state_idle;
     }
 }

--- a/bootloader/firmware/main.c
+++ b/bootloader/firmware/main.c
@@ -165,6 +165,8 @@ void run_update() {
                     Error_Handler();
                 }
             }
+        } else {
+            HAL_Delay(1);
         }
         // Refresh the watch dog.
         iwdg_refresh();

--- a/bootloader/firmware/main.c
+++ b/bootloader/firmware/main.c
@@ -77,6 +77,10 @@ int main() {
     RCC_Peripheral_Clock_Select();
     MX_IWDG_Init();
 
+    // Enable the flash interrupt.
+    HAL_NVIC_SetPriority(FLASH_IRQn, 15, 15);
+    HAL_NVIC_EnableIRQ(FLASH_IRQn);
+
     bool requires_update = requires_an_update();
 
     // Clear reset flags. Otherwise, they will persist for the lifetime of

--- a/bootloader/firmware/stm32G4/stm32g4xx_it.c
+++ b/bootloader/firmware/stm32G4/stm32g4xx_it.c
@@ -151,4 +151,9 @@ void PendSV_Handler(void) {}
 void SysTick_Handler(void) {}
 
 
+void FLASH_IRQHandler(void) {
+    HAL_FLASH_IRQHandler();
+}
+
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/bootloader/firmware/stm32G4/stm32g4xx_it.c
+++ b/bootloader/firmware/stm32G4/stm32g4xx_it.c
@@ -148,7 +148,9 @@ void DMA1_Channel3_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_spi1_tx); }
 /** Interrupt handlers that are typically routed to FreeRTOS. No FreeRTOS on Bootloader. */
 void SVC_Handler(void) {}
 void PendSV_Handler(void) {}
-void SysTick_Handler(void) {}
+void SysTick_Handler(void) {
+    HAL_IncTick();
+}
 
 
 void FLASH_IRQHandler(void) {

--- a/bootloader/firmware/stm32L5/stm32l5xx_it.c
+++ b/bootloader/firmware/stm32L5/stm32l5xx_it.c
@@ -150,7 +150,9 @@ void TIM7_IRQHandler(void) {  }
 /** Interrupt handlers that are typically routed to FreeRTOS. No FreeRTOS on Bootloader. */
 void SVC_Handler(void) {}
 void PendSV_Handler(void) {}
-void SysTick_Handler(void) {}
+void SysTick_Handler(void) {
+    HAL_IncTick();
+}
 
 void FLASH_IRQHandler(void) {
     HAL_FLASH_IRQHandler();

--- a/bootloader/firmware/stm32L5/stm32l5xx_it.c
+++ b/bootloader/firmware/stm32L5/stm32l5xx_it.c
@@ -152,5 +152,9 @@ void SVC_Handler(void) {}
 void PendSV_Handler(void) {}
 void SysTick_Handler(void) {}
 
+void FLASH_IRQHandler(void) {
+    HAL_FLASH_IRQHandler();
+}
+
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/bootloader/firmware/updater.c
+++ b/bootloader/firmware/updater.c
@@ -123,7 +123,7 @@ FwUpdateReturn fw_update_erase_application(UpdateState* state) {
     erase_struct.Banks=FLASH_BANK_2;
     erase_struct.Page=0;
     erase_struct.NbPages=FLASH_PAGE_NB_PER_BANK;
-    error = 0;
+    
     if (HAL_FLASHEx_Erase_IT(&erase_struct) != HAL_OK) {
         return fw_update_error;
     }

--- a/bootloader/firmware/updater.c
+++ b/bootloader/firmware/updater.c
@@ -123,7 +123,7 @@ FwUpdateReturn fw_update_erase_application(UpdateState* state) {
     erase_struct.Banks=FLASH_BANK_2;
     erase_struct.Page=0;
     erase_struct.NbPages=FLASH_PAGE_NB_PER_BANK;
-    
+
     if (HAL_FLASHEx_Erase_IT(&erase_struct) != HAL_OK) {
         return fw_update_error;
     }
@@ -147,13 +147,13 @@ void fw_update_wait_erase(const UpdateState * state) {
  * Callback from HAL_FLASH_IRQHandler indicating that an operation is
  * complete.
  * @param ReturnValue This is overloaded to mean a whole heck of a lot.
- *  for page erase it is the page (or 0xFFFFFFFFU indicating complete)
+ *  for page erase it is the page (or 0xFFFFFFFF indicating complete)
  *  for mass erase this is the bank. (not in use by us)
  *  for program it is the address. (not in use by us)
  */
 void HAL_FLASH_EndOfOperationCallback(uint32_t ReturnValue) {
     // If we're erasing and getting the magic ReturnValue then we're done.
-    if (get_update_state()->erase_state == erase_state_running && ReturnValue == 0xFFFFFFFFu) {
+    if (get_update_state()->erase_state == erase_state_running && ReturnValue == 0xFFFFFFFFU) {
         get_update_state()->erase_state = erase_state_done;
     }
     // Refresh the watch dog

--- a/include/bootloader/core/update_state.h
+++ b/include/bootloader/core/update_state.h
@@ -2,6 +2,13 @@
 
 #include <stdint.h>
 
+#ifndef __cplusplus
+#include <stdatomic.h>
+#else
+// _Atomic keyword is not supported in CPP and we don't need it.
+#define _Atomic
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus

--- a/include/bootloader/core/update_state.h
+++ b/include/bootloader/core/update_state.h
@@ -20,8 +20,9 @@ typedef struct {
     uint32_t num_messages_received;
     /** Running error detection value of update date. */
     uint32_t error_detection;
-    /** The current flash erasing state */
-    EraseState erase_state;
+    /** The current flash erasing state. Marked `_Atomic` because it's
+     * modified in interrupt and main process. */
+    _Atomic EraseState erase_state;
 
 } UpdateState;
 

--- a/include/bootloader/core/update_state.h
+++ b/include/bootloader/core/update_state.h
@@ -7,11 +7,22 @@ extern "C" {
 #endif  // __cplusplus
 
 
+typedef enum {
+    erase_state_idle,
+    erase_state_running,
+    erase_state_error,
+    erase_state_done,
+} EraseState;
+
+
 typedef struct {
     /** Number of data messages received. */
     uint32_t num_messages_received;
     /** Running error detection value of update date. */
     uint32_t error_detection;
+    /** The current flash erasing state */
+    EraseState erase_state;
+
 } UpdateState;
 
 


### PR DESCRIPTION
Instead of using `HAL_FLASHEx_Erase` we are now using `HAL_FLASHEx_Erase_IT` to erase flash. 

`HAL_FLASHEx_Erase` was taking about 5 seconds which didn't give us an opportunity to reset the watchdog resulting in reset.

This PR enables flash interrupt and implements the complete and error callbacks called from the HAL Flash IRQ handler.

This has been tested on G4, but not L5.