### PR TITLE
fix(pipettes): fix typo in sensor CAN messages and change data type

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -507,19 +507,15 @@ struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
 struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
     uint8_t sensor = 0;
     uint8_t sample_rate = 1;
-    uint8_t offset_update = 0;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> BaselineSensorRequest {
         uint8_t sensor = 0;
         uint8_t sample_rate = 0;
-        uint8_t offset_update = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, sample_rate);
-        body = bit_utils::bytes_to_int(body, limit, offset_update);
         return BaselineSensorRequest{.sensor = sensor,
-                                     .sample_rate = sample_rate,
-                                     .offset_update = offset_update};
+                                     .sample_rate = sample_rate};
     }
 
     auto operator==(const BaselineSensorRequest& other) const -> bool = default;
@@ -527,13 +523,13 @@ struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
 
 struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
     can_ids::SensorType sensor{};
-    uint32_t sensor_data = 0;
+    int32_t sensor_data = 0;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
-        iter = bit_utils::int_to_bytes(sensor_data, body, limit);
+        iter = bit_utils::int_to_bytes(sensor_data, iter, limit);
         return iter - body;
     }
     auto operator==(const ReadFromSensorResponse& other) const
@@ -543,12 +539,12 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
 struct SetSensorThresholdRequest
     : BaseMessage<MessageId::set_sensor_threshold_request> {
     uint8_t sensor;
-    uint32_t threshold;
+    int32_t threshold;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SetSensorThresholdRequest {
         uint8_t sensor = 0;
-        uint8_t threshold = 0;
+        int32_t threshold = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, threshold);
         return SetSensorThresholdRequest{.sensor = sensor,
@@ -562,13 +558,13 @@ struct SetSensorThresholdRequest
 struct SensorThresholdResponse
     : BaseMessage<MessageId::set_sensor_threshold_response> {
     can_ids::SensorType sensor{};
-    uint32_t threshold = 0;
+    int32_t threshold = 0;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
-        iter = bit_utils::int_to_bytes(threshold, body, limit);
+        iter = bit_utils::int_to_bytes(threshold, iter, limit);
         return iter - body;
     }
     auto operator==(const SensorThresholdResponse& other) const

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -22,7 +22,7 @@ template <message_writer_task::TaskClient CanClient, class I2CQueueWriter>
 struct ReadCapacitanceCallback {
   public:
     ReadCapacitanceCallback(CanClient &can_client, I2CQueueWriter &i2c_writer,
-                            uint32_t threshold, float current_offset)
+                            int32_t threshold, float current_offset)
         : can_client{can_client},
           i2c_writer{i2c_writer},
           current_offset{current_offset},
@@ -42,12 +42,12 @@ struct ReadCapacitanceCallback {
     }
 
     void send_to_can() {
-        uint32_t capacitance =
+        int32_t capacitance =
             convert_capacitance(measurement, number_of_reads, current_offset);
         auto message = can_messages::ReadFromSensorResponse{
-            {}, SensorType::capacitive, capacitance};
+            .sensor = SensorType::capacitive, .sensor_data = capacitance};
         can_client.send_can_message(can_ids::NodeId::host, message);
-        if (capacitance > zero_threshold || capacitance < -zero_threshold) {
+        if (capacitance > zero_threshold || capacitance < zero_threshold) {
             LOG("Capacitance %d exceeds zero threshold %d ", capacitance,
                 zero_threshold);
             auto capdac = update_capdac(capacitance, current_offset);
@@ -76,8 +76,8 @@ struct ReadCapacitanceCallback {
     CanClient &can_client;
     I2CQueueWriter &i2c_writer;
     float current_offset;
-    uint32_t zero_threshold;
-    uint32_t measurement = 0;
+    int32_t zero_threshold;
+    int32_t measurement = 0;
     uint16_t number_of_reads = 1;
 };
 

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -42,7 +42,7 @@ class CapacitiveMessageHandler {
         // We should send a message that the sensor is in a ready state,
         // not sure if we should have a separate can message to do that
         // holding off for this PR.
-        uint16_t configuration_data =
+        uint32_t configuration_data =
             CONFIGURATION_MEASUREMENT << 8 | DEVICE_CONFIGURATION;
         writer.write(configuration_data, ADDRESS);
         configuration_data = FDC_CONFIGURATION << 8 | SAMPLE_RATE;
@@ -64,9 +64,8 @@ class CapacitiveMessageHandler {
         capdac_offset = capacitance_handler.get_offset();
         if (bool(m.offset_reading)) {
             auto message = can_messages::ReadFromSensorResponse{
-                {},
-                SensorType::capacitive,
-                static_cast<uint32_t>(capdac_offset)};
+                .sensor = SensorType::capacitive,
+                .sensor_data = static_cast<int32_t>(capdac_offset)};
             can_client.send_can_message(can_ids::NodeId::host, message);
         } else {
             capacitance_handler.reset();
@@ -104,14 +103,14 @@ class CapacitiveMessageHandler {
             m.threshold, m.sensor);
         zero_threshold = m.threshold;
         auto message = can_messages::SensorThresholdResponse{
-            {}, SensorType::capacitive, zero_threshold};
+            .sensor = SensorType::capacitive, .threshold = zero_threshold};
         can_client.send_can_message(can_ids::NodeId::host, message);
     }
 
     InternalCallback internal_callback{};
     sensor_task_utils::BitMode mode = sensor_task_utils::BitMode::MSB;
     // 3 pF
-    uint32_t zero_threshold = 0x3;
+    int32_t zero_threshold = 0x3;
     // 0 pF
     float capdac_offset = 0x0;
     static constexpr uint16_t DELAY = 20;

--- a/include/sensors/core/tasks/environment_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/environment_sensor_callbacks.hpp
@@ -20,18 +20,20 @@ struct HumidityReadingCallback {
         const auto *iter = buffer.cbegin();
         iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
         humidity = convert(data, SensorType::humidity);
+        LOG("Handling data data received %d", humidity);
     }
 
     void send_to_can() {
+        LOG("Sending humidity data %d", humidity);
         auto message = can_messages::ReadFromSensorResponse{
-            {}, SensorType::humidity, humidity};
+            .sensor = SensorType::humidity, .sensor_data = humidity};
         can_client.send_can_message(can_ids::NodeId::host, message);
         humidity = 0;
     }
 
   private:
     CanClient &can_client;
-    uint32_t humidity = 0;
+    int32_t humidity = 0;
 };
 
 template <message_writer_task::TaskClient CanClient>
@@ -45,18 +47,19 @@ struct TemperatureReadingCallback {
         const auto *iter = buffer.cbegin();
         iter = bit_utils::bytes_to_int(iter, buffer.cend(), data);
         temperature = convert(data, SensorType::temperature);
+        LOG("Handling temperature data received %d", temperature);
     }
 
     void send_to_can() {
         auto message = can_messages::ReadFromSensorResponse{
-            {}, SensorType::temperature, temperature};
+            .sensor = SensorType::temperature, .sensor_data = temperature};
         can_client.send_can_message(can_ids::NodeId::host, message);
         temperature = 0;
     }
 
   private:
     CanClient &can_client;
-    uint32_t temperature = 0;
+    int32_t temperature = 0;
 };
 
 // TODO (lc: 02-24-2022 pull into its own shared file)


### PR DESCRIPTION
## Overview
Can message typo was causing the message to not send over all of the expected data. Also changed the
type of the data to support positive or negative values.