### PR TITLE
refactor(motor-current): change ihold irun values for gantrys and heads

### DIFF
--- a/gantry/core/utils.cpp
+++ b/gantry/core/utils.cpp
@@ -23,7 +23,7 @@ auto utils::driver_config_by_axis(enum GantryAxisType which)
             return tmc2130::TMC2130DriverConfig{
                 .registers = {.gconfig = {.en_pwm_mode = 1},
                               .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x10,
+                                             .run_current = 0x18,
                                              .hold_current_delay = 0x7},
                               .thigh = {.threshold = 0xFFFFF},
                               .chopconf = {.toff = 0x5,
@@ -41,7 +41,7 @@ auto utils::driver_config_by_axis(enum GantryAxisType which)
             return tmc2130::TMC2130DriverConfig{
                 .registers = {.gconfig = {.en_pwm_mode = 1},
                               .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x10,
+                                             .run_current = 0x18,
                                              .hold_current_delay = 0x7},
                               .thigh = {.threshold = 0xFFFFF},
                               .chopconf = {.toff = 0x5,

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -133,10 +133,9 @@ static tmc2130::TMC2130DriverConfig MotorDriverConfigurations{
     .registers =
         {
             .gconfig = {.en_pwm_mode = 1},
-            .ihold_irun = {.hold_current = 0x2,
-                           .run_current = 0x10,
+            .ihold_irun = {.hold_current = 0xB,
+                           .run_current = 0x19,
                            .hold_current_delay = 0x7},
-            .tpowerdown = {},
             .tcoolthrs = {.threshold = 0},
             .thigh = {.threshold = 0xFFFFF},
             .chopconf = {.toff = 0x5,


### PR DESCRIPTION
Updating the gantry & head's irun value to `0x18` which sets the motor current to be roughly 1.4 A.