### PR TITLE
ZA Encoder Pulse Counter and reset Pulse Counter

### DIFF
--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -67,8 +67,10 @@ jobs:
         run: cmake --build ./build-cross-pipettes --target pipettes-format-ci
       - name: "Build"
         run: cmake --build ./build-cross-pipettes --target pipettes
-      - name: "Lint"
-        run: cmake --build ./build-cross-pipettes --target pipettes-lint
+      - name: "Lint Single Channel"
+        run: cmake --build ./build-cross-pipettes --target pipettes-single-lint
+      - name: "Lint Multi Channel"
+        run: cmake --build ./build-cross-pipettes --target pipettes-multi-lint
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"
@@ -88,6 +90,12 @@ jobs:
         run: cmake --preset=host-gcc10 .
       - name: 'Build and test'
         run: cmake --build ./build-host --target pipettes-build-and-test
-      - name: 'Build simulator'
-        run: cmake --build ./build-host --target pipettes-simulator
+      - name: 'Build single simulator'
+        run: cmake --build ./build-host --target pipettes-single-simulator
+      - name: 'Build multi simulator'
+        run: cmake --build ./build-host --target pipettes-multi-simulator
+      - name: 'Build 96 simulator'
+        run: cmake --build ./build-host --target pipettes-96-simulator
+      - name: 'Build 384 simulator'
+        run: cmake --build ./build-host --target pipettes-384-simulator
 

--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -1,4 +1,7 @@
-on: [ pull_request, push ]
+on:
+  pull_request:
+  workflow_dispatch:
+
 
 env:
   ci: 1

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -94,25 +94,37 @@
       "name": "pipettes-single",
       "inherits": "pipettes",
       "displayName": "pipettes single binary",
-      "description": "Build the single channel pipettes cross binary"
+      "description": "Build the single channel pipettes cross binary",
+      "targets": [
+        "pipettes-single"
+      ]
     },
     {
       "name": "pipettes-multi",
       "inherits": "pipettes",
       "displayName": "pipettes multi binary",
-      "description": "Build the multi channel pipettes cross binary"
+      "description": "Build the multi channel pipettes cross binary",
+      "targets": [
+        "pipettes-multi"
+      ]
     },
     {
       "name": "pipettes-96",
       "inherits": "pipettes",
       "displayName": "pipettes 96 channel binary",
-      "description": "Build the 96 channel pipettes cross binary"
+      "description": "Build the 96 channel pipettes cross binary",
+      "targets": [
+        "pipettes-96"
+      ]
     },
     {
       "name": "pipettes-384",
       "inherits": "pipettes",
       "displayName": "pipettes 384 channel binary",
-      "description": "Build the 384 channel pipettes cross binary"
+      "description": "Build the 384 channel pipettes cross binary",
+      "targets": [
+        "pipettes-384"
+      ]
     },
     {
       "name": "gripper",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -84,8 +84,35 @@
       "configurePreset": "cross-pipettes",
       "jobs": 4,
       "targets": [
-        "pipettes"
+        "pipettes-single",
+        "pipettes-multi",
+        "pipettes-96",
+        "pipettes-384"
       ]
+    },
+    {
+      "name": "pipettes-single",
+      "inherits": "pipettes",
+      "displayName": "pipettes single binary",
+      "description": "Build the single channel pipettes cross binary"
+    },
+    {
+      "name": "pipettes-multi",
+      "inherits": "pipettes",
+      "displayName": "pipettes multi binary",
+      "description": "Build the multi channel pipettes cross binary"
+    },
+    {
+      "name": "pipettes-96",
+      "inherits": "pipettes",
+      "displayName": "pipettes 96 channel binary",
+      "description": "Build the 96 channel pipettes cross binary"
+    },
+    {
+      "name": "pipettes-384",
+      "inherits": "pipettes",
+      "displayName": "pipettes 384 channel binary",
+      "description": "Build the 384 channel pipettes cross binary"
     },
     {
       "name": "gripper",
@@ -182,7 +209,10 @@
         "head-simulator",
         "gantry-x-simulator",
         "gantry-y-simulator",
-        "pipettes-simulator",
+        "pipettes-single-simulator",
+        "pipettes-multi-simulator",
+        "pipettes-96-simulator",
+        "pipettes-384-simulator",
         "gripper-simulator"
       ]
     },
@@ -197,7 +227,10 @@
         "head-simulator",
         "gantry-x-simulator",
         "gantry-y-simulator",
-        "pipettes-simulator",
+        "pipettes-single-simulator",
+        "pipettes-multi-simulator",
+        "pipettes-96-simulator",
+        "pipettes-384-simulator",
         "gripper-simulator"
       ]
     }

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -63,11 +63,17 @@ struct motion_controller::HardwareConfig motor_pins_x {
             .port = GPIOC,
             .pin = GPIO_PIN_2,
             .active_setting = GPIO_PIN_SET},
-    .led = {
+    .led =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOB,
+            .pin = GPIO_PIN_11,
+            .active_setting = GPIO_PIN_RESET},
+    .sync_in = {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         .port = GPIOB,
-        .pin = GPIO_PIN_11,
-        .active_setting = GPIO_PIN_RESET},
+        .pin = GPIO_PIN_7,
+        .active_setting = GPIO_PIN_RESET}
 };
 
 struct motion_controller::HardwareConfig motor_pins_y {
@@ -95,11 +101,17 @@ struct motion_controller::HardwareConfig motor_pins_y {
             .port = GPIOC,
             .pin = GPIO_PIN_2,
             .active_setting = GPIO_PIN_SET},
-    .led = {
+    .led =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOB,
+            .pin = GPIO_PIN_11,
+            .active_setting = GPIO_PIN_RESET},
+    .sync_in = {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         .port = GPIOB,
-        .pin = GPIO_PIN_11,
-        .active_setting = GPIO_PIN_RESET},
+        .pin = GPIO_PIN_5,
+        .active_setting = GPIO_PIN_RESET}
 };
 
 /**

--- a/gantry/firmware/utility_gpio.c
+++ b/gantry/firmware/utility_gpio.c
@@ -1,24 +1,6 @@
 #include "common/firmware/utility_gpio.h"
 #include "platform_specific_hal_conf.h"
 
-
-/**
- * @brief Limit Switch GPIO Initialization Function
- * @param None
- * @retval None
- */
-void limit_switch_gpio_init(void) {
-    /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-
-    /*Configure GPIO pin : PC2 */
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Pin = GPIO_PIN_2;
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-}
-
 /**
  * @brief LED GPIO Initialization Function
  * @param None
@@ -36,7 +18,39 @@ void LED_drive_gpio_init(void) {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 }
+void sync_drive_gpio_init() {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+
+    /*Configure GPIO pin : PB7:sync in*/
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_5 | GPIO_PIN_7;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+}
+
+
+#include "platform_specific_hal_conf.h"
+
+/**
+ * @brief Limit Switch GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+void limit_switch_gpio_init(void) {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+
+    /*Configure GPIO pin : PC2 */
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_2;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+}
 void utility_gpio_init(void) {
     limit_switch_gpio_init();
     LED_drive_gpio_init();
+    sync_drive_gpio_init();
 }

--- a/generate_header.py
+++ b/generate_header.py
@@ -37,8 +37,8 @@ class block:
 def generate_file_comment(output: io.StringIO) -> None:
     """Generate the header file comment."""
     output.write("/********************************************\n")
-    output.write("* This is a generated file. Do not modify.  *\n")
-    output.write("********************************************/\n")
+    output.write(" * This is a generated file. Do not modify.  *\n")
+    output.write(" ********************************************/\n")
     output.write("#pragma once\n\n")
 
 
@@ -90,7 +90,7 @@ def write_enum_c(e: Type[Enum], output: io.StringIO, prefix: str) -> None:
     ):
         for i in e:
             name = "_".join(("can", e.__name__, i.name)).lower()
-            output.write(f"  {name} = 0x{i.value:x},\n")
+            output.write(f"    {name} = 0x{i.value:x},\n")
 
 
 def write_arbitration_id_c(output: io.StringIO, prefix: str, arbitration_id: ModuleType) -> None:
@@ -102,7 +102,7 @@ def write_arbitration_id_c(output: io.StringIO, prefix: str, arbitration_id: Mod
         terminate=f"}} {prefix}{arbitration_id.ArbitrationIdParts.__name__};\n\n",
     ):
         for i in arbitration_id.ArbitrationIdParts._fields_:
-            output.write(f"  unsigned int {i[0]}: {i[2]};\n")
+            output.write(f"    unsigned int {i[0]}: {i[2]};\n")
 
 
 class Languge(str, Enum):

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -27,6 +27,7 @@ set(GRIPPER_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
         ${CMAKE_CURRENT_SOURCE_DIR}/can.c
         ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/motor_timer_hardware.c
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
         ${COMMON_EXECUTABLE_DIR}/system/app_update.c

--- a/gripper/firmware/interfaces.cpp
+++ b/gripper/firmware/interfaces.cpp
@@ -146,23 +146,19 @@ struct motor_hardware::BrushedHardwareConfig brushed_motor_pins {
     .pwm_1 =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOC,
-            .pin = GPIO_PIN_0,
-            .active_setting = GPIO_PIN_SET},
+            .tim = &htim1,
+            .channel = TIM_CHANNEL_1},
     .pwm_2 =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOA,
