### PR TITLE
feat(gripper): generate pwm signals

### DIFF
--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -27,6 +27,7 @@ set(GRIPPER_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
         ${CMAKE_CURRENT_SOURCE_DIR}/can.c
         ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/motor_timer_hardware.c
         ${COMMON_EXECUTABLE_DIR}/spi/spi.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
         ${COMMON_EXECUTABLE_DIR}/system/app_update.c

--- a/gripper/firmware/interfaces.cpp
+++ b/gripper/firmware/interfaces.cpp
@@ -198,6 +198,9 @@ void interfaces::initialize() {
     // Initialize DAC
     initialize_dac();
 
+    // Initialize PWM timers
+    initialize_pwm();
+
     // Start the can bus
     can_start();
 

--- a/gripper/firmware/interfaces.cpp
+++ b/gripper/firmware/interfaces.cpp
@@ -146,23 +146,19 @@ struct motor_hardware::BrushedHardwareConfig brushed_motor_pins {
     .pwm_1 =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOC,
-            .pin = GPIO_PIN_0,
-            .active_setting = GPIO_PIN_SET},
+            .tim = &htim1,
+            .channel = TIM_CHANNEL_1},
     .pwm_2 =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOA,
-            .pin = GPIO_PIN_6,
-            .active_setting = GPIO_PIN_SET},
+            .tim = &htim3,
+            .channel = TIM_CHANNEL_1},
     .enable =
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        {  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             .port = GPIOC,
             .pin = GPIO_PIN_11,
             .active_setting = GPIO_PIN_SET},
