### PR TITLE
Feat(Encoders): Add pipette encoder functionality

### DIFF
--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/i2c_setup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/can.c
     ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/motor_encoder_hardware.c
     ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
     ${CMAKE_CURRENT_SOURCE_DIR}/mount_detect_hardware.c
     ${COMMON_EXECUTABLE_DIR}/errors/errors.c

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -29,8 +29,8 @@
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
 #pragma GCC diagnostic ignored "-Wvolatile"
-#include "motor_hardware.h"
 #include "motor_encoder_hardware.h"
+#include "motor_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
 #pragma GCC diagnostic pop
 

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -30,6 +30,7 @@
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "motor_hardware.h"
+#include "motor_encoder_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
 #pragma GCC diagnostic pop
 
@@ -91,7 +92,7 @@ struct motion_controller::HardwareConfig plunger_pins {
         .active_setting = GPIO_PIN_RESET}
 };
 
-static motor_hardware::MotorHardware plunger_hw(plunger_pins, &htim7, nullptr);
+static motor_hardware::MotorHardware plunger_hw(plunger_pins, &htim7, &htim2);
 static motor_handler::MotorInterruptHandler plunger_interrupt(
     motor_queue, pipettes_tasks::get_queues(), plunger_hw);
 
@@ -120,6 +121,7 @@ auto main() -> int {
     MX_ICACHE_Init();
     utility_gpio_init();
     adc_init();
+    initialize_enc(PIPETTE_TYPE);
     auto id = pipette_mounts::detect_id();
 
     i2c_setup(&i2chandler_struct, PIPETTE_TYPE);

--- a/pipettes/firmware/main_multi_i2c.cpp
+++ b/pipettes/firmware/main_multi_i2c.cpp
@@ -30,6 +30,7 @@
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "motor_hardware.h"
+#include "motor_encoder_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
 #pragma GCC diagnostic pop
 
@@ -86,7 +87,7 @@ struct motion_controller::HardwareConfig plunger_pins {
         .active_setting = GPIO_PIN_RESET},
 };
 
-static motor_hardware::MotorHardware plunger_hw(plunger_pins, &htim7, nullptr);
+static motor_hardware::MotorHardware plunger_hw(plunger_pins, &htim7, &htim2);
 static motor_handler::MotorInterruptHandler plunger_interrupt(
     motor_queue, pipettes_tasks::get_queues(), plunger_hw);
 
@@ -115,6 +116,7 @@ auto main() -> int {
     MX_ICACHE_Init();
     utility_gpio_init();
     adc_init();
+    initialize_enc(PIPETTE_TYPE);
     auto id = pipette_mounts::detect_id();
 
     i2c_setup(&i2chandler_struct, PIPETTE_TYPE);

--- a/pipettes/firmware/main_multi_i2c.cpp
+++ b/pipettes/firmware/main_multi_i2c.cpp
@@ -29,8 +29,8 @@
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
 #pragma GCC diagnostic ignored "-Wvolatile"
-#include "motor_hardware.h"
 #include "motor_encoder_hardware.h"
+#include "motor_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
 #pragma GCC diagnostic pop
 

--- a/pipettes/firmware/motor_encoder_hardware.c
+++ b/pipettes/firmware/motor_encoder_hardware.c
@@ -1,0 +1,105 @@
+#include "motor_encoder_hardware.h"
+#include "common/firmware/errors.h"
+#include "stm32l5xx_hal.h"
+#include "pipettes/core/pipette_type.h"
+
+TIM_HandleTypeDef htim2;
+
+void Encoder_GPIO_Init(PipetteType pipette_type){
+    /* Peripheral clock enable */
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __GPIOA_CLK_ENABLE();
+    __HAL_RCC_TIM2_CLK_ENABLE();
+    /* Encoder P Axis GPIO Configuration
+    PA0     ------> CHANNEL B ----> GPIO_PIN_0
+    PA1     ------> CHANNEL A ----> GPIO_PIN_1
+    PA5    ------> CHANNEL I -----> GPIO_PIN_5
+    */
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    /*
+    * The Index Pin is routed to different GPIO pins
+    * depending on the pipette type.
+    */
+    switch (pipette_type){
+        case NINETY_SIX_CHANNEL: {
+            GPIO_InitStruct.Pin = GPIO_PIN_3;
+            GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+            GPIO_InitStruct.Pull = GPIO_NOPULL;
+            GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+            GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
+            HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+        }
+        case THREE_EIGHTY_FOUR_CHANNEL: {
+            GPIO_InitStruct.Pin = GPIO_PIN_3;
+            GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+            GPIO_InitStruct.Pull = GPIO_NOPULL;
+            GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+            GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
+            HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+        }
+        case EIGHT_CHANNEL: {
+            GPIO_InitStruct.Pin = GPIO_PIN_7;
+            GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+            GPIO_InitStruct.Pull = GPIO_NOPULL;
+            GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+            GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
+            HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+        }
+        case SINGLE_CHANNEL:{
+            GPIO_InitStruct.Pin = GPIO_PIN_7;
+            GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+            GPIO_InitStruct.Pull = GPIO_NOPULL;
+            GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+            GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
+            HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+        }
+        default:
+            break;
+    }
+
+}
+/**
+  * This currently only works for the Lseries
+  * TODO/CF Change this when single pipette boards switch to STMG491 MCU
+*/
+void TIM2_EncoderP_Init(void){
+    TIM_Encoder_InitTypeDef sConfig = {0};
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+    htim2.Instance = TIM2;
+    htim2.Init.Prescaler = 0;
+    htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim2.Init.Period = UINT16_MAX;
+    htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+    htim2.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+    sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
+    sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
+    sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
+    sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
+    sConfig.IC1Filter = 0;
+    sConfig.IC2Polarity = TIM_ICPOLARITY_RISING;
+    sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
+    sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
+    sConfig.IC2Filter = 0;
+    if (HAL_TIM_Encoder_Init(&htim2, &sConfig) != HAL_OK)
+    {
+      Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig) != HAL_OK)
+    {
+      Error_Handler();
+    }
+    /* Reset counter */
+    __HAL_TIM_SET_COUNTER(&htim2, 0);
+    /* Start Encoder */
+    HAL_TIM_Encoder_Start(&htim2, TIM_CHANNEL_ALL);
+}
+
+void initialize_enc(PipetteType pipette_type) {Encoder_GPIO_Init(pipette_type); TIM2_EncoderP_Init();}

