### PR TITLE
feat(pipettes): add tip handling CAN messages

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -73,6 +73,8 @@ typedef enum {
     can_messageid_fw_update_erase_app_ack = 0x69,
     can_messageid_limit_sw_request = 0x8,
     can_messageid_limit_sw_response = 0x9,
+    can_messageid_do_self_contained_tip_action_request = 0x501,
+    can_messageid_do_self_contained_tip_action_response = 0x502,
     can_messageid_read_sensor_request = 0x82,
     can_messageid_write_sensor_request = 0x83,
     can_messageid_baseline_sensor_request = 0x84,
@@ -130,9 +132,10 @@ typedef enum {
 
 /** A bit field of the arbitration id parts. */
 typedef struct {
-    unsigned int function_code : 4;
-    unsigned int node_id : 7;
-    unsigned int originating_node_id : 7;
-    unsigned int message_id : 11;
-    unsigned int padding : 3;
+    unsigned int function_code: 4;
+    unsigned int node_id: 7;
+    unsigned int originating_node_id: 7;
+    unsigned int message_id: 11;
+    unsigned int padding: 3;
 } CANArbitrationIdParts;
+

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -75,6 +75,8 @@ enum class MessageId {
     fw_update_erase_app_ack = 0x69,
     limit_sw_request = 0x8,
     limit_sw_response = 0x9,
+    do_self_contained_tip_action_request = 0x501,
+    do_self_contained_tip_action_response = 0x502,
     read_sensor_request = 0x82,
     write_sensor_request = 0x83,
     baseline_sensor_request = 0x84,
@@ -142,7 +144,6 @@ enum class SensorType {
 
 /** Links sensor threshold triggers to pins. */
 enum class SensorOutputBinding {
-    none = 0x0,
     sync = 0x1,
     report = 0x2,
 };

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -760,7 +760,7 @@ struct TipActionRequest
                                 .velocity = velocity};
     }
 
-    auto operator==(const PickUpTipRequest& other) const -> bool = default;
+    auto operator==(const TipActionRequest& other) const -> bool = default;
 };
 
 struct TipActionResponse

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -770,6 +770,7 @@ struct TipActionResponse
     uint32_t current_position_um;
     uint32_t encoder_position;
     uint8_t ack_id;
+    uint8_t success;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
@@ -778,6 +779,7 @@ struct TipActionResponse
         iter = bit_utils::int_to_bytes(current_position_um, iter, limit);
         iter = bit_utils::int_to_bytes(encoder_position, iter, limit);
         iter = bit_utils::int_to_bytes(ack_id, iter, limit);
+        iter = bit_utils::int_to_bytes(success, iter, limit);
         return iter - body;
     }
 


### PR DESCRIPTION
## Overview

Add the firmware side of the tip handling commands. Implementation of these commands will happen in
a separate PR.