### PR TITLE
fix(build): proper deps for combined hex files

### DIFF
--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -219,7 +219,7 @@ add_custom_target(gantry-debug-y
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
         OUTPUT gantry-x-image.hex
-        DEPENDS gantry-x-hex bootloader-gantry-x-hex
+        DEPENDS gantry-x-hex bootloader-gantry-x-hex gantry-x.hex $<TARGET_FILE_DIR:bootloader-gantry-x>/bootloader-gantry-x.hex
         COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py gantry-x-image.hex $<TARGET_FILE_DIR:bootloader-gantry-x>/bootloader-gantry-x.hex gantry-x.hex
         VERBATIM)
 add_custom_target(gantry-x-image-hex ALL
@@ -227,7 +227,7 @@ add_custom_target(gantry-x-image-hex ALL
 
 add_custom_command(
         OUTPUT gantry-y-image.hex
-        DEPENDS gantry-y-hex bootloader-gantry-y-hex
+        DEPENDS gantry-y-hex bootloader-gantry-y-hex gantry-y.hex $<TARGET_FILE_DIR:bootloader-gantry-y>/bootloader-gantry-y.hex
         COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py gantry-y-image.hex $<TARGET_FILE_DIR:bootloader-gantry-y>/bootloader-gantry-y.hex gantry-y.hex
         VERBATIM)
 add_custom_target(gantry-y-image-hex ALL

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -154,7 +154,7 @@ add_custom_target(gripper-debug
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
         OUTPUT gripper-image.hex
-        DEPENDS gripper-hex bootloader-gripper-hex
+        DEPENDS gripper-hex bootloader-gripper-hex gripper.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
         COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py gripper-image.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex gripper.hex
         VERBATIM)
 add_custom_target(gripper-image-hex ALL

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -150,7 +150,7 @@ add_custom_target(head-debug
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
         OUTPUT head-image.hex
-        DEPENDS head-hex bootloader-head-hex
+        DEPENDS head-hex bootloader-head-hex head.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex
         COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py head-image.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex head.hex
         VERBATIM)
 add_custom_target(head-image-hex ALL

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -155,7 +155,7 @@ add_custom_target(pipettes-debug
 # Targets to create full image hex file containing both bootloader and application
 add_custom_command(
         OUTPUT pipettes-image.hex
-        DEPENDS pipettes-hex bootloader-pipettes-hex
+        DEPENDS pipettes-hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex pipettes.hex
         COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py pipettes-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex pipettes.hex
         VERBATIM)
 add_custom_target(pipettes-image-hex ALL


### PR DESCRIPTION
Now that we have bootloaders, the thing we flash when we run a
`project-flash` target is a hex file created by a python script
combining an application hex file and a bootloader hex file.

This was done in cmake by having custom commands+targets for the
application and hex files, and then a custom command+target for the
combined hex called `target-hex-image`.

The custom command for `target-hex-image` had a DEPENDS for the custom
target portion of the application and bootloader hexes. Unfortunately,
per https://cmake.org/cmake/help/v3.21/command/add_custom_command.html,
a DEPENDS argument that is a custom target creates a target level
dependency "to make sure the target is built before any target using
this custom command"; but because the DEPENDS arg is a custom target and
_not_ a library or executable, it does _not_ create a file-level
dependency to cause the command to rerun when its deps change.

That means that `$TARGET-image-hex` and `$TARGET-image.hex` (which is
the one used by the `$TARGET-flash` command) was stealthily not being
rebuilt when you changed source code, even though the actual application
was. This meant changes would not apply until you used the
`$TARGET-debug` target, which does not use the combined hex image.

The way to fix this (and what this commit does) is to not only have a
dependency on the custom targets for the individual application/binary
hexes, but also have direct file dependencies on their outputs; this
creates the proper deps and now the combined image gets rebuilt properly.