### PR TITLE
fix(simulation): explicitly link boost date_time

### DIFF
--- a/common/simulation/CMakeLists.txt
+++ b/common/simulation/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(common-simulation STATIC
         app_update.cpp
         logging.cpp)
 
-target_link_libraries(common-simulation PUBLIC can-core Boost::boost pthread)
+target_link_libraries(common-simulation PUBLIC can-core Boost::boost Boost::date_time pthread)
 
 target_compile_definitions(common-simulation PUBLIC ENABLE_LOGGING)
 


### PR DESCRIPTION
On at least some boost installations, I think ones with solibs, you need
to explicitly link the date_time component to not get linker errors now.