### PR TITLE
feat(*): real position in move-complete

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -48,7 +48,7 @@ SCENARIO("message serializing works") {
     GIVEN("a MoveCompleted message") {
         auto message = MoveCompleted{.group_id = 1,
                                      .seq_id = 2,
-                                     .current_position = 0x3456789a,
+                                     .current_position_um = 0x3456789a,
                                      .ack_id = 1};
         auto arr = std::array<uint8_t, 8>{};
         auto body = std::span{arr};

--- a/gantry/core/tasks.cpp
+++ b/gantry/core/tasks.cpp
@@ -19,8 +19,8 @@ static auto move_group_task_builder =
     move_group_task_starter::TaskStarter<512, gantry_tasks::QueueClient,
                                          gantry_tasks::QueueClient>{};
 static auto move_status_task_builder =
-    move_status_reporter_task_starter::TaskStarter<512,
-                                                   gantry_tasks::QueueClient>{};
+    move_status_reporter_task_starter::TaskStarter<
+        512, gantry_tasks::QueueClient, lms::BeltConfig>{};
 
 /**
  * Start gantry tasks.
@@ -34,7 +34,8 @@ void gantry_tasks::start_tasks(
     auto& motion = mc_task_builder.start(5, motion_controller, queues);
     auto& motor = motor_driver_task_builder.start(5, motor_driver, queues);
     auto& move_group = move_group_task_builder.start(5, queues, queues);
-    auto& move_status_reporter = move_status_task_builder.start(5, queues);
+    auto& move_status_reporter = move_status_task_builder.start(
+        5, queues, motion_controller.get_mechanical_config());
 
     tasks.can_writer = &can_writer;
     tasks.motion_controller = &motion;

--- a/gripper/core/tasks.cpp
+++ b/gripper/core/tasks.cpp
@@ -20,7 +20,7 @@ static auto move_group_task_builder =
                                          gripper_tasks::QueueClient>{};
 static auto move_status_task_builder =
     move_status_reporter_task_starter::TaskStarter<
-        512, gripper_tasks::QueueClient>{};
+        512, gripper_tasks::QueueClient, lms::LeadScrewConfig>{};
 static auto brushed_motor_driver_task_builder =
     brushed_motor_driver_task_starter::TaskStarter<
         512, gripper_tasks::QueueClient>{};
@@ -38,7 +38,8 @@ void gripper_tasks::start_tasks(
     auto& motion = mc_task_builder.start(5, motion_controller, queues);
     auto& motor = motor_driver_task_builder.start(5, motor_driver, queues);
     auto& move_group = move_group_task_builder.start(5, queues, queues);
-    auto& move_status_reporter = move_status_task_builder.start(5, queues);
+    auto& move_status_reporter = move_status_task_builder.start(
+        5, queues, motion_controller.get_mechanical_config());
     auto& brushed_motor = brushed_motor_driver_task_builder.start(
         5, brushed_motor_driver, queues);
 

--- a/head/core/tasks.cpp
+++ b/head/core/tasks.cpp
@@ -35,10 +35,10 @@ static auto right_move_group_task_builder =
                                          head_tasks::MotorQueueClient>{};
 static auto left_move_status_task_builder =
     move_status_reporter_task_starter::TaskStarter<
-        512, head_tasks::MotorQueueClient>{};
+        512, head_tasks::MotorQueueClient, lms::LeadScrewConfig>{};
 static auto right_move_status_task_builder =
     move_status_reporter_task_starter::TaskStarter<
-        512, head_tasks::MotorQueueClient>{};
+        512, head_tasks::MotorQueueClient, lms::LeadScrewConfig>{};
 
 static auto presence_sensing_driver_task_builder =
     presence_sensing_driver_task_starter::TaskStarter<
@@ -78,8 +78,8 @@ void head_tasks::start_tasks(
         left_motor_driver_task_builder.start(5, left_motor_driver, left_queues);
     auto& left_move_group =
         left_move_group_task_builder.start(5, left_queues, left_queues);
-    auto& left_move_status_reporter =
-        left_move_status_task_builder.start(5, left_queues);
+    auto& left_move_status_reporter = left_move_status_task_builder.start(
+        5, left_queues, left_motion_controller.get_mechanical_config());
 
     // Assign left motor task collection task pointers
     left_tasks.motion_controller = &left_motion;
@@ -102,8 +102,8 @@ void head_tasks::start_tasks(
         5, right_motor_driver, right_queues);
     auto& right_move_group =
         right_move_group_task_builder.start(5, right_queues, right_queues);
-    auto& right_move_status_reporter =
-        right_move_status_task_builder.start(5, right_queues);
+    auto& right_move_status_reporter = right_move_status_task_builder.start(
+        5, right_queues, right_motion_controller.get_mechanical_config());
 
     // Assign right motor task collection task pointers
     right_tasks.motion_controller = &right_motion;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -267,14 +267,14 @@ using ClearAllMoveGroupsRequest =
 struct MoveCompleted : BaseMessage<MessageId::move_completed> {
     uint8_t group_id;
     uint8_t seq_id;
-    uint32_t current_position;
+    uint32_t current_position_um;
     uint8_t ack_id;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter = bit_utils::int_to_bytes(group_id, body, limit);
         iter = bit_utils::int_to_bytes(seq_id, iter, limit);
-        iter = bit_utils::int_to_bytes(current_position, iter, limit);
+        iter = bit_utils::int_to_bytes(current_position_um, iter, limit);
         iter = bit_utils::int_to_bytes(ack_id, iter, limit);
         return iter - body;
     }

--- a/include/gantry/core/tasks.hpp
+++ b/include/gantry/core/tasks.hpp
@@ -58,8 +58,8 @@ struct AllTask {
         freertos_message_queue::FreeRTOSMessageQueue, lms::BeltConfig,
         QueueClient>* motion_controller{nullptr};
     move_status_reporter_task::MoveStatusReporterTask<
-        freertos_message_queue::FreeRTOSMessageQueue, QueueClient>*
-        move_status_reporter{nullptr};
+        freertos_message_queue::FreeRTOSMessageQueue, QueueClient,
+        lms::BeltConfig>* move_status_reporter{nullptr};
     move_group_task::MoveGroupTask<freertos_message_queue::FreeRTOSMessageQueue,
                                    QueueClient, QueueClient>* move_group{
         nullptr};

--- a/include/gripper/core/tasks.hpp
+++ b/include/gripper/core/tasks.hpp
@@ -66,8 +66,8 @@ struct AllTask {
         freertos_message_queue::FreeRTOSMessageQueue, lms::LeadScrewConfig,
         QueueClient>* motion_controller{nullptr};
     move_status_reporter_task::MoveStatusReporterTask<
-        freertos_message_queue::FreeRTOSMessageQueue, QueueClient>*
-        move_status_reporter{nullptr};
+        freertos_message_queue::FreeRTOSMessageQueue, QueueClient,
+        lms::LeadScrewConfig>* move_status_reporter{nullptr};
     move_group_task::MoveGroupTask<freertos_message_queue::FreeRTOSMessageQueue,
                                    QueueClient, QueueClient>* move_group{
         nullptr};

--- a/include/head/core/tasks.hpp
+++ b/include/head/core/tasks.hpp
@@ -91,8 +91,8 @@ struct MotorTasks {
         freertos_message_queue::FreeRTOSMessageQueue, lms::LeadScrewConfig,
         MotorQueueClient>* motion_controller{nullptr};
     move_status_reporter_task::MoveStatusReporterTask<
-        freertos_message_queue::FreeRTOSMessageQueue, MotorQueueClient>*
-        move_status_reporter{nullptr};
+        freertos_message_queue::FreeRTOSMessageQueue, MotorQueueClient,
+        lms::LeadScrewConfig>* move_status_reporter{nullptr};
     move_group_task::MoveGroupTask<freertos_message_queue::FreeRTOSMessageQueue,
                                    MotorQueueClient, MotorQueueClient>*
         move_group{nullptr};

--- a/include/motor-control/core/linear_motion_system.hpp
+++ b/include/motor-control/core/linear_motion_system.hpp
@@ -34,6 +34,10 @@ struct LinearMotionSystemConfig {
         return (steps_per_rev * microstep * gear_ratio) /
                (mech_config.get_mm_per_rev());
     }
+    [[nodiscard]] constexpr auto get_um_per_step() const -> float {
+        return (mech_config.get_mm_per_rev()) /
+               (steps_per_rev * microstep * gear_ratio) * 1000;
+    }
 };
 
 }  // namespace lms

--- a/include/motor-control/core/motion_controller.hpp
+++ b/include/motor-control/core/motion_controller.hpp
@@ -41,6 +41,11 @@ class MotionController {
 
     ~MotionController() = default;
 
+    [[nodiscard]] auto get_mechanical_config() const
+        -> const lms::LinearMotionSystemConfig<MEConfig>& {
+        return linear_motion_sys_config;
+    }
+
     void move(const can_messages::AddLinearMoveRequest& can_msg) {
         steps_per_tick velocity_steps =
             fixed_point_multiply(steps_per_mm, can_msg.velocity);

--- a/include/motor-control/core/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/motor_interrupt_handler.hpp
@@ -193,10 +193,8 @@ class MotorInterruptHandler {
             auto ack = Ack{
                 .group_id = buffered_move.group_id,
                 .seq_id = buffered_move.seq_id,
-                .current_position = static_cast<uint32_t>(
-                    position_tracker >>
-                    31),  // TODO (AA 2021-11-10): convert
-                          // this value to mm instead of steps
+                .current_position_steps =
+                    static_cast<uint32_t>(position_tracker >> 31),
                 .ack_id = ack_msg_id,
             };
             static_cast<void>(

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -43,7 +43,7 @@ enum class AckMessageId : uint8_t {
 struct Ack {
     uint8_t group_id;
     uint8_t seq_id;
-    uint32_t current_position;
+    uint32_t current_position_steps;
     AckMessageId ack_id;
 };
 

--- a/include/motor-control/core/tasks/move_status_reporter_task_starter.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task_starter.hpp
@@ -2,21 +2,23 @@
 
 #include "common/core/freertos_message_queue.hpp"
 #include "common/core/freertos_task.hpp"
+#include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/tasks/move_status_reporter_task.hpp"
 
 namespace move_status_reporter_task_starter {
 
-template <uint32_t StackDepth, message_writer_task::TaskClient CanClient>
+template <uint32_t StackDepth, message_writer_task::TaskClient CanClient,
+          lms::MotorMechanicalConfig LmsConfig>
 class TaskStarter {
   public:
     using MoveStatusReporterTaskType =
         move_status_reporter_task::MoveStatusReporterTask<
-            freertos_message_queue::FreeRTOSMessageQueue, CanClient>;
+            freertos_message_queue::FreeRTOSMessageQueue, CanClient, LmsConfig>;
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         move_status_reporter_task::TaskMessage>;
-    using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, MoveStatusReporterTaskType,
-                                    CanClient>;
+    using TaskType = freertos_task::FreeRTOSTask<
+        StackDepth, MoveStatusReporterTaskType, CanClient,
+        const lms::LinearMotionSystemConfig<LmsConfig>>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;
@@ -25,9 +27,10 @@ class TaskStarter {
     auto operator=(const TaskStarter&& c) = delete;
     ~TaskStarter() = default;
 
-    auto start(uint32_t priority, CanClient& can_client)
+    auto start(uint32_t priority, CanClient& can_client,
+               const lms::LinearMotionSystemConfig<LmsConfig>& lms_config)
         -> MoveStatusReporterTaskType& {
-        task.start(priority, "move-status", &can_client);
+        task.start(priority, "move-status", &can_client, &lms_config);
         return task_entry;
     }
 

--- a/include/motor-control/core/utils.hpp
+++ b/include/motor-control/core/utils.hpp
@@ -15,4 +15,6 @@ auto fixed_point_multiply(sq0_31 a, sq0_31 b) -> sq0_31;
 
 auto fixed_point_multiply(sq31_31 a, sq0_31 b) -> sq0_31;
 
+auto fixed_point_multiply(sq31_31 a, uint32_t b) -> uint32_t;
+
 auto fixed_point_to_float(uint32_t data, int to_radix) -> float;

--- a/include/pipettes/core/tasks.hpp
+++ b/include/pipettes/core/tasks.hpp
@@ -91,8 +91,8 @@ struct AllTask {
         freertos_message_queue::FreeRTOSMessageQueue, lms::LeadScrewConfig,
         QueueClient>* motion_controller{nullptr};
     move_status_reporter_task::MoveStatusReporterTask<
-        freertos_message_queue::FreeRTOSMessageQueue, QueueClient>*
-        move_status_reporter{nullptr};
+        freertos_message_queue::FreeRTOSMessageQueue, QueueClient,
+        lms::LeadScrewConfig>* move_status_reporter{nullptr};
     move_group_task::MoveGroupTask<freertos_message_queue::FreeRTOSMessageQueue,
                                    QueueClient, QueueClient>* move_group{
         nullptr};

--- a/motor-control/core/utils.cpp
+++ b/motor-control/core/utils.cpp
@@ -29,3 +29,8 @@ sq0_31 fixed_point_multiply(sq31_31 a, sq0_31 b) {
 float fixed_point_to_float(uint32_t data, int to_radix) {
     return (1.0 * static_cast<float>(data)) / static_cast<float>(2 << to_radix);
 }
+
+uint32_t fixed_point_multiply(sq31_31 a, uint32_t b) {
+    uint64_t result = a * static_cast<uint64_t>(b);
+    return static_cast<uint32_t>((result >> 31) & 0xFFFFFFFF);
+}

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(motor-control
         test_fixed_point_utils.cpp
         test_motor_driver.cpp
         test_limit_switch.cpp
+        test_move_status_handling.cpp
 )
 
 target_ot_motor_control(motor-control)
@@ -31,7 +32,7 @@ target_compile_options(motor-control
         -Wsign-promo
         -Wextra-semi
         -Wctor-dtor-privacy)
-target_link_libraries(motor-control PUBLIC Catch2::Catch2 common-simulation)
+target_link_libraries(motor-control PUBLIC Catch2::Catch2 common-simulation motor-utils)
 
 catch_discover_tests(motor-control)
 add_build_and_test_target(motor-control)

--- a/motor-control/tests/test_linear_motion_config.cpp
+++ b/motor-control/tests/test_linear_motion_config.cpp
@@ -9,6 +9,11 @@ TEST_CASE("Linear motion system using a leadscrew") {
             .mech_config = LeadScrewConfig{.lead_screw_pitch = 2},
             .steps_per_rev = 200, .microstep = 32,
         };
-        REQUIRE(linearConfig.get_steps_per_mm() == 3200);
+        THEN("the steps/mm calculation should match the known value") {
+            REQUIRE(linearConfig.get_steps_per_mm() == 3200);
+        }
+        THEN("the um/step calculation should match the known value") {
+            REQUIRE(linearConfig.get_um_per_step() == 0.3125);
+        }
     }
 }

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -300,7 +300,7 @@ TEST_CASE("Finishing a move") {
             auto msg = test_objs.reporter.messages[0];
             REQUIRE(msg.group_id == move.group_id);
             REQUIRE(msg.seq_id == move.seq_id);
-            REQUIRE(msg.current_position == 100);
+            REQUIRE(msg.current_position_steps == 100);
         }
     }
 }

--- a/motor-control/tests/test_move_status_handling.cpp
+++ b/motor-control/tests/test_move_status_handling.cpp
@@ -1,0 +1,83 @@
+#include <climits>
+#include <cstdint>
+#include <deque>
+#include <utility>
+#include <variant>
+
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+#include "catch2/catch.hpp"
+#include "motor-control/core/linear_motion_system.hpp"
+#include "motor-control/core/motor_messages.hpp"
+#include "motor-control/core/tasks/move_status_reporter_task.hpp"
+
+using namespace motor_messages;
+using namespace move_status_reporter_task;
+using namespace lms;
+
+struct MockCanClient {
+    std::deque<std::pair<can_ids::NodeId, can_messages::ResponseMessageType>>
+        queue{};
+    auto send_can_message(can_ids::NodeId node_id,
+                          const can_messages::ResponseMessageType& m) -> void {
+        queue.push_back(std::make_pair(node_id, m));
+    }
+};
+
+SCENARIO("testing move status position translation") {
+    GIVEN("a status handler with known LMS config") {
+        struct LinearMotionSystemConfig<LeadScrewConfig> linearConfig {
+            .mech_config = LeadScrewConfig{.lead_screw_pitch = 2},
+            .steps_per_rev = 200, .microstep = 32,
+        };
+        auto mcc = MockCanClient();
+        auto handler = MoveStatusMessageHandler(mcc, linearConfig);
+        WHEN("passing a position of 0 steps") {
+            handler.handle_message(Ack{.group_id = 11,
+                                       .seq_id = 8,
+                                       .current_position_steps = 0,
+                                       .ack_id = AckMessageId::timeout});
+            CHECK(mcc.queue.size() == 1);
+
+            auto resp = mcc.queue.front();
+            auto resp_msg = std::get<can_messages::MoveCompleted>(resp.second);
+            THEN("the non-position values should be passed through") {
+                REQUIRE(resp_msg.group_id == 11);
+                REQUIRE(resp_msg.seq_id == 8);
+                REQUIRE(resp_msg.ack_id == 3);
+            }
+            THEN("the position value should still be 0") {
+                REQUIRE(resp_msg.current_position_um == 0);
+            }
+        }
+        WHEN("passing a position of fullscale steps") {
+            handler.handle_message(
+                Ack{.group_id = 0,
+                    .seq_id = 0,
+                    .current_position_steps = UINT_MAX,
+                    .ack_id = AckMessageId::complete_without_condition});
+            CHECK(mcc.queue.size() == 1);
+            auto resp = mcc.queue.front();
+            auto resp_msg = std::get<can_messages::MoveCompleted>(resp.second);
+            THEN("the position value should not be clipped") {
+                REQUIRE(
+                    resp_msg.current_position_um ==
+                    static_cast<uint32_t>(
+                        static_cast<double>(linearConfig.get_um_per_step()) *
+                        static_cast<double>(UINT_MAX)));
+            }
+        }
+        WHEN("passing a known input position in steps") {
+            handler.handle_message(Ack{.group_id = 0,
+                                       .seq_id = 0,
+                                       .current_position_steps = 10000,
+                                       .ack_id = AckMessageId::position_error});
+            CHECK(mcc.queue.size() == 1);
+            auto resp = mcc.queue.front();
+            auto resp_msg = std::get<can_messages::MoveCompleted>(resp.second);
+            THEN("the position in micrometers should be accurate") {
+                REQUIRE(resp_msg.current_position_um == 3125);
+            }
+        }
+    }
+}

--- a/pipettes/core/tasks.cpp
+++ b/pipettes/core/tasks.cpp
@@ -26,7 +26,7 @@ static auto move_group_task_builder =
                                          pipettes_tasks::QueueClient>{};
 static auto move_status_task_builder =
     move_status_reporter_task_starter::TaskStarter<
-        512, pipettes_tasks::QueueClient>{};
+        512, pipettes_tasks::QueueClient, lms::LeadScrewConfig>{};
 static auto eeprom_task_builder =
     eeprom_task_starter::TaskStarter<512, pipettes_tasks::QueueClient>{};
 
@@ -60,7 +60,8 @@ void pipettes_tasks::start_tasks(
     auto& motion = mc_task_builder.start(5, motion_controller, queues);
     auto& motor = motor_driver_task_builder.start(5, motor_driver, queues);
     auto& move_group = move_group_task_builder.start(5, queues, queues);
-    auto& move_status_reporter = move_status_task_builder.start(5, queues);
+    auto& move_status_reporter = move_status_task_builder.start(
+        5, queues, motion_controller.get_mechanical_config());
 
     auto& eeprom_task = eeprom_task_builder.start(5, i2c_task_client, queues);
     auto& environment_sensor_task =

--- a/pipettes/core/tasks_multiple_i2c.cpp
+++ b/pipettes/core/tasks_multiple_i2c.cpp
@@ -27,7 +27,7 @@ static auto move_group_task_builder =
                                          pipettes_tasks::QueueClient>{};
 static auto move_status_task_builder =
     move_status_reporter_task_starter::TaskStarter<
-        512, pipettes_tasks::QueueClient>{};
+        512, pipettes_tasks::QueueClient, lms::LeadScrewConfig>{};
 static auto eeprom_task_builder =
     eeprom_task_starter::TaskStarter<512, pipettes_tasks::QueueClient>{};
 
@@ -63,7 +63,8 @@ void pipettes_tasks::start_tasks(
     auto& motion = mc_task_builder.start(5, motion_controller, queues);
     auto& motor = motor_driver_task_builder.start(5, motor_driver, queues);
     auto& move_group = move_group_task_builder.start(5, queues, queues);
-    auto& move_status_reporter = move_status_task_builder.start(5, queues);
+    auto& move_status_reporter = move_status_task_builder.start(
+        5, queues, motion_controller.get_mechanical_config());
 
     auto& eeprom_task = eeprom_task_builder.start(5, i2c3_task_client, queues);
     auto& environment_sensor_task =


### PR DESCRIPTION
We've always been sending the current position back after a move
completes, but it's also always been in steps. That isn't a useful unit
when the host doesn't know the steps/mm of each device.

Instead, let's use our knowledge of the mechanical configuration to
translate the current position from steps to micrometers before sending
it back over the canbus.
