### PR TITLE
feat(sensors): add diagnostic messages for sensors

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -73,6 +73,8 @@ typedef enum {
     can_messageid_read_sensor_response = 0x85,
     can_messageid_set_sensor_threshold_request = 0x86,
     can_messageid_set_sensor_threshold_response = 0x87,
+    can_messageid_sensor_diagnostic_request = 0x88,
+    can_messageid_sensor_diagnostic_response = 0x89,
 } CANMessageId;
 
 /** Can bus arbitration id node id. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -130,4 +130,3 @@ enum class SensorType {
 };
 
 }  // namespace can_ids
-

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -75,6 +75,8 @@ enum class MessageId {
     read_sensor_response = 0x85,
     set_sensor_threshold_request = 0x86,
     set_sensor_threshold_response = 0x87,
+    sensor_diagnostic_request = 0x88,
+    sensor_diagnostic_response = 0x89,
 };
 
 /** Can bus arbitration id node id. */
@@ -128,3 +130,4 @@ enum class SensorType {
 };
 
 }  // namespace can_ids
+

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -572,6 +572,41 @@ struct SensorThresholdResponse
         -> bool = default;
 };
 
+struct SensorDiagnosticRequest : BaseMessage<MessageId::sensor_diagnostic_request> {
+    uint8_t sensor;
+    uint8_t reg_address;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> SensorDiagnosticRequest {
+        uint8_t sensor = 0;
+        int32_t reg_address = 0;
+        body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, reg_address);
+        return SensorDiagnosticRequest{.sensor = sensor,
+            .reg_address = reg_address};
+    }
+
+    auto operator==(const SensorDiagnosticRequest& other) const
+    -> bool = default;
+};
+
+struct SensorDiagnosticResponse: BaseMessage<MessageId::sensor_diagnostic_response> {
+    can_ids::SensorType sensor;
+    uint8_t reg_address;
+    uint32_t data;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter =
+            bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
+        iter = bit_utils::int_to_bytes(reg_address, iter, limit);
+        iter = bit_utils::int_to_bytes(data, iter, limit);
+        return iter - body;
+    }
+    auto operator==(const SensorDiagnosticResponse& other) const
+    -> bool = default;
+};
+
 using PipetteInfoRequest = Empty<MessageId::pipette_info_request>;
 
 struct PipetteInfoResponse : BaseMessage<MessageId::pipette_info_response> {
@@ -603,6 +638,7 @@ using ResponseMessageType = std::variant<
     ReadFromEEPromResponse, MoveCompleted, ReadPresenceSensingVoltageResponse,
     PushToolsDetectedNotification, ReadLimitSwitchResponse,
     ReadFromSensorResponse, FirmwareUpdateStatusResponse,
-    SensorThresholdResponse, TaskInfoResponse, PipetteInfoResponse>;
+    SensorThresholdResponse, SensorDiagnosticResponse, TaskInfoResponse,
+    PipetteInfoResponse>;
 
 }  // namespace can_messages

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -572,7 +572,8 @@ struct SensorThresholdResponse
         -> bool = default;
 };
 
-struct SensorDiagnosticRequest : BaseMessage<MessageId::sensor_diagnostic_request> {
+struct SensorDiagnosticRequest
+    : BaseMessage<MessageId::sensor_diagnostic_request> {
     uint8_t sensor;
     uint8_t reg_address;
 
@@ -583,14 +584,15 @@ struct SensorDiagnosticRequest : BaseMessage<MessageId::sensor_diagnostic_reques
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, reg_address);
         return SensorDiagnosticRequest{.sensor = sensor,
-            .reg_address = reg_address};
+                                       .reg_address = reg_address};
     }
 
     auto operator==(const SensorDiagnosticRequest& other) const
-    -> bool = default;
+        -> bool = default;
 };
 
-struct SensorDiagnosticResponse: BaseMessage<MessageId::sensor_diagnostic_response> {
+struct SensorDiagnosticResponse
+    : BaseMessage<MessageId::sensor_diagnostic_response> {
     can_ids::SensorType sensor;
     uint8_t reg_address;
     uint32_t data;
@@ -604,7 +606,7 @@ struct SensorDiagnosticResponse: BaseMessage<MessageId::sensor_diagnostic_respon
         return iter - body;
     }
     auto operator==(const SensorDiagnosticResponse& other) const
-    -> bool = default;
+        -> bool = default;
 };
 
 using PipetteInfoRequest = Empty<MessageId::pipette_info_request>;
@@ -632,13 +634,14 @@ struct PipetteInfoResponse : BaseMessage<MessageId::pipette_info_response> {
  * A variant of all message types we might send..
  */
 
-using ResponseMessageType = std::variant<
-    HeartbeatResponse, DeviceInfoResponse, GetMotionConstraintsResponse,
-    GetMoveGroupResponse, ReadMotorDriverRegisterResponse,
-    ReadFromEEPromResponse, MoveCompleted, ReadPresenceSensingVoltageResponse,
-    PushToolsDetectedNotification, ReadLimitSwitchResponse,
-    ReadFromSensorResponse, FirmwareUpdateStatusResponse,
-    SensorThresholdResponse, SensorDiagnosticResponse, TaskInfoResponse,
-    PipetteInfoResponse>;
+using ResponseMessageType =
+    std::variant<HeartbeatResponse, DeviceInfoResponse,
+                 GetMotionConstraintsResponse, GetMoveGroupResponse,
+                 ReadMotorDriverRegisterResponse, ReadFromEEPromResponse,
+                 MoveCompleted, ReadPresenceSensingVoltageResponse,
+                 PushToolsDetectedNotification, ReadLimitSwitchResponse,
+                 ReadFromSensorResponse, FirmwareUpdateStatusResponse,
+                 SensorThresholdResponse, SensorDiagnosticResponse,
+                 TaskInfoResponse, PipetteInfoResponse>;
 
 }  // namespace can_messages


### PR DESCRIPTION
## Overview
For now, adding the diagnostic messages only to get additional information from the sensors that is
not directly related to a reading. This will be integrated with the driver refactors.