### PR TITLE
fix(FreeRTOS): use Freertos systick

### DIFF
--- a/gantry/firmware/FreeRTOSConfig.h
+++ b/gantry/firmware/FreeRTOSConfig.h
@@ -145,21 +145,21 @@ PRIORITY THAN THIS! (higher priorities are lower numeric values. */
 
 /* Interrupt priorities used by the kernel port layer itself.  These are generic
 to all Cortex-M ports, and do not rely on any particular library functions. */
-#define configKERNEL_INTERRUPT_PRIORITY                                        \
-  (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+#define configKERNEL_INTERRUPT_PRIORITY \
+    (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
 See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY                                   \
-  (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY \
+    (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
 
 /* Normal assert() semantics without relying on the provision of an assert.h
 header file. */
-#define configASSERT(x)                                                        \
-  if ((x) == 0) {                                                              \
-    taskDISABLE_INTERRUPTS();                                                  \
-    for (;;)                                                                   \
-      ;                                                                        \
-  }
+#define configASSERT(x)           \
+    if ((x) == 0) {               \
+        taskDISABLE_INTERRUPTS(); \
+        for (;;)                  \
+            ;                     \
+    }
 
 /* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS
    standard names. */
@@ -170,6 +170,6 @@ header file. */
    sure the system and peripherials are using a different time base (TIM based
    for example).
  */
-#define xPortSysTickHandler SysTick_Handler
+#define xPortSysTickHandler FreeRTOS_SysTick_Handler
 
 #endif /* FREERTOS_CONFIG_H */

--- a/gantry/firmware/stm32g4xx_it.c
+++ b/gantry/firmware/stm32g4xx_it.c
@@ -22,9 +22,9 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g4xx_it.h"
 
-#include "stm32g4xx_hal.h"
-
+#include "FreeRTOSConfig.h"
 #include "can/firmware/hal_can.h"
+#include "stm32g4xx_hal.h"
 
 /** @addtogroup STM32G4xx_HAL_Examples
  * @{
@@ -46,7 +46,6 @@
 DMA_HandleTypeDef hdma_spi1_tx;
 DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim7;
-
 
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
@@ -138,12 +137,18 @@ void DMA1_Channel3_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_spi1_tx); }
 /**
  * @brief This function handles FDCAN1 interrupt 0.
  */
-void FDCAN1_IT0_IRQHandler(void) { HAL_FDCAN_IRQHandler(can_get_device_handle()); }
-
+void FDCAN1_IT0_IRQHandler(void) {
+    HAL_FDCAN_IRQHandler(can_get_device_handle());
+}
 
 /**
  * @brief This function handles TIM7 global interrupt.
  */
 void TIM7_IRQHandler(void) { HAL_TIM_IRQHandler(&htim7); }
 
+extern void xPortSysTickHandler(void);
+void SysTick_Handler(void) {
+    HAL_IncTick();
+    xPortSysTickHandler();
+}
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/head/firmware/FreeRTOSConfig.h
+++ b/head/firmware/FreeRTOSConfig.h
@@ -145,21 +145,21 @@ PRIORITY THAN THIS! (higher priorities are lower numeric values. */
 
 /* Interrupt priorities used by the kernel port layer itself.  These are generic
 to all Cortex-M ports, and do not rely on any particular library functions. */
-#define configKERNEL_INTERRUPT_PRIORITY                                        \
-  (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+#define configKERNEL_INTERRUPT_PRIORITY \
+    (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
 /* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
 See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY                                   \
-  (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY \
+    (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
 
 /* Normal assert() semantics without relying on the provision of an assert.h
 header file. */
-#define configASSERT(x)                                                        \
-  if ((x) == 0) {                                                              \
-    taskDISABLE_INTERRUPTS();                                                  \
-    for (;;)                                                                   \
-      ;                                                                        \
-  }
+#define configASSERT(x)           \
+    if ((x) == 0) {               \
+        taskDISABLE_INTERRUPTS(); \
+        for (;;)                  \
+            ;                     \
+    }
 
 /* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS
    standard names. */
@@ -170,6 +170,6 @@ header file. */
    sure the system and peripherials are using a different time base (TIM based
    for example).
  */
-#define xPortSysTickHandler SysTick_Handler
+#define xPortSysTickHandler FreeRTOS_SysTick_Handler
 
 #endif /* FREERTOS_CONFIG_H */

--- a/head/firmware/stm32g4xx_it.c
+++ b/head/firmware/stm32g4xx_it.c
@@ -22,9 +22,9 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32g4xx_it.h"
 
-#include "stm32g4xx_hal.h"
-
+#include "FreeRTOSConfig.h"
 #include "can/firmware/hal_can.h"
+#include "stm32g4xx_hal.h"
 
 /** @addtogroup STM32G4xx_HAL_Examples
  * @{
@@ -46,7 +46,6 @@
 DMA_HandleTypeDef hdma_spi1_tx;
 DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim7;
-
 
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
@@ -138,12 +137,18 @@ void DMA1_Channel3_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_spi1_tx); }
 /**
  * @brief This function handles FDCAN1 interrupt 0.
  */
-void FDCAN1_IT0_IRQHandler(void) { HAL_FDCAN_IRQHandler(can_get_device_handle()); }
-
+void FDCAN1_IT0_IRQHandler(void) {
+    HAL_FDCAN_IRQHandler(can_get_device_handle());
+}
 
 /**
  * @brief This function handles TIM7 global interrupt.
  */
 void TIM7_IRQHandler(void) { HAL_TIM_IRQHandler(&htim7); }
 
+extern void xPortSysTickHandler(void);
+void SysTick_Handler(void) {
+    HAL_IncTick();
+    xPortSysTickHandler();
+}
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
This fixes HAL_Delay hanging issues by updating `SysTick_Handler` to (1) increment tick and (2) call the freeRTOS xPortSysTickHandler.