### PR TITLE
refactor(common): do not use abort for pin configuration switch cases

### DIFF
--- a/gantry/core/utils.cpp
+++ b/gantry/core/utils.cpp
@@ -1,15 +1,16 @@
 #include "gantry/core/utils.hpp"
 
-#include <cstdlib>
-
 auto utils::get_node_id_by_axis(enum GantryAxisType which) -> can_ids::NodeId {
     switch (which) {
         case GantryAxisType::gantry_x:
             return can_ids::NodeId::gantry_x;
         case GantryAxisType::gantry_y:
             return can_ids::NodeId::gantry_y;
+        default:
+            // Return a bootloader node id for the X gantry
+            // if both other cases fail.
+            return can_ids::NodeId::gantry_x_bootloader;
     }
-    std::abort();
 }
 
 auto utils::get_node_id() -> can_ids::NodeId {
@@ -31,8 +32,9 @@ auto utils::linear_motion_sys_config_by_axis(enum GantryAxisType which)
                 .steps_per_rev = 200,
                 .microstep = 32,
             };
+        default:
+            return lms::LinearMotionSystemConfig<lms::BeltConfig>{};
     }
-    std::abort();
 }
 
 auto utils::linear_motion_system_config()

--- a/gantry/firmware/axis_x_hardware_config.c
+++ b/gantry/firmware/axis_x_hardware_config.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-
 #include "axis_hardware_config.h"
 
 GantryHardwarePin gantry_hardware_get_gpio(GantryHardwareDevice device) {
@@ -21,6 +19,9 @@ GantryHardwarePin gantry_hardware_get_gpio(GantryHardwareDevice device) {
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_6;
             return pinout;
+        default:
+            pinout.port = 0;
+            pinout.pin = 0;
+            return pinout;
     }
-    abort();
 }

--- a/gantry/firmware/axis_x_hardware_config.c
+++ b/gantry/firmware/axis_x_hardware_config.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "axis_hardware_config.h"
 
 GantryHardwarePin gantry_hardware_get_gpio(GantryHardwareDevice device) {
@@ -19,9 +21,6 @@ GantryHardwarePin gantry_hardware_get_gpio(GantryHardwareDevice device) {
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_6;
             return pinout;
-        default:
-            pinout.port = 0;
-            pinout.pin = 0;
-            return pinout;
     }
+    abort();
 }

--- a/gantry/firmware/axis_y_hardware_config.c
+++ b/gantry/firmware/axis_y_hardware_config.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "axis_hardware_config.h"
 
 GantryHardwarePin gantry_hardware_get_gpio(GantryHardwareDevice device) {
@@ -19,9 +21,6 @@ GantryHardwarePin gantry_hardware_get_gpio(GantryHardwareDevice device) {
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_6;
             return pinout;
-        default:
-            pinout.port = 0;
-            pinout.pin = 0;
-            return pinout;
     }
+    abort();
 }

--- a/gantry/firmware/axis_y_hardware_config.c
+++ b/gantry/firmware/axis_y_hardware_config.c
@@ -21,6 +21,9 @@ GantryHardwarePin gantry_hardware_get_gpio(GantryHardwareDevice device) {
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_6;
             return pinout;
+        default:
+            pinout.port = 0;
+            pinout.pin = 0;
+            return pinout;
     }
-    abort();
 }

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-
 #include "hardware_config.h"
 #include "platform_specific_hal_conf.h"
 #include "stm32l5xx_hal_gpio.h"
@@ -20,8 +18,11 @@ static PipetteHardwarePin get_gpio_ht(PipetteHardwareDevice device) {
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_5;
             return pinout;
+        default:
+            pinout.port = 0;
+            pinout.pin = 0;
+            return pinout;
     }
-    abort();
 
 }
 
@@ -41,8 +42,8 @@ static uint16_t get_spi_pins_ht(GPIO_TypeDef* for_handle) {
         case (uint32_t)GPIOB: return GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
         // PC6, PC8, PC9
         case (uint32_t)GPIOC: return GPIO_PIN_6 | GPIO_PIN_9 | GPIO_PIN_10;
+        default: return 0;
     }
-    abort();
 }
 
 static PipetteHardwarePin get_gpio_lt(PipetteHardwareDevice device) {
@@ -60,8 +61,11 @@ static PipetteHardwarePin get_gpio_lt(PipetteHardwareDevice device) {
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_4;
             return pinout;
+        default:
+            pinout.port = 0;
+            pinout.pin = 0;
+            return pinout;
     }
-    abort();
 }
 
 
@@ -78,8 +82,8 @@ static uint16_t get_spi_pins_lt(GPIO_TypeDef* for_handle) {
     switch((uint32_t)for_handle) {
         case (uint32_t)GPIOB: return GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
         case (uint32_t)GPIOC: return GPIO_PIN_6;
+        default: return 0;
     }
-    abort();
 }
 
 static uint16_t get_motor_driver_pins_ht(GPIO_TypeDef* for_handle) {
@@ -105,8 +109,8 @@ static uint16_t get_motor_driver_pins_ht(GPIO_TypeDef* for_handle) {
         case (uint32_t)GPIOB: return GPIO_PIN_8 | GPIO_PIN_10;
         case (uint32_t)GPIOC: return GPIO_PIN_7 | GPIO_PIN_8 | GPIO_PIN_13;
         case (uint32_t)GPIOD: return GPIO_PIN_2;
+        default: return 0;
     }
-    abort();
 }
 
 static uint16_t get_motor_driver_pins_lt(GPIO_TypeDef* for_handle) {
@@ -122,8 +126,8 @@ static uint16_t get_motor_driver_pins_lt(GPIO_TypeDef* for_handle) {
     switch((uint32_t)for_handle) {
         case (uint32_t)GPIOA: return GPIO_PIN_5;
         case (uint32_t)GPIOC: return GPIO_PIN_3 | GPIO_PIN_7 | GPIO_PIN_8;
+        default: return 0;
     }
-    abort();
 }
 
 

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include "hardware_config.h"
 #include "platform_specific_hal_conf.h"
 #include "stm32l5xx_hal_gpio.h"
@@ -17,11 +19,9 @@ static PipetteHardwarePin get_gpio_ht(PipetteHardwareDevice device) {
         case pipette_hardware_device_sync_out:
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_5;
-        default:
-            pinout.port = 0;
-            pinout.pin = 0;
             return pinout;
     }
+    abort();
 
 }
 
