### PR TITLE
feat(eeprom): eeprom can messages generalized

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -7,6 +7,7 @@
 
 #include "can/core/ids.hpp"
 #include "common/core/bit_utils.hpp"
+#include "common/core/eeprom.hpp"
 #include "common/core/version.h"
 #include "parse.hpp"
 
@@ -127,26 +128,55 @@ using SetupRequest = Empty<MessageId::setup_request>;
 using ReadLimitSwitchRequest = Empty<MessageId::limit_sw_request>;
 
 struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {
-    uint16_t serial_number;
+    eeprom::address address;
+    eeprom::data_length data_length;
+    eeprom::EepromData data;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> WriteToEEPromRequest {
-        uint16_t serial_number = 0;
-        body = bit_utils::bytes_to_int(body, limit, serial_number);
-        return WriteToEEPromRequest{.serial_number = serial_number};
+        eeprom::address address = 0;
+        eeprom::data_length data_length = 0;
+        eeprom::EepromData data{};
+
+        body = bit_utils::bytes_to_int(body, limit, address);
+        body = bit_utils::bytes_to_int(body, limit, data_length);
+        std::copy_n(body,
+                    std::min(static_cast<size_t>(data_length), data.size()),
+                    data.begin());
+
+        return WriteToEEPromRequest{
+            .address = address, .data_length = data_length, .data = data};
     }
 
     auto operator==(const WriteToEEPromRequest& other) const -> bool = default;
 };
 
-using ReadFromEEPromRequest = Empty<MessageId::read_eeprom_request>;
-
-struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
-    uint16_t serial_number;
+struct ReadFromEEPromRequest : BaseMessage<MessageId::read_eeprom_request> {
+    eeprom::address address;
+    eeprom::data_length data_length;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
-        auto iter = bit_utils::int_to_bytes(serial_number, body, limit);
+        auto iter = bit_utils::int_to_bytes(address, body, limit);
+        iter = bit_utils::int_to_bytes(data_length, body, limit);
+        return iter - body;
+    }
+
+    auto operator==(const ReadFromEEPromRequest& other) const -> bool = default;
+};
+
+struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
+    eeprom::address address;
+    eeprom::data_length data_length;
+    eeprom::EepromData data;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(address, body, limit);
+        iter = bit_utils::int_to_bytes(data_length, body, limit);
+        iter = std::copy_n(
+            data.cbegin(),
+            std::min(data.size(), static_cast<size_t>(limit - iter)), iter);
         return iter - body;
     }
     auto operator==(const ReadFromEEPromResponse& other) const

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -163,10 +163,9 @@ struct ReadFromEEPromRequest : BaseMessage<MessageId::read_eeprom_request> {
         body = bit_utils::bytes_to_int(body, limit, address);
         body = bit_utils::bytes_to_int(body, limit, data_length);
 
-        return ReadFromEEPromRequest{
-            .address = address, .data_length = data_length};
+        return ReadFromEEPromRequest{.address = address,
+                                     .data_length = data_length};
     }
-
 
     auto operator==(const ReadFromEEPromRequest& other) const -> bool = default;
 };
@@ -185,8 +184,8 @@ struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
      * @return new instance
      */
     template <bit_utils::ByteIterator DataIter, typename Limit>
-    static auto create(eeprom_types::address address, DataIter data_iter, Limit limit)
-        -> ReadFromEEPromResponse {
+    static auto create(eeprom_types::address address, DataIter data_iter,
+                       Limit limit) -> ReadFromEEPromResponse {
         eeprom_types::EepromData data{};
         eeprom_types::data_length data_length =
             std::min(eeprom_types::max_data_length,

--- a/include/common/core/eeprom.hpp
+++ b/include/common/core/eeprom.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-
 namespace eeprom_types {
 
 // 0-8192
@@ -13,4 +12,4 @@ constexpr data_length max_data_length = 32;
 
 using EepromData = std::array<uint8_t, max_data_length>;
 
-}
+}  // namespace eeprom_types

--- a/include/common/core/eeprom.hpp
+++ b/include/common/core/eeprom.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+
+namespace eeprom {
+
+// 0-8192
+using address = uint16_t;
+
+// 0-32
+using data_length = uint8_t;
+
+constexpr auto max_data_length = 32;
+
+using EepromData = std::array<uint8_t, max_data_length>;
+
+}

--- a/include/common/core/eeprom.hpp
+++ b/include/common/core/eeprom.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 
-namespace eeprom {
+namespace eeprom_types {
 
 // 0-8192
 using address = uint16_t;

--- a/include/common/core/eeprom.hpp
+++ b/include/common/core/eeprom.hpp
@@ -9,7 +9,7 @@ using address = uint16_t;
 // 0-32
 using data_length = uint8_t;
 
-constexpr auto max_data_length = 32;
+constexpr data_length max_data_length = 32;
 
 using EepromData = std::array<uint8_t, max_data_length>;
 

--- a/include/pipettes/core/tasks/eeprom_task.hpp
+++ b/include/pipettes/core/tasks/eeprom_task.hpp
@@ -43,19 +43,13 @@ class EEPromMessageHandler {
     void visit(std::monostate &m) {}
 
     void visit(i2c::messages::TransactionResponse &m) {
-        uint16_t data = 0;
-        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
-                                                  m.read_buffer.cend(), data));
-        auto message =
-            can_messages::ReadFromEEPromResponse{.serial_number = data};
+        auto message = can_messages::ReadFromEEPromResponse::create(0, m.read_buffer.cbegin(), m.read_buffer.cend());
         can_client.send_can_message(can_ids::NodeId::host, message);
     }
 
     void visit(can_messages::WriteToEEPromRequest &m) {
-        LOG("Received request to write serial number: %d", m.serial_number);
-        std::array serial_buf{static_cast<uint8_t>(m.serial_number >> 8),
-                              static_cast<uint8_t>(m.serial_number & 0xff)};
-        writer.write(DEVICE_ADDRESS, serial_buf);
+        LOG("Received request to write %d bytes to address %x", m.data_length, m.data);
+        writer.write(DEVICE_ADDRESS, m.data);
     }
 
     void visit(can_messages::ReadFromEEPromRequest &m) {
@@ -64,7 +58,6 @@ class EEPromMessageHandler {
     }
 
     static constexpr uint16_t DEVICE_ADDRESS = 0x1;
-    static constexpr int SERIAL_NUMBER_SIZE = 0x2;
     I2CQueueWriter &writer;
     CanClient &can_client;
     OwnQueue &own_queue;

--- a/include/pipettes/core/tasks/eeprom_task.hpp
+++ b/include/pipettes/core/tasks/eeprom_task.hpp
@@ -43,12 +43,14 @@ class EEPromMessageHandler {
     void visit(std::monostate &m) {}
 
     void visit(i2c::messages::TransactionResponse &m) {
-        auto message = can_messages::ReadFromEEPromResponse::create(0, m.read_buffer.cbegin(), m.read_buffer.cend());
+        auto message = can_messages::ReadFromEEPromResponse::create(
+            0, m.read_buffer.cbegin(), m.read_buffer.cend());
         can_client.send_can_message(can_ids::NodeId::host, message);
     }
 
     void visit(can_messages::WriteToEEPromRequest &m) {
-        LOG("Received request to write %d bytes to address %x", m.data_length, m.data);
+        LOG("Received request to write %d bytes to address %x", m.data_length,
+            m.data);
         writer.write(DEVICE_ADDRESS, m.data);
     }
 


### PR DESCRIPTION
Modify eeprom can message payloads. These can specify a target address, data length, and buffer.

The messages don't do anything yet. That's for a future PR.