-    .limit_switch = {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    .limit_switch = {  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
         .port = GPIOC,
         .pin = GPIO_PIN_2,
         .active_setting = GPIO_PIN_SET},

--- a/gripper/firmware/interfaces.cpp
+++ b/gripper/firmware/interfaces.cpp
@@ -194,9 +194,6 @@ void interfaces::initialize() {
     // Initialize DAC
     initialize_dac();
 
-    // Initialize PWM timers
-    initialize_pwm();
-
     // Start the can bus
     can_start();
 

--- a/gripper/firmware/motor_hardware.c
+++ b/gripper/firmware/motor_hardware.c
@@ -1,5 +1,7 @@
 #include "motor_hardware.h"
 
+TIM_HandleTypeDef htim1;
+TIM_HandleTypeDef htim3;
 TIM_HandleTypeDef htim7;
 DAC_HandleTypeDef hdac1;
 
@@ -207,3 +209,117 @@ void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac) {
 }
 
 void initialize_dac() { MX_DAC1_Init(); }
+
+/**
+ * @brief TIM1 Initialization Function for AIN1
+ * @param None
+ * @retval None
+ */
+static void MX_TIM1_Init(void) {
+    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
+
+    htim1.Instance = TIM1;
+    htim1.Init.Prescaler = 50000;
+    htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim1.Init.Period = 4000;
+    htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim1.Init.RepetitionCounter = 0;
+    htim1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(&htim1) != HAL_OK) {
+        Error_Handler();
+    }
+    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+    if (HAL_TIM_ConfigClockSource(&htim1, &sClockSourceConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_Init(&htim1) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim1, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 2000;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+    if (HAL_TIM_PWM_ConfigChannel(&htim1, &sConfigOC, TIM_CHANNEL_1) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
+    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
+    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
+    sBreakDeadTimeConfig.DeadTime = 0;
+    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
+    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
+    sBreakDeadTimeConfig.BreakFilter = 0;
+    sBreakDeadTimeConfig.BreakAFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.Break2State = TIM_BREAK2_DISABLE;
+    sBreakDeadTimeConfig.Break2Polarity = TIM_BREAK2POLARITY_HIGH;
+    sBreakDeadTimeConfig.Break2Filter = 0;
+    sBreakDeadTimeConfig.Break2AFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
+    if (HAL_TIMEx_ConfigBreakDeadTime(&htim1, &sBreakDeadTimeConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    HAL_TIM_MspPostInit(&htim1);
+}
+
+/**
+ * @brief TIM3 Initialization Function for AIN2
+ * @param None
+ * @retval None
+ */
+static void MX_TIM3_Init(void) {
+    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+
+    htim3.Instance = TIM3;
+    htim3.Init.Prescaler = 50000;
+    htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim3.Init.Period = 4000;
+    htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(&htim3) != HAL_OK) {
+        Error_Handler();
+    }
+    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+    if (HAL_TIM_ConfigClockSource(&htim3, &sClockSourceConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_Init(&htim3) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim3, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 2000;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    if (HAL_TIM_PWM_ConfigChannel(&htim3, &sConfigOC, TIM_CHANNEL_1) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    HAL_TIM_MspPostInit(&htim3);
+}
+
+void initialize_pwm() {
+    MX_TIM1_Init();
+    MX_TIM3_Init();
+}

--- a/gripper/firmware/motor_hardware.c
+++ b/gripper/firmware/motor_hardware.c
@@ -93,19 +93,6 @@ HAL_StatusTypeDef initialize_spi() {
 }
 
 /**
- * @brief GPIO Initialization Function
- * @param None
- * @retval None
- */
-void MX_GPIO_Init(void) {
-    /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOF_CLK_ENABLE();
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    __HAL_RCC_GPIOB_CLK_ENABLE();
-}
-
-/**
  * @brief DAC1 Initialization Function
  * @param None
  * @retval None

--- a/gripper/firmware/motor_hardware.c
+++ b/gripper/firmware/motor_hardware.c
@@ -1,8 +1,5 @@
 #include "motor_hardware.h"
 
-TIM_HandleTypeDef htim1;
-TIM_HandleTypeDef htim3;
-TIM_HandleTypeDef htim7;
 DAC_HandleTypeDef hdac1;
 
 void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
@@ -95,8 +92,6 @@ HAL_StatusTypeDef initialize_spi() {
     return HAL_SPI_Init(&hspi2);
 }
 
-static motor_interrupt_callback timer_callback = NULL;
-
 /**
  * @brief GPIO Initialization Function
  * @param None
@@ -108,57 +103,6 @@ void MX_GPIO_Init(void) {
     __HAL_RCC_GPIOF_CLK_ENABLE();
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOB_CLK_ENABLE();
-
-    /*Configure GPIO pin : LD2_Pin */
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Pin = GPIO_PIN_5;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-}
-
-void MX_TIM7_Init(void) {
-    TIM_MasterConfigTypeDef sMasterConfig = {0};
-
-    htim7.Instance = TIM7;
-    htim7.Init.Prescaler = 849;
-    htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim7.Init.Period = 1;
-    htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
-    if (HAL_TIM_Base_Init(&htim7) != HAL_OK) {
-        Error_Handler();
-    }
-    sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
-    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-    if (HAL_TIMEx_MasterConfigSynchronization(&htim7, &sMasterConfig) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-}
-
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
-    // Check which version of the timer triggered this callback
-    if (htim == &htim7 && timer_callback) {
-        timer_callback();
-    }
-}
-
-void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
-    if (htim == &htim7) {
-        /* Peripheral clock enable */
-        __HAL_RCC_TIM7_CLK_ENABLE();
-
-        /* TIM7 interrupt Init */
-        HAL_NVIC_SetPriority(TIM7_IRQn, 6, 0);
-        HAL_NVIC_EnableIRQ(TIM7_IRQn);
-    }
-}
-
-void initialize_timer(motor_interrupt_callback callback) {
-    timer_callback = callback;
-    MX_GPIO_Init();
-    MX_TIM7_Init();
 }
 
 /**
@@ -209,117 +153,3 @@ void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac) {
 }
 
 void initialize_dac() { MX_DAC1_Init(); }
-
-/**
- * @brief TIM1 Initialization Function for AIN1
- * @param None
- * @retval None
- */
-static void MX_TIM1_Init(void) {
-    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
-    TIM_MasterConfigTypeDef sMasterConfig = {0};
-    TIM_OC_InitTypeDef sConfigOC = {0};
-    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
-
-    htim1.Instance = TIM1;
-    htim1.Init.Prescaler = 50000;
-    htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim1.Init.Period = 4000;
-    htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-    htim1.Init.RepetitionCounter = 0;
-    htim1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-    if (HAL_TIM_Base_Init(&htim1) != HAL_OK) {
-        Error_Handler();
-    }
-    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
-    if (HAL_TIM_ConfigClockSource(&htim1, &sClockSourceConfig) != HAL_OK) {
-        Error_Handler();
-    }
-    if (HAL_TIM_PWM_Init(&htim1) != HAL_OK) {
-        Error_Handler();
-    }
-    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
-    sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
-    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-    if (HAL_TIMEx_MasterConfigSynchronization(&htim1, &sMasterConfig) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-    sConfigOC.OCMode = TIM_OCMODE_PWM1;
-    sConfigOC.Pulse = 2000;
-    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
-    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
-    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
-    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
-    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
-    if (HAL_TIM_PWM_ConfigChannel(&htim1, &sConfigOC, TIM_CHANNEL_1) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
-    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
-    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
-    sBreakDeadTimeConfig.DeadTime = 0;
-    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
-    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
-    sBreakDeadTimeConfig.BreakFilter = 0;
-    sBreakDeadTimeConfig.BreakAFMode = TIM_BREAK_AFMODE_INPUT;
-    sBreakDeadTimeConfig.Break2State = TIM_BREAK2_DISABLE;
-    sBreakDeadTimeConfig.Break2Polarity = TIM_BREAK2POLARITY_HIGH;
-    sBreakDeadTimeConfig.Break2Filter = 0;
-    sBreakDeadTimeConfig.Break2AFMode = TIM_BREAK_AFMODE_INPUT;
-    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
-    if (HAL_TIMEx_ConfigBreakDeadTime(&htim1, &sBreakDeadTimeConfig) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-    HAL_TIM_MspPostInit(&htim1);
-}
-
-/**
- * @brief TIM3 Initialization Function for AIN2
- * @param None
- * @retval None
- */
-static void MX_TIM3_Init(void) {
-    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
-    TIM_MasterConfigTypeDef sMasterConfig = {0};
-    TIM_OC_InitTypeDef sConfigOC = {0};
-
-    htim3.Instance = TIM3;
-    htim3.Init.Prescaler = 50000;
-    htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim3.Init.Period = 4000;
-    htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
-    htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-    if (HAL_TIM_Base_Init(&htim3) != HAL_OK) {
-        Error_Handler();
-    }
-    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
-    if (HAL_TIM_ConfigClockSource(&htim3, &sClockSourceConfig) != HAL_OK) {
-        Error_Handler();
-    }
-    if (HAL_TIM_PWM_Init(&htim3) != HAL_OK) {
-        Error_Handler();
-    }
-    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
-    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-    if (HAL_TIMEx_MasterConfigSynchronization(&htim3, &sMasterConfig) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-    sConfigOC.OCMode = TIM_OCMODE_PWM1;
-    sConfigOC.Pulse = 2000;
-    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
-    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
-    if (HAL_TIM_PWM_ConfigChannel(&htim3, &sConfigOC, TIM_CHANNEL_1) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-    HAL_TIM_MspPostInit(&htim3);
-}
-
-void initialize_pwm() {
-    MX_TIM1_Init();
-    MX_TIM3_Init();
-}

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -23,8 +23,6 @@ void initialize_timer(motor_interrupt_callback callback);
 
 void initialize_dac();
 
-void initialize_pwm();
-
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif  // __cplusplus
 
 extern SPI_HandleTypeDef hspi2;
+extern TIM_HandleTypeDef htim1;
+extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim7;
 extern DAC_HandleTypeDef hdac1;
 
@@ -20,6 +22,8 @@ HAL_StatusTypeDef initialize_spi();
 void initialize_timer(motor_interrupt_callback callback);
 
 void initialize_dac();
+
+void initialize_pwm();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -45,9 +45,9 @@ static void MX_TIM1_Init(void) {
     TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
 
     htim1.Instance = TIM1;
-    htim1.Init.Prescaler = 50000;
+    htim1.Init.Prescaler = 500;
     htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim1.Init.Period = 4000;
+    htim1.Init.Period = 40;
     htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     htim1.Init.RepetitionCounter = 0;
     htim1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
@@ -69,7 +69,7 @@ static void MX_TIM1_Init(void) {
         Error_Handler();
     }
     sConfigOC.OCMode = TIM_OCMODE_PWM1;
-    sConfigOC.Pulse = 2000;
+    sConfigOC.Pulse = 36;
     sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
     sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
@@ -110,9 +110,9 @@ static void MX_TIM3_Init(void) {
     TIM_OC_InitTypeDef sConfigOC = {0};
 
     htim3.Instance = TIM3;
-    htim3.Init.Prescaler = 50000;
+    htim3.Init.Prescaler = 5000;
     htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim3.Init.Period = 4000;
+    htim3.Init.Period = 400;
     htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
     if (HAL_TIM_Base_Init(&htim3) != HAL_OK) {
@@ -132,7 +132,7 @@ static void MX_TIM3_Init(void) {
         Error_Handler();
     }
     sConfigOC.OCMode = TIM_OCMODE_PWM1;
-    sConfigOC.Pulse = 3600;
+    sConfigOC.Pulse = 360;
     sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
     if (HAL_TIM_PWM_ConfigChannel(&htim3, &sConfigOC, TIM_CHANNEL_1) !=
@@ -231,6 +231,4 @@ void initialize_timer(motor_interrupt_callback callback) {
     MX_TIM1_Init();
     MX_TIM3_Init();
     MX_TIM7_Init();
-    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_11, GPIO_PIN_SET);
-    HAL_TIM_PWM_Start(&htim3, TIM_CHANNEL_1);
 }

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -132,7 +132,7 @@ static void MX_TIM3_Init(void) {
         Error_Handler();
     }
     sConfigOC.OCMode = TIM_OCMODE_PWM1;
-    sConfigOC.Pulse = 2000;
+    sConfigOC.Pulse = 3600;
     sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
     if (HAL_TIM_PWM_ConfigChannel(&htim3, &sConfigOC, TIM_CHANNEL_1) !=
@@ -204,14 +204,33 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
     }
 }
 
+/**
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+void MX_GPIO_Init(void) {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_11;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                  &GPIO_InitStruct);
+}
+
 void initialize_timer(motor_interrupt_callback callback) {
     timer_callback = callback;
     MX_GPIO_Init();
-    MX_TIM7_Init();
-}
-
-void initialize_pwm() {
     MX_TIM1_Init();
     MX_TIM3_Init();
-    HAL_TIM_PWM_Start(&htim1, TIM_CHANNEL_1);
+    MX_TIM7_Init();
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_11, GPIO_PIN_SET);
+    HAL_TIM_PWM_Start(&htim3, TIM_CHANNEL_1);
 }

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -1,0 +1,217 @@
+#include "motor_hardware.h"
+
+TIM_HandleTypeDef htim1;
+TIM_HandleTypeDef htim3;
+TIM_HandleTypeDef htim7;
+
+static motor_interrupt_callback timer_callback = NULL;
+
+void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim) {
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    if (htim->Instance == TIM1) {
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /**TIM1 GPIO Configuration
+        PC0     ------> TIM1_CH1
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_0;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF2_TIM1;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+    } else if (htim->Instance == TIM3) {
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        /**TIM3 GPIO Configuration
+        PA6     ------> TIM3_CH1
+        */
+        GPIO_InitStruct.Pin = GPIO_PIN_6;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Alternate = GPIO_AF2_TIM3;
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    }
+}
+
+/**
+ * @brief TIM1 Initialization Function for AIN1
+ * @param None
+ * @retval None
+ */
+static void MX_TIM1_Init(void) {
+    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+    TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
+
+    htim1.Instance = TIM1;
+    htim1.Init.Prescaler = 50000;
+    htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim1.Init.Period = 4000;
+    htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim1.Init.RepetitionCounter = 0;
+    htim1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(&htim1) != HAL_OK) {
+        Error_Handler();
+    }
+    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+    if (HAL_TIM_ConfigClockSource(&htim1, &sClockSourceConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_Init(&htim1) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim1, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 2000;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+    sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+    if (HAL_TIM_PWM_ConfigChannel(&htim1, &sConfigOC, TIM_CHANNEL_1) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
+    sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
+    sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
+    sBreakDeadTimeConfig.DeadTime = 0;
+    sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
+    sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
+    sBreakDeadTimeConfig.BreakFilter = 0;
+    sBreakDeadTimeConfig.BreakAFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.Break2State = TIM_BREAK2_DISABLE;
+    sBreakDeadTimeConfig.Break2Polarity = TIM_BREAK2POLARITY_HIGH;
+    sBreakDeadTimeConfig.Break2Filter = 0;
+    sBreakDeadTimeConfig.Break2AFMode = TIM_BREAK_AFMODE_INPUT;
+    sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
+    if (HAL_TIMEx_ConfigBreakDeadTime(&htim1, &sBreakDeadTimeConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    HAL_TIM_MspPostInit(&htim1);
+}
+
+/**
+ * @brief TIM3 Initialization Function for AIN2
+ * @param None
+ * @retval None
+ */
+static void MX_TIM3_Init(void) {
+    TIM_ClockConfigTypeDef sClockSourceConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    TIM_OC_InitTypeDef sConfigOC = {0};
+
+    htim3.Instance = TIM3;
+    htim3.Init.Prescaler = 50000;
+    htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim3.Init.Period = 4000;
+    htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    if (HAL_TIM_Base_Init(&htim3) != HAL_OK) {
+        Error_Handler();
+    }
+    sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+    if (HAL_TIM_ConfigClockSource(&htim3, &sClockSourceConfig) != HAL_OK) {
+        Error_Handler();
+    }
+    if (HAL_TIM_PWM_Init(&htim3) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim3, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    sConfigOC.OCMode = TIM_OCMODE_PWM1;
+    sConfigOC.Pulse = 2000;
+    sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+    sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+    if (HAL_TIM_PWM_ConfigChannel(&htim3, &sConfigOC, TIM_CHANNEL_1) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    HAL_TIM_MspPostInit(&htim3);
+}
+
+void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base) {
+    if (htim_base->Instance == TIM1) {
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM1_CLK_DISABLE();
+        /* TIM1 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(TIM1_UP_TIM16_IRQn);
+    } else if (htim_base->Instance == TIM3) {
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM3_CLK_DISABLE();
+        /* TIM3 interrupt DeInit */
+        HAL_NVIC_DisableIRQ(TIM3_IRQn);
+    }
+}
+
+void MX_TIM7_Init(void) {
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+
+    htim7.Instance = TIM7;
+    htim7.Init.Prescaler = 849;
+    htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim7.Init.Period = 1;
+    htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
+    if (HAL_TIM_Base_Init(&htim7) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim7, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+}
+
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
+    // Check which version of the timer triggered this callback
+    if (htim == &htim7 && timer_callback) {
+        timer_callback();
+    }
+}
+
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
+    if (htim == &htim7) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM7_CLK_ENABLE();
+        /* TIM7 interrupt Init */
+        HAL_NVIC_SetPriority(TIM7_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM7_IRQn);
+    } else if (htim == &htim1) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM1_CLK_ENABLE();
+        /* TIM1 interrupt Init */
+        HAL_NVIC_SetPriority(TIM1_UP_TIM16_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM1_UP_TIM16_IRQn);
+    } else if (htim == &htim3) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM3_CLK_ENABLE();
+        /* TIM3 interrupt Init */
+        HAL_NVIC_SetPriority(TIM3_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM3_IRQn);
+    }
+}
+
+void initialize_timer(motor_interrupt_callback callback) {
+    timer_callback = callback;
+    MX_GPIO_Init();
+    MX_TIM7_Init();
+}
+
+void initialize_pwm() {
+    MX_TIM1_Init();
+    MX_TIM3_Init();
+    HAL_TIM_PWM_Start(&htim1, TIM_CHANNEL_1);
+}

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -45,6 +45,8 @@
 DMA_HandleTypeDef hdma_spi1_tx;
 DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim7;
+extern TIM_HandleTypeDef htim1;
+extern TIM_HandleTypeDef htim3;
 
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
@@ -116,14 +118,6 @@ void DebugMon_Handler(void) {}
 /******************************************************************************/
 
 /**
- * @brief  This function handles PPP interrupt request.
- * @param  None
- * @retval None
- */
-/*void PPP_IRQHandler(void)
-{
-}*/
-/**
  * @brief This function handles DMA1 channel2 global interrupt.
  */
 void DMA1_Channel2_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_spi1_rx); }
@@ -139,6 +133,17 @@ void DMA1_Channel3_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_spi1_tx); }
 void FDCAN1_IT0_IRQHandler(void) {
     HAL_FDCAN_IRQHandler(can_get_device_handle());
 }
+
+/**
+ * @brief This function handles TIM1 update interrupt and TIM16 global
+ * interrupt.
+ */
+void TIM1_UP_TIM16_IRQHandler(void) { HAL_TIM_IRQHandler(&htim1); }
+
+/**
+ * @brief This function handles TIM3 global interrupt.
+ */
+void TIM3_IRQHandler(void) { HAL_TIM_IRQHandler(&htim3); }
 
 /**
  * @brief This function handles TIM7 global interrupt.

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -155,4 +155,9 @@ void SysTick_Handler(void) {
     HAL_IncTick();
     xPortSysTickHandler();
 }
+
+/**
+ * @brief This function handles EXTI line[15:10] interrupts.
+ */
+void EXTI15_10_IRQHandler(void) { HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_13); }
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -156,8 +156,4 @@ void SysTick_Handler(void) {
     xPortSysTickHandler();
 }
 
-/**
- * @brief This function handles EXTI line[15:10] interrupts.
- */
-void EXTI15_10_IRQHandler(void) { HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_13); }
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/gripper/firmware/stm32g4xx_it.h
+++ b/gripper/firmware/stm32g4xx_it.h
@@ -1,28 +1,28 @@
 /**
-  ******************************************************************************
-  * @file    Templates/Inc/stm32g4xx_it.h
-  * @author  MCD Application Team
-  * @brief   This file contains the headers of the interrupt handlers.
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file    Templates/Inc/stm32g4xx_it.h
+ * @author  MCD Application Team
+ * @brief   This file contains the headers of the interrupt handlers.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
+ * All rights reserved.</center></h2>
+ *
+ * This software component is licensed by ST under BSD 3-Clause license,
+ * the "License"; You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ *                        opensource.org/licenses/BSD-3-Clause
+ *
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32G4xx_IT_H
 #define STM32G4xx_IT_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -42,6 +42,10 @@ void PendSV_Handler(void);
 void SysTick_Handler(void);
 void DMA1_Channel2_IRQHandler(void);
 void DMA1_Channel3_IRQHandler(void);
+void FDCAN1_IT0_IRQHandler(void);
+void TIM1_UP_TIM16_IRQHandler(void);
+void TIM3_IRQHandler(void);
+void TIM7_IRQHandler(void);
 
 #ifdef __cplusplus
 }

--- a/include/motor-control/firmware/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor_hardware.hpp
@@ -6,9 +6,14 @@
 
 namespace motor_hardware {
 
+struct PwmConfig {
+    void* tim;
+    uint32_t channel;
+};
+
 struct BrushedHardwareConfig {
-    PinConfig pwm_1;
-    PinConfig pwm_2;
+    PwmConfig pwm_1;
+    PwmConfig pwm_2;
     PinConfig enable;
     PinConfig limit_switch;
 };

--- a/motor-control/firmware/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor_hardware.cpp
@@ -5,13 +5,13 @@
 using namespace motor_hardware;
 
 void BrushedMotorHardware::positive_direction() {
-    motor_hardware_start_pwm();
-    motor_hardware_stop_pwm();
+    motor_hardware_start_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
+    motor_hardware_stop_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
 }
 
 void BrushedMotorHardware::negative_direction() {
-    motor_hardware_start_pwm();
-    motor_hardware_stop_pwm();
+    motor_hardware_stop_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
+    motor_hardware_start_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
 }
 
 void BrushedMotorHardware::activate_motor() {

--- a/motor-control/firmware/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor_hardware.cpp
@@ -4,9 +4,15 @@
 
 using namespace motor_hardware;
 
-void BrushedMotorHardware::positive_direction() {}
+void BrushedMotorHardware::positive_direction() {
+    motor_hardware_start_pwm();
+    motor_hardware_stop_pwm();
+}
 
-void BrushedMotorHardware::negative_direction() {}
+void BrushedMotorHardware::negative_direction() {
+    motor_hardware_start_pwm();
+    motor_hardware_stop_pwm();
+}
 
 void BrushedMotorHardware::activate_motor() {
     motor_hardware_set_pin(pins.enable.port, pins.enable.pin,

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -55,3 +55,11 @@ bool motor_hardware_set_dac_value(void* hdac, uint32_t channel,
                                   uint32_t data_algn, uint32_t val) {
     return HAL_DAC_SetValue(hdac, channel, data_algn, val) == HAL_OK;
 }
+
+bool motor_hardware_start_pwm(void* htim, uint32_t channel) {
+    return HAL_TIM_PWM_Start(htim, channel) == HAL_OK;
+}
+
+bool motor_hardware_stop_pwm(void* htim, uint32_t channel) {
+    return HAL_TIM_PWM_Stop(htim, channel) == HAL_OK;
+}

--- a/motor-control/firmware/motor_control_hardware.h
+++ b/motor-control/firmware/motor_control_hardware.h
@@ -18,6 +18,8 @@ bool motor_hardware_start_dac(void* dac_handle, uint32_t channel);
 bool motor_hardware_stop_dac(void* dac_handle, uint32_t channel);
 bool motor_hardware_set_dac_value(void* dac_handle, uint32_t channel,
                                   uint32_t data_algn, uint32_t val);
+bool motor_hardware_start_pwm(void* tim_handle, uint32_t channel);
+bool motor_hardware_stop_pwm(void* tim_handle, uint32_t channel);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
We're using two separate timers to generate two PWM signals to drive the brushed motor. One line is connected to the PC0 pin (TIM1) and the other PA6 (TIM3). 

Next steps are to implement these features in the motor control module and allow to adjust the Vref, duty cycle and test for and use the optimum PWM frequency.