### PR TITLE
feat(actions): run CI actions with the debug flag

### DIFF
--- a/.github/workflows/bootloader.yaml
+++ b/.github/workflows/bootloader.yaml
@@ -51,7 +51,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure l5"
-        run: cmake --preset=cross-pipettes .
+        run: cmake --preset=cross-pipettes . -DCMAKE_BUILD_TYPE=debug
       - name: "Build l5"
         run: cmake --build --preset=bootloader-pipettes
       - name: "Configure g4"

--- a/.github/workflows/can.yaml
+++ b/.github/workflows/can.yaml
@@ -51,7 +51,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target can-format-ci
       - name: "Build"

--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -50,7 +50,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target common-format-ci
         # TODO (AL 2021-07-09) - uncomment when adding common-lint is added

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -60,7 +60,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target gantry-format-ci
       - name: "Build"

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -66,7 +66,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target gripper-format-ci
       - name: "Build"

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -64,7 +64,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target head-format-ci
       - name: "Build"

--- a/.github/workflows/i2c.yaml
+++ b/.github/workflows/i2c.yaml
@@ -54,7 +54,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target i2c-format-ci
   host-compile-test:

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -66,7 +66,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross-pipettes .
+        run: cmake --preset=cross-pipettes . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build --preset=pipettes --target pipettes-format-ci
       - name: "Build"

--- a/.github/workflows/sensors.yaml
+++ b/.github/workflows/sensors.yaml
@@ -64,7 +64,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target sensors-format-ci
   host-compile-test:

--- a/.github/workflows/spi.yaml
+++ b/.github/workflows/spi.yaml
@@ -53,7 +53,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross .
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
       - name: "Format"
         run: cmake --build ./build-cross --target spi-format-ci
   host-compile-test:


### PR DESCRIPTION
## Overview

 For some reason, certain things get optimized out of the code using _RelWithDebInfo_ that causes compilation to be successful when it shouldn't be. There isn't a good way to switch between D flags in CMAKE, so for now we should just run CI using the debug flag to try and catch any things that compiling locally did not catch.