### PR TITLE
feat(pipettes): add pipette info messages

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -23,6 +23,8 @@ typedef enum {
     can_messageid_device_info_response = 0x303,
     can_messageid_task_info_request = 0x304,
     can_messageid_task_info_response = 0x305,
+    can_messageid_pipette_info_request = 0x306,
+    can_messageid_pipette_info_response = 0x307,
     can_messageid_stop_request = 0x0,
     can_messageid_get_status_request = 0x1,
     can_messageid_get_status_response = 0x5,
@@ -46,6 +48,9 @@ typedef enum {
     can_messageid_write_motor_driver_register_request = 0x30,
     can_messageid_read_motor_driver_register_request = 0x31,
     can_messageid_read_motor_driver_register_response = 0x32,
+    can_messageid_write_motor_current_request = 0x33,
+    can_messageid_read_motor_current_request = 0x34,
+    can_messageid_read_motor_current_response = 0x35,
     can_messageid_read_presence_sensing_voltage_request = 0x600,
     can_messageid_read_presence_sensing_voltage_response = 0x601,
     can_messageid_attached_tools_request = 0x700,
@@ -113,9 +118,10 @@ typedef enum {
 
 /** A bit field of the arbitration id parts. */
 typedef struct {
-    unsigned int function_code : 4;
-    unsigned int node_id : 7;
-    unsigned int originating_node_id : 7;
-    unsigned int message_id : 11;
-    unsigned int padding : 3;
+    unsigned int function_code: 4;
+    unsigned int node_id: 7;
+    unsigned int originating_node_id: 7;
+    unsigned int message_id: 11;
+    unsigned int padding: 3;
 } CANArbitrationIdParts;
+

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -25,6 +25,8 @@ enum class MessageId {
     device_info_response = 0x303,
     task_info_request = 0x304,
     task_info_response = 0x305,
+    pipette_info_request = 0x306,
+    pipette_info_response = 0x307,
     stop_request = 0x0,
     get_status_request = 0x1,
     get_status_response = 0x5,
@@ -84,8 +86,8 @@ enum class NodeId {
     gantry_x = 0x30,
     gantry_y = 0x40,
     head = 0x50,
-    head_r = 0x52,
     head_l = 0x51,
+    head_r = 0x52,
     gripper = 0x20,
     pipette_left_bootloader = 0x6f,
     pipette_right_bootloader = 0x7f,
@@ -122,6 +124,8 @@ enum class SensorType {
     capacitive = 0x1,
     humidity = 0x2,
     temperature = 0x3,
+    pressure = 0x4,
 };
 
 }  // namespace can_ids
+

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -128,4 +128,3 @@ enum class SensorType {
 };
 
 }  // namespace can_ids
-

--- a/include/pipettes/core/pipette_info.hpp
+++ b/include/pipettes/core/pipette_info.hpp
@@ -16,6 +16,8 @@ using namespace can_messages;
 enum class PipetteName {
     P1000_SINGLE = 0,
     P1000_MULTI = 1,
+    P1000_96 = 2,
+    P1000_384 = 3,
 };
 
 struct PipetteInfo {
@@ -23,6 +25,11 @@ struct PipetteInfo {
     uint16_t model;
     std::array<char, 12> serial;
 };
+
+// These are implemented in pipette-type-specific source files in core
+// e.g. pipettes/core/pipette_type_single.cpp
+PipetteName get_name();
+uint16_t get_model();
 
 /**
  * A HandlesMessages implementing class that will respond to system messages.
@@ -39,8 +46,8 @@ class PipetteInfoMessageHandler {
      */
     explicit PipetteInfoMessageHandler(CanClient &writer)
         : PipetteInfoMessageHandler(
-              writer, PipetteInfo{.name = PipetteName::P1000_SINGLE,
-                                  .model = 0,
+              writer, PipetteInfo{.name = get_name(),
+                                  .model = get_model(),
                                   .serial = std::array{'2', '0', '2', '2', '0',
                                                        '3', '2', '1', 'A', '0',
                                                        '5', '\0'}}) {}

--- a/include/pipettes/core/pipette_info.hpp
+++ b/include/pipettes/core/pipette_info.hpp
@@ -1,0 +1,85 @@
+/*
+** Functions and definitions for deciding what kind of pipette this is.
+*/
+#pragma once
+#include <array>
+#include <cstdint>
+
+#include "can/core/can_writer_task.hpp"
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+
+namespace pipette_info {
+using namespace can_ids;
+using namespace can_messages;
+
+enum class PipetteName {
+    P1000_SINGLE = 0,
+    P1000_MULTI = 1,
+};
+
+struct PipetteInfo {
+    PipetteName name;
+    uint16_t model;
+    std::array<char, 12> serial;
+};
+
+/**
+ * A HandlesMessages implementing class that will respond to system messages.
+ *
+ * @tparam CanClient can writer task client
+ */
+template <message_writer_task::TaskClient CanClient>
+class PipetteInfoMessageHandler {
+  public:
+    /**
+     * Constructor
+     *
+     * @param writer A message writer for sending the response
+     */
+    explicit PipetteInfoMessageHandler(CanClient &writer)
+        : PipetteInfoMessageHandler(
+              writer, PipetteInfo{.name = PipetteName::P1000_SINGLE,
+                                  .model = 0,
+                                  .serial = std::array{'2', '0', '2', '2', '0',
+                                                       '3', '2', '1', 'A', '0',
+                                                       '5', '\0'}}) {}
+    PipetteInfoMessageHandler(CanClient &writer,
+                              const PipetteInfo &pipette_info)
+        : writer(writer),
+          response{.name = static_cast<uint16_t>(pipette_info.name),
+                   .model = pipette_info.model} {
+        std::copy_n(
+            pipette_info.serial.cbegin(),
+            std::min(pipette_info.serial.size(), response.serial.size()),
+            response.serial.begin());
+    }
+    PipetteInfoMessageHandler(const PipetteInfoMessageHandler &) = delete;
+    PipetteInfoMessageHandler(const PipetteInfoMessageHandler &&) = delete;
+    auto operator=(const PipetteInfoMessageHandler &)
+        -> PipetteInfoMessageHandler & = delete;
+    auto operator=(const PipetteInfoMessageHandler &&)
+        -> PipetteInfoMessageHandler && = delete;
+    ~PipetteInfoMessageHandler() = default;
+
+    using MessageType = std::variant<std::monostate, PipetteInfoRequest>;
+
+    /**
+     * Message handler
+     * @param m The incoming message.
+     */
+    void handle(MessageType &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+  private:
+    void visit(std::monostate &m) {}
+
+    void visit(PipetteInfoRequest &m) {
+        writer.send_can_message(can_ids::NodeId::host, response);
+    }
+
+    CanClient &writer;
+    can_messages::PipetteInfoResponse response;
+};
+};  // namespace pipette_info

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -14,6 +14,7 @@
 #include "common/core/freertos_task.hpp"
 #include "common/core/version.h"
 #include "pipettes/core/message_handlers/eeprom.hpp"
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/tasks.hpp"
 #include "sensors/core/message_handlers/sensors.hpp"
 
@@ -40,6 +41,9 @@ static auto system_message_handler = system_handler::SystemMessageHandler{
 
 static auto sensor_handler =
     sensor_message_handler::SensorHandler{queue_client};
+
+static auto pipette_info_handler =
+    pipette_info::PipetteInfoMessageHandler{queue_client};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target = can_dispatch::DispatchParseTarget<
@@ -78,11 +82,17 @@ static auto sensor_dispatch_target = can_dispatch::DispatchParseTarget<
     can_messages::WriteToSensorRequest, can_messages::BaselineSensorRequest,
     can_messages::SetSensorThresholdRequest>{sensor_handler};
 
+static auto pipette_info_target =
+    can_dispatch::DispatchParseTarget<decltype(pipette_info_handler),
+                                      can_messages::PipetteInfoRequest>{
+        pipette_info_handler};
+
 /** Dispatcher to the various handlers */
 static auto dispatcher = can_dispatch::Dispatcher(
     [](auto _) -> bool { return true; }, motor_dispatch_target,
     motion_controller_dispatch_target, motion_group_dispatch_target,
-    eeprom_dispatch_target, sensor_dispatch_target, system_dispatch_target);
+    eeprom_dispatch_target, sensor_dispatch_target, system_dispatch_target,
+    pipette_info_target);
 
 /**
  * The type of the message buffer populated by HAL ISR.

--- a/pipettes/core/pipette_type_384.cpp
+++ b/pipettes/core/pipette_type_384.cpp
@@ -1,5 +1,12 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType {
     return THREE_EIGHTY_FOUR_CHANNEL;
 }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_384; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/core/pipette_type_96.cpp
+++ b/pipettes/core/pipette_type_96.cpp
@@ -1,3 +1,10 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType { return NINETY_SIX_CHANNEL; }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_96; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/core/pipette_type_multi.cpp
+++ b/pipettes/core/pipette_type_multi.cpp
@@ -1,3 +1,10 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType { return EIGHT_CHANNEL; }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_MULTI; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/core/pipette_type_single.cpp
+++ b/pipettes/core/pipette_type_single.cpp
@@ -1,3 +1,10 @@
+#include "pipettes/core/pipette_info.hpp"
 #include "pipettes/core/pipette_type.h"
 
 extern "C" auto get_pipette_type() -> PipetteType { return SINGLE_CHANNEL; }
+
+namespace pipette_info {
+auto get_name() -> PipetteName { return PipetteName::P1000_SINGLE; }
+
+auto get_model() -> uint16_t { return 0; }
+};  // namespace pipette_info

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -122,7 +122,7 @@ function(add_pipettes_executable TARGET)
             NO_DEFAULT_PATH
             REQUIRED)
     add_custom_command(OUTPUT ${TARGET}.hex
-            COMMAND ${CROSS_OBJCOPY} ARGS pipettes "-Oihex" pipettes.hex
+            COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET} "-Oihex" ${TARGET}.hex
             DEPENDS ${TARGET}
             VERBATIM)
     add_custom_target(${TARGET}-hex ALL


### PR DESCRIPTION
The host needs to be able to query what kind of pipette is attached so
it can display this information to the user, load appropriate settings,
and similar. This information doesn't really belong in the device info
because it's only present on pipettes.

This PR carves out messages and enums for the information and hooks up a
basic message handler that hardcodes a response. In the future, this
information will be either compiled in or stored on the EEPROM.
