### PR TITLE
fix(motor-control): homing fixups

### DIFF
--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -168,6 +168,9 @@ class MotorInterruptHandler {
 
     void update_move() {
         has_active_move = queue.try_read_isr(&buffered_move);
+        if (buffered_move.stop_condition == MoveStopCondition::limit_switch) {
+            position_tracker = 0x7FFFFFFFFFFFFFFF;
+        }
         // (TODO: lc) We should check the direction (and set respectively)
         // the direction pin for the motor once a move is being pulled off the
         // queue stack. We'll probably want to think about moving the hardware

--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -106,7 +106,8 @@ class MotorInterruptHandler {
         }
         if (has_active_move) {
             if (buffered_move.stop_condition ==
-                MoveStopCondition::limit_switch && homing_stopped()) {
+                    MoveStopCondition::limit_switch &&
+                homing_stopped()) {
                 return false;
             }
             if (can_step() && tick()) {
@@ -169,7 +170,8 @@ class MotorInterruptHandler {
 
     void update_move() {
         has_active_move = queue.try_read_isr(&buffered_move);
-        if (has_active_move && buffered_move.stop_condition == MoveStopCondition::limit_switch) {
+        if (has_active_move &&
+            buffered_move.stop_condition == MoveStopCondition::limit_switch) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
         }
         // (TODO: lc) We should check the direction (and set respectively)

--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -106,20 +106,13 @@ class MotorInterruptHandler {
         }
         if (has_active_move) {
             if (buffered_move.stop_condition ==
-                MoveStopCondition::limit_switch) {
-                if (homing_stopped()) {
-                    return false;
-                }
+                MoveStopCondition::limit_switch && homing_stopped()) {
+                return false;
             }
             if (can_step() && tick()) {
                 return true;
             }
             if (!can_step()) {
-                if (buffered_move.stop_condition ==
-                    MoveStopCondition::limit_switch) {
-                    finish_current_move();
-                    return false;
-                }
                 finish_current_move();
                 if (has_messages()) {
                     update_move();

--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -129,6 +129,7 @@ class MotorInterruptHandler {
     auto homing_stopped() -> bool {
         if (limit_switch_triggered()) {
             finish_current_move(AckMessageId::stopped_by_condition);
+            position_tracker = 0;
             return true;
         }
         return false;
@@ -168,7 +169,7 @@ class MotorInterruptHandler {
 
     void update_move() {
         has_active_move = queue.try_read_isr(&buffered_move);
-        if (buffered_move.stop_condition == MoveStopCondition::limit_switch) {
+        if (has_active_move && buffered_move.stop_condition == MoveStopCondition::limit_switch) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
         }
         // (TODO: lc) We should check the direction (and set respectively)

--- a/include/motor-control/core/tmc2130.hpp
+++ b/include/motor-control/core/tmc2130.hpp
@@ -15,6 +15,9 @@
 #include "tmc2130_config.hpp"
 #include "tmc2130_registers.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
 namespace tmc2130 {
 
 using namespace std::numbers;
@@ -370,3 +373,4 @@ class TMC2130 {
 };
 
 }  // namespace tmc2130
+#pragma GCC diagnostic pop

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -38,14 +38,17 @@ TEST_CASE("Move with stop condition == limit switch") {
         test_objs.queue.try_write_isr(msg1);
         WHEN("the limit switch has been triggered") {
             test_objs.hw.set_mock_lim_sw(true);
-            CHECK(!test_objs.handler.pulse());
+            REQUIRE(!test_objs.handler.pulse());
+            (test_objs.handler.get_current_position() ==
+             0x7FFFFFFFFFFFFFFF);
             CHECK(!test_objs.handler.pulse());
             CHECK(!test_objs.handler.pulse());
             CHECK(!test_objs.handler.pulse());
             THEN(
                 "the move should be stopped with ack id = stopped by "
-                "condition") {
+                "condition, and position should be reset") {
                 REQUIRE(!test_objs.handler.pulse());
+                REQUIRE(test_objs.handler.get_current_position() == 0);
                 REQUIRE(test_objs.reporter.messages.size() >= 1);
                 Ack read_ack = test_objs.reporter.messages.back();
                 REQUIRE(read_ack.ack_id == AckMessageId::stopped_by_condition);
@@ -67,8 +70,10 @@ TEST_CASE("Move with stop condition == limit switch, case 2") {
         CHECK(!test_objs.handler.pulse());
         WHEN("the move is finished") {
             THEN("the move should have ack_id complete_without_condition") {
+                REQUIRE(test_objs.handler.get_current_position() ==
+                        0x7FFFFFFFFFFFFFFF);
                 REQUIRE(!test_objs.handler.pulse());
-                REQUIRE(test_objs.handler.pulse());
+                REQUIRE(!test_objs.handler.pulse());
                 REQUIRE(!test_objs.handler.pulse());
                 REQUIRE(test_objs.reporter.messages.size() >= 1);
                 Ack read_ack = test_objs.reporter.messages.back();
@@ -91,6 +96,8 @@ TEST_CASE("Move with stop condition != limit switch") {
         test_objs.hw.set_mock_lim_sw(true);
         CHECK(!test_objs.handler.pulse());
         WHEN("the move is finished") {
+            REQUIRE(test_objs.handler.get_current_position() !=
+                    0x7FFFFFFFFFFFFFFF);
             REQUIRE(!test_objs.handler.pulse());
             REQUIRE(test_objs.handler.pulse());
             REQUIRE(!test_objs.handler.pulse());

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -39,8 +39,7 @@ TEST_CASE("Move with stop condition == limit switch") {
         WHEN("the limit switch has been triggered") {
             test_objs.hw.set_mock_lim_sw(true);
             REQUIRE(!test_objs.handler.pulse());
-            (test_objs.handler.get_current_position() ==
-             0x7FFFFFFFFFFFFFFF);
+            (test_objs.handler.get_current_position() == 0x7FFFFFFFFFFFFFFF);
             CHECK(!test_objs.handler.pulse());
             CHECK(!test_objs.handler.pulse());
             CHECK(!test_objs.handler.pulse());

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -36,21 +36,29 @@ TEST_CASE("Move with stop condition == limit switch") {
 
     GIVEN("the move is in progress") {
         test_objs.queue.try_write_isr(msg1);
-        WHEN("the limit switch has been triggered") {
-            test_objs.hw.set_mock_lim_sw(true);
-            REQUIRE(!test_objs.handler.pulse());
-            (test_objs.handler.get_current_position() == 0x7FFFFFFFFFFFFFFF);
+        WHEN("the move is loaded") {
             CHECK(!test_objs.handler.pulse());
-            CHECK(!test_objs.handler.pulse());
-            CHECK(!test_objs.handler.pulse());
-            THEN(
-                "the move should be stopped with ack id = stopped by "
-                "condition, and position should be reset") {
+            THEN("position gets set to large positive number") {
+                REQUIRE(test_objs.handler.get_current_position() ==
+                        0x7FFFFFFFFFFFFFFF);
+            }
+            AND_WHEN("the limit switch has been triggered") {
+                test_objs.hw.set_mock_lim_sw(true);
                 REQUIRE(!test_objs.handler.pulse());
-                REQUIRE(test_objs.handler.get_current_position() == 0);
-                REQUIRE(test_objs.reporter.messages.size() >= 1);
-                Ack read_ack = test_objs.reporter.messages.back();
-                REQUIRE(read_ack.ack_id == AckMessageId::stopped_by_condition);
+                CHECK(!test_objs.handler.pulse());
+                CHECK(!test_objs.handler.pulse());
+                THEN(
+                    "the move should be stopped with ack id = stopped by "
+                    "condition") {
+                    REQUIRE(!test_objs.handler.pulse());
+                    REQUIRE(test_objs.reporter.messages.size() >= 1);
+                    Ack read_ack = test_objs.reporter.messages.back();
+                    REQUIRE(read_ack.ack_id ==
+                            AckMessageId::stopped_by_condition);
+                }
+                THEN("position should be reset") {
+                    REQUIRE(test_objs.handler.get_current_position() == 0);
+                }
             }
         }
     }
@@ -66,45 +74,58 @@ TEST_CASE("Move with stop condition == limit switch, case 2") {
     GIVEN("the limit switch has not been triggered") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_lim_sw(false);
-        CHECK(!test_objs.handler.pulse());
-        WHEN("the move is finished") {
-            THEN("the move should have ack_id complete_without_condition") {
+        WHEN("the move is loaded") {
+            CHECK(!test_objs.handler.pulse());
+            THEN("position should be preset to large positive number") {
                 REQUIRE(test_objs.handler.get_current_position() ==
                         0x7FFFFFFFFFFFFFFF);
-                REQUIRE(!test_objs.handler.pulse());
-                REQUIRE(!test_objs.handler.pulse());
-                REQUIRE(!test_objs.handler.pulse());
-                REQUIRE(test_objs.reporter.messages.size() >= 1);
-                Ack read_ack = test_objs.reporter.messages.back();
-                REQUIRE(read_ack.ack_id ==
-                        AckMessageId::complete_without_condition);
+            }
+            AND_WHEN("the move is finished") {
+                THEN("the move should have ack_id complete_without_condition") {
+                    REQUIRE(!test_objs.handler.pulse());
+                    REQUIRE(!test_objs.handler.pulse());
+                    REQUIRE(!test_objs.handler.pulse());
+                    REQUIRE(test_objs.reporter.messages.size() >= 1);
+                    Ack read_ack = test_objs.reporter.messages.back();
+                    REQUIRE(read_ack.ack_id ==
+                            AckMessageId::complete_without_condition);
+                }
+                THEN("the position should not be reset") {
+                    REQUIRE(test_objs.handler.get_current_position() != 0x0);
+                }
             }
         }
     }
 }
 TEST_CASE("Move with stop condition != limit switch") {
     HandlerContainer test_objs{};
+    test_objs.handler.set_current_position(0x0);
     Move msg1 = Move{.duration = 2,
                      .velocity = convert_velocity_to(.5),
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
                      .stop_condition = MoveStopCondition::none};
-    GIVEN("Move with stop condition none in progress") {
+    GIVEN("Move with stop condition = none in progress") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_lim_sw(true);
-        CHECK(!test_objs.handler.pulse());
-        WHEN("the move is finished") {
-            REQUIRE(test_objs.handler.get_current_position() !=
-                    0x7FFFFFFFFFFFFFFF);
-            REQUIRE(!test_objs.handler.pulse());
-            REQUIRE(test_objs.handler.pulse());
-            REQUIRE(!test_objs.handler.pulse());
-            THEN("the move should have ack_id complete_without_condition") {
-                REQUIRE(test_objs.reporter.messages.size() >= 1);
-                Ack read_ack = test_objs.reporter.messages.back();
-                REQUIRE(read_ack.ack_id ==
-                        AckMessageId::complete_without_condition);
+        WHEN("the first move is loaded") {
+            CHECK(!test_objs.handler.pulse());
+            THEN("position is not immediately changed") {
+                REQUIRE(test_objs.handler.get_current_position() == 0);
+            }
+            AND_WHEN("the move is finished") {
+                REQUIRE(!test_objs.handler.pulse());
+                REQUIRE(test_objs.handler.pulse());
+                REQUIRE(!test_objs.handler.pulse());
+                THEN(
+                    "the move should have ack_id complete_without_condition, "
+                    "and position = 4") {
+                    REQUIRE(test_objs.reporter.messages.size() >= 1);
+                    Ack read_ack = test_objs.reporter.messages.back();
+                    REQUIRE(read_ack.ack_id ==
+                            AckMessageId::complete_without_condition);
+                }
             }
         }
     }


### PR DESCRIPTION
- Set position to 0 after homing concludes
- Initialize the position tracker to a large positive value before homing starts, since homing will move negative and if we start the position at 0 and move negative we'll run into trouble

This is hardware tested and works great but we should probably have some unit testing