### PR TITLE
refactor(*): remove start args from task template

### DIFF
--- a/gantry/core/can_task.cpp
+++ b/gantry/core/can_task.cpp
@@ -64,11 +64,11 @@ auto static reader_task = can_task::CanMessageReaderTask{reader_message_buffer};
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask,
-                                can_bus::CanBus>{reader_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask>{
+        reader_task};
 auto static writer_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask,
-                                can_bus::CanBus>{writer_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask>{
+        writer_task};
 
 /**
  * Start the can reader task

--- a/gripper/core/can_tasks.cpp
+++ b/gripper/core/can_tasks.cpp
@@ -71,11 +71,11 @@ auto static reader_task = can_task::CanMessageReaderTask{reader_message_buffer};
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask,
-                                can_bus::CanBus>{reader_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask>{
+        reader_task};
 auto static writer_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask,
-                                can_bus::CanBus>{writer_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask>{
+        writer_task};
 
 /**
  * Start the can reader task

--- a/head/core/can_task.cpp
+++ b/head/core/can_task.cpp
@@ -190,11 +190,11 @@ auto static reader_task = can_task::CanMessageReaderTask{};
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask,
-                                can_bus::CanBus>{reader_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask>{
+        reader_task};
 auto static writer_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask,
-                                can_bus::CanBus>{writer_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask>{
+        writer_task};
 
 auto can_task::start_reader(can_bus::CanBus& canbus)
     -> can_task::CanMessageReaderTask& {

--- a/include/can/simlib/sim_canbus.hpp
+++ b/include/can/simlib/sim_canbus.hpp
@@ -129,7 +129,7 @@ class SimCANBus : public CanBus {
     Reader reader;
     void* new_message_callback_data{nullptr};
     IncomingMessageCallback new_message_callback{nullptr};
-    FreeRTOSTask<256, Reader, SimCANBus> reader_task;
+    FreeRTOSTask<256, Reader> reader_task;
     std::vector<sim_filter::Filter> filters{};
 };
 

--- a/include/common/core/freertos_task.hpp
+++ b/include/common/core/freertos_task.hpp
@@ -72,6 +72,5 @@ class FreeRTOSTask {
 
     std::function<void()> starter{};
 };
-};
 
 }  // namespace freertos_task

--- a/include/common/core/freertos_task.hpp
+++ b/include/common/core/freertos_task.hpp
@@ -40,7 +40,7 @@ class FreeRTOSTask {
         using InstanceDataType = std::pair<void*, std::tuple<TaskArgs*...>>;
 
         InstanceDataType instance_data{this, std::make_tuple(task_args...)};
-        starter = [instance_data](void) -> void {
+        starter = [instance_data]() -> void {
             auto instance = static_cast<FreeRTOSTask<StackDepth, EntryPoint>*>(
                 instance_data.first);
             LOG("Entering task: %s", pcTaskGetName(instance->handle));

--- a/include/head/core/tasks/presence_sensing_driver_task_starter.hpp
+++ b/include/head/core/tasks/presence_sensing_driver_task_starter.hpp
@@ -16,9 +16,8 @@ class TaskStarter {
             freertos_message_queue::FreeRTOSMessageQueue, CanClient>;
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         presence_sensing_driver_task::TaskMessage>;
-    using TaskType = freertos_task::FreeRTOSTask<
-        StackDepth, PresenceSensingDriverTaskType,
-        presence_sensing_driver::PresenceSensingDriver, CanClient>;
+    using TaskType =
+        freertos_task::FreeRTOSTask<StackDepth, PresenceSensingDriverTaskType>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/i2c/core/tasks/i2c_poller_task_starter.hpp
+++ b/include/i2c/core/tasks/i2c_poller_task_starter.hpp
@@ -22,8 +22,7 @@ class PollerTaskStarter {
         freertos_message_queue::FreeRTOSMessageQueue<poller::TaskMessage>;
     using I2CWriterType =
         i2c::writer::Writer<freertos_message_queue::FreeRTOSMessageQueue>;
-    using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, PollerTaskType, I2CWriterType>;
+    using TaskType = freertos_task::FreeRTOSTask<StackDepth, PollerTaskType>;
 
     PollerTaskStarter() : task_entry{queue}, task{task_entry} {}
     PollerTaskStarter(const PollerTaskStarter& c) = delete;

--- a/include/i2c/core/tasks/i2c_task_starter.hpp
+++ b/include/i2c/core/tasks/i2c_task_starter.hpp
@@ -18,8 +18,7 @@ class I2CTaskStarter {
         tasks::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>;
     using QueueType =
         freertos_message_queue::FreeRTOSMessageQueue<writer::TaskMessage>;
-    using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, I2CTaskType, I2CBaseType>;
+    using TaskType = freertos_task::FreeRTOSTask<StackDepth, I2CTaskType>;
 
     I2CTaskStarter() : task_entry{queue}, task{task_entry} {}
     I2CTaskStarter(const I2CTaskStarter& c) = delete;

--- a/include/motor-control/core/tasks/brushed_motion_controller_task_starter.hpp
+++ b/include/motor-control/core/tasks/brushed_motion_controller_task_starter.hpp
@@ -15,8 +15,7 @@ class TaskStarter {
         freertos_message_queue::FreeRTOSMessageQueue, CanClient>;
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         brushed_motion_controller_task::TaskMessage>;
-    using TaskType = freertos_task::FreeRTOSTask<StackDepth, MotorTaskType,
-                                                 MotorType, CanClient>;
+    using TaskType = freertos_task::FreeRTOSTask<StackDepth, MotorTaskType>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/motor-control/core/tasks/brushed_motor_driver_task_starter.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task_starter.hpp
@@ -15,8 +15,7 @@ class TaskStarter {
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         brushed_motor_driver_task::TaskMessage>;
     using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, MotorDriverTaskType,
-                                    MotorDriverType, CanClient>;
+        freertos_task::FreeRTOSTask<StackDepth, MotorDriverTaskType>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/motor-control/core/tasks/motion_controller_task_starter.hpp
+++ b/include/motor-control/core/tasks/motion_controller_task_starter.hpp
@@ -19,8 +19,7 @@ class TaskStarter {
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         motion_controller_task::TaskMessage>;
     using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, MotionControllerTaskType,
-                                    MotionControllerType, CanClient>;
+        freertos_task::FreeRTOSTask<StackDepth, MotionControllerTaskType>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/motor-control/core/tasks/motor_driver_task_starter.hpp
+++ b/include/motor-control/core/tasks/motor_driver_task_starter.hpp
@@ -15,8 +15,7 @@ class TaskStarter {
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         motor_driver_task::TaskMessage>;
     using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, MotorDriverTaskType,
-                                    MotorDriverType, CanClient>;
+        freertos_task::FreeRTOSTask<StackDepth, MotorDriverTaskType>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/motor-control/core/tasks/move_group_task_starter.hpp
+++ b/include/motor-control/core/tasks/move_group_task_starter.hpp
@@ -14,8 +14,7 @@ class TaskStarter {
         freertos_message_queue::FreeRTOSMessageQueue, MotionClient, CanClient>;
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         move_group_task::TaskMessage>;
-    using TaskType = freertos_task::FreeRTOSTask<StackDepth, MoveGroupTaskType,
-                                                 MotionClient, CanClient>;
+    using TaskType = freertos_task::FreeRTOSTask<StackDepth, MoveGroupTaskType>;
 
     TaskStarter() : task_entry{queue, move_group_manager}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/motor-control/core/tasks/move_status_reporter_task_starter.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task_starter.hpp
@@ -16,9 +16,8 @@ class TaskStarter {
             freertos_message_queue::FreeRTOSMessageQueue, CanClient, LmsConfig>;
     using QueueType = freertos_message_queue::FreeRTOSMessageQueue<
         move_status_reporter_task::TaskMessage>;
-    using TaskType = freertos_task::FreeRTOSTask<
-        StackDepth, MoveStatusReporterTaskType, CanClient,
-        const lms::LinearMotionSystemConfig<LmsConfig>>;
+    using TaskType =
+        freertos_task::FreeRTOSTask<StackDepth, MoveStatusReporterTaskType>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/pipettes/core/tasks/eeprom_task_starter.hpp
+++ b/include/pipettes/core/tasks/eeprom_task_starter.hpp
@@ -17,8 +17,7 @@ class TaskStarter {
                                 I2CWriterType, CanClient>;
     using QueueType =
         freertos_message_queue::FreeRTOSMessageQueue<eeprom_task::TaskMessage>;
-    using TaskType = freertos_task::FreeRTOSTask<StackDepth, EEPromTaskType,
-                                                 I2CWriterType, CanClient>;
+    using TaskType = freertos_task::FreeRTOSTask<StackDepth, EEPromTaskType>;
 
     TaskStarter() : task_entry{queue}, task{task_entry} {}
     TaskStarter(const TaskStarter& c) = delete;

--- a/include/sensors/core/tasks/capacitive_sensor_task_starter.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task_starter.hpp
@@ -24,9 +24,7 @@ class CapacitiveSensorTaskStarter {
     using QueueType =
         freertos_message_queue::FreeRTOSMessageQueue<utils::TaskMessage>;
     using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, CapacitiveTaskType,
-                                    I2CWriterType, I2CPollerType,
-                                    hardware::SensorHardwareBase, CanClient>;
+        freertos_task::FreeRTOSTask<StackDepth, CapacitiveTaskType>;
 
     CapacitiveSensorTaskStarter() : task_entry{queue}, task{task_entry} {}
     CapacitiveSensorTaskStarter(const CapacitiveSensorTaskStarter& c) = delete;

--- a/include/sensors/core/tasks/environmental_sensor_task_starter.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task_starter.hpp
@@ -20,8 +20,7 @@ class EnvironmentalSensorTaskStarter {
     using QueueType =
         freertos_message_queue::FreeRTOSMessageQueue<utils::TaskMessage>;
     using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, EnvironmentTaskType,
-                                    I2CWriterType, CanClient>;
+        freertos_task::FreeRTOSTask<StackDepth, EnvironmentTaskType>;
 
     EnvironmentalSensorTaskStarter() : task_entry{queue}, task{task_entry} {}
     EnvironmentalSensorTaskStarter(const EnvironmentalSensorTaskStarter& c) =

--- a/include/sensors/core/tasks/pressure_sensor_task_starter.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task_starter.hpp
@@ -22,9 +22,7 @@ class PressureSensorTaskStarter {
                            I2CWriterType, I2CPollerType, CanClient>;
     using QueueType =
         freertos_message_queue::FreeRTOSMessageQueue<utils::TaskMessage>;
-    using TaskType =
-        freertos_task::FreeRTOSTask<StackDepth, PressureTaskType, I2CWriterType,
-                                    I2CPollerType, CanClient>;
+    using TaskType = freertos_task::FreeRTOSTask<StackDepth, PressureTaskType>;
 
     PressureSensorTaskStarter() : task_entry{queue}, task{task_entry} {}
     PressureSensorTaskStarter(const PressureSensorTaskStarter& c) = delete;

--- a/pipettes/core/can_task.cpp
+++ b/pipettes/core/can_task.cpp
@@ -130,11 +130,11 @@ auto static reader_task =
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask,
-                                can_bus::CanBus>{reader_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask>{
+        reader_task};
 auto static writer_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask,
-                                can_bus::CanBus>{writer_task};
+    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask>{
+        writer_task};
 
 auto can_task::start_reader(can_bus::CanBus& canbus, can_ids::NodeId id)
     -> can_task::CanMessageReaderTask& {


### PR DESCRIPTION
The types of the arguments that you use to start a task aren't actually
relevant to the FreeRTOSTask _class_ template, just its start() method.
If that start method becomes templated instead of the class, then its
argument types can be inferred from the call.

This requires a minor refactor to curry the argument holding tuples
through a lambda so that the task starter data doesn't need a
class-level type definition.