### PR TITLE
feat(logging): better logging in simulation

### DIFF
--- a/bootloader/simulator/main.cpp
+++ b/bootloader/simulator/main.cpp
@@ -63,7 +63,9 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
-    LOG_INIT("BOOTLOADER", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+    LOG_INIT("BOOTLOADER", []() -> const char* {
+        return pcTaskGetName(xTaskGetCurrentTaskHandle());
+    });
 
     canbus.setup_node_id_filter(static_cast<can_ids::NodeId>(get_node_id()));
     canbus.set_incoming_message_callback(nullptr, on_can_message);

--- a/bootloader/simulator/main.cpp
+++ b/bootloader/simulator/main.cpp
@@ -39,24 +39,24 @@ void on_can_message(void* cb_data, uint32_t identifier, uint8_t* data,
     auto handle_message_return = handle_message(&message, &response);
     switch (handle_message_return) {
         case handle_message_ok:
-            LOG("Message ok. No response\n");
+            LOG("Message ok. No response");
             break;
         case handle_message_has_response:
-            LOG("Message ok. Has response\n");
+            LOG("Message ok. Has response");
             canbus.send(response.arbitration_id.id, response.data,
                         static_cast<CanFDMessageLength>(response.size));
             break;
         case handle_message_error:
-            LOG("Message error.\n");
+            LOG("Message error.");
             break;
         default:
-            LOG("Unknown return.\n");
+            LOG("Unknown return.");
             break;
     }
 }
 
 void signal_handler(int signum) {
-    LOG("Interrupt signal (%d) received.\n", signum);
+    LOG("Interrupt signal (%d) received.", signum);
     exit(signum);
 }
 

--- a/bootloader/simulator/main.cpp
+++ b/bootloader/simulator/main.cpp
@@ -63,6 +63,8 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
+    LOG_INIT("BOOTLOADER", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+
     canbus.setup_node_id_filter(static_cast<can_ids::NodeId>(get_node_id()));
     canbus.set_incoming_message_callback(nullptr, on_can_message);
 

--- a/common/simulation/app_update.cpp
+++ b/common/simulation/app_update.cpp
@@ -2,6 +2,6 @@
 
 #include "common/core/logging.h"
 
-void app_update_start() { LOG("Starting app update!\n"); }
+void app_update_start() { LOG("Starting app update!"); }
 
 update_flag_type app_update_flags() { return 0; }

--- a/common/simulation/logging.cpp
+++ b/common/simulation/logging.cpp
@@ -1,29 +1,29 @@
 #ifdef ENABLE_LOGGING
 
 #include "common/core/logging.h"
+
 #include <stdio.h>
+
 #include <boost/asio.hpp>
 
+#include "boost/date_time/posix_time/posix_time.hpp"
 
 struct FormatSpecs {
     std::string app_name{};
     logging_task_name_get task_name_getter{nullptr};
 };
 
-
 static auto format_specs = FormatSpecs{};
-
 
 /**
  * Initialize logging
  * @param app_name  Name of the application.
  * @param task_getter Callback to get the current task name.
  */
-void log_init(const char * app_name, logging_task_name_get task_getter) {
+void log_init(const char* app_name, logging_task_name_get task_getter) {
     format_specs.app_name = app_name;
     format_specs.task_name_getter = task_getter;
 }
-
 
 void log_message(const char* format, ...) {
     va_list argp;
@@ -34,12 +34,16 @@ void log_message(const char* format, ...) {
     auto sigblock = boost::asio::detail::posix_signal_blocker{};
     vsnprintf(buff, sizeof(buff), format, argp);
 
-    const char * task_name = format_specs.task_name_getter ? format_specs.task_name_getter() : "none";
+    const char* task_name = format_specs.task_name_getter
+                                ? format_specs.task_name_getter()
+                                : "none";
 
-    printf("[%s] [%s] %s\n",
-               format_specs.app_name.c_str(),
-               task_name,
-               buff);
+    using namespace boost::posix_time;
+
+    auto time = microsec_clock::local_time();
+
+    printf("[%s] [%s] [%s] %s\n", to_iso_extended_string(time).c_str(),
+           format_specs.app_name.c_str(), task_name, buff);
 
     va_end(argp);
 }

--- a/common/simulation/logging.cpp
+++ b/common/simulation/logging.cpp
@@ -1,17 +1,45 @@
 #ifdef ENABLE_LOGGING
 
 #include "common/core/logging.h"
-
 #include <stdio.h>
-
 #include <boost/asio.hpp>
+
+
+struct FormatSpecs {
+    std::string app_name{};
+    logging_task_name_get task_name_getter{nullptr};
+};
+
+
+static auto format_specs = FormatSpecs{};
+
+
+/**
+ * Initialize logging
+ * @param app_name  Name of the application.
+ * @param task_getter Callback to get the current task name.
+ */
+void log_init(const char * app_name, logging_task_name_get task_getter) {
+    format_specs.app_name = app_name;
+    format_specs.task_name_getter = task_getter;
+}
+
 
 void log_message(const char* format, ...) {
     va_list argp;
     va_start(argp, format);
 
+    char buff[256];
+
     auto sigblock = boost::asio::detail::posix_signal_blocker{};
-    vprintf(format, argp);
+    vsnprintf(buff, sizeof(buff), format, argp);
+
+    const char * task_name = format_specs.task_name_getter ? format_specs.task_name_getter() : "none";
+
+    printf("[%s] [%s] %s\n",
+               format_specs.app_name.c_str(),
+               task_name,
+               buff);
 
     va_end(argp);
 }

--- a/common/simulation/spi.cpp
+++ b/common/simulation/spi.cpp
@@ -14,7 +14,7 @@ bool sim_spi::SimSpiDeviceBase::transmit_receive(
     iter = bit_utils::bytes_to_int(iter, transmit.end(), control);
     iter = bit_utils::bytes_to_int(iter, transmit.end(), data);
 
-    LOG("transmit_receive: control=%d, data=%d\n", control, data);
+    LOG("transmit_receive: control=%d, data=%d", control, data);
 
     constexpr uint8_t write_mask =
         static_cast<uint8_t>(spi::SpiDeviceBase::Mode::WRITE);

--- a/gantry/core/can_task.cpp
+++ b/gantry/core/can_task.cpp
@@ -77,7 +77,7 @@ auto static writer_task_control =
  */
 auto can_task::start_reader(can_bus::CanBus& canbus)
     -> can_task::CanMessageReaderTask& {
-    LOG("Starting the CAN reader task\n");
+    LOG("Starting the CAN reader task");
 
     canbus.setup_node_id_filter(my_node_id);
 
@@ -93,7 +93,7 @@ auto can_task::start_reader(can_bus::CanBus& canbus)
  */
 auto can_task::start_writer(can_bus::CanBus& canbus)
     -> can_task::CanMessageWriterTask& {
-    LOG("Starting the CAN writer task\n");
+    LOG("Starting the CAN writer task");
 
     writer_task_control.start(5, "can writer task", &canbus);
     return writer_task;

--- a/gantry/simulator/main.cpp
+++ b/gantry/simulator/main.cpp
@@ -13,6 +13,8 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
+    LOG_INIT(get_axis_type() == GantryAxisType.gantry_x ? "GANTRY-X" : "GANTRY-Y", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+
     interfaces::initialize();
 
     gantry_tasks::start_tasks(interfaces::get_can_bus(),

--- a/gantry/simulator/main.cpp
+++ b/gantry/simulator/main.cpp
@@ -6,7 +6,7 @@
 #include "task.h"
 
 void signal_handler(int signum) {
-    LOG("Interrupt signal (%d) received.\n", signum);
+    LOG("Interrupt signal (%d) received.", signum);
     exit(signum);
 }
 

--- a/gantry/simulator/main.cpp
+++ b/gantry/simulator/main.cpp
@@ -1,6 +1,7 @@
 #include <signal.h>
 
 #include "FreeRTOS.h"
+#include "gantry/core/axis_type.h"
 #include "gantry/core/interfaces.hpp"
 #include "gantry/core/tasks.hpp"
 #include "task.h"
@@ -13,7 +14,11 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
-    LOG_INIT(get_axis_type() == GantryAxisType.gantry_x ? "GANTRY-X" : "GANTRY-Y", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+    LOG_INIT(
+        get_axis_type() == GantryAxisType::gantry_x ? "GANTRY-X" : "GANTRY-Y",
+        []() -> const char* {
+            return pcTaskGetName(xTaskGetCurrentTaskHandle());
+        });
 
     interfaces::initialize();
 

--- a/gripper/core/can_tasks.cpp
+++ b/gripper/core/can_tasks.cpp
@@ -78,7 +78,7 @@ auto static writer_task_control =
  */
 auto can_task::start_reader(can_bus::CanBus& canbus)
     -> can_task::CanMessageReaderTask& {
-    LOG("Starting the CAN reader task\n");
+    LOG("Starting the CAN reader task");
 
     canbus.setup_node_id_filter(can_ids::NodeId::gripper);
 
@@ -94,7 +94,7 @@ auto can_task::start_reader(can_bus::CanBus& canbus)
  */
 auto can_task::start_writer(can_bus::CanBus& canbus)
     -> can_task::CanMessageWriterTask& {
-    LOG("Starting the CAN writer task\n");
+    LOG("Starting the CAN writer task");
 
     writer_task_control.start(5, "can writer task", &canbus);
     return writer_task;

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -13,7 +13,9 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
-    LOG_INIT("GRIPPER", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+    LOG_INIT("GRIPPER", []() -> const char* {
+        return pcTaskGetName(xTaskGetCurrentTaskHandle());
+    });
 
     interfaces::initialize();
 

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -6,7 +6,7 @@
 #include "task.h"
 
 void signal_handler(int signum) {
-    LOG("Interrupt signal (%d) received.\n", signum);
+    LOG("Interrupt signal (%d) received.", signum);
     exit(signum);
 }
 

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -13,6 +13,8 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
+    LOG_INIT("GRIPPER", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+
     interfaces::initialize();
 
     gripper_tasks::start_tasks(

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -111,8 +111,17 @@ void signal_handler(int signum) {
     exit(signum);
 }
 
+/**
+ *
+ * @return
+ */
+const char * get_task_name() { return pcTaskGetName(xTaskGetCurrentTaskHandle()); }
+
+
 int main() {
     signal(SIGINT, signal_handler);
+
+    LOG_INIT("HEAD", get_task_name);
 
     head_tasks::start_tasks(canbus, motor_left.motion_controller,
                             motor_left.driver, motor_right.motion_controller,

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -111,18 +111,11 @@ void signal_handler(int signum) {
     exit(signum);
 }
 
-/**
- *
- * @return
- */
-const char* get_task_name() {
-    return pcTaskGetName(xTaskGetCurrentTaskHandle());
-}
 
 int main() {
     signal(SIGINT, signal_handler);
 
-    LOG_INIT("HEAD", get_task_name);
+    LOG_INIT("HEAD", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
 
     head_tasks::start_tasks(canbus, motor_left.motion_controller,
                             motor_left.driver, motor_right.motion_controller,

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -115,8 +115,9 @@ void signal_handler(int signum) {
  *
  * @return
  */
-const char * get_task_name() { return pcTaskGetName(xTaskGetCurrentTaskHandle()); }
-
+const char* get_task_name() {
+    return pcTaskGetName(xTaskGetCurrentTaskHandle());
+}
 
 int main() {
     signal(SIGINT, signal_handler);

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -111,11 +111,12 @@ void signal_handler(int signum) {
     exit(signum);
 }
 
-
 int main() {
     signal(SIGINT, signal_handler);
 
-    LOG_INIT("HEAD", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+    LOG_INIT("HEAD", []() -> const char* {
+        return pcTaskGetName(xTaskGetCurrentTaskHandle());
+    });
 
     head_tasks::start_tasks(canbus, motor_left.motion_controller,
                             motor_left.driver, motor_right.motion_controller,

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -107,7 +107,7 @@ static auto presence_sense_driver =
     presence_sensing_driver::PresenceSensingDriver(adc_comms);
 
 void signal_handler(int signum) {
-    LOG("Interrupt signal (%d) received.\n", signum);
+    LOG("Interrupt signal (%d) received.", signum);
     exit(signum);
 }
 

--- a/include/can/simlib/sim_canbus.hpp
+++ b/include/can/simlib/sim_canbus.hpp
@@ -77,7 +77,7 @@ class SimCANBus : public CanBus {
         void operator()(SimCANBus* bus) {
             while (true) {
                 if (!bus->transport->open()) {
-                    LOG("Failed to connect.\n");
+                    LOG("Failed to connect.");
 
                     auto sigblock = boost::asio::detail::posix_signal_blocker{};
                     struct timespec tspec;
@@ -100,7 +100,7 @@ class SimCANBus : public CanBus {
 
                 if (!bus->transport->read(arb_id, read_buffer.data(),
                                           read_length)) {
-                    LOG("Disconnected.\n");
+                    LOG("Disconnected.");
                     break;
                 }
 
@@ -116,7 +116,7 @@ class SimCANBus : public CanBus {
                             read_buffer.begin(), read_length);
                     }
                 } else {
-                    LOG("Message with arb_id %X and length %d is rejected\n",
+                    LOG("Message with arb_id %X and length %d is rejected",
                         arb_id, read_length);
                 }
             }

--- a/include/can/simlib/socket_transport.hpp
+++ b/include/can/simlib/socket_transport.hpp
@@ -41,7 +41,7 @@ class SocketTransport : public can_transport::BusTransportBase {
 
 template <synchronization::LockableProtocol CriticalSection>
 auto SocketTransport<CriticalSection>::open() -> bool {
-    LOG("Creating connection to %s:%d\n", host.c_str(), port);
+    LOG("Creating connection to %s:%d", host.c_str(), port);
 
     tcp::resolver resolver(context);
     try {
@@ -51,7 +51,7 @@ auto SocketTransport<CriticalSection>::open() -> bool {
         return false;
     }
 
-    LOG("Connected to %s:%d\n", host.c_str(), port);
+    LOG("Connected to %s:%d", host.c_str(), port);
     return true;
 }
 
@@ -64,7 +64,7 @@ template <synchronization::LockableProtocol CriticalSection>
 auto SocketTransport<CriticalSection>::write(uint32_t arb_id,
                                              const uint8_t *buff,
                                              uint32_t buff_len) -> bool {
-    LOG("Sending: arbitration %X dlc %d\n", arb_id, buff_len);
+    LOG("Sending: arbitration %X dlc %d", arb_id, buff_len);
 
     // Critical section block
     auto lock = synchronization::Lock(critical_section);
@@ -109,7 +109,7 @@ auto SocketTransport<CriticalSection>::read(uint32_t &arb_id, uint8_t *buff,
     buff_len = std::min(static_cast<uint32_t>(message_core::MaxMessageSize),
                         ntohl(buff_len));
 
-    LOG("Read: arbitration %X dlc %d\n", arb_id, buff_len);
+    LOG("Read: arbitration %X dlc %d", arb_id, buff_len);
     if (buff_len > 0) {
         if (boost::asio::read(socket, boost::asio::buffer(buff, buff_len)) <
             buff_len)

--- a/include/can/simlib/socketcan_transport.hpp
+++ b/include/can/simlib/socketcan_transport.hpp
@@ -47,7 +47,7 @@ auto SocketCanTransport<CriticalSection>::open() -> bool {
     int s = 0;
     constexpr int use_canfd = 1;
 
-    LOG("Trying to connect to %s\n", address.c_str());
+    LOG("Trying to connect to %s", address.c_str());
 
     if ((s = socket(PF_CAN, SOCK_RAW, CAN_RAW)) == -1) {
         return false;
@@ -68,7 +68,7 @@ auto SocketCanTransport<CriticalSection>::open() -> bool {
     if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
         return false;
     }
-    LOG("Connected to %s\n", address.c_str());
+    LOG("Connected to %s", address.c_str());
     handle = s;
     return true;
 }
@@ -87,7 +87,7 @@ auto SocketCanTransport<CriticalSection>::write(uint32_t arb_id,
     frame.can_id = arb_id | (1 << 31);
     frame.len = buff_len;
     ::memcpy(frame.data, cbuff, buff_len);
-    LOG("Writing: arb_id %X dlc %d\n", arb_id, buff_len);
+    LOG("Writing: arb_id %X dlc %d", arb_id, buff_len);
     auto lock = synchronization::Lock(critical_section);
     return ::write(handle, &frame, sizeof(struct can_frame)) > 0;
 }
@@ -109,11 +109,11 @@ auto SocketCanTransport<CriticalSection>::read(uint32_t &arb_id, uint8_t *buff,
         buff_len = frame.len;
         ::memcpy(buff, frame.data, buff_len);
 
-        LOG("Read: arb_id %X dlc %d\n", arb_id, buff_len);
+        LOG("Read: arb_id %X dlc %d", arb_id, buff_len);
 
         return true;
     } else {
-        LOG("Read failed: %d\n", errno);
+        LOG("Read failed: %d", errno);
     }
     return false;
 }

--- a/include/common/core/freertos_task.hpp
+++ b/include/common/core/freertos_task.hpp
@@ -52,7 +52,7 @@ class FreeRTOSTask {
         auto instance =
             static_cast<FreeRTOSTask<StackDepth, EntryPoint, TaskArgs...>*>(
                 instance_data->first);
-        LOG("Entering task: %s\n", pcTaskGetName(instance->handle));
+        LOG("Entering task: %s", pcTaskGetName(instance->handle));
         // Call the entry point with the argument
         std::apply(instance->entry_point, instance_data->second);
     }

--- a/include/common/core/logging.h
+++ b/include/common/core/logging.h
@@ -4,22 +4,41 @@
 extern "C" {
 #endif  // __cplusplus
 
+
 #ifdef ENABLE_LOGGING
 
 #include <stdarg.h>
+
+
+/**
+ * Call back to get the current task name.
+ */
+typedef const char * (*logging_task_name_get)();
+
+/**
+ * Initialize logging
+ * @param app_name  Name of the application.
+ * @param task_getter Callback to get the current task name.
+ */
+void log_init(const char * app_name, logging_task_name_get task_getter);
 
 /**
  * Log message function. Not to be used directly. Use LOG macro.
  */
 void log_message(const char * format, ...);
 
+
 #define LOG(format, ...) log_message(format, ## __VA_ARGS__)
+
+#define LOG_INIT(name, task_getter) log_init(name, task_getter)
 
 #else
 
 #define LOG(...)
+#define LOG_INIT(...)
 
 #endif
+
 
 
 #ifdef __cplusplus

--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -5,7 +5,7 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
-#include "common/core/logging.hpp"
+#include "common/core/logging.h"
 #include "motor-control/core/brushed_motor/driver_interface.hpp"
 #include "motor-control/core/tasks/messages.hpp"
 

--- a/include/motor-control/core/tasks/motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/motion_controller_task.hpp
@@ -40,17 +40,17 @@ class MotionControllerMessageHandler {
     void handle(std::monostate m) { static_cast<void>(m); }
 
     void handle(const can_messages::StopRequest& m) {
-        LOG("Received stop request\n");
+        LOG("Received stop request");
         controller.stop();
     }
 
     void handle(const can_messages::EnableMotorRequest& m) {
-        LOG("Received enable motor request\n");
+        LOG("Received enable motor request");
         controller.enable_motor();
     }
 
     void handle(const can_messages::DisableMotorRequest& m) {
-        LOG("Received disable motor request\n");
+        LOG("Received disable motor request");
         controller.disable_motor();
     }
 
@@ -62,13 +62,13 @@ class MotionControllerMessageHandler {
             .min_acceleration = constraints.min_acceleration,
             .max_acceleration = constraints.max_acceleration,
         };
-        LOG("Received get motion constraints request\n");
+        LOG("Received get motion constraints request");
         can_client.send_can_message(can_ids::NodeId::host, response_msg);
     }
 
     void handle(const can_messages::SetMotionConstraints& m) {
         LOG("Received set motion constraints: minvel=%d, maxvel=%d, minacc=%d, "
-            "maxacc=%d\n",
+            "maxacc=%d",
             m.min_velocity, m.max_velocity, m.min_acceleration,
             m.max_acceleration);
         controller.set_motion_constraints(m);
@@ -76,7 +76,7 @@ class MotionControllerMessageHandler {
 
     void handle(const can_messages::AddLinearMoveRequest& m) {
         LOG("Received add linear move request: velocity=%d, acceleration=%d, "
-            "groupid=%d, seqid=%d, duration=%d, stopcondition=%d\n",
+            "groupid=%d, seqid=%d, duration=%d, stopcondition=%d",
             m.velocity, m.acceleration, m.group_id, m.seq_id, m.duration,
             m.request_stop_condition);
         controller.move(m);
@@ -84,14 +84,14 @@ class MotionControllerMessageHandler {
 
     void handle(const can_messages::HomeRequest& m) {
         LOG("Received home request: velocity=%d, "
-            "groupid=%d, seqid=%d\n",
+            "groupid=%d, seqid=%d",
             m.velocity, m.group_id, m.seq_id);
         controller.move(m);
     }
 
     void handle(const can_messages::ReadLimitSwitchRequest& m) {
         auto response = static_cast<uint8_t>(controller.read_limit_switch());
-        LOG("Received read limit switch: limit_switch=%d\n", response);
+        LOG("Received read limit switch: limit_switch=%d", response);
         can_messages::ReadLimitSwitchResponse msg{{}, response};
         can_client.send_can_message(can_ids::NodeId::host, msg);
     }

--- a/include/motor-control/core/tasks/motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/motor_driver_task.hpp
@@ -42,12 +42,12 @@ class MotorDriverMessageHandler {
     void handle(std::monostate m) { static_cast<void>(m); }
 
     void handle(const can_messages::SetupRequest& m) {
-        LOG("Received motor setup request\n");
+        LOG("Received motor setup request");
         driver.setup();
     }
 
     void handle(const can_messages::WriteMotorDriverRegister& m) {
-        LOG("Received write motor driver request: addr=%d, data=%d\n",
+        LOG("Received write motor driver request: addr=%d, data=%d",
             m.reg_address, m.data);
         if (motor_driver_config::DriverRegisters::is_valid_address(
                 m.reg_address)) {
@@ -56,7 +56,7 @@ class MotorDriverMessageHandler {
     }
 
     void handle(const can_messages::ReadMotorDriverRegister& m) {
-        LOG("Received read motor driver request: addr=%d\n", m.reg_address);
+        LOG("Received read motor driver request: addr=%d", m.reg_address);
         uint32_t data = 0;
         if (motor_driver_config::DriverRegisters::is_valid_address(
                 m.reg_address)) {
@@ -71,7 +71,7 @@ class MotorDriverMessageHandler {
 
     void handle(const can_messages::WriteMotorCurrentRequest& m) {
         LOG("Received write motor current request: hold_current=%d, "
-            "run_current=%d\n",
+            "run_current=%d",
             m.hold_current, m.run_current);
 
         if (m.hold_current != 0U) {

--- a/include/motor-control/core/tasks/move_group_task.hpp
+++ b/include/motor-control/core/tasks/move_group_task.hpp
@@ -53,19 +53,19 @@ class MoveGroupMessageHandler {
     void handle(std::monostate m) { static_cast<void>(m); }
 
     void handle(const can_messages::AddLinearMoveRequest& m) {
-        LOG("Received add linear move request: groupid=%d, seqid=%d\n",
+        LOG("Received add linear move request: groupid=%d, seqid=%d",
             m.group_id, m.seq_id);
         static_cast<void>(move_groups[m.group_id].set_move(m));
     }
 
     void handle(const can_messages::HomeRequest& m) {
-        LOG("Received home request: groupid=%d, seqid=%d\n", m.group_id,
+        LOG("Received home request: groupid=%d, seqid=%d", m.group_id,
             m.seq_id);
         static_cast<void>(move_groups[m.group_id].set_move(m));
     }
 
     void handle(const can_messages::GetMoveGroupRequest& m) {
-        LOG("Received get move group request: groupid=%d\n", m.group_id);
+        LOG("Received get move group request: groupid=%d", m.group_id);
         auto group = move_groups[m.group_id];
         auto response = can_messages::GetMoveGroupResponse{
             .group_id = m.group_id,
@@ -75,14 +75,14 @@ class MoveGroupMessageHandler {
     }
 
     void handle(const can_messages::ClearAllMoveGroupsRequest& m) {
-        LOG("Received clear move groups request\n");
+        LOG("Received clear move groups request");
         for (auto& group : move_groups) {
             group.clear();
         }
     }
 
     void handle(const can_messages::ExecuteMoveGroupRequest& m) {
-        LOG("Received execute move group request: groupid=%d\n", m.group_id);
+        LOG("Received execute move group request: groupid=%d", m.group_id);
         auto group = move_groups[m.group_id];
         for (std::size_t i = 0; i < max_moves_per_group; i++) {
             auto move = group.get_move(i);

--- a/include/motor-control/simulation/motor_interrupt_driver.hpp
+++ b/include/motor-control/simulation/motor_interrupt_driver.hpp
@@ -33,12 +33,12 @@ class MotorInterruptDriver {
                 auto move = motor_messages::Move{};
                 if (queue.peek(&move, queue.max_delay)) {
                     LOG("Enabling motor interrupt handler for group %d, seq "
-                        "%d, duration %ld\n",
+                        "%d, duration %ld",
                         move.group_id, move.seq_id, move.duration);
                     do {
                         handler.run_interrupt();
                     } while (handler.has_active_move);
-                    LOG("Move completed. Stopping interrupt simulation..\n");
+                    LOG("Move completed. Stopping interrupt simulation..");
                 }
             }
         }

--- a/include/pipettes/core/tasks/eeprom_task.hpp
+++ b/include/pipettes/core/tasks/eeprom_task.hpp
@@ -58,12 +58,12 @@ class EEPromMessageHandler {
     void visit(std::monostate &m) {}
 
     void visit(can_messages::WriteToEEPromRequest &m) {
-        LOG("Received request to write serial number: %d\n", m.serial_number);
+        LOG("Received request to write serial number: %d", m.serial_number);
         writer.write(m.serial_number, DEVICE_ADDRESS);
     }
 
     void visit(can_messages::ReadFromEEPromRequest &m) {
-        LOG("Received request to read serial number\n");
+        LOG("Received request to read serial number");
         writer.read(
             DEVICE_ADDRESS, [this]() { handler.send_to_can(); },
             [this](auto message_a) { handler.handle_data(message_a); });

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -48,12 +48,12 @@ struct ReadCapacitanceCallback {
             {}, SensorType::capacitive, capacitance};
         can_client.send_can_message(can_ids::NodeId::host, message);
         if (capacitance > zero_threshold || capacitance < -zero_threshold) {
-            LOG("Capacitance %d exceeds zero threshold %d \n", capacitance,
+            LOG("Capacitance %d exceeds zero threshold %d ", capacitance,
                 zero_threshold);
             auto capdac = update_capdac(capacitance, current_offset);
             // convert back to pF
             current_offset = get_offset_pf(capdac);
-            LOG("Setting offset to %d \n", static_cast<int>(current_offset));
+            LOG("Setting offset to %d ", static_cast<int>(current_offset));
             uint16_t update = CONFIGURATION_MEASUREMENT |
                               POSITIVE_INPUT_CHANNEL | NEGATIVE_INPUT_CHANNEL |
                               capdac;

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -60,7 +60,7 @@ class CapacitiveMessageHandler {
          * may occur on the capacitve sensor.
          *
          */
-        LOG("Received request to read from %d sensor\n", m.sensor);
+        LOG("Received request to read from %d sensor", m.sensor);
         capdac_offset = capacitance_handler.get_offset();
         if (bool(m.offset_reading)) {
             auto message = can_messages::ReadFromSensorResponse{
@@ -81,13 +81,13 @@ class CapacitiveMessageHandler {
     }
 
     void visit(can_messages::WriteToSensorRequest &m) {
-        LOG("Received request to write data %d to %d sensor\n", m.data,
+        LOG("Received request to write data %d to %d sensor", m.data,
             m.sensor);
         writer.write(m.data, ADDRESS);
     }
 
     void visit(can_messages::BaselineSensorRequest &m) {
-        LOG("Received request to read from %d sensor\n", m.sensor);
+        LOG("Received request to read from %d sensor", m.sensor);
         capdac_offset = capacitance_handler.get_offset();
         capacitance_handler.reset();
         capacitance_handler.set_number_of_reads(m.sample_rate);
@@ -101,7 +101,7 @@ class CapacitiveMessageHandler {
     }
 
     void visit(can_messages::SetSensorThresholdRequest &m) {
-        LOG("Received request to set threshold to %d from %d sensor\n",
+        LOG("Received request to set threshold to %d from %d sensor",
             m.threshold, m.sensor);
         zero_threshold = m.threshold;
         auto message = can_messages::SensorThresholdResponse{

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -81,8 +81,7 @@ class CapacitiveMessageHandler {
     }
 
     void visit(can_messages::WriteToSensorRequest &m) {
-        LOG("Received request to write data %d to %d sensor", m.data,
-            m.sensor);
+        LOG("Received request to write data %d to %d sensor", m.data, m.sensor);
         writer.write(m.data, ADDRESS);
     }
 

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -62,8 +62,7 @@ class EnvironmentSensorMessageHandler {
     void visit(can_messages::SetSensorThresholdRequest &m) {}
 
     void visit(can_messages::WriteToSensorRequest &m) {
-        LOG("Received request to write data %d to %d sensor", m.data,
-            m.sensor);
+        LOG("Received request to write data %d to %d sensor", m.data, m.sensor);
         writer.write(m.data, ADDRESS);
     }
 

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -62,13 +62,13 @@ class EnvironmentSensorMessageHandler {
     void visit(can_messages::SetSensorThresholdRequest &m) {}
 
     void visit(can_messages::WriteToSensorRequest &m) {
-        LOG("Received request to write data %d to %d sensor\n", m.data,
+        LOG("Received request to write data %d to %d sensor", m.data,
             m.sensor);
         writer.write(m.data, ADDRESS);
     }
 
     void visit(can_messages::ReadFromSensorRequest &m) {
-        LOG("Received request to read from %d sensor\n", m.sensor);
+        LOG("Received request to read from %d sensor", m.sensor);
         if (SensorType(m.sensor) == SensorType::humidity) {
             writer.write(HUMIDITY_REGISTER, ADDRESS);
             writer.read(

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -83,23 +83,23 @@ static motor_class::Motor pipette_motor{
 
 static auto node_from_env(const char* env) -> can_ids::NodeId {
     if (!env) {
-        LOG("On left mount by default\n");
+        LOG("On left mount by default");
         return can_ids::NodeId::pipette_left;
     }
     if (strncmp(env, "left", strlen("left")) == 0) {
-        LOG("On left mount from env var\n");
+        LOG("On left mount from env var");
         return can_ids::NodeId::pipette_left;
     } else if (strncmp(env, "right", strlen("right")) == 0) {
-        LOG("On right mount from env var\n");
+        LOG("On right mount from env var");
         return can_ids::NodeId::pipette_right;
     } else {
-        LOG("On left mount from invalid env var\n");
+        LOG("On left mount from invalid env var");
         return can_ids::NodeId::pipette_left;
     }
 }
 
 void signal_handler(int signum) {
-    LOG("Interrupt signal (%d) received.\n", signum);
+    LOG("Interrupt signal (%d) received.", signum);
     exit(signum);
 }
 

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -106,6 +106,8 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
+    LOG_INIT("PIPETTE", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+
     pipettes_tasks::start_tasks(can_bus_1, pipette_motor.motion_controller,
                                 pipette_motor.driver, i2c_comms,
                                 node_from_env(std::getenv("MOUNT")));

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -106,7 +106,9 @@ void signal_handler(int signum) {
 int main() {
     signal(SIGINT, signal_handler);
 
-    LOG_INIT("PIPETTE", []() -> const char * {return pcTaskGetName(xTaskGetCurrentTaskHandle());});
+    LOG_INIT("PIPETTE", []() -> const char* {
+        return pcTaskGetName(xTaskGetCurrentTaskHandle());
+    });
 
     pipettes_tasks::start_tasks(can_bus_1, pipette_motor.motion_controller,
                                 pipette_motor.driver, i2c_comms,


### PR DESCRIPTION
Add timestamp, subsystem, and freertos task to logging. 

I tried using Boost but it was brutal. There were some weird cmake hacks I had to make just to get it to (almost) build. I cursed and gave up.

```
[2022-03-14T14:53:27.642285] [GANTRY-Y] [motor-driver] transmit_receive: control=144, data=464898
[2022-03-14T14:53:27.642289] [GANTRY-Y] [motor-driver] transmit_receive: control=145, data=0
[2022-03-14T14:53:27.642293] [GANTRY-Y] [motor-driver] transmit_receive: control=148, data=0
[2022-03-14T14:53:27.642297] [GANTRY-Y] [motor-driver] transmit_receive: control=149, data=1048575
[2022-03-14T14:53:27.642302] [GANTRY-Y] [motor-driver] transmit_receive: control=236, data=50397653
[2022-03-14T14:53:27.642306] [GANTRY-Y] [motor-driver] transmit_receive: control=237, data=393216
[2022-03-14T14:53:27.642324] [GANTRY-Y] [move-group] Entering task: move-group
[2022-03-14T14:53:27.646325] [GANTRY-Y] [] Connected to localhost:9898
[2022-03-14T14:53:27.724018] [HEAD] [move-status] Entering task: move-status
[2022-03-14T14:53:27.724684] [HEAD] [] Entering task:
[2022-03-14T14:53:27.724711] [HEAD] [] Creating connection to localhost:9898
[2022-03-14T14:53:27.725078] [HEAD] [sim_motor_isr] Entering task: sim_motor_isr
[2022-03-14T14:53:27.725113] [HEAD] [sim_motor_isr] Entering task: sim_motor_isr
[2022-03-14T14:53:27.725144] [HEAD] [can writer task] Entering task: can writer task
[2022-03-14T14:53:27.725171] [HEAD] [can reader task] Entering task: can reader task
[2022-03-14T14:53:27.725203] [HEAD] [presence-sensin] Entering task: presence-sensin
[2022-03-14T14:53:27.725228] [HEAD] [motion-ctrl] Entering task: motion-ctrl
[2022-03-14T14:53:27.725251] [HEAD] [motor-driver] Entering task: motor-driver
[2022-03-14T14:53:27.725259] [HEAD] [motor-driver] transmit_receive: control=128, data=4
[2022-03-14T14:53:27.725263] [HEAD] [motor-driver] transmit_receive: control=144, data=462850
```