@@ -41,8 +41,8 @@ static uint16_t get_spi_pins_ht(GPIO_TypeDef* for_handle) {
         case (uint32_t)GPIOB: return GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
         // PC6, PC8, PC9
         case (uint32_t)GPIOC: return GPIO_PIN_6 | GPIO_PIN_9 | GPIO_PIN_10;
-        default: return 0;
     }
+    abort();
 }
 
 static PipetteHardwarePin get_gpio_lt(PipetteHardwareDevice device) {
@@ -59,11 +59,9 @@ static PipetteHardwarePin get_gpio_lt(PipetteHardwareDevice device) {
         case pipette_hardware_device_sync_out:
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_4;
-        default:
-            pinout.port = 0;
-            pinout.pin = 0;
             return pinout;
     }
+    abort();
 }
 
 
@@ -80,8 +78,8 @@ static uint16_t get_spi_pins_lt(GPIO_TypeDef* for_handle) {
     switch((uint32_t)for_handle) {
         case (uint32_t)GPIOB: return GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
         case (uint32_t)GPIOC: return GPIO_PIN_6;
-        default: return 0;
     }
+    abort();
 }
 
 static uint16_t get_motor_driver_pins_ht(GPIO_TypeDef* for_handle) {
@@ -107,8 +105,8 @@ static uint16_t get_motor_driver_pins_ht(GPIO_TypeDef* for_handle) {
         case (uint32_t)GPIOB: return GPIO_PIN_8 | GPIO_PIN_10;
         case (uint32_t)GPIOC: return GPIO_PIN_7 | GPIO_PIN_8 | GPIO_PIN_13;
         case (uint32_t)GPIOD: return GPIO_PIN_2;
-        default: return 0;
     }
+    abort();
 }
 
 static uint16_t get_motor_driver_pins_lt(GPIO_TypeDef* for_handle) {
@@ -124,8 +122,8 @@ static uint16_t get_motor_driver_pins_lt(GPIO_TypeDef* for_handle) {
     switch((uint32_t)for_handle) {
         case (uint32_t)GPIOA: return GPIO_PIN_5;
         case (uint32_t)GPIOC: return GPIO_PIN_3 | GPIO_PIN_7 | GPIO_PIN_8;
-        default: return 0;
     }
+    abort();
 }
 
 

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -13,7 +13,7 @@ auto interfaces::driver_config_by_axis(PipetteType which)
             return tmc2130::configs::TMC2130DriverConfig{
                 .registers = {.gconfig = {.en_pwm_mode = 1},
                               .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x10,
+                                             .run_current = 0x18,
                                              .hold_current_delay = 0x7},
                               .tpowerdown = {},
                               .tcoolthrs = {.threshold = 0},

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -16,12 +16,6 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
         PB13     ------> SPI2_SCK
         PB14     ------> SPI2_CIPO
         PB15     ------> SPI2_COPI
-
-         Step/Dir
-         PC3  ---> Dir Pin
-         PC7  ---> Step Pin
-         Enable
-         PC8  ---> Enable Pin
         */
         PipetteType pipette_type = get_pipette_type();
         GPIO_InitStruct.Pin = pipette_hardware_spi_pins(pipette_type, GPIOB);
@@ -74,18 +68,24 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
     }
 }
 
+void motor_driver_CLK_gpio_init() {
+    // Driver Clock Pin
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = GPIO_PIN_2;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_2, GPIO_PIN_RESET);
+}
+
 void motor_driver_gpio_init() {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     PipetteType pipette_type = get_pipette_type();
 
-    // EnableDir/Step pin
-    GPIO_InitStruct.Pin = pipette_hardware_motor_driver_pins(pipette_type, GPIOA);
+    GPIO_InitStruct.Pin = pipette_hardware_motor_driver_pins(pipette_type, GPIOC);
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
-    GPIO_InitStruct.Pin = pipette_hardware_motor_driver_pins(pipette_type, GPIOC);
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
     if (pipette_type != NINETY_SIX_CHANNEL) {
@@ -98,11 +98,11 @@ void motor_driver_gpio_init() {
          * should ignore this setup when we're compiling for the 96 channel.
          */
         // Driver Clock Pin.
-        GPIO_InitStruct.Pin = GPIO_PIN_2;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_2, GPIO_PIN_RESET);
+        motor_driver_CLK_gpio_init();
     } else {
+        // Enable Dir/Step pin
+        GPIO_InitStruct.Pin = pipette_hardware_motor_driver_pins(pipette_type, GPIOA);
+        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
         // Enable/Dir/Step pin
         GPIO_InitStruct.Pin = pipette_hardware_motor_driver_pins(pipette_type, GPIOB);
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -24,6 +24,13 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+
+        // Chip Select
+        GPIO_InitStruct.Pin = pipette_hardware_spi_pins(pipette_type, GPIOC);
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     }
 }
 


### PR DESCRIPTION
## Overview

Rather than sending back bogus values, we should simply use `abort` from the standard library to
exit out of a switch statement that doesn't meet the required case.

Also fixed an issue where I accidentally deleted a return statement for the `sync_out` pin response.