### PR TITLE
refactor(gantry): update motion system config

### DIFF
--- a/gantry/core/utils.cpp
+++ b/gantry/core/utils.cpp
@@ -30,7 +30,7 @@ auto utils::driver_config_by_axis(enum GantryAxisType which)
                                            .hstrt = 0x5,
                                            .hend = 0x3,
                                            .tbl = 0x2,
-                                           .mres = 0x4},
+                                           .mres = 0x3},
                               .coolconf = {.sgt = 0x6}},
                 .current_config = {
                     .r_sense = 0.1,
@@ -48,7 +48,7 @@ auto utils::driver_config_by_axis(enum GantryAxisType which)
                                            .hstrt = 0x5,
                                            .hend = 0x3,
                                            .tbl = 0x2,
-                                           .mres = 0x4},
+                                           .mres = 0x3},
                               .coolconf = {.sgt = 0x6}},
                 .current_config = {
                     .r_sense = 0.1,
@@ -60,4 +60,28 @@ auto utils::driver_config_by_axis(enum GantryAxisType which)
 
 auto utils::driver_config() -> tmc2130::TMC2130DriverConfig {
     return driver_config_by_axis(get_axis_type());
+}
+
+auto utils::linear_motion_sys_config_by_axis(enum GantryAxisType which)
+    -> lms::LinearMotionSystemConfig<lms::BeltConfig> {
+    switch (which) {
+        case GantryAxisType::gantry_x:
+            return lms::LinearMotionSystemConfig<lms::BeltConfig>{
+                .mech_config = lms::BeltConfig{.pulley_diameter = 12.7},
+                .steps_per_rev = 200,
+                .microstep = 32,
+            };
+        case GantryAxisType::gantry_y:
+            return lms::LinearMotionSystemConfig<lms::BeltConfig>{
+                .mech_config = lms::BeltConfig{.pulley_diameter = 12.7254},
+                .steps_per_rev = 200,
+                .microstep = 32,
+            };
+    }
+    std::abort();
+}
+
+auto utils::linear_motion_system_config()
+    -> lms::LinearMotionSystemConfig<lms::BeltConfig> {
+    return linear_motion_sys_config_by_axis(get_axis_type());
 }

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -124,11 +124,7 @@ static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
  */
 static motor_class::Motor motor{
     spi_comms,
-    lms::LinearMotionSystemConfig<lms::BeltConfig>{
-        .mech_config =
-            lms::BeltConfig{.belt_pitch = 2, .pulley_tooth_count = 20},
-        .steps_per_rev = 200,
-        .microstep = 16},
+    utils::linear_motion_system_config(),
     motor_hardware_iface,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -36,10 +36,9 @@ static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
 static motor_class::Motor motor{
     spi_comms,
     lms::LinearMotionSystemConfig<lms::BeltConfig>{
-        .mech_config =
-            lms::BeltConfig{.belt_pitch = 2, .pulley_tooth_count = 10},
+        .mech_config = lms::BeltConfig{.pulley_diameter = 12.7},
         .steps_per_rev = 200,
-        .microstep = 16},
+        .microstep = 32},
     motor_interface,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,

--- a/gantry/tests/test_linear_motion_config.cpp
+++ b/gantry/tests/test_linear_motion_config.cpp
@@ -6,10 +6,9 @@ using namespace lms;
 TEST_CASE("Linear motion system using a belt") {
     GIVEN("OT2 X,Y gantry config") {
         struct LinearMotionSystemConfig<BeltConfig> linearConfig {
-            .mech_config =
-                BeltConfig{.belt_pitch = 2, .pulley_tooth_count = 20},
-            .steps_per_rev = 200, .microstep = 16,
+            .mech_config = BeltConfig{.pulley_diameter = 12.7},
+            .steps_per_rev = 200, .microstep = 32,
         };
-        REQUIRE(linearConfig.get_steps_per_mm() == 80);
+        REQUIRE(linearConfig.get_steps_per_mm() == 160.40813f);
     }
 }

--- a/include/gantry/core/utils.hpp
+++ b/include/gantry/core/utils.hpp
@@ -2,6 +2,7 @@
 
 #include "can/core/ids.hpp"
 #include "gantry/core/axis_type.h"
+#include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/tmc2130_config.hpp"
 
 namespace utils {
@@ -15,4 +16,9 @@ auto driver_config_by_axis(enum GantryAxisType which)
 
 auto driver_config() -> tmc2130::TMC2130DriverConfig;
 
+auto linear_motion_sys_config_by_axis(enum GantryAxisType which)
+    -> lms::LinearMotionSystemConfig<lms::BeltConfig>;
+
+auto linear_motion_system_config()
+    -> lms::LinearMotionSystemConfig<lms::BeltConfig>;
 }  // namespace utils

--- a/include/motor-control/core/linear_motion_system.hpp
+++ b/include/motor-control/core/linear_motion_system.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <concepts>
+#include <numbers>
 
 namespace lms {
 
 struct BeltConfig {
-    float belt_pitch;          // mm/count
-    float pulley_tooth_count;  // count/rev
+    float pulley_diameter;  // mm
     [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
-        return belt_pitch * pulley_tooth_count;
+        return static_cast<float>(pulley_diameter * std::numbers::pi);
     }
 };
 


### PR DESCRIPTION
Updating the numbers for steps/mm for Gantry X and Gantry Y based on the following values from HW:

> For X:
12.7mm pulley diameter
200 steps / revolution
1/32 microstepping
0.006234097922 mm per microstep

>For Y:
12.7254mm pulley diameter
200 steps / revolution
1/32 microstepping
0.006246566118 mm per microstep

This requires us to update the linear motion system belt config to take in `pulley diameter` instead of pulley tooth pitch. We also need to update the MRES value for the chopconf register from 0x4 to 0x3 to set microstep resolution at 32. 