-            .pin = GPIO_PIN_6,
-            .active_setting = GPIO_PIN_SET},
+            .tim = &htim3,
+            .channel = TIM_CHANNEL_1},
     .enable =
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        {  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             .port = GPIOC,
             .pin = GPIO_PIN_11,
             .active_setting = GPIO_PIN_SET},
-    .limit_switch = {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    .limit_switch = {  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         .port = GPIOC,
         .pin = GPIO_PIN_2,
         .active_setting = GPIO_PIN_SET},

--- a/gripper/firmware/motor_hardware.c
+++ b/gripper/firmware/motor_hardware.c
@@ -1,6 +1,5 @@
 #include "motor_hardware.h"
 
-TIM_HandleTypeDef htim7;
 DAC_HandleTypeDef hdac1;
 
 void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
@@ -91,72 +90,6 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
 HAL_StatusTypeDef initialize_spi() {
     __HAL_RCC_SPI2_CLK_ENABLE();
     return HAL_SPI_Init(&hspi2);
-}
-
-static motor_interrupt_callback timer_callback = NULL;
-
-/**
- * @brief GPIO Initialization Function
- * @param None
- * @retval None
- */
-void MX_GPIO_Init(void) {
-    /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-
-    /*Configure GPIO pin : LD2_Pin */
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Pin = GPIO_PIN_5;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-}
-
-void MX_TIM7_Init(void) {
-    TIM_MasterConfigTypeDef sMasterConfig = {0};
-
-    htim7.Instance = TIM7;
-    htim7.Init.Prescaler = 849;
-    htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim7.Init.Period = 1;
-    htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
-    if (HAL_TIM_Base_Init(&htim7) != HAL_OK) {
-        Error_Handler();
-    }
-    sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
-    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-    if (HAL_TIMEx_MasterConfigSynchronization(&htim7, &sMasterConfig) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-}
-
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
-    // Check which version of the timer triggered this callback
-    if (htim == &htim7 && timer_callback) {
-        timer_callback();
-    }
-}
-
-void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
-    if (htim == &htim7) {
-        /* Peripheral clock enable */
-        __HAL_RCC_TIM7_CLK_ENABLE();
-
-        /* TIM7 interrupt Init */
-        HAL_NVIC_SetPriority(TIM7_IRQn, 6, 0);
-        HAL_NVIC_EnableIRQ(TIM7_IRQn);
-    }
-}
-
-void initialize_timer(motor_interrupt_callback callback) {
-    timer_callback = callback;
-    MX_GPIO_Init();
-    MX_TIM7_Init();
 }
 
 /**

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif  // __cplusplus
 
 extern SPI_HandleTypeDef hspi2;
+extern TIM_HandleTypeDef htim1;
+extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim7;
 extern DAC_HandleTypeDef hdac1;
 

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -1,0 +1,234 @@
+#include "motor_hardware.h"
+
+TIM_HandleTypeDef htim1;
+TIM_HandleTypeDef htim3;
+TIM_HandleTypeDef htim7;
+
+static motor_interrupt_callback timer_callback = NULL;
+
+void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (htim->Instance == TIM1) {
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**TIM1 GPIO Configuration
+        PC0     ------> TIM1_CH1
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_0;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF2_TIM1;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+    } else if (htim->Instance == TIM3) {
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        /**TIM3 GPIO Configuration
+        PA6     ------> TIM3_CH1
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_6;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF2_TIM3;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    }
+}
+
+/**
+ * @brief TIM1 Initialization Function for AIN1
+ * @param None
+ * @retval None
+ */
+static void MX_TIM1_Init(void) {
+    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
+
+    htim1.Instance = TIM1;
+    htim1.Init.Prescaler = 500;
+    htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim1.Init.Period = 40;
+    htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim1.Init.RepetitionCounter = 0;
+    htim1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(&htim1) != HAL_OK) {
+        Error_Handler();
+    }
+    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+    if (HAL_TIM_ConfigClockSource(&htim1, &sClockSourceConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_Init(&htim1) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim1, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 36;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+    if (HAL_TIM_PWM_ConfigChannel(&htim1, &sConfigOC, TIM_CHANNEL_1) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
+    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
+    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
+    sBreakDeadTimeConfig.DeadTime = 0;
+    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
+    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
+    sBreakDeadTimeConfig.BreakFilter = 0;
+    sBreakDeadTimeConfig.BreakAFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.Break2State = TIM_BREAK2_DISABLE;
+    sBreakDeadTimeConfig.Break2Polarity = TIM_BREAK2POLARITY_HIGH;
+    sBreakDeadTimeConfig.Break2Filter = 0;
+    sBreakDeadTimeConfig.Break2AFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
+    if (HAL_TIMEx_ConfigBreakDeadTime(&htim1, &sBreakDeadTimeConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    HAL_TIM_MspPostInit(&htim1);
+}
+
+/**
+ * @brief TIM3 Initialization Function for AIN2
+ * @param None
+ * @retval None
+ */
+static void MX_TIM3_Init(void) {
+    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+
+    htim3.Instance = TIM3;
+    htim3.Init.Prescaler = 5000;
+    htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim3.Init.Period = 400;
+    htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(&htim3) != HAL_OK) {
+        Error_Handler();
+    }
+    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+    if (HAL_TIM_ConfigClockSource(&htim3, &sClockSourceConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_Init(&htim3) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim3, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 360;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    if (HAL_TIM_PWM_ConfigChannel(&htim3, &sConfigOC, TIM_CHANNEL_1) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    HAL_TIM_MspPostInit(&htim3);
+}
+
+void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base) {
+    if (htim_base->Instance == TIM1) {
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM1_CLK_DISABLE();
+        /* TIM1 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(TIM1_UP_TIM16_IRQn);
+    } else if (htim_base->Instance == TIM3) {
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM3_CLK_DISABLE();
+        /* TIM3 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(TIM3_IRQn);
+    }
+}
+
+void MX_TIM7_Init(void) {
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+
+    htim7.Instance = TIM7;
+    htim7.Init.Prescaler = 849;
+    htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim7.Init.Period = 1;
+    htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
+    if (HAL_TIM_Base_Init(&htim7) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim7, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+}
+
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
+    // Check which version of the timer triggered this callback
+    if (htim == &htim7 && timer_callback) {
+        timer_callback();
+    }
+}
+
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
+    if (htim == &htim7) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM7_CLK_ENABLE();
+        /* TIM7 interrupt Init */
+        HAL_NVIC_SetPriority(TIM7_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM7_IRQn);
+    } else if (htim == &htim1) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM1_CLK_ENABLE();
+        /* TIM1 interrupt Init */
+        HAL_NVIC_SetPriority(TIM1_UP_TIM16_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM1_UP_TIM16_IRQn);
+    } else if (htim == &htim3) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM3_CLK_ENABLE();
+        /* TIM3 interrupt Init */
+        HAL_NVIC_SetPriority(TIM3_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM3_IRQn);
+    }
+}
+
+/**
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+void MX_GPIO_Init(void) {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_11;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                  &GPIO_InitStruct);
+}
+
+void initialize_timer(motor_interrupt_callback callback) {
+    timer_callback = callback;
+    MX_GPIO_Init();
+    MX_TIM1_Init();
+    MX_TIM3_Init();
+    MX_TIM7_Init();
+}

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -45,6 +45,8 @@
 DMA_HandleTypeDef hdma_spi1_tx;
 DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim7;
+extern TIM_HandleTypeDef htim1;
+extern TIM_HandleTypeDef htim3;
 
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
@@ -116,14 +118,6 @@ void DebugMon_Handler(void) {}
 /******************************************************************************/
 
 /**
- * @brief  This function handles PPP interrupt request.
- * @param  None
- * @retval None
- */
-/*void PPP_IRQHandler(void)
-{
-}*/
-/**
  * @brief This function handles DMA1 channel2 global interrupt.
  */
 void DMA1_Channel2_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_spi1_rx); }
@@ -141,6 +135,17 @@ void FDCAN1_IT0_IRQHandler(void) {
 }
 
 /**
+ * @brief This function handles TIM1 update interrupt and TIM16 global
+ * interrupt.
+ */
+void TIM1_UP_TIM16_IRQHandler(void) { HAL_TIM_IRQHandler(&htim1); }
+
+/**
+ * @brief This function handles TIM3 global interrupt.
+ */
+void TIM3_IRQHandler(void) { HAL_TIM_IRQHandler(&htim3); }
+
+/**
  * @brief This function handles TIM7 global interrupt.
  */
 void TIM7_IRQHandler(void) { HAL_TIM_IRQHandler(&htim7); }
@@ -150,4 +155,5 @@ void SysTick_Handler(void) {
     HAL_IncTick();
     xPortSysTickHandler();
 }
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/gripper/firmware/stm32g4xx_it.h
+++ b/gripper/firmware/stm32g4xx_it.h
@@ -1,28 +1,28 @@
 /**
-  ******************************************************************************
-  * @file    Templates/Inc/stm32g4xx_it.h
-  * @author  MCD Application Team
-  * @brief   This file contains the headers of the interrupt handlers.
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file    Templates/Inc/stm32g4xx_it.h
+ * @author  MCD Application Team
+ * @brief   This file contains the headers of the interrupt handlers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32G4xx_IT_H
 #define STM32G4xx_IT_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -42,6 +42,10 @@ void PendSV_Handler(void);
 void SysTick_Handler(void);
 void DMA1_Channel2_IRQHandler(void);
 void DMA1_Channel3_IRQHandler(void);
+void FDCAN1_IT0_IRQHandler(void);
+void TIM1_UP_TIM16_IRQHandler(void);
+void TIM3_IRQHandler(void);
+void TIM7_IRQHandler(void);
 
 #ifdef __cplusplus
 }

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -91,11 +91,17 @@ struct motor_hardware::HardwareConfig pin_configurations_left {
             .port = GPIOB,
             .pin = GPIO_PIN_7,
             .active_setting = GPIO_PIN_SET},
-    .led = {
+    .led =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOB,
+            .pin = GPIO_PIN_6,
+            .active_setting = GPIO_PIN_RESET},
+    .sync_in = {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-        .port = GPIOB,
-        .pin = GPIO_PIN_6,
-        .active_setting = GPIO_PIN_RESET},
+        .port = GPIOA,
+        .pin = GPIO_PIN_8,
+        .active_setting = GPIO_PIN_SET}
 };
 
 struct motor_hardware::HardwareConfig pin_configurations_right {
@@ -123,11 +129,17 @@ struct motor_hardware::HardwareConfig pin_configurations_right {
             .port = GPIOB,
             .pin = GPIO_PIN_9,
             .active_setting = GPIO_PIN_SET},
-    .led = {
+    .led =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOB,
+            .pin = GPIO_PIN_6,
+            .active_setting = GPIO_PIN_RESET},
+    .sync_in = {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-        .port = GPIOB,
-        .pin = GPIO_PIN_6,
-        .active_setting = GPIO_PIN_RESET},
+        .port = GPIOA,
+        .pin = GPIO_PIN_8,
+        .active_setting = GPIO_PIN_RESET}
 };
 
 static tmc2130::TMC2130DriverConfig MotorDriverConfigurations{

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -287,8 +287,6 @@ void MX_TIM2_Init(void){
     {
     Error_Handler();
     }
-    HAL_NVIC_SetPriority(TIM3_IRQn, 4, 0);
-    HAL_NVIC_EnableIRQ(TIM3_IRQn);
     HAL_TIM_Encoder_Start_IT(&htim2, TIM_CHANNEL_ALL);
 }
 
@@ -333,8 +331,6 @@ void MX_TIM3_Init(void){
     {
     Error_Handler();
     }
-    HAL_NVIC_SetPriority(TIM3_IRQn, 4, 0);
-    HAL_NVIC_EnableIRQ(TIM3_IRQn);
     HAL_TIM_Encoder_Start_IT(&htim3, TIM_CHANNEL_ALL);
 }
 
@@ -375,7 +371,7 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim) {
     }
 }
 
-uint16_t encoder_pulse_count(TIM_HandleTypeDef *htim){
+uint32_t encoder_pulse_count(TIM_HandleTypeDef *htim){
     if (htim == &htim2){
         enc_pulse_counter = __HAL_TIM_GET_COUNTER(&htim2);
     }

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -175,48 +175,47 @@ HAL_StatusTypeDef initialize_spi(SPI_HandleTypeDef* hspi) {
 }
 
 
-void Encoder_GPIO_Init(void)
-{
+void Encoder_GPIO_Init(void){
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOD_CLK_ENABLE();
     __GPIOA_CLK_ENABLE();
     __GPIOD_CLK_ENABLE();
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    // EN CHAN A&B A Axis PIN Configure
+    // ENC CHAN A&B A Axis PIN Configure
     GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    // EN CHANNELB A AXIS PIN Configure
+    // ENC CHANNELB A AXIS PIN Configure
     GPIO_InitStruct.Pin = GPIO_PIN_1;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    // EN CHANNELI A AXIS PIN Configure
+    // ENC CHANNELI A AXIS PIN Configure
     GPIO_InitStruct.Pin = GPIO_PIN_15;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    // EN CHAN A&B Z AXIS PIN Configure
+    // ENC CHANNELA Z AXIS PIN Configure
     GPIO_InitStruct.Pin = GPIO_PIN_6;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    // EN CHANNELB Z AXIS PIN Configure
+    // ENC CHANNELB Z AXIS PIN Configure
     GPIO_InitStruct.Pin = GPIO_PIN_7;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    // EN CHANNELI Z AXIS PIN Configure
+    // ENC CHANNELI Z AXIS PIN Configure
     GPIO_InitStruct.Pin = GPIO_PIN_2;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -5,8 +5,7 @@
 TIM_HandleTypeDef htim7;
 TIM_HandleTypeDef htim2;
 TIM_HandleTypeDef htim3;
-uint32_t pulse_counter;
-uint16_t pulse_count;
+uint32_t enc_pulse_counter;
 
 motor_interrupt_callback motor_callback = NULL;
 
@@ -385,29 +384,25 @@ void stop_encoder_interrupt(TIM_HandleTypeDef *htim){
     HAL_TIM_Encoder_Stop_IT(htim, TIM_CHANNEL_ALL);
 }
 
-uint16_t encoder_count(TIM_HandleTypeDef *htim){
+uint16_t encoder_pulse_count(TIM_HandleTypeDef *htim){
     if (htim == &htim2){
-        uint32_t pulse_count = __HAL_TIM_GET_COUNTER(&htim2);
-        pulse_count = (uint16_t)pulse_counter;
+        enc_pulse_counter = __HAL_TIM_GET_COUNTER(&htim2);
     }
     else if(htim == &htim3){
-        uint32_t pulse_count = __HAL_TIM_GET_COUNTER(&htim3);
-        pulse_count = (uint16_t)pulse_counter;
+        enc_pulse_counter = __HAL_TIM_GET_COUNTER(&htim3);
     }
-    return pulse_count;
+    return enc_pulse_counter;
 }
 
 void reset_encoder_counter(TIM_HandleTypeDef *htim){
     if (htim == &htim2){
         __HAL_TIM_SET_COUNTER(&htim2, 0);
-        pulse_count = encoder_count(&htim2);
+        enc_pulse_counter = encoder_pulse_count(&htim2);
     }
     else if(htim == &htim3){
         __HAL_TIM_SET_COUNTER(&htim3, 0);
-        pulse_count = encoder_count(&htim3);
-
+        enc_pulse_counter = encoder_pulse_count(&htim3);
     }
-    return pulse_count;
 }
 
 void initialize_timer(motor_interrupt_callback callback) {

--- a/head/firmware/motor_hardware.c
+++ b/head/firmware/motor_hardware.c
@@ -375,14 +375,6 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim) {
     }
 }
 
-void start_encoder_interrupt(TIM_HandleTypeDef *htim){
-    HAL_TIM_Encoder_Start_IT(htim, TIM_CHANNEL_ALL);
-}
-
-void stop_encoder_interrupt(TIM_HandleTypeDef *htim){
-    HAL_TIM_Encoder_Stop_IT(htim, TIM_CHANNEL_ALL);
-}
-
 uint16_t encoder_pulse_count(TIM_HandleTypeDef *htim){
     if (htim == &htim2){
         enc_pulse_counter = __HAL_TIM_GET_COUNTER(&htim2);

--- a/head/firmware/motor_hardware.h
+++ b/head/firmware/motor_hardware.h
@@ -11,6 +11,7 @@ extern SPI_HandleTypeDef hspi2;
 extern TIM_HandleTypeDef htim7;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim3;
+extern uint32_t enc_pulse_counter;
 
 typedef void (*motor_interrupt_callback)();
 HAL_StatusTypeDef initialize_spi(SPI_HandleTypeDef* hspi);

--- a/head/firmware/utility_hardware.c
+++ b/head/firmware/utility_hardware.c
@@ -38,7 +38,20 @@ void limit_switch_gpio_init() {
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 }
 
+void sync_drive_gpio_init() {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+
+    /*Configure GPIO pin : PA8:sync in*/
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_8;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+}
+
 void utility_gpio_init() {
     limit_switch_gpio_init();
     LED_drive_gpio_init();
+    sync_drive_gpio_init();
 }

