### PR TITLE
fix(head): Head detect bug

### DIFF
--- a/include/head/core/tasks/messages.hpp
+++ b/include/head/core/tasks/messages.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "can/core/messages.hpp"
+
+namespace presence_sensing_driver_task_messages {
+
+struct PollForChange {
+
+};
+
+using TaskMessage =
+    std::variant<std::monostate,
+                 can_messages::ReadPresenceSensingVoltageRequest,
+                 can_messages::AttachedToolsRequest,
+                 PollForChange>;
+
+}  // namespace presence_sensing_driver_task_messages

--- a/include/head/core/tasks/messages.hpp
+++ b/include/head/core/tasks/messages.hpp
@@ -4,14 +4,14 @@
 
 namespace presence_sensing_driver_task_messages {
 
-struct PollForChange {
-
-};
+/**
+ * A message sent to check for new tool.
+ */
+struct CheckForToolChange {};
 
 using TaskMessage =
     std::variant<std::monostate,
                  can_messages::ReadPresenceSensingVoltageRequest,
-                 can_messages::AttachedToolsRequest,
-                 PollForChange>;
+                 can_messages::AttachedToolsRequest, CheckForToolChange>;
 
 }  // namespace presence_sensing_driver_task_messages

--- a/include/head/core/tasks/presence_sensing_driver_task.hpp
+++ b/include/head/core/tasks/presence_sensing_driver_task.hpp
@@ -48,6 +48,9 @@ class PresenceSensingDriverMessageHandler {
     void visit(can_messages::ReadPresenceSensingVoltageRequest& m) {
         auto voltage_read = driver.get_readings();
 
+        LOG("Received read presence sensing voltage request: z=%d, a=%d, gripper=%d",
+            voltage_read.z_motor, voltage_read.a_motor, voltage_read.gripper);
+
         can_messages::ReadPresenceSensingVoltageResponse resp{
             .z_motor = voltage_read.z_motor,
             .a_motor = voltage_read.a_motor,
@@ -57,6 +60,7 @@ class PresenceSensingDriverMessageHandler {
     }
 
     void visit(can_messages::AttachedToolsRequest& m) {
+        LOG("Received attached tools request");
         auto tools = driver.update_tools();
         auto new_tools = tools.second;
         can_client.send_can_message(

--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -41,7 +41,7 @@ class MotorDriverMessageHandler {
     void handle(std::monostate m) { static_cast<void>(m); }
 
     void handle(const can_messages::SetupRequest& m) {
-        LOG("Received motor setup request\n");
+        LOG("Received motor setup request");
         driver.setup();
     }
 


### PR DESCRIPTION
`AttatchToolRequest` should always respond with attached tools. Regardless of whether there's a change from the last poll.