### PR TITLE
fix(pipettes): Fix builds and workflows

### DIFF
--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -64,13 +64,13 @@ jobs:
       - name: "Configure"
         run: cmake --preset=cross-pipettes .
       - name: "Format"
-        run: cmake --build ./build-cross-pipettes --target pipettes-format-ci
+        run: cmake --build --preset=pipettes --target pipettes-format-ci
       - name: "Build"
-        run: cmake --build ./build-cross-pipettes --target pipettes
+        run: cmake --build --preset=pipettes --target pipettes
       - name: "Lint Single Channel"
-        run: cmake --build ./build-cross-pipettes --target pipettes-single-lint
+        run: cmake --build --preset=pipettes --target pipettes-single-lint
       - name: "Lint Multi Channel"
-        run: cmake --build ./build-cross-pipettes --target pipettes-multi-lint
+        run: cmake --build --preset=pipettes --target pipettes-multi-lint
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -59,6 +59,7 @@ find_program(ARM_GDB
 
 find_package(Clang)
 
+add_custom_target(pipettes)
 
 function(add_pipettes_executable TARGET)
     add_executable(${TARGET}
@@ -185,6 +186,8 @@ function(add_pipettes_executable TARGET)
             VERBATIM
             COMMENT "Flashing board"
             DEPENDS ${TARGET}-image-hex)
+
+    add_dependencies(pipettes ${TARGET})
 endfunction()
 
 add_pipettes_executable(pipettes-single)

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -47,6 +47,7 @@ void sync_drive_gpio_init() {
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_PULLUP;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+}
 
 void utility_gpio_init(void) {
     limit_switch_gpio_init();


### PR DESCRIPTION
The commit that added the different pipette build types also removed the
`pipette` CMake target, so now cmake silently does nothing in the
pipette build workflows, which means we didn't notice accidentally
breaking the pipette build.

Add the target back to cmake, fix the build issure, and update the
workflow to use presets.