--- a/pipettes/firmware/motor_encoder_hardware.c
+++ b/pipettes/firmware/motor_encoder_hardware.c
@@ -8,7 +8,9 @@ TIM_HandleTypeDef htim2;
 void Encoder_GPIO_Init(PipetteType pipette_type){
     /* Peripheral clock enable */
     __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
     __GPIOA_CLK_ENABLE();
+    __GPIOC_CLK_ENABLE();
     __HAL_RCC_TIM2_CLK_ENABLE();
     /* Encoder P Axis GPIO Configuration
     PA0     ------> CHANNEL B ----> GPIO_PIN_0

--- a/pipettes/firmware/motor_encoder_hardware.c
+++ b/pipettes/firmware/motor_encoder_hardware.c
@@ -15,7 +15,6 @@ void Encoder_GPIO_Init(PipetteType pipette_type){
     /* Encoder P Axis GPIO Configuration
     PA0     ------> CHANNEL B ----> GPIO_PIN_0
     PA1     ------> CHANNEL A ----> GPIO_PIN_1
-    PA5    ------> CHANNEL I -----> GPIO_PIN_5
     */
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1;
@@ -24,12 +23,13 @@ void Encoder_GPIO_Init(PipetteType pipette_type){
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-    /*
-    * The Index Pin is routed to different GPIO pins
+    /*Encoder P Axis Index Pin Configuration
+    PC3    ------> CHANNEL I -----> SINGLE_CHANNEL/EIGHT_CHANNEL
+    PA7    ------> CHANNEL I -----> NINETY_SIX_CHANNEL/THREE_EIGHTY_FOUR_CHANNEL
+    * The Encoder Index Pin is routed to different GPIO pins
     * depending on the pipette type.
     */
-    switch (pipette_type){
-        case NINETY_SIX_CHANNEL: {
+    if (pipette_type == NINETY_SIX_CHANNEL || pipette_type == THREE_EIGHTY_FOUR_CHANNEL){
             GPIO_InitStruct.Pin = GPIO_PIN_3;
             GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
             GPIO_InitStruct.Pull = GPIO_NOPULL;
@@ -37,15 +37,7 @@ void Encoder_GPIO_Init(PipetteType pipette_type){
             GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
             HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
         }
-        case THREE_EIGHTY_FOUR_CHANNEL: {
-            GPIO_InitStruct.Pin = GPIO_PIN_3;
-            GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-            GPIO_InitStruct.Pull = GPIO_NOPULL;
-            GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-            GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
-            HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-        }
-        case EIGHT_CHANNEL: {
+    else{
             GPIO_InitStruct.Pin = GPIO_PIN_7;
             GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
             GPIO_InitStruct.Pull = GPIO_NOPULL;
@@ -53,17 +45,6 @@ void Encoder_GPIO_Init(PipetteType pipette_type){
             GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
             HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
         }
-        case SINGLE_CHANNEL:{
-            GPIO_InitStruct.Pin = GPIO_PIN_7;
-            GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-            GPIO_InitStruct.Pull = GPIO_NOPULL;
-            GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-            GPIO_InitStruct.Alternate = GPIO_AF2_TIM2;
-            HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-        }
-        default:
-            break;
-    }
 
 }
 /**

--- a/pipettes/firmware/motor_encoder_hardware.h
+++ b/pipettes/firmware/motor_encoder_hardware.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "platform_specific_hal_conf.h"
+#include "pipettes/core/pipette_type.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+extern TIM_HandleTypeDef htim2;
+
+void initialize_enc(PipetteType pipette_type);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -97,24 +97,6 @@ HAL_StatusTypeDef initialize_spi(void) {
     return HAL_SPI_Init(&hspi2);
 }
 
-/**
- * @brief GPIO Initialization Function
- * @param None
- * @retval None
- */
-void MX_GPIO_Init(void) {
-    /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-
-    /*Configure GPIO pin : PA0 which can be used as a timer */
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Pin = GPIO_PIN_0;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-}
-
 void MX_TIM7_Init(void) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
 

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -136,6 +136,5 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim) {
 
 void initialize_timer(motor_interrupt_callback callback) {
     plunger_callback = callback;
-    MX_GPIO_Init();
     MX_TIM7_Init();
 }

--- a/pipettes/firmware/stm32l5xx_it.c
+++ b/pipettes/firmware/stm32l5xx_it.c
@@ -36,6 +36,7 @@
 /* External variables --------------------------------------------------------*/
 DMA_HandleTypeDef hdma_spi1_tx;
 DMA_HandleTypeDef hdma_spi1_rx;
+extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim7;
 /******************************************************************************/
 /*            Cortex-M33 Processor Exceptions Handlers                         */
@@ -134,11 +135,15 @@ void DMA1_Channel4_IRQHandler(void)
     HAL_DMA_IRQHandler(&hdma_spi1_tx);
 }
 
-
 /**
  * @brief This function handles FDCAN1 interrupt 0.
  */
 void FDCAN1_IT0_IRQHandler(void) { HAL_FDCAN_IRQHandler(can_get_device_handle()); }
+
+/**
+ * @brief This function handles TIM2 global interrupt.
+ */
+void TIM2_IRQHandler(void) { HAL_TIM_IRQHandler(&htim2); }
 
 /**
  * @brief This function handles TIM7 global interrupt.

--- a/pipettes/firmware/stm32l5xx_it.c
+++ b/pipettes/firmware/stm32l5xx_it.c
@@ -36,7 +36,6 @@
 /* External variables --------------------------------------------------------*/
 DMA_HandleTypeDef hdma_spi1_tx;
 DMA_HandleTypeDef hdma_spi1_rx;
-extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim7;
 /******************************************************************************/
 /*            Cortex-M33 Processor Exceptions Handlers                         */
@@ -139,11 +138,6 @@ void DMA1_Channel4_IRQHandler(void)
  * @brief This function handles FDCAN1 interrupt 0.
  */
 void FDCAN1_IT0_IRQHandler(void) { HAL_FDCAN_IRQHandler(can_get_device_handle()); }
-
-/**
- * @brief This function handles TIM2 global interrupt.
- */
-void TIM2_IRQHandler(void) { HAL_TIM_IRQHandler(&htim2); }
 
 /**
  * @brief This function handles TIM7 global interrupt.

--- a/pipettes/firmware/stm32l5xx_it.h
+++ b/pipettes/firmware/stm32l5xx_it.h
@@ -54,6 +54,7 @@ void DMA2_Channel1_IRQHandler(void);
 void SDMMC1_IRQHandler(void);
 void OCTOSPI1_IRQHandler(void);
 void FDCAN1_IT0_IRQHandler(void);
+void TIM2_IRQHandler(void);
 void TIM7_IRQHandler(void);
 
 #ifdef __cplusplus

--- a/pipettes/firmware/stm32l5xx_it.h
+++ b/pipettes/firmware/stm32l5xx_it.h
@@ -54,7 +54,6 @@ void DMA2_Channel1_IRQHandler(void);
 void SDMMC1_IRQHandler(void);
 void OCTOSPI1_IRQHandler(void);
 void FDCAN1_IT0_IRQHandler(void);
-void TIM2_IRQHandler(void);
 void TIM7_IRQHandler(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR enables the encoder for each Pipette type. The encoder index pin is a different pin configuration based on the low throughput pipettes vs the high throughput pipettes. I have made a condition to compensate the encoder index pin configuration based on pipette_type. This firmware is functional on the pipette by just reading the count register when rotating the pipette. This should bring up encoder pulse count to the CANbus messages that was enable on PR [#317](https://github.com/Opentrons/ot3-firmware/pull/317). 