### PR TITLE
feat(spi): Support multiple cs lines

### DIFF
--- a/gantry/core/utils.cpp
+++ b/gantry/core/utils.cpp
@@ -16,52 +16,6 @@ auto utils::get_node_id() -> can_ids::NodeId {
     return get_node_id_by_axis(get_axis_type());
 }
 
-auto utils::driver_config_by_axis(enum GantryAxisType which)
-    -> tmc2130::configs::TMC2130DriverConfig {
-    switch (which) {
-        case GantryAxisType::gantry_x:
-            return tmc2130::configs::TMC2130DriverConfig{
-                .registers = {.gconfig = {.en_pwm_mode = 1},
-                              .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x18,
-                                             .hold_current_delay = 0x7},
-                              .thigh = {.threshold = 0xFFFFF},
-                              .chopconf = {.toff = 0x5,
-                                           .hstrt = 0x5,
-                                           .hend = 0x3,
-                                           .tbl = 0x2,
-                                           .mres = 0x3},
-                              .coolconf = {.sgt = 0x6}},
-                .current_config = {
-                    .r_sense = 0.1,
-                    .v_sf = 0.325,
-                }};
-
-        case GantryAxisType::gantry_y:
-            return tmc2130::configs::TMC2130DriverConfig{
-                .registers = {.gconfig = {.en_pwm_mode = 1},
-                              .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x18,
-                                             .hold_current_delay = 0x7},
-                              .thigh = {.threshold = 0xFFFFF},
-                              .chopconf = {.toff = 0x5,
-                                           .hstrt = 0x5,
-                                           .hend = 0x3,
-                                           .tbl = 0x2,
-                                           .mres = 0x3},
-                              .coolconf = {.sgt = 0x6}},
-                .current_config = {
-                    .r_sense = 0.1,
-                    .v_sf = 0.325,
-                }};
-    }
-    std::abort();
-}
-
-auto utils::driver_config() -> tmc2130::configs::TMC2130DriverConfig {
-    return driver_config_by_axis(get_axis_type());
-}
-
 auto utils::linear_motion_sys_config_by_axis(enum GantryAxisType which)
     -> lms::LinearMotionSystemConfig<lms::BeltConfig> {
     switch (which) {

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -168,7 +168,7 @@ static motor_hardware::MotorHardware motor_hardware_iface(
  * The motor driver config.
  */
 static tmc2130::configs::TMC2130DriverConfig motor_driver_config =
-    (get_axis_type() == gantry_x) ? gantry_x_driver_configs : gantry_y_driver_configs);
+    (get_axis_type() == gantry_x) ? gantry_x_driver_configs : gantry_y_driver_configs;
 
 /**
  * The can bus.

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -168,7 +168,8 @@ static motor_hardware::MotorHardware motor_hardware_iface(
  * The motor driver config.
  */
 static tmc2130::configs::TMC2130DriverConfig motor_driver_config =
-    (get_axis_type() == gantry_x) ? gantry_x_driver_configs : gantry_y_driver_configs;
+    (get_axis_type() == gantry_x) ? gantry_x_driver_configs
+                                  : gantry_y_driver_configs;
 
 /**
  * The can bus.

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -30,7 +30,27 @@ static auto motor_interface = sim_motor_hardware_iface::SimMotorHardwareIface();
 static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
     motor_queue("Motor Queue");
 
-static auto driver_configs = utils::driver_config();
+static tmc2130::configs::TMC2130DriverConfig driver_configs{
+    .registers = {.gconfig = {.en_pwm_mode = 1},
+                  .ihold_irun = {.hold_current = 0x2,
+                                 .run_current = 0x18,
+                                 .hold_current_delay = 0x7},
+                  .thigh = {.threshold = 0xFFFFF},
+                  .chopconf = {.toff = 0x5,
+                               .hstrt = 0x5,
+                               .hend = 0x3,
+                               .tbl = 0x2,
+                               .mres = 0x3},
+                  .coolconf = {.sgt = 0x6}},
+    .current_config =
+        {
+            .r_sense = 0.1,
+            .v_sf = 0.325,
+        },
+    .chip_select{
+        .cs_pin = 0,
+        .GPIO_handle = 0,
+    }};
 
 /**
  * The motor struct.

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -19,9 +19,6 @@
  */
 static spi::hardware::SPI_interface SPI_intf = {
     .SPI_handle = &hspi2,
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    .GPIO_handle = GPIOB,
-    .pin = GPIO_PIN_12,
 };
 
 /**
@@ -90,9 +87,15 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
                          .mres = 0x4},
             .coolconf = {.sgt = 0x6},
         },
-    .current_config = {
-        .r_sense = 0.1,
-        .v_sf = 0.325,
+    .current_config =
+        {
+            .r_sense = 0.1,
+            .v_sf = 0.325,
+        },
+    .chip_select = {
+        .cs_pin = GPIO_PIN_12,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        .GPIO_handle = GPIOB,
     }};
 
 /**

--- a/head/core/tasks.cpp
+++ b/head/core/tasks.cpp
@@ -67,7 +67,8 @@ void head_tasks::start_tasks(
     presence_sensing_driver::PresenceSensingDriver& presence_sensing_driver,
     spi::hardware::SpiDeviceBase& spi2_device,
     spi::hardware::SpiDeviceBase& spi3_device,
-    tmc2130::configs::TMC2130DriverConfig& driver_configs) {
+    tmc2130::configs::TMC2130DriverConfig& left_driver_configs,
+    tmc2130::configs::TMC2130DriverConfig& right_driver_configs) {
     // Start the head tasks
     auto& can_writer = can_task::start_writer(can_bus);
     can_task::start_reader(can_bus);
@@ -92,7 +93,8 @@ void head_tasks::start_tasks(
     auto& left_motion = left_mc_task_builder.start(
         5, "left mc", left_motion_controller, left_queues);
     auto& left_tmc2130_driver = left_motor_driver_task_builder.start(
-        5, "left motor driver", driver_configs, left_queues, spi3_task_client);
+        5, "left motor driver", left_driver_configs, left_queues,
+        spi3_task_client);
     auto& left_move_group = left_move_group_task_builder.start(
         5, "left move group", left_queues, left_queues);
     auto& left_move_status_reporter = left_move_status_task_builder.start(
@@ -118,7 +120,7 @@ void head_tasks::start_tasks(
     auto& right_motion = right_mc_task_builder.start(
         5, "right mc", right_motion_controller, right_queues);
     auto& right_tmc2130_driver = right_motor_driver_task_builder.start(
-        5, "right motor driver", driver_configs, right_queues,
+        5, "right motor driver", right_driver_configs, right_queues,
         spi2_task_client);
     auto& right_move_group = right_move_group_task_builder.start(
         5, "right move group", right_queues, right_queues);

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -51,17 +51,11 @@ static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
 
 spi::hardware::SPI_interface SPI_intf2 = {
     .SPI_handle = &hspi2,
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    .GPIO_handle = GPIOB,
-    .pin = GPIO_PIN_12,
 };
 static spi::hardware::Spi spi_comms2(SPI_intf2);
 
 spi::hardware::SPI_interface SPI_intf3 = {
     .SPI_handle = &hspi3,
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    .GPIO_handle = GPIOA,
-    .pin = GPIO_PIN_4,
 };
 static spi::hardware::Spi spi_comms3(SPI_intf3);
 
@@ -141,7 +135,8 @@ struct motor_hardware::HardwareConfig pin_configurations_right {
         .active_setting = GPIO_PIN_RESET}
 };
 
-static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
+// TODO clean up the head main file by using interfaces.
+static tmc2130::configs::TMC2130DriverConfig motor_driver_configs_right{
     .registers =
         {
             .gconfig = {.en_pwm_mode = 1},
@@ -157,10 +152,44 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
                          .mres = 0x4},
             .coolconf = {.sgt = 0x6},
         },
-    .current_config = {
-        .r_sense = 0.1,
-        .v_sf = 0.325,
+    .current_config =
+        {
+            .r_sense = 0.1,
+            .v_sf = 0.325,
+        },
+    .chip_select{
+        .cs_pin = GPIO_PIN_12,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        .GPIO_handle = GPIOB,
     }};
+
+static tmc2130::configs::TMC2130DriverConfig motor_driver_configs_left{
+    .registers =
+        {
+            .gconfig = {.en_pwm_mode = 1},
+            .ihold_irun = {.hold_current = 0xB,
+                           .run_current = 0x19,
+                           .hold_current_delay = 0x7},
+            .tcoolthrs = {.threshold = 0},
+            .thigh = {.threshold = 0xFFFFF},
+            .chopconf = {.toff = 0x5,
+                         .hstrt = 0x5,
+                         .hend = 0x3,
+                         .tbl = 0x2,
+                         .mres = 0x4},
+            .coolconf = {.sgt = 0x6},
+        },
+    .current_config =
+        {
+            .r_sense = 0.1,
+            .v_sf = 0.325,
+        },
+    .chip_select{
+        .cs_pin = GPIO_PIN_4,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        .GPIO_handle = GPIOA,
+    }};
+
 /**
  * TODO: This motor class is only used in motor handler and should be
  * instantiated inside of the MotorHandler class. However, some refactors
@@ -241,7 +270,8 @@ auto main() -> int {
 
     head_tasks::start_tasks(can_bus_1, motor_left.motion_controller,
                             motor_right.motion_controller, psd, spi_comms2,
-                            spi_comms3, MotorDriverConfigurations);
+                            spi_comms3, motor_driver_configs_left,
+                            motor_driver_configs_right);
 
     timer_for_notifier.start();
 

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -61,7 +61,10 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
             .r_sense = 0.1,
             .v_sf = 0.325,
         },
-};
+    .chip_select{
+        .cs_pin = 0,
+        .GPIO_handle = 0,
+    }};
 
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_interface_right);
@@ -115,10 +118,10 @@ int main() {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
 
-    head_tasks::start_tasks(canbus, motor_left.motion_controller,
-                            motor_right.motion_controller,
-                            presence_sense_driver, spi_comms_right,
-                            spi_comms_left, MotorDriverConfigurations);
+    head_tasks::start_tasks(
+        canbus, motor_left.motion_controller, motor_right.motion_controller,
+        presence_sense_driver, spi_comms_right, spi_comms_left,
+        MotorDriverConfigurations, MotorDriverConfigurations);
 
     vTaskStartScheduler();
     return 0;

--- a/include/gantry/core/utils.hpp
+++ b/include/gantry/core/utils.hpp
@@ -11,11 +11,6 @@ auto get_node_id_by_axis(enum GantryAxisType which) -> can_ids::NodeId;
 
 auto get_node_id() -> can_ids::NodeId;
 
-auto driver_config_by_axis(enum GantryAxisType which)
-    -> tmc2130::configs::TMC2130DriverConfig;
-
-auto driver_config() -> tmc2130::configs::TMC2130DriverConfig;
-
 auto linear_motion_sys_config_by_axis(enum GantryAxisType which)
     -> lms::LinearMotionSystemConfig<lms::BeltConfig>;
 

--- a/include/head/core/tasks.hpp
+++ b/include/head/core/tasks.hpp
@@ -27,7 +27,8 @@ void start_tasks(
     presence_sensing_driver::PresenceSensingDriver& presence_sensing_driver,
     spi::hardware::SpiDeviceBase& spi2_device,
     spi::hardware::SpiDeviceBase& spi3_device,
-    tmc2130::configs::TMC2130DriverConfig& configs);
+    tmc2130::configs::TMC2130DriverConfig& left_driver_configs,
+    tmc2130::configs::TMC2130DriverConfig& right_driver_configs);
 
 /**
  * The client for all head message queues not associated with a single motor.

--- a/include/motor-control/core/stepper_motor/tmc2130.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130.hpp
@@ -13,6 +13,8 @@
 #include <concepts>
 #include <cstdint>
 
+#include "spi/core/utils.hpp"
+
 namespace tmc2130 {
 
 namespace registers {
@@ -474,6 +476,7 @@ struct TMC2130MotorCurrentConfig {
 struct TMC2130DriverConfig {
     registers::TMC2130RegisterMap registers{};
     TMC2130MotorCurrentConfig current_config{};
+    spi::utils::ChipSelectInterface chip_select{};
 };
 
 }  // namespace configs

--- a/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
@@ -42,6 +42,7 @@ class TMC2130 {
         : _registers(conf.registers),
           _current_config(conf.current_config),
           _spi_manager(spi_manager),
+          _cs_intf(conf.chip_select),
           _task_queue(task_queue),
           _initialized(false) {}
 
@@ -53,12 +54,13 @@ class TMC2130 {
 
     auto read(Registers addr, uint32_t command_data) -> void {
         auto converted_addr = static_cast<uint8_t>(addr);
-        _spi_manager.read(converted_addr, command_data, _task_queue);
+        _spi_manager.read(converted_addr, command_data, _task_queue, _cs_intf);
     }
 
     auto write(Registers addr, uint32_t command_data) -> bool {
         auto converted_addr = static_cast<uint8_t>(addr);
-        return _spi_manager.write(converted_addr, command_data, _task_queue);
+        return _spi_manager.write(converted_addr, command_data, _task_queue,
+                                  _cs_intf);
     }
 
     /**
@@ -399,6 +401,7 @@ class TMC2130 {
     TMC2130RegisterMap _registers = {};
     TMC2130MotorCurrentConfig _current_config = {};
     Writer& _spi_manager;
+    spi::utils::ChipSelectInterface _cs_intf;
     TaskQueue& _task_queue;
     bool _initialized;
 };

--- a/include/pipettes/core/configs.hpp
+++ b/include/pipettes/core/configs.hpp
@@ -1,13 +1,9 @@
 #pragma once
 
 #include "motor-control/core/linear_motion_system.hpp"
-#include "motor-control/core/stepper_motor/tmc2130_driver.hpp"
 #include "pipettes/core/pipette_type.h"
 
 namespace configs {
-
-auto driver_config_by_axis(PipetteType which)
-    -> tmc2130::configs::TMC2130DriverConfig;
 
 auto linear_motion_sys_config_by_axis(PipetteType which)
     -> lms::LinearMotionSystemConfig<lms::LeadScrewConfig>;

--- a/include/pipettes/core/interfaces.hpp
+++ b/include/pipettes/core/interfaces.hpp
@@ -1,0 +1,7 @@
+#include "motor-control/core/stepper_motor/tmc2130.hpp"
+#include "pipettes/core/pipette_type.h"
+
+namespace interfaces {
+auto driver_config_by_axis(PipetteType which)
+    -> tmc2130::configs::TMC2130DriverConfig;
+}

--- a/include/spi/core/messages.hpp
+++ b/include/spi/core/messages.hpp
@@ -30,6 +30,7 @@ struct TransactionIdentifier {
  */
 struct Transaction {
     spi::utils::MaxMessageBuffer txBuffer;
+    spi::utils::ChipSelectInterface cs_interface;
 
     auto operator==(const Transaction&) const -> bool = default;
 };

--- a/include/spi/core/spi.hpp
+++ b/include/spi/core/spi.hpp
@@ -26,7 +26,9 @@ class SpiDeviceBase {
      * @param receive The receive buffer.
      */
     virtual auto transmit_receive(const utils::MaxMessageBuffer& transmit,
-                                  utils::MaxMessageBuffer& receive) -> bool = 0;
+                                  utils::MaxMessageBuffer& receive,
+                                  utils::ChipSelectInterface cs_intf)
+        -> bool = 0;
 
     /**
      * Fill a buffer with a command.

--- a/include/spi/core/tasks/spi_task.hpp
+++ b/include/spi/core/tasks/spi_task.hpp
@@ -39,8 +39,9 @@ class MessageHandler {
     void visit(spi::messages::Transact& m) {
         LOG("Received SPI read request");
         spi::utils::MaxMessageBuffer rxBuffer{};
-        auto success =
-            driver.transmit_receive(m.transaction.txBuffer, rxBuffer);
+        auto transaction = m.transaction;
+        auto success = driver.transmit_receive(transaction.txBuffer, rxBuffer,
+                                               transaction.cs_interface);
         if (m.id.requires_response) {
             m.response_writer.write(spi::messages::TransactResponse{
                 .id = m.id, .rxBuffer = rxBuffer, .success = success});

--- a/include/spi/core/utils.hpp
+++ b/include/spi/core/utils.hpp
@@ -11,6 +11,11 @@ using std::size_t;
 static constexpr std::size_t MAX_BUFFER_SIZE = 5;
 using MaxMessageBuffer = std::array<uint8_t, MAX_BUFFER_SIZE>;
 
+struct ChipSelectInterface {
+    uint32_t cs_pin;
+    void* GPIO_handle;
+};
+
 }  // namespace utils
 
 }  // namespace spi

--- a/include/spi/core/writer.hpp
+++ b/include/spi/core/writer.hpp
@@ -47,16 +47,18 @@ class Writer {
      */
     template <OriginatingResponseQueue RQType>
     auto read(uint8_t register_addr, uint32_t command_data,
-              RQType& response_queue) -> bool {
+              RQType& response_queue, utils::ChipSelectInterface cs_intf)
+        -> bool {
         auto txBuffer = build_message(register_addr, spi::hardware::Mode::READ,
                                       command_data);
         TransactionIdentifier _transaction_id{
             .token = register_addr,
             .command_type = static_cast<uint8_t>(spi::hardware::Mode::READ),
             .requires_response = false};
-        Transact message{.id = _transaction_id,
-                         .transaction = {.txBuffer = txBuffer},
-                         .response_writer = ResponseWriter(response_queue)};
+        Transact message{
+            .id = _transaction_id,
+            .transaction = {.txBuffer = txBuffer, .cs_interface = cs_intf},
+            .response_writer = ResponseWriter(response_queue)};
         queue->try_write(message);
 
         message.id.requires_response = true;
@@ -76,16 +78,18 @@ class Writer {
      */
     template <OriginatingResponseQueue RQType>
     auto write(uint8_t register_addr, uint32_t command_data,
-               RQType& response_queue) -> bool {
+               RQType& response_queue, utils::ChipSelectInterface cs_intf)
+        -> bool {
         auto txBuffer = build_message(register_addr, spi::hardware::Mode::WRITE,
                                       command_data);
         TransactionIdentifier _transaction_id{
             .token = register_addr,
             .command_type = static_cast<uint8_t>(spi::hardware::Mode::WRITE),
             .requires_response = true};
-        Transact message{.id = _transaction_id,
-                         .transaction = {.txBuffer = txBuffer},
-                         .response_writer = ResponseWriter(response_queue)};
+        Transact message{
+            .id = _transaction_id,
+            .transaction = {.txBuffer = txBuffer, .cs_interface = cs_intf},
+            .response_writer = ResponseWriter(response_queue)};
         queue->try_write(message);
         return true;
     }

--- a/include/spi/firmware/spi_comms.hpp
+++ b/include/spi/firmware/spi_comms.hpp
@@ -16,8 +16,6 @@ namespace hardware {
 
 struct SPI_interface {
     SPI_HandleTypeDef* SPI_handle;
-    GPIO_TypeDef* GPIO_handle;
-    uint32_t pin;
 };
 
 class Spi : public SpiDeviceBase {
@@ -25,7 +23,8 @@ class Spi : public SpiDeviceBase {
     explicit Spi(SPI_interface SPI_int);
 
     auto transmit_receive(const utils::MaxMessageBuffer& transmit,
-                          utils::MaxMessageBuffer& receive) -> bool final;
+                          utils::MaxMessageBuffer& receive,
+                          utils::ChipSelectInterface cs_intf) -> bool final;
 
   private:
     static constexpr uint32_t TIMEOUT = 0xFFFF;

--- a/include/spi/simulation/spi.hpp
+++ b/include/spi/simulation/spi.hpp
@@ -29,7 +29,8 @@ class SimSpiDeviceBase : public SpiDeviceBase {
         : register_map{register_map} {}
 
     bool transmit_receive(const spi::utils::MaxMessageBuffer& transmit,
-                          spi::utils::MaxMessageBuffer& receive) final;
+                          spi::utils::MaxMessageBuffer& receive,
+                          spi::utils::ChipSelectInterface cs_intf) final;
 
     auto get_txrx_count() const -> std::size_t;
     auto get_last_received() const -> const std::vector<uint8_t>&;

--- a/pipettes/core/configs.cpp
+++ b/pipettes/core/configs.cpp
@@ -1,30 +1,5 @@
 #include "pipettes/core/configs.hpp"
 
-auto configs::driver_config_by_axis(PipetteType which)
-    -> tmc2130::configs::TMC2130DriverConfig {
-    switch (which) {
-        default:
-            return tmc2130::configs::TMC2130DriverConfig{
-                .registers = {.gconfig = {.en_pwm_mode = 1},
-                              .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x10,
-                                             .hold_current_delay = 0x7},
-                              .tpowerdown = {},
-                              .tcoolthrs = {.threshold = 0},
-                              .thigh = {.threshold = 0xFFFFF},
-                              .chopconf = {.toff = 0x5,
-                                           .hstrt = 0x5,
-                                           .hend = 0x3,
-                                           .tbl = 0x2,
-                                           .mres = 0x3},
-                              .coolconf = {.sgt = 0x6}},
-                .current_config = {
-                    .r_sense = 0.1,
-                    .v_sf = 0.325,
-                }};
-    }
-}
-
 auto configs::linear_motion_sys_config_by_axis(PipetteType which)
     -> lms::LinearMotionSystemConfig<lms::LeadScrewConfig> {
     switch (which) {

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CAN_FW_DIR "${CMAKE_SOURCE_DIR}/can/firmware")
 set(PIPETTE_FW_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
     ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
     ${COMMON_EXECUTABLE_DIR}/gpio.cpp
     ${CAN_FW_DIR}/hal_can.c

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -1,0 +1,38 @@
+#include "pipettes/core/interfaces.hpp"
+
+#pragma GCC diagnostic push
+// NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
+#pragma GCC diagnostic ignored "-Wvolatile"
+#include "platform_specific_hal_conf.h"
+#pragma GCC diagnostic pop
+
+auto interfaces::driver_config_by_axis(PipetteType which)
+    -> tmc2130::configs::TMC2130DriverConfig {
+    switch (which) {
+        default:
+            return tmc2130::configs::TMC2130DriverConfig{
+                .registers = {.gconfig = {.en_pwm_mode = 1},
+                              .ihold_irun = {.hold_current = 0x2,
+                                             .run_current = 0x10,
+                                             .hold_current_delay = 0x7},
+                              .tpowerdown = {},
+                              .tcoolthrs = {.threshold = 0},
+                              .thigh = {.threshold = 0xFFFFF},
+                              .chopconf = {.toff = 0x5,
+                                           .hstrt = 0x5,
+                                           .hend = 0x3,
+                                           .tbl = 0x2,
+                                           .mres = 0x3},
+                              .coolconf = {.sgt = 0x6}},
+                .current_config =
+                    {
+                        .r_sense = 0.1,
+                        .v_sf = 0.325,
+                    },
+                .chip_select = {
+                    .cs_pin = GPIO_PIN_6,
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .GPIO_handle = GPIOC,
+                }};
+    }
+}

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -22,6 +22,7 @@
 #include "motor-control/firmware/stepper_motor/motor_hardware.hpp"
 #include "mount_detection.hpp"
 #include "pipettes/core/configs.hpp"
+#include "pipettes/core/interfaces.hpp"
 #include "pipettes/core/pipette_type.h"
 #include "pipettes/core/tasks.hpp"
 #include "sensors/firmware/sensor_hardware.hpp"
@@ -44,12 +45,8 @@ static auto can_bus_1 = hal_can_bus::HalCanBus(can_get_device_handle());
 static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
     motor_queue("Motor Queue");
 
-spi::hardware::SPI_interface SPI_intf = {
-    .SPI_handle = &hspi2,
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    .GPIO_handle = GPIOC,
-    .pin = GPIO_PIN_6,
-};
+spi::hardware::SPI_interface SPI_intf = {.SPI_handle = &hspi2};
+
 static spi::hardware::Spi spi_comms(SPI_intf);
 
 static auto i2c_comms3 = i2c::hardware::I2C();
@@ -106,7 +103,7 @@ static motor_class::Motor pipette_motor{
                                       .max_acceleration = 2},
     motor_queue};
 
-static auto driver_configs = configs::driver_config_by_axis(PIPETTE_TYPE);
+static auto driver_configs = interfaces::driver_config_by_axis(PIPETTE_TYPE);
 
 extern "C" void plunger_callback() { plunger_interrupt.run_interrupt(); }
 

--- a/pipettes/simulator/CMakeLists.txt
+++ b/pipettes/simulator/CMakeLists.txt
@@ -28,20 +28,11 @@ add_library(freertos-pipettes STATIC ${FREERTOS_SOURCES})
 target_include_directories(freertos-pipettes PUBLIC ${PIPETTE_SIM_INCLUDE})
 
 function(add_simulator_executable TARGET)
-    if(${TARGET} STREQUAL "pipettes-single-simulator")
-        set(PIPETTES_SIMULATOR_SRC
-                ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-                ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
-                )
-    else()
-        set(PIPETTES_SIMULATOR_SRC
-                ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-                ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
-                )
-    endif()
     add_executable(
             ${TARGET}
-            ${PIPETTES_SIMULATOR_SRC}
+            ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
             )
     target_include_directories(${TARGET} PUBLIC ${PIPETTE_SIM_INCLUDE})
     target_i2c_simlib(${TARGET})

--- a/pipettes/simulator/interfaces.cpp
+++ b/pipettes/simulator/interfaces.cpp
@@ -1,0 +1,31 @@
+#include "pipettes/core/interfaces.hpp"
+
+auto interfaces::driver_config_by_axis(PipetteType which)
+    -> tmc2130::configs::TMC2130DriverConfig {
+    switch (which) {
+        default:
+            return tmc2130::configs::TMC2130DriverConfig{
+                .registers = {.gconfig = {.en_pwm_mode = 1},
+                              .ihold_irun = {.hold_current = 0x2,
+                                             .run_current = 0x10,
+                                             .hold_current_delay = 0x7},
+                              .tpowerdown = {},
+                              .tcoolthrs = {.threshold = 0},
+                              .thigh = {.threshold = 0xFFFFF},
+                              .chopconf = {.toff = 0x5,
+                                           .hstrt = 0x5,
+                                           .hend = 0x3,
+                                           .tbl = 0x2,
+                                           .mres = 0x3},
+                              .coolconf = {.sgt = 0x6}},
+                .current_config =
+                    {
+                        .r_sense = 0.1,
+                        .v_sf = 0.325,
+                    },
+                .chip_select = {
+                    .cs_pin = 0,
+                    .GPIO_handle = 0,
+                }};
+    }
+}

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -16,6 +16,7 @@
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
 #include "pipettes/core/configs.hpp"
+#include "pipettes/core/interfaces.hpp"
 #include "pipettes/core/tasks.hpp"
 #include "pipettes/simulation/eeprom.hpp"
 #include "sensors/simulation/fdc1004.hpp"
@@ -92,7 +93,7 @@ static const char* PipetteTypeString[] = {
     "SINGLE CHANNEL PIPETTE", "EIGHT CHANNEL PIPETTE",
     "NINETY SIX CHANNEL PIPETTE", "THREE EIGHTY FOUR CHANNEL PIPETTE"};
 
-static auto driver_configs = configs::driver_config_by_axis(PIPETTE_TYPE);
+static auto driver_configs = interfaces::driver_config_by_axis(PIPETTE_TYPE);
 
 int main() {
     signal(SIGINT, signal_handler);

--- a/spi/firmware/spi_comms.cpp
+++ b/spi/firmware/spi_comms.cpp
@@ -31,13 +31,15 @@ using namespace spi::hardware;
 Spi::Spi(SPI_interface SPI_intf_instance) : SPI_intf(SPI_intf_instance) {}
 
 auto Spi::transmit_receive(const MaxMessageBuffer& transmit,
-                           MaxMessageBuffer& receive) -> bool {
-    Reset_CS_Pin(SPI_intf.GPIO_handle, SPI_intf.pin);
+                           MaxMessageBuffer& receive,
+                           ChipSelectInterface cs_intf) -> bool {
+    Reset_CS_Pin(static_cast<GPIO_TypeDef*>(cs_intf.GPIO_handle),
+                 cs_intf.cs_pin);
     auto response = hal_transmit_receive(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         const_cast<uint8_t*>(transmit.data()), receive.data(), MAX_BUFFER_SIZE,
         TIMEOUT, this->SPI_intf.SPI_handle);
 
-    Set_CS_Pin(SPI_intf.GPIO_handle, SPI_intf.pin);
+    Set_CS_Pin(static_cast<GPIO_TypeDef*>(cs_intf.GPIO_handle), cs_intf.cs_pin);
     return response == HAL_OK;
 }

--- a/spi/simulation/spi.cpp
+++ b/spi/simulation/spi.cpp
@@ -5,7 +5,8 @@
 
 bool spi::hardware::SimSpiDeviceBase::transmit_receive(
     const spi::utils::MaxMessageBuffer& transmit,
-    spi::utils::MaxMessageBuffer& receive) {
+    spi::utils::MaxMessageBuffer& receive,
+    spi::utils::ChipSelectInterface cs_intf) {
     txrx_count++;
     uint8_t control = 0;
     uint32_t data = 0;
@@ -18,7 +19,8 @@ bool spi::hardware::SimSpiDeviceBase::transmit_receive(
     iter = bit_utils::bytes_to_int(iter, transmit.end(), control);
     iter = bit_utils::bytes_to_int(iter, transmit.end(), data);
 
-    LOG("transmit_receive: control=%d, data=%d", control, data);
+    LOG("transmit_receive for pin %d on port %d: control=%d, data=%d",
+        cs_intf.cs_pin, cs_intf.GPIO_handle, control, data);
 
     auto out_iter = receive.begin();
     // Write status byte into buffer.

--- a/spi/tests/test_spi.cpp
+++ b/spi/tests/test_spi.cpp
@@ -36,17 +36,18 @@ SCENARIO("build_command works") {
 SCENARIO("simulator works") {
     auto transmit = spi::utils::MaxMessageBuffer{};
     auto receive = spi::utils::MaxMessageBuffer{};
+    auto empty_cs = spi::utils::ChipSelectInterface{};
 
     GIVEN("a register write command") {
         auto subject = spi::hardware::SimSpiDeviceBase{};
         subject.build_command(transmit, spi::hardware::Mode::WRITE, 0x01,
                               0xBEEFDEAD);
-        subject.transmit_receive(transmit, receive);
+        subject.transmit_receive(transmit, receive, empty_cs);
 
         WHEN("called with a read command") {
             spi::hardware::SpiDeviceBase::build_command(
                 transmit, spi::hardware::Mode::READ, 0x01, 0);
-            subject.transmit_receive(transmit, receive);
+            subject.transmit_receive(transmit, receive, empty_cs);
             THEN("the data is what was written") {
                 REQUIRE(receive[1] == 0xBE);
                 REQUIRE(receive[2] == 0xEF);
@@ -64,8 +65,8 @@ SCENARIO("simulator works") {
         WHEN("called with a read command") {
             spi::hardware::SpiDeviceBase::build_command(
                 transmit, spi::hardware::Mode::READ, 0x01, 0);
-            subject.transmit_receive(transmit, receive);
-            subject.transmit_receive(transmit, receive);
+            subject.transmit_receive(transmit, receive, empty_cs);
+            subject.transmit_receive(transmit, receive, empty_cs);
             THEN("the data is was in the register map") {
                 REQUIRE(receive[1] == 0x0);
                 REQUIRE(receive[2] == 0x0);
@@ -75,8 +76,8 @@ SCENARIO("simulator works") {
 
             spi::hardware::SpiDeviceBase::build_command(
                 transmit, spi::hardware::Mode::READ, 0x02, 0);
-            subject.transmit_receive(transmit, receive);
-            subject.transmit_receive(transmit, receive);
+            subject.transmit_receive(transmit, receive, empty_cs);
+            subject.transmit_receive(transmit, receive, empty_cs);
             THEN("the data is was in the register map") {
                 REQUIRE(receive[1] == 0x0);
                 REQUIRE(receive[2] == 0x0);

--- a/spi/tests/test_writer.cpp
+++ b/spi/tests/test_writer.cpp
@@ -6,6 +6,7 @@
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
 #include "spi/core/tasks/spi_task.hpp"
+#include "spi/core/utils.hpp"
 #include "spi/core/writer.hpp"
 #include "spi/tests/mock_response_queue.hpp"
 
@@ -24,12 +25,14 @@ SCENARIO("Test the spi command queue writer") {
     auto writer = spi::writer::Writer<test_mocks::MockMessageQueue>{};
     writer.set_queue(&queue);
     spi::writer::TaskMessage empty_msg{};
+
+    spi::utils::ChipSelectInterface empty_cs{};
     GIVEN("a write request") {
         constexpr uint8_t TEST_REGISTER = 0x23;
         constexpr uint8_t WRITE_BIT = 0x80;
 
         WHEN("we write some data to a register") {
-            writer.write(TEST_REGISTER, 0xd34db33f, response_queue);
+            writer.write(TEST_REGISTER, 0xd34db33f, response_queue, empty_cs);
             THEN("the queue should contain one messages") {
                 REQUIRE(queue.get_size() == 1);
             }
@@ -46,7 +49,7 @@ SCENARIO("Test the spi command queue writer") {
     GIVEN("a read request") {
         constexpr uint8_t TEST_REGISTER = 0x1;
         WHEN("we receive a read request") {
-            writer.read(TEST_REGISTER, 0x0, response_queue);
+            writer.read(TEST_REGISTER, 0x0, response_queue, empty_cs);
             THEN("the queue should contain one message") {
                 REQUIRE(queue.get_size() == 2);
             }


### PR DESCRIPTION
## Overview

Closes #Ret-917. Last supporting component before multiple motor drivers can be supported on the same SPI bus.

## Changelog

- Add chip select interface struct that gets passed around using the driver configs (there might be a better place to put this)
- Modify all of the subprojects to support this change
- Modify tests as needed

## Tasks

- [x] Test on hardware