--- a/head/firmware/utility_hardware.h
+++ b/head/firmware/utility_hardware.h
@@ -5,6 +5,7 @@ extern "C" {
 void limit_switch_gpio_init();
 void LED_drive_gpio_init();
 void utility_gpio_init();
+void sync_drive_gpio_init();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -23,6 +23,8 @@ typedef enum {
     can_messageid_device_info_response = 0x303,
     can_messageid_task_info_request = 0x304,
     can_messageid_task_info_response = 0x305,
+    can_messageid_pipette_info_request = 0x306,
+    can_messageid_pipette_info_response = 0x307,
     can_messageid_stop_request = 0x0,
     can_messageid_get_status_request = 0x1,
     can_messageid_get_status_response = 0x5,
@@ -46,6 +48,9 @@ typedef enum {
     can_messageid_write_motor_driver_register_request = 0x30,
     can_messageid_read_motor_driver_register_request = 0x31,
     can_messageid_read_motor_driver_register_response = 0x32,
+    can_messageid_write_motor_current_request = 0x33,
+    can_messageid_read_motor_current_request = 0x34,
+    can_messageid_read_motor_current_response = 0x35,
     can_messageid_read_presence_sensing_voltage_request = 0x600,
     can_messageid_read_presence_sensing_voltage_response = 0x601,
     can_messageid_attached_tools_request = 0x700,
@@ -113,9 +118,10 @@ typedef enum {
 
 /** A bit field of the arbitration id parts. */
 typedef struct {
-    unsigned int function_code : 4;
-    unsigned int node_id : 7;
-    unsigned int originating_node_id : 7;
-    unsigned int message_id : 11;
-    unsigned int padding : 3;
+    unsigned int function_code: 4;
+    unsigned int node_id: 7;
+    unsigned int originating_node_id: 7;
+    unsigned int message_id: 11;
+    unsigned int padding: 3;
 } CANArbitrationIdParts;
+

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -25,6 +25,8 @@ enum class MessageId {
     device_info_response = 0x303,
     task_info_request = 0x304,
     task_info_response = 0x305,
+    pipette_info_request = 0x306,
+    pipette_info_response = 0x307,
     stop_request = 0x0,
     get_status_request = 0x1,
     get_status_response = 0x5,
@@ -84,8 +86,8 @@ enum class NodeId {
     gantry_x = 0x30,
     gantry_y = 0x40,
     head = 0x50,
-    head_r = 0x52,
     head_l = 0x51,
+    head_r = 0x52,
     gripper = 0x20,
     pipette_left_bootloader = 0x6f,
     pipette_right_bootloader = 0x7f,
@@ -122,6 +124,7 @@ enum class SensorType {
     capacitive = 0x1,
     humidity = 0x2,
     temperature = 0x3,
+    pressure = 0x4,
 };
 
 }  // namespace can_ids

--- a/include/common/firmware/i2c.h
+++ b/include/common/firmware/i2c.h
@@ -26,13 +26,6 @@ HAL_I2C_HANDLE MX_I2C3_Init();
 int data_ready();
 void enable_eeprom();
 void disable_eeprom();
-int tip_present();
-typedef enum Type { MULTI_CHANNEL, SINGLE_CHANNEL } PipetteType;
-typedef struct HandlerStruct {
-    HAL_I2C_HANDLE i2c1;
-    HAL_I2C_HANDLE i2c3;
-} I2CHandlerStruct;
-void i2c_setup(I2CHandlerStruct* temp_struct, PipetteType pipette_type);
 
 
 #ifdef __cplusplus

--- a/include/common/firmware/utility_gpio.h
+++ b/include/common/firmware/utility_gpio.h
@@ -7,6 +7,7 @@ extern "C" {
 void limit_switch_gpio_init();
 void LED_drive_gpio_init();
 void utility_gpio_init();
+void sync_drive_gpio_init();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -72,6 +72,8 @@ class MotionController {
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }
 
+    auto check_read_sync_line() -> bool { return hardware.check_sync_in(); }
+
     void enable_motor() {
         hardware.start_timer_interrupt();
         hardware.activate_motor();

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -21,6 +21,7 @@ class MotorHardwareIface {
     virtual void activate_motor() = 0;
     virtual void deactivate_motor() = 0;
     virtual auto check_limit_switch() -> bool = 0;
+    virtual auto check_sync_in() -> bool = 0;
 };
 
 class StepperMotorHardwareIface : virtual public MotorHardwareIface {

--- a/include/motor-control/firmware/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor_hardware.hpp
@@ -16,6 +16,7 @@ struct BrushedHardwareConfig {
     PwmConfig pwm_2;
     PinConfig enable;
     PinConfig limit_switch;
+    PinConfig sync_in;
 };
 
 class BrushedMotorHardware : public BrushedMotorHardwareIface {
@@ -33,6 +34,7 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     void activate_motor() final;
     void deactivate_motor() final;
     auto check_limit_switch() -> bool final;
+    auto check_sync_in() -> bool final;
 
   private:
     BrushedHardwareConfig pins;

--- a/include/motor-control/firmware/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor_hardware.hpp
@@ -6,9 +6,14 @@
 
 namespace motor_hardware {
 
+struct PwmConfig {
+    void* tim;
+    uint32_t channel;
+};
+
 struct BrushedHardwareConfig {
-    PinConfig pwm_1;
-    PinConfig pwm_2;
+    PwmConfig pwm_1;
+    PwmConfig pwm_2;
     PinConfig enable;
     PinConfig limit_switch;
 };

--- a/include/motor-control/firmware/motor_hardware.hpp
+++ b/include/motor-control/firmware/motor_hardware.hpp
@@ -12,6 +12,7 @@ struct HardwareConfig {
     PinConfig enable;
     PinConfig limit_switch;
     PinConfig led;
+    PinConfig sync_in;
 };
 
 class MotorHardware : public StepperMotorHardwareIface {
@@ -34,6 +35,7 @@ class MotorHardware : public StepperMotorHardwareIface {
     void stop_timer_interrupt() final;
     auto check_limit_switch() -> bool final;
     void set_LED(bool status) final;
+    auto check_sync_in() -> bool final;
 
   private:
     HardwareConfig pins;

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -22,6 +22,7 @@ class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
     }
     void set_LED(bool status) final {}
     void trigger_limit_switch() { limit_switch_status = true; }
+    bool check_sync_in() final { return true; }
 
   private:
     bool limit_switch_status = false;

--- a/include/motor-control/tests/mock_motor_hardware.hpp
+++ b/include/motor-control/tests/mock_motor_hardware.hpp
@@ -21,6 +21,7 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
     bool check_limit_switch() final { return mock_lim_sw_value; }
+    bool check_sync_in() final { return true; }
     void set_LED(bool status) final {}
     void set_mock_lim_sw(bool value) { mock_lim_sw_value = value; }
     void set_finished_ack_id(uint8_t id) { finished_move_id = id; }

--- a/include/pipettes/core/configs.hpp
+++ b/include/pipettes/core/configs.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "motor-control/core/linear_motion_system.hpp"
+#include "motor-control/core/tmc2130_config.hpp"
+#include "pipettes/core/pipette_type.h"
+
+namespace configs {
+
+auto driver_config_by_axis(PipetteType which) -> tmc2130::TMC2130DriverConfig;
+
+auto linear_motion_sys_config_by_axis(PipetteType which)
+    -> lms::LinearMotionSystemConfig<lms::LeadScrewConfig>;
+
+}  // namespace configs

--- a/include/pipettes/core/pipette_info.hpp
+++ b/include/pipettes/core/pipette_info.hpp
@@ -1,0 +1,92 @@
+/*
+** Functions and definitions for deciding what kind of pipette this is.
+*/
+#pragma once
+#include <array>
+#include <cstdint>
+
+#include "can/core/can_writer_task.hpp"
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+
+namespace pipette_info {
+using namespace can_ids;
+using namespace can_messages;
+
+enum class PipetteName {
+    P1000_SINGLE = 0,
+    P1000_MULTI = 1,
+    P1000_96 = 2,
+    P1000_384 = 3,
+};
+
+struct PipetteInfo {
+    PipetteName name;
+    uint16_t model;
+    std::array<char, 12> serial;
+};
+
+// These are implemented in pipette-type-specific source files in core
+// e.g. pipettes/core/pipette_type_single.cpp
+PipetteName get_name();
+uint16_t get_model();
+
+/**
+ * A HandlesMessages implementing class that will respond to system messages.
+ *
+ * @tparam CanClient can writer task client
+ */
+template <message_writer_task::TaskClient CanClient>
+class PipetteInfoMessageHandler {
+  public:
+    /**
+     * Constructor
+     *
+     * @param writer A message writer for sending the response
+     */
+    explicit PipetteInfoMessageHandler(CanClient &writer)
+        : PipetteInfoMessageHandler(
+              writer, PipetteInfo{.name = get_name(),
+                                  .model = get_model(),
+                                  .serial = std::array{'2', '0', '2', '2', '0',
+                                                       '3', '2', '1', 'A', '0',
+                                                       '5', '\0'}}) {}
+    PipetteInfoMessageHandler(CanClient &writer,
+                              const PipetteInfo &pipette_info)
+        : writer(writer),
+          response{.name = static_cast<uint16_t>(pipette_info.name),
+                   .model = pipette_info.model} {
+        std::copy_n(
+            pipette_info.serial.cbegin(),
+            std::min(pipette_info.serial.size(), response.serial.size()),
+            response.serial.begin());
+    }
+    PipetteInfoMessageHandler(const PipetteInfoMessageHandler &) = delete;
+    PipetteInfoMessageHandler(const PipetteInfoMessageHandler &&) = delete;
+    auto operator=(const PipetteInfoMessageHandler &)
+        -> PipetteInfoMessageHandler & = delete;
+    auto operator=(const PipetteInfoMessageHandler &&)
+        -> PipetteInfoMessageHandler && = delete;
+    ~PipetteInfoMessageHandler() = default;
+
+    using MessageType = std::variant<std::monostate, PipetteInfoRequest>;
+
+    /**
+     * Message handler
+     * @param m The incoming message.
+     */
+    void handle(MessageType &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+  private:
+    void visit(std::monostate &m) {}
+
+    void visit(PipetteInfoRequest &m) {
+        writer.send_can_message(can_ids::NodeId::host, response);
+    }
+
+    CanClient &writer;
+    can_messages::PipetteInfoResponse response;
+};
+};  // namespace pipette_info

--- a/include/pipettes/core/pipette_type.h
+++ b/include/pipettes/core/pipette_type.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef enum Type {
+    SINGLE_CHANNEL,
+    EIGHT_CHANNEL,
+    NINETY_SIX_CHANNEL,
+    THREE_EIGHTY_FOUR_CHANNEL
+} PipetteType;
+
+/**
+ * Get the current pipette type
+ *
+ * @return a pipette type
+ */
+PipetteType get_pipette_type();
+
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/include/pipettes/core/tasks.hpp
+++ b/include/pipettes/core/tasks.hpp
@@ -17,13 +17,23 @@
 namespace pipettes_tasks {
 
 /**
- * Start pipettes tasks.
+ * Start pipettes tasks with one i2c bus.
  */
 void start_tasks(can_bus::CanBus& can_bus,
                  motion_controller::MotionController<lms::LeadScrewConfig>&
                      motion_controller,
                  motor_driver::MotorDriver& motor_driver,
                  i2c::I2CDeviceBase& i2c, can_ids::NodeId id);
+
+/**
+ * Start pipettes tasks with two i2c buses.
+ */
+void start_tasks(can_bus::CanBus& can_bus,
+                 motion_controller::MotionController<lms::LeadScrewConfig>&
+                     motion_controller,
+                 motor_driver::MotorDriver& motor_driver,
+                 i2c::I2CDeviceBase& i2c3_device,
+                 i2c::I2CDeviceBase& i2c1_device, can_ids::NodeId id);
 
 /**
  * Access to all the message queues in the system.
@@ -63,7 +73,9 @@ struct QueueClient : can_message_writer::MessageWriter {
     freertos_message_queue::FreeRTOSMessageQueue<
         sensor_task_utils::TaskMessage>* capacitive_sensor_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<i2c_task::TaskMessage>*
-        i2c_queue{nullptr};
+        i2c3_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<i2c_task::TaskMessage>*
+        i2c1_queue{nullptr};
 };
 
 /**
@@ -85,7 +97,9 @@ struct AllTask {
                                    QueueClient, QueueClient>* move_group{
         nullptr};
 
-    i2c_task::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>* i2c_task{
+    i2c_task::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>* i2c3_task{
+        nullptr};
+    i2c_task::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>* i2c1_task{
         nullptr};
     eeprom_task::EEPromTask<
         freertos_message_queue::FreeRTOSMessageQueue,

--- a/include/pipettes/firmware/i2c_setup.h
+++ b/include/pipettes/firmware/i2c_setup.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "common/firmware/i2c.h"
+#include "pipettes/core/pipette_type.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+int tip_present();
+typedef struct HandlerStruct {
+    HAL_I2C_HANDLE i2c1;
+    HAL_I2C_HANDLE i2c3;
+} I2CHandlerStruct;
+void i2c_setup(I2CHandlerStruct* temp_struct, PipetteType pipette_type);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/motor-control/firmware/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor_hardware.cpp
@@ -27,3 +27,8 @@ bool BrushedMotorHardware::check_limit_switch() {
                                         pins.limit_switch.pin,
                                         pins.limit_switch.active_setting);
 }
+
+bool BrushedMotorHardware::check_sync_in() {
+    return motor_hardware_get_pin_value(pins.sync_in.port, pins.sync_in.pin,
+                                        pins.sync_in.active_setting);
+}

--- a/motor-control/firmware/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor_hardware.cpp
@@ -4,9 +4,15 @@
 
 using namespace motor_hardware;
 
-void BrushedMotorHardware::positive_direction() {}
+void BrushedMotorHardware::positive_direction() {
+    motor_hardware_start_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
+    motor_hardware_stop_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
+}
 
-void BrushedMotorHardware::negative_direction() {}
+void BrushedMotorHardware::negative_direction() {
+    motor_hardware_stop_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
+    motor_hardware_start_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
+}
 
 void BrushedMotorHardware::activate_motor() {
     motor_hardware_set_pin(pins.enable.port, pins.enable.pin,

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -55,3 +55,11 @@ bool motor_hardware_set_dac_value(void* hdac, uint32_t channel,
                                   uint32_t data_algn, uint32_t val) {
     return HAL_DAC_SetValue(hdac, channel, data_algn, val) == HAL_OK;
 }
+
+bool motor_hardware_start_pwm(void* htim, uint32_t channel) {
+    return HAL_TIM_PWM_Start(htim, channel) == HAL_OK;
+}
+
+bool motor_hardware_stop_pwm(void* htim, uint32_t channel) {
+    return HAL_TIM_PWM_Stop(htim, channel) == HAL_OK;
+}

--- a/motor-control/firmware/motor_control_hardware.h
+++ b/motor-control/firmware/motor_control_hardware.h
@@ -18,6 +18,8 @@ bool motor_hardware_start_dac(void* dac_handle, uint32_t channel);
 bool motor_hardware_stop_dac(void* dac_handle, uint32_t channel);
 bool motor_hardware_set_dac_value(void* dac_handle, uint32_t channel,
                                   uint32_t data_algn, uint32_t val);
+bool motor_hardware_start_pwm(void* tim_handle, uint32_t channel);
+bool motor_hardware_stop_pwm(void* tim_handle, uint32_t channel);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/motor-control/firmware/motor_hardware.cpp
+++ b/motor-control/firmware/motor_hardware.cpp
@@ -41,6 +41,12 @@ bool MotorHardware::check_limit_switch() {
                                         pins.limit_switch.pin,
                                         pins.limit_switch.active_setting);
 }
+
+bool MotorHardware::check_sync_in() {
+    return motor_hardware_get_pin_value(pins.sync_in.port, pins.sync_in.pin,
+                                        pins.sync_in.active_setting);
+}
+
 void MotorHardware::set_LED(bool status) {
     if (status) {
         motor_hardware_set_pin(pins.led.port, pins.led.pin,

--- a/pipettes/core/CMakeLists.txt
+++ b/pipettes/core/CMakeLists.txt
@@ -1,7 +1,35 @@
-function(target_pipettes_core TARGET)
+function(target_pipettes_core_common TARGET)
     target_sources(${TARGET} PUBLIC
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/can_task.cpp
-            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tasks.cpp)
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/configs.cpp)
     target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_FUNCTION_LIST_DIR})
     target_link_libraries(${TARGET} PUBLIC common-core)
+endfunction()
+
+function(target_pipettes_core_single TARGET)
+    target_pipettes_core_common(${TARGET})
+    target_sources(${TARGET} PUBLIC
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_single.cpp
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tasks.cpp)
+endfunction()
+
+function(target_pipettes_core_multi TARGET)
+    target_pipettes_core_common(${TARGET})
+    target_sources(${TARGET} PUBLIC
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_multi.cpp
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tasks_multiple_i2c.cpp)
+endfunction()
+
+function(target_pipettes_core_96 TARGET)
+    target_pipettes_core_common(${TARGET})
+    target_sources(${TARGET} PUBLIC
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_96.cpp
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tasks_multiple_i2c.cpp)
+endfunction()
+
+function(target_pipettes_core_384 TARGET)
+    target_pipettes_core_common(${TARGET})
+    target_sources(${TARGET} PUBLIC
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_384.cpp
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tasks_multiple_i2c.cpp)
 endfunction()

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -14,6 +14,7 @@
 #include "common/core/freertos_task.hpp"
 #include "common/core/version.h"
 #include "pipettes/core/message_handlers/eeprom.hpp"
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/tasks.hpp"
 #include "sensors/core/message_handlers/sensors.hpp"
 
@@ -40,6 +41,9 @@ static auto system_message_handler = system_handler::SystemMessageHandler{
 
 static auto sensor_handler =
     sensor_message_handler::SensorHandler{queue_client};
+
+static auto pipette_info_handler =
+    pipette_info::PipetteInfoMessageHandler{queue_client};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target = can_dispatch::DispatchParseTarget<
@@ -78,11 +82,17 @@ static auto sensor_dispatch_target = can_dispatch::DispatchParseTarget<
     can_messages::WriteToSensorRequest, can_messages::BaselineSensorRequest,
     can_messages::SetSensorThresholdRequest>{sensor_handler};
 
+static auto pipette_info_target =
+    can_dispatch::DispatchParseTarget<decltype(pipette_info_handler),
+                                      can_messages::PipetteInfoRequest>{
+        pipette_info_handler};
+
 /** Dispatcher to the various handlers */
 static auto dispatcher = can_dispatch::Dispatcher(
     [](auto _) -> bool { return true; }, motor_dispatch_target,
     motion_controller_dispatch_target, motion_group_dispatch_target,
-    eeprom_dispatch_target, sensor_dispatch_target, system_dispatch_target);
+    eeprom_dispatch_target, sensor_dispatch_target, system_dispatch_target,
+    pipette_info_target);
 
 /**
  * The type of the message buffer populated by HAL ISR.

--- a/pipettes/core/configs.cpp
+++ b/pipettes/core/configs.cpp
@@ -1,0 +1,37 @@
+#include "pipettes/core/configs.hpp"
+
+auto configs::driver_config_by_axis(PipetteType which)
+    -> tmc2130::TMC2130DriverConfig {
+    switch (which) {
+        default:
+            return tmc2130::TMC2130DriverConfig{
+                .registers = {.gconfig = {.en_pwm_mode = 1},
+                              .ihold_irun = {.hold_current = 0x2,
+                                             .run_current = 0x10,
+                                             .hold_current_delay = 0x7},
+                              .tpowerdown = {},
+                              .tcoolthrs = {.threshold = 0},
+                              .thigh = {.threshold = 0xFFFFF},
+                              .chopconf = {.toff = 0x5,
+                                           .hstrt = 0x5,
+                                           .hend = 0x3,
+                                           .tbl = 0x2,
+                                           .mres = 0x3},
+                              .coolconf = {.sgt = 0x6}},
+                .current_config = {
+                    .r_sense = 0.1,
+                    .v_sf = 0.325,
+                }};
+    }
+}
+
+auto configs::linear_motion_sys_config_by_axis(PipetteType which)
+    -> lms::LinearMotionSystemConfig<lms::LeadScrewConfig> {
+    switch (which) {
+        default:
+            return lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
+                .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 3.03},
+                .steps_per_rev = 200,
+                .microstep = 32};
+    }
+}

--- a/pipettes/core/pipette_type_384.cpp
+++ b/pipettes/core/pipette_type_384.cpp
@@ -1,5 +1,12 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType {
     return THREE_EIGHTY_FOUR_CHANNEL;
 }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_384; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/core/pipette_type_384.cpp
+++ b/pipettes/core/pipette_type_384.cpp
@@ -1,0 +1,5 @@
+#include "pipettes/core/pipette_type.h"
+
+extern "C" auto get_pipette_type() -> PipetteType {
+    return THREE_EIGHTY_FOUR_CHANNEL;
+}

--- a/pipettes/core/pipette_type_96.cpp
+++ b/pipettes/core/pipette_type_96.cpp
@@ -1,0 +1,3 @@
+#include "pipettes/core/pipette_type.h"
+
+extern "C" auto get_pipette_type() -> PipetteType { return NINETY_SIX_CHANNEL; }

--- a/pipettes/core/pipette_type_96.cpp
+++ b/pipettes/core/pipette_type_96.cpp
@@ -1,3 +1,10 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType { return NINETY_SIX_CHANNEL; }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_96; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/core/pipette_type_multi.cpp
+++ b/pipettes/core/pipette_type_multi.cpp
@@ -1,3 +1,10 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType { return EIGHT_CHANNEL; }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_MULTI; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/core/pipette_type_multi.cpp
+++ b/pipettes/core/pipette_type_multi.cpp
@@ -1,0 +1,3 @@
+#include "pipettes/core/pipette_type.h"
+
+extern "C" auto get_pipette_type() -> PipetteType { return EIGHT_CHANNEL; }

--- a/pipettes/core/pipette_type_single.cpp
+++ b/pipettes/core/pipette_type_single.cpp
@@ -1,3 +1,10 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType { return SINGLE_CHANNEL; }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_SINGLE; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/core/pipette_type_single.cpp
+++ b/pipettes/core/pipette_type_single.cpp
@@ -1,0 +1,3 @@
+#include "pipettes/core/pipette_type.h"
+
+extern "C" auto get_pipette_type() -> PipetteType { return SINGLE_CHANNEL; }

--- a/pipettes/core/tasks_multiple_i2c.cpp
+++ b/pipettes/core/tasks_multiple_i2c.cpp
@@ -1,5 +1,3 @@
-#include "pipettes/core/tasks.hpp"
-
 #include "can/core/ids.hpp"
 #include "common/core/freertos_message_queue.hpp"
 #include "motor-control/core/tasks/motion_controller_task_starter.hpp"
@@ -7,6 +5,7 @@
 #include "motor-control/core/tasks/move_group_task_starter.hpp"
 #include "motor-control/core/tasks/move_status_reporter_task_starter.hpp"
 #include "pipettes/core/can_task.hpp"
+#include "pipettes/core/tasks.hpp"
 #include "pipettes/core/tasks/eeprom_task_starter.hpp"
 #include "pipettes/core/tasks/i2c_task_starter.hpp"
 #include "sensors/core/tasks/capacitive_sensor_task_starter.hpp"
@@ -14,7 +13,9 @@
 
 static auto tasks = pipettes_tasks::AllTask{};
 static auto queue_client = pipettes_tasks::QueueClient{};
-static auto i2c_task_client =
+static auto i2c1_task_client =
+    i2c_writer::I2CWriter<freertos_message_queue::FreeRTOSMessageQueue>();
+static auto i2c3_task_client =
     i2c_writer::I2CWriter<freertos_message_queue::FreeRTOSMessageQueue>();
 static auto mc_task_builder =
     motion_controller_task_starter::TaskStarter<lms::LeadScrewConfig, 512,
@@ -46,28 +47,31 @@ void pipettes_tasks::start_tasks(
     can_bus::CanBus& can_bus,
     motion_controller::MotionController<lms::LeadScrewConfig>&
         motion_controller,
-    motor_driver::MotorDriver& motor_driver, i2c::I2CDeviceBase& i2c_device,
-    can_ids::NodeId id) {
+    motor_driver::MotorDriver& motor_driver, i2c::I2CDeviceBase& i2c3_device,
+    i2c::I2CDeviceBase& i2c1_device, can_ids::NodeId id) {
     queue_client.set_node_id(id);
     auto& queues = pipettes_tasks::get_queues();
     auto& tasks = pipettes_tasks::get_tasks();
 
     auto& can_writer = can_task::start_writer(can_bus);
     can_task::start_reader(can_bus, id);
-    auto& i2c3_task = i2c_task_builder.start(5, i2c_device);
-    i2c_task_client.set_queue(&i2c3_task.get_queue());
+    auto& i2c3_task = i2c_task_builder.start(5, i2c3_device);
+    i2c3_task_client.set_queue(&i2c3_task.get_queue());
+    auto& i2c1_task = i2c_task_builder.start(5, i2c1_device);
+    i2c1_task_client.set_queue(&i2c1_task.get_queue());
 
     auto& motion = mc_task_builder.start(5, motion_controller, queues);
     auto& motor = motor_driver_task_builder.start(5, motor_driver, queues);
     auto& move_group = move_group_task_builder.start(5, queues, queues);
     auto& move_status_reporter = move_status_task_builder.start(5, queues);
 
-    auto& eeprom_task = eeprom_task_builder.start(5, i2c_task_client, queues);
+    auto& eeprom_task = eeprom_task_builder.start(5, i2c3_task_client, queues);
     auto& environment_sensor_task =
-        environment_sensor_task_builder.start(5, i2c_task_client, queues);
+        environment_sensor_task_builder.start(5, i2c3_task_client, queues);
     auto& capacitive_sensor_task =
-        capacitive_sensor_task_builder.start(5, i2c_task_client, queues);
+        capacitive_sensor_task_builder.start(5, i2c3_task_client, queues);
 
+    // TODO (lc: 03-21-2022, add necessary sensor tasks for secondary i2c bus
     tasks.can_writer = &can_writer;
     tasks.motion_controller = &motion;
     tasks.motor_driver = &motor;
@@ -77,6 +81,7 @@ void pipettes_tasks::start_tasks(
     tasks.environment_sensor_task = &environment_sensor_task;
     tasks.capacitive_sensor_task = &capacitive_sensor_task;
     tasks.i2c3_task = &i2c3_task;
+    tasks.i2c1_task = &i2c1_task;
 
     queues.motion_queue = &motion.get_queue();
     queues.motor_queue = &motor.get_queue();
@@ -88,6 +93,7 @@ void pipettes_tasks::start_tasks(
     queues.capacitive_sensor_queue = &capacitive_sensor_task.get_queue();
 
     queues.i2c3_queue = &i2c3_task.get_queue();
+    queues.i2c1_queue = &i2c1_task.get_queue();
 }
 
 pipettes_tasks::QueueClient::QueueClient()

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -12,7 +12,6 @@ set(CAN_FW_DIR "${CMAKE_SOURCE_DIR}/can/firmware")
 
 # Add source files that should be checked by clang-tidy here
 set(PIPETTE_FW_LINTABLE_SRCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
     ${COMMON_EXECUTABLE_DIR}/spi/spi_comms.cpp
     ${COMMON_EXECUTABLE_DIR}/i2c/i2c_comms.cpp
@@ -36,40 +35,6 @@ set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${COMMON_EXECUTABLE_DIR}/system/app_update.c
     ${COMMON_EXECUTABLE_DIR}/system/iwdg.c)
 
-add_executable(pipettes
-        ${PIPETTE_FW_LINTABLE_SRCS}
-        ${PIPETTE_FW_NON_LINTABLE_SRCS})
-
-target_pipettes_core(pipettes)
-
-target_ot_motor_control(pipettes)
-
-target_link_libraries(pipettes
-        PUBLIC STM32L562RETx
-        STM32L5xx_Drivers_Pipettes STM32L5xx_FreeRTOS_Pipettes
-        can-core common-core
-        )
-
-set_target_properties(pipettes
-        PROPERTIES CXX_STANDARD 20
-        CXX_STANDARD_REQUIRED TRUE
-        C_STANDARD 11
-        C_STANDARD_REQUIRED TRUE)
-
-target_include_directories(
-        pipettes
-        PUBLIC ${CMAKE_SOURCE_DIR}/include)
-
-target_compile_options(pipettes
-        PUBLIC
-        -Wall
-        -Werror
-        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
-        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
 
 target_include_directories(STM32L5xx_Drivers_Pipettes
         PUBLIC .)
@@ -91,82 +56,138 @@ find_program(ARM_GDB
         PATHS "${CrossGCC_BINDIR}"
         NO_DEFAULT_PATH
         REQUIRED)
-# Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
-# this dir
-set_target_properties(pipettes
-        PROPERTIES
-        CROSSCOMPILING_EMULATOR
-        "${ARM_GDB};--command=${CMAKE_BINARY_DIR}/common/firmware/STM32L562RETx/gdbinit")
-
-find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
-        PATHS "${CrossGCC_BINDIR}"
-        NO_DEFAULT_PATH
-        REQUIRED)
-add_custom_command(OUTPUT pipettes.hex
-        COMMAND ${CROSS_OBJCOPY} ARGS pipettes "-Oihex" pipettes.hex
-        DEPENDS pipettes
-        VERBATIM)
-add_custom_target(pipettes-hex ALL
-        DEPENDS pipettes.hex)
-
-add_custom_command(OUTPUT pipettes.bin
-        COMMAND ${CROSS_OBJCOPY} ARGS pipettes "-Obinary" pipettes.bin
-        DEPENDS pipettes
-        VERBATIM)
-add_custom_target(pipettes-bin ALL
-        DEPENDS pipettes.bin)
-
-
 
 find_package(Clang)
 
-# # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
-# # which is a catch-all static analyzer/linter
-# # the empty --config= tells clang-tidy to use the .clang-tidy file in the top level
-# # An odd thing about this target is that it requires the existance of a compiledb, which
-# # is produced when you build, and may change if you change compilation options, so in a way
-# # it depends on a build. But we also want to be able to run this when there wasn't a successful
-# # build, so there's no explicit dependency set.
-# # This awful transform is required because the implicit includes that gcc knows how to find (e.g. its
-# # own implementation of the STL) don't get added to the compile db that clang-tidy uses to figure out
-# # include directories. So we can use the actually fairly cool transform command to turn them all into
-# # extra-arg invocations and it'll figure it out.
-set(CLANG_EXTRA_ARGS ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
-list(TRANSFORM CLANG_EXTRA_ARGS PREPEND --extra-arg=-I)
-# This helps with clang accepting what GCC accepts around the implementations of the message queue
-list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
-add_custom_target(pipettes-lint
-        ALL
-        COMMAND ${Clang_CLANGTIDY_EXECUTABLE} "--extra-arg=-DOPENTRONS_CLANG_TIDY_WORKAROUND_44178" ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${PIPETTE_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES})
-list(APPEND LINT_TARGETS pipettes-lint)
-set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)
-# Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
-# arguable misuse of the concept) to the appropriate cross-gdb with
-# remote-target. You should make sure st-util is running; that's not
-# done here because it won't be multi-os compatible, and also it
-# should be running the entire time and that's tough to accomplish
-# in a custom command
-add_custom_target(pipettes-debug
-        COMMAND pipettes
-        USES_TERMINAL
-        )
+
+function(add_pipettes_executable TARGET)
+    add_executable(${TARGET}
+            ${PIPETTE_FW_LINTABLE_SRCS}
+            ${PIPETTE_FW_NON_LINTABLE_SRCS})
+
+    target_ot_motor_control(${TARGET})
+
+    target_link_libraries(${TARGET}
+            PUBLIC STM32L562RETx
+            STM32L5xx_Drivers_Pipettes STM32L5xx_FreeRTOS_Pipettes
+            can-core common-core
+            )
+
+    set_target_properties(${TARGET}
+            PROPERTIES CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED TRUE
+            C_STANDARD 11
+            C_STANDARD_REQUIRED TRUE)
+
+    target_include_directories(
+            ${TARGET}
+            PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+    target_compile_options(${TARGET}
+            PUBLIC
+            -Wall
+            -Werror
+            $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+            $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+            $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+            $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+            $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+            $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+
+    if(${TARGET} STREQUAL "pipettes-single")
+        target_sources(${TARGET} PUBLIC main.cpp)
+        target_pipettes_core_single(${TARGET})
+    elseif(${TARGET} STREQUAL "pipettes-multi")
+        target_sources(${TARGET} PUBLIC main_multi_i2c.cpp)
+        target_pipettes_core_multi(${TARGET})
+    elseif(${TARGET} STREQUAL "pipettes-96")
+        target_sources(${TARGET} PUBLIC main_multi_i2c.cpp)
+        target_pipettes_core_96(${TARGET})
+    elseif(${TARGET} STREQUAL "pipettes-384")
+        target_sources(${TARGET} PUBLIC main_multi_i2c.cpp)
+        target_pipettes_core_384(${TARGET})
+    else ()
+        message(FATAL_ERROR "Invalid pipette target provided.")
+    endif ()
+
+    # Configure gdb (full path to cross-gdb set in the toolchain) to use the gdbinit in
+    # this dir
+    set_target_properties(${TARGET}
+            PROPERTIES
+            CROSSCOMPILING_EMULATOR
+            "${ARM_GDB};--command=${CMAKE_BINARY_DIR}/common/firmware/STM32L562RETx/gdbinit")
+
+    find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
+            PATHS "${CrossGCC_BINDIR}"
+            NO_DEFAULT_PATH
+            REQUIRED)
+    add_custom_command(OUTPUT ${TARGET}.hex
+            COMMAND ${CROSS_OBJCOPY} ARGS pipettes "-Oihex" pipettes.hex
+            DEPENDS ${TARGET}
+            VERBATIM)
+    add_custom_target(${TARGET}-hex ALL
+            DEPENDS ${TARGET}.hex)
+
+    add_custom_command(OUTPUT ${TARGET}.bin
+            COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET} "-Obinary" ${TARGET}.bin
+            DEPENDS ${TARGET}
+            VERBATIM)
+    add_custom_target(${TARGET}-bin ALL
+            DEPENDS ${TARGET}.bin)
+
+    # # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
+    # # which is a catch-all static analyzer/linter
+    # # the empty --config= tells clang-tidy to use the .clang-tidy file in the top level
+    # # An odd thing about this target is that it requires the existance of a compiledb, which
+    # # is produced when you build, and may change if you change compilation options, so in a way
+    # # it depends on a build. But we also want to be able to run this when there wasn't a successful
+    # # build, so there's no explicit dependency set.
+    # # This awful transform is required because the implicit includes that gcc knows how to find (e.g. its
+    # # own implementation of the STL) don't get added to the compile db that clang-tidy uses to figure out
+    # # include directories. So we can use the actually fairly cool transform command to turn them all into
+    # # extra-arg invocations and it'll figure it out.
+    set(CLANG_EXTRA_ARGS ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+    list(TRANSFORM CLANG_EXTRA_ARGS PREPEND --extra-arg=-I)
+    # This helps with clang accepting what GCC accepts around the implementations of the message queue
+    list(APPEND CLANG_EXTRA_ARGS "--extra-arg=-frelaxed-template-template-args")
+    add_custom_target(${TARGET}-lint
+            ALL
+            COMMAND ${Clang_CLANGTIDY_EXECUTABLE} "--extra-arg=-DOPENTRONS_CLANG_TIDY_WORKAROUND_44178" ${CLANG_EXTRA_ARGS} -p ${CMAKE_BINARY_DIR} ${PIPETTE_FW_LINTABLE_SRCS} ${CORE_LINTABLE_SOURCES})
+    list(APPEND LINT_TARGETS ${TARGET}-lint)
+    set(LINT_TARGETS ${LINT_TARGETS} PARENT_SCOPE)
+    # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
+    # arguable misuse of the concept) to the appropriate cross-gdb with
+    # remote-target. You should make sure st-util is running; that's not
+    # done here because it won't be multi-os compatible, and also it
+    # should be running the entire time and that's tough to accomplish
+    # in a custom command
+    add_custom_target(${TARGET}-debug
+            COMMAND ${TARGET}
+            USES_TERMINAL
+            )
 
 
-# Targets to create full image hex file containing both bootloader and application
-add_custom_command(
-        OUTPUT pipettes-image.hex
-        DEPENDS pipettes-hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex pipettes.hex
-        COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py pipettes-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex pipettes.hex
-        VERBATIM)
-add_custom_target(pipettes-image-hex ALL
-        DEPENDS pipettes-image.hex)
+    # Targets to create full image hex file containing both bootloader and application
+    add_custom_command(
+            OUTPUT ${TARGET}-image.hex
+            DEPENDS ${TARGET}-hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
+            COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py ${TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
+            VERBATIM)
+    add_custom_target(${TARGET}-image-hex ALL
+            DEPENDS ${TARGET}-image.hex)
 
 
-set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32L562RETx/stm32l5discovery.cfg")
+    set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32L562RETx/stm32l5discovery.cfg")
 
-# Targets to flash bootloader and firmware
-add_custom_target(pipettes-flash
-        COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/pipettes-image.hex;reset;exit"
-        VERBATIM
-        COMMENT "Flashing board"
-        DEPENDS pipettes-image-hex)
+    # Targets to flash bootloader and firmware
+    add_custom_target(${TARGET}-flash
+            COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}-image.hex;reset;exit"
+            VERBATIM
+            COMMENT "Flashing board"
+            DEPENDS ${TARGET}-image-hex)
+endfunction()
+
+add_pipettes_executable(pipettes-single)
+add_pipettes_executable(pipettes-multi)
+add_pipettes_executable(pipettes-96)
+add_pipettes_executable(pipettes-384)

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -122,7 +122,7 @@ function(add_pipettes_executable TARGET)
             NO_DEFAULT_PATH
             REQUIRED)
     add_custom_command(OUTPUT ${TARGET}.hex
-            COMMAND ${CROSS_OBJCOPY} ARGS pipettes "-Oihex" pipettes.hex
+            COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET} "-Oihex" ${TARGET}.hex
             DEPENDS ${TARGET}
             VERBATIM)
     add_custom_target(${TARGET}-hex ALL

--- a/pipettes/firmware/i2c_setup.c
+++ b/pipettes/firmware/i2c_setup.c
@@ -1,5 +1,5 @@
 #include "platform_specific_hal_conf.h"
-#include "common/firmware/i2c.h"
+#include "pipettes/firmware/i2c_setup.h"
 #include "common/firmware/errors.h"
 
 static I2C_HandleTypeDef hi2c;
@@ -167,7 +167,17 @@ void i2c_setup(I2CHandlerStruct* temp_struct, PipetteType pipette_type) {
     tip_sense_gpio_init();
     eeprom_write_gpio_init();
     switch (pipette_type) {
-        case MULTI_CHANNEL: {
+        case EIGHT_CHANNEL: {
+            HAL_I2C_HANDLE i2c1 = MX_I2C1_Init();
+            temp_struct->i2c1 = i2c1;
+            break;
+        }
+        case NINETY_SIX_CHANNEL: {
+            HAL_I2C_HANDLE i2c1 = MX_I2C1_Init();
+            temp_struct->i2c1 = i2c1;
+            break;
+        }
+        case THREE_EIGHTY_FOUR_CHANNEL: {
             HAL_I2C_HANDLE i2c1 = MX_I2C1_Init();
             temp_struct->i2c1 = i2c1;
             break;

--- a/pipettes/firmware/main_multi_i2c.cpp
+++ b/pipettes/firmware/main_multi_i2c.cpp
@@ -51,6 +51,7 @@ spi::SPI_interface SPI_intf = {
 static spi::Spi spi_comms(SPI_intf);
 
 static auto i2c_comms3 = i2c::I2C();
+static auto i2c_comms1 = i2c::I2C();
 static I2CHandlerStruct i2chandler_struct{};
 
 struct motion_controller::HardwareConfig plunger_pins {
@@ -118,6 +119,7 @@ auto main() -> int {
 
     i2c_setup(&i2chandler_struct, PIPETTE_TYPE);
     i2c_comms3.set_handle(i2chandler_struct.i2c3);
+    i2c_comms1.set_handle(i2chandler_struct.i2c1);
 
     if (initialize_spi() != HAL_OK) {
         Error_Handler();
@@ -130,7 +132,8 @@ auto main() -> int {
     can_start();
 
     pipettes_tasks::start_tasks(can_bus_1, pipette_motor.motion_controller,
-                                pipette_motor.driver, i2c_comms3, id);
+                                pipette_motor.driver, i2c_comms3, i2c_comms1,
+                                id);
 
     iWatchdog.start(6);
 

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -7,7 +7,7 @@
  * @param None
  * @retval None
  */
-void limit_switch_gpio_init() {
+void limit_switch_gpio_init(void) {
     /* GPIO Ports Clock Enable */
     __HAL_RCC_GPIOC_CLK_ENABLE();
 
@@ -24,20 +24,32 @@ void limit_switch_gpio_init() {
  * @param None
  * @retval None
  */
-void LED_drive_gpio_init() {
+void LED_drive_gpio_init(void) {
     /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
 
-    /*Configure GPIO pin : PA8 */
+    /*Configure GPIO pin : PB11 */
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Pin = GPIO_PIN_8;
+    GPIO_InitStruct.Pin = GPIO_PIN_11;
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Pull = GPIO_PULLDOWN;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 }
 
-void utility_gpio_init() {
+void sync_drive_gpio_init() {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+
+    /*Configure GPIO pin : PB5:sync in*/
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_5;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+void utility_gpio_init(void) {
     limit_switch_gpio_init();
     LED_drive_gpio_init();
+    sync_drive_gpio_init();
 }

--- a/pipettes/simulator/CMakeLists.txt
+++ b/pipettes/simulator/CMakeLists.txt
@@ -5,10 +5,10 @@ find_package(FreeRTOS)
 include_directories(
         .
         ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+        ${CMAKE_BINARY_DIR}/generated/
         ${FreeRTOS_SOURCE_DIR}/FreeRTOS/Source/include
         ${FreeRTOS_SOURCE_DIR}/FreeRTOS/Source/portable/ThirdParty/GCC/Posix
         ${FreeRTOS_SOURCE_DIR}/FreeRTOS/Source/portable/ThirdParty/GCC/Posix/utils
-
 )
 
 # Create the FreeRTOS source file list
@@ -26,40 +26,61 @@ list(APPEND FREERTOS_SOURCES "${FreeRTOS_SOURCE_DIR}/FreeRTOS/Source/portable/Th
 # Create the freertos lib
 add_library(freertos-pipettes STATIC ${FREERTOS_SOURCES})
 
-set(PIPETTES_SIMULATOR_SRC
-        ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
-        )
 
-add_executable(
-        pipettes-simulator
-        ${PIPETTES_SIMULATOR_SRC}
-)
+function(add_simulator_executable TARGET)
+    if(${TARGET} STREQUAL "pipettes-single-simulator")
+        set(PIPETTES_SIMULATOR_SRC
+                ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
+                )
+    else()
+        set(PIPETTES_SIMULATOR_SRC
+                ${CMAKE_CURRENT_SOURCE_DIR}/main_multi_i2c.cpp
+                ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
+                )
+    endif()
+    add_executable(
+            ${TARGET}
+            ${PIPETTES_SIMULATOR_SRC}
+    )
 
-if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
-    target_compile_definitions(pipettes-simulator PUBLIC USE_SOCKETCAN)
-endif()
+    if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
+        target_compile_definitions(${TARGET} PUBLIC USE_SOCKETCAN)
+    endif()
 
-target_compile_definitions(pipettes-simulator PUBLIC ENABLE_LOGGING)
-
-target_can_simlib(pipettes-simulator)
-
-target_pipettes_core(pipettes-simulator)
-
-target_ot_motor_control(pipettes-simulator)
-
-target_link_libraries(pipettes-simulator PRIVATE can-core common-simulation freertos-pipettes pthread Boost::boost)
-
-
-# Set up the include directories
-target_include_directories(
-        pipettes-simulator
-        PUBLIC ${CMAKE_SOURCE_DIR}/include)
+    target_compile_definitions(${TARGET} PUBLIC ENABLE_LOGGING)
 
 
-set_target_properties(pipettes-simulator
-        PROPERTIES CXX_STANDARD 20
-        CXX_STANDARD_REQUIRED TRUE
-        C_STANDARD 11
-        C_STANDARD_REQUIRED TRUE)
+    target_can_simlib(${TARGET})
+    target_ot_motor_control(${TARGET})
 
+    if(${TARGET} STREQUAL "pipettes-single-simulator")
+        target_pipettes_core_single(${TARGET})
+    elseif(${TARGET} STREQUAL "pipettes-multi-simulator")
+        target_pipettes_core_multi(${TARGET})
+    elseif(${TARGET} STREQUAL "pipettes-96-simulator")
+        target_pipettes_core_96(${TARGET})
+    elseif(${TARGET} STREQUAL "pipettes-384-simulator")
+        target_pipettes_core_384(${TARGET})
+    else ()
+        message(FATAL_ERROR "Invalid pipette target provided.")
+    endif ()
+
+    target_link_libraries(${TARGET} PRIVATE can-core common-simulation freertos-pipettes pthread Boost::boost)
+
+    # Set up the include directories
+    target_include_directories(
+            ${TARGET}
+            PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+    set_target_properties(${TARGET}
+            PROPERTIES CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED TRUE
+            C_STANDARD 11
+            C_STANDARD_REQUIRED TRUE)
+endfunction()
+
+add_simulator_executable(pipettes-single-simulator)
+add_simulator_executable(pipettes-multi-simulator)
+add_simulator_executable(pipettes-96-simulator)
+add_simulator_executable(pipettes-384-simulator)

--- a/pipettes/simulator/main_multi_i2c.cpp
+++ b/pipettes/simulator/main_multi_i2c.cpp
@@ -50,6 +50,7 @@ std::map<uint16_t, sensor_simulator::SensorType> sensor_map = {
     {capsensor.ADDRESS, capsensor}};
 
 static auto i2c3_comms = sim_i2c::SimI2C{sensor_map};
+static auto i2c1_comms = sim_i2c::SimI2C{sensor_map};
 
 static motor_class::Motor pipette_motor{
     spi_comms,
@@ -96,7 +97,7 @@ int main() {
     });
 
     pipettes_tasks::start_tasks(can_bus_1, pipette_motor.motion_controller,
-                                pipette_motor.driver, i2c3_comms,
+                                pipette_motor.driver, i2c3_comms, i2c1_comms,
                                 node_from_env(std::getenv("MOUNT")));
 
     vTaskStartScheduler();

--- a/run_simulators.sh
+++ b/run_simulators.sh
@@ -4,7 +4,7 @@ trap "kill 0" EXIT
 ./build-host/head/simulator/head-simulator &
 ./build-host/gantry/simulator/gantry-x-simulator &
 ./build-host/gantry/simulator/gantry-y-simulator &
-./build-host/pipettes/simulator/pipettes-simulator &
+./build-host/pipettes/simulator/pipettes-single-simulator &
 ./build-host/gripper/simulator/gripper-simulator &
 ./build-host/bootloader/simulator/bootloader-simulator &
 


### PR DESCRIPTION
This PR adds a few things to the motor hardware of the head.
-Motor Encoder pulse count can now be retrieved
-A reset Motor Encoder pulse count
-Separated the Encoder GPIO Configuration from MX_GPIO_Init() function. 

These changes were tested with gdb with setting breaking points and reading the enc_pulse_counter when rotating the motor manually. 
