### PR TITLE
chore: Add workflow dispatch, remove push to run_emulation workflow

### DIFF
--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -1,4 +1,7 @@
-on: [ pull_request, push ]
+on:
+  pull_request:
+  workflow_dispatch:
+
 
 env:
   ci: 1


### PR DESCRIPTION
Add `workflow_dispatch` remove `push` from `run_emulation` workflow