### PR TITLE
refactor: i2c and eeprom refactor stuff

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -45,11 +45,11 @@ SCENARIO("message deserializing works") {
 
     GIVEN("a write to eeprom message") {
         auto arr = std::array<uint8_t, 9>{// Address
-                                           0x12,
-                                           // Data Length
-                                           7,
-                                           // Data
-                                           1, 2, 3, 4, 5, 6, 7};
+                                          0x12,
+                                          // Data Length
+                                          7,
+                                          // Data
+                                          1, 2, 3, 4, 5, 6, 7};
         WHEN("constructed") {
             auto r = WriteToEEPromRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -44,8 +44,8 @@ SCENARIO("message deserializing works") {
     }
 
     GIVEN("a write to eeprom message") {
-        auto arr = std::array<uint8_t, 10>{// Address
-                                           0x5, 0x12,
+        auto arr = std::array<uint8_t, 9>{// Address
+                                           0x12,
                                            // Data Length
                                            7,
                                            // Data
@@ -53,7 +53,7 @@ SCENARIO("message deserializing works") {
         WHEN("constructed") {
             auto r = WriteToEEPromRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {
-                REQUIRE(r.address == 0x0512);
+                REQUIRE(r.address == 0x12);
                 REQUIRE(r.data_length == 7);
                 REQUIRE(r.data[0] == 1);
                 REQUIRE(r.data[1] == 2);
@@ -74,7 +74,7 @@ SCENARIO("message deserializing works") {
 
     GIVEN("a write to eeprom message with too large data length") {
         auto arr = std::array<uint8_t, 35>{// Address
-                                           0x5, 0x12,
+                                           0x5,
                                            // Data Length
                                            122,
                                            // Data
@@ -82,8 +82,8 @@ SCENARIO("message deserializing works") {
         WHEN("constructed") {
             auto r = WriteToEEPromRequest::parse(arr.begin(), arr.end());
             THEN("it is converted to a the correct structure") {
-                REQUIRE(r.address == 0x0512);
-                REQUIRE(r.data_length == 32);
+                REQUIRE(r.address == 0x05);
+                REQUIRE(r.data_length == 8);
                 REQUIRE(r.data[0] == 0);
                 REQUIRE(r.data[1] == 1);
                 REQUIRE(r.data[2] == 0);
@@ -182,7 +182,7 @@ SCENARIO("message serializing works") {
     GIVEN("a read from eeprom response") {
         auto data = std::array<uint8_t, 5>{0, 1, 2, 3, 4};
         auto message =
-            ReadFromEEPromResponse::create(513, data.cbegin(), data.cend());
+            ReadFromEEPromResponse::create(13, data.cbegin(), data.cend());
 
         THEN("the length is correctly set.") {
             REQUIRE(message.data_length == data.size());
@@ -192,11 +192,11 @@ SCENARIO("message serializing works") {
             auto arr = std::array<uint8_t, 5>{};
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is written into the buffer.") {
-                REQUIRE(arr[0] == 0x2);
-                REQUIRE(arr[1] == 0x1);
-                REQUIRE(arr[2] == 0x5);
-                REQUIRE(arr[3] == 0x0);
-                REQUIRE(arr[4] == 0x1);
+                REQUIRE(arr[0] == 13);
+                REQUIRE(arr[1] == 0x5);
+                REQUIRE(arr[2] == 0x0);
+                REQUIRE(arr[3] == 0x1);
+                REQUIRE(arr[4] == 0x2);
             }
             THEN("size is correct") { REQUIRE(size == 5); }
         }
@@ -205,18 +205,18 @@ SCENARIO("message serializing works") {
             auto arr = std::array<uint8_t, 10>{};
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is written into the buffer.") {
-                REQUIRE(arr[0] == 0x2);
-                REQUIRE(arr[1] == 0x1);
-                REQUIRE(arr[2] == 0x5);
-                REQUIRE(arr[3] == 0x0);
-                REQUIRE(arr[4] == 0x1);
-                REQUIRE(arr[5] == 0x2);
-                REQUIRE(arr[6] == 0x3);
-                REQUIRE(arr[7] == 0x4);
+                REQUIRE(arr[0] == 13);
+                REQUIRE(arr[1] == 0x5);
+                REQUIRE(arr[2] == 0x0);
+                REQUIRE(arr[3] == 0x1);
+                REQUIRE(arr[4] == 0x2);
+                REQUIRE(arr[5] == 0x3);
+                REQUIRE(arr[6] == 0x4);
+                REQUIRE(arr[7] == 0x0);
                 REQUIRE(arr[8] == 0x0);
                 REQUIRE(arr[9] == 0x0);
             }
-            THEN("size is correct") { REQUIRE(size == 8); }
+            THEN("size is correct") { REQUIRE(size == 7); }
         }
     }
 }

--- a/i2c/tests/test_i2c_poll_task.cpp
+++ b/i2c/tests/test_i2c_poll_task.cpp
@@ -49,7 +49,8 @@ SCENARIO("test the limited-count i2c poller") {
             .bytes_to_read = 4,
             .bytes_to_write = 3,
             .write_buffer =
-                i2c::messages::MaxMessageBuffer{u8(0x2), u8(0x3), u8(0x4), u8(0x5), u8(0x6)},
+                i2c::messages::MaxMessageBuffer{u8(0x2), u8(0x3), u8(0x4),
+                                                u8(0x5), u8(0x6)},
         };
         i2c::messages::SingleRegisterPollRead msg{
             .polling = poll_count,
@@ -89,7 +90,8 @@ SCENARIO("test the limited-count i2c poller") {
                         get_message<i2c::messages::Transact>(i2c_queue);
                     REQUIRE(transaction.transaction == original_txn);
                     AND_WHEN("that transaction is responded to") {
-                        auto response_buffer = i2c::messages::MaxMessageBuffer{0xf, 0xe, 0xd, 0xc, 0xb};
+                        auto response_buffer = i2c::messages::MaxMessageBuffer{
+                            0xf, 0xe, 0xd, 0xc, 0xb};
                         i2c::messages::TransactionResponse response{
                             .id = transaction.id,
                             .bytes_read = 4,
@@ -112,8 +114,8 @@ SCENARIO("test the limited-count i2c poller") {
                 }
             }
             AND_WHEN("firing the timer poll_count-1 times") {
-                auto response_buffer=i2c::messages::MaxMessageBuffer{0xaa, 0xbb, 0xcc, 0xdd,
-                                                       0xee};
+                auto response_buffer = i2c::messages::MaxMessageBuffer{
+                    0xaa, 0xbb, 0xcc, 0xdd, 0xee};
                 i2c::messages::TransactionResponse response{
                     .id = msg.id,
                     .bytes_read = msg.first.bytes_to_read,
@@ -148,8 +150,8 @@ SCENARIO("test the limited-count i2c poller") {
                         poll.timer.fire();
                         auto last_txn =
                             get_message<i2c::messages::Transact>(i2c_queue);
-                        auto response_buffer = i2c::messages::MaxMessageBuffer{0xf, 0xe, 0xd,
-                                                                  0xc, 0xb};
+                        auto response_buffer = i2c::messages::MaxMessageBuffer{
+                            0xf, 0xe, 0xd, 0xc, 0xb};
                         response = {
                             .id = last_txn.id,
                             .bytes_read = 3,
@@ -181,8 +183,10 @@ SCENARIO("test the limited-count i2c poller") {
 
     GIVEN("multi register limited poll command") {
         uint16_t addr = 0x1234;
-        auto register_payload_1=i2c::messages::MaxMessageBuffer{0x2, 0x3, 0x4, 0x5, 0x6};
-        auto register_payload_2=i2c::messages::MaxMessageBuffer{0x4, 0x6, 0x8, 0xa, 0xc};
+        auto register_payload_1 =
+            i2c::messages::MaxMessageBuffer{0x2, 0x3, 0x4, 0x5, 0x6};
+        auto register_payload_2 =
+            i2c::messages::MaxMessageBuffer{0x4, 0x6, 0x8, 0xa, 0xc};
         int poll_count = 10;
         int delay = 100;
         i2c::messages::Transaction original_txn_1{
@@ -236,7 +240,8 @@ SCENARIO("test the limited-count i2c poller") {
                     REQUIRE(msg.id.is_completed_poll == false);
                     REQUIRE(msg.id.transaction_index == 0);
                     AND_WHEN("that transaction is responded to") {
-                        auto response_buf_1 = i2c::messages::MaxMessageBuffer{0xf, 0xe, 0xd, 0xc, 0xb};
+                        auto response_buf_1 = i2c::messages::MaxMessageBuffer{
+                            0xf, 0xe, 0xd, 0xc, 0xb};
                         i2c::messages::TransactionResponse response_1{
                             .id = msg.id,
                             .bytes_read = 4,
@@ -274,8 +279,9 @@ SCENARIO("test the limited-count i2c poller") {
                             REQUIRE(msg.id.transaction_index == 1);
                             REQUIRE(msg.id.is_completed_poll == false);
                             AND_WHEN("that second transaction is handled") {
-                                auto response_buf_2 = i2c::messages::MaxMessageBuffer{
-                                    0xff, 0xee, 0xdd, 0xcc, 0xbb};
+                                auto response_buf_2 =
+                                    i2c::messages::MaxMessageBuffer{
+                                        0xff, 0xee, 0xdd, 0xcc, 0xbb};
                                 i2c::messages::TransactionResponse response_2{
                                     .id = msg.id,
                                     .bytes_read = msg.transaction.bytes_to_read,
@@ -304,10 +310,10 @@ SCENARIO("test the limited-count i2c poller") {
                 }
             }
             AND_WHEN("firing the timer enough times to exhaust the poll") {
-                auto first_response_buf = i2c::messages::MaxMessageBuffer{0xf, 0xe, 0xd, 0xc,
-                                                             0xb};
-                auto second_response_buf = i2c::messages::MaxMessageBuffer{0xff, 0xee, 0xdd,
-                                                              0xcc, 0xbb};
+                auto first_response_buf =
+                    i2c::messages::MaxMessageBuffer{0xf, 0xe, 0xd, 0xc, 0xb};
+                auto second_response_buf = i2c::messages::MaxMessageBuffer{
+                    0xff, 0xee, 0xdd, 0xcc, 0xbb};
                 for (int count = 0; count < (poll_count - 1); count++) {
                     poll.timer.fire();
                     auto txn = get_message<i2c::messages::Transact>(i2c_queue);
@@ -433,7 +439,8 @@ SCENARIO("test the ongoing i2c polling") {
                       .bytes_to_read = 3,
                       .bytes_to_write = 5,
                       .write_buffer =
-                          i2c::messages::MaxMessageBuffer{0x1, 0x2, 0x3, 0x4, 0x5}},
+                          i2c::messages::MaxMessageBuffer{0x1, 0x2, 0x3, 0x4,
+                                                          0x5}},
             .id = {.token = 12345,
                    .is_completed_poll = false,
                    .transaction_index = 0},
@@ -454,7 +461,8 @@ SCENARIO("test the ongoing i2c polling") {
                     i2c::messages::TransactionResponse response_msg{
                         .id = transaction.id,
                         .bytes_read = transaction.transaction.bytes_to_read,
-                        .read_buffer = i2c::messages::MaxMessageBuffer{1, 2, 3, 4, 5}};
+                        .read_buffer =
+                            i2c::messages::MaxMessageBuffer{1, 2, 3, 4, 5}};
                     static_cast<void>(
                         transaction.response_writer.write(response_msg));
                     auto next = get_message<i2c::messages::TransactionResponse>(
@@ -492,12 +500,14 @@ SCENARIO("test the ongoing i2c polling") {
             .address = 0x1234,
             .bytes_to_read = 3,
             .bytes_to_write = 5,
-            .write_buffer = i2c::messages::MaxMessageBuffer{0x1, 0x2, 0x3, 0x4, 0x5}};
+            .write_buffer =
+                i2c::messages::MaxMessageBuffer{0x1, 0x2, 0x3, 0x4, 0x5}};
         auto second_txn = i2c::messages::Transaction{
             .address = 0x1234,
             .bytes_to_read = 3,
             .bytes_to_write = 5,
-            .write_buffer = i2c::messages::MaxMessageBuffer{0x6, 0x7, 0x8, 0x9, 0xa}};
+            .write_buffer =
+                i2c::messages::MaxMessageBuffer{0x6, 0x7, 0x8, 0x9, 0xa}};
         i2c::messages::ConfigureMultiRegisterContinuousPolling poll_msg{
             .delay_ms = 100,
             .first = first_txn,
@@ -515,7 +525,8 @@ SCENARIO("test the ongoing i2c polling") {
                     get_message<i2c::messages::Transact>(i2c_queue);
                 REQUIRE(transaction.transaction == first_txn);
                 AND_WHEN("responding to that transaction") {
-                    auto first_resp_buffer = i2c::messages::MaxMessageBuffer{5, 4, 3, 2, 1};
+                    auto first_resp_buffer =
+                        i2c::messages::MaxMessageBuffer{5, 4, 3, 2, 1};
                     i2c::messages::TransactionResponse first_resp{
                         .id = transaction.id,
                         .bytes_read = 3,
@@ -538,8 +549,8 @@ SCENARIO("test the ongoing i2c polling") {
                             get_message<i2c::messages::Transact>(i2c_queue);
                         REQUIRE(second_transaction.transaction == second_txn);
                         AND_WHEN("responding to the second transaction") {
-                            auto second_resp_buffer= i2c::messages::MaxMessageBuffer{10, 9, 8,
-                                                                      7, 6};
+                            auto second_resp_buffer =
+                                i2c::messages::MaxMessageBuffer{10, 9, 8, 7, 6};
                             i2c::messages::TransactionResponse second_resp{
                                 .id = second_transaction.id,
                                 .bytes_read = 3,

--- a/i2c/tests/test_i2c_poller.cpp
+++ b/i2c/tests/test_i2c_poller.cpp
@@ -50,7 +50,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -63,9 +64,12 @@ SCENARIO("Test the i2c poller command queue") {
             }
         }
         WHEN("we request a poll with the data overload") {
-            auto data = std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE+4>{};
+            auto data =
+                std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE + 4>{};
             data.fill(0xfe);
-            poller.single_register_poll(ADDRESS, data, i2c::messages::MAX_BUFFER_SIZE + 4, 20, 15, queue, 2015);
+            poller.single_register_poll(ADDRESS, data,
+                                        i2c::messages::MAX_BUFFER_SIZE + 4, 20,
+                                        15, queue, 2015);
             auto poll_msg =
                 get_message<i2c::messages::SingleRegisterPollRead>(queue);
             THEN("the top data members are correct") {
@@ -78,9 +82,11 @@ SCENARIO("Test the i2c poller command queue") {
 
             THEN("the transaction is correct and limited") {
                 REQUIRE(poll_msg.first.address == ADDRESS);
-                REQUIRE(poll_msg.first.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
-                REQUIRE(poll_msg.first.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
-                REQUIRE(poll_msg.first.write_buffer ==expected_write_buffer);
+                REQUIRE(poll_msg.first.bytes_to_read ==
+                        i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(poll_msg.first.bytes_to_write ==
+                        i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(poll_msg.first.write_buffer == expected_write_buffer);
             }
             THEN("the id is passed along") {
                 REQUIRE(poll_msg.id.token == 2015);
@@ -94,7 +100,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -125,7 +132,8 @@ SCENARIO("Test the i2c poller command queue") {
                 REQUIRE(poll_msg.first.bytes_to_read == 4);
                 REQUIRE(poll_msg.first.bytes_to_write == 1);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        i2c::messages::MaxMessageBuffer{u8(5), u8(0), u8(0), u8(0), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(5), u8(0), u8(0),
+                                                        u8(0), u8(0)});
             }
             THEN("the id is passed through") {
                 REQUIRE(poll_msg.id.token == 15);
@@ -139,7 +147,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -152,10 +161,11 @@ SCENARIO("Test the i2c poller command queue") {
             }
         }
         WHEN("we request a poll with the data overload") {
-            auto data = std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE+4>{};
+            auto data =
+                std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE + 4>{};
             data.fill(0xfe);
-            poller.continuous_single_register_poll(ADDRESS, data, data.size(), 15, queue,
-                                                   2015);
+            poller.continuous_single_register_poll(ADDRESS, data, data.size(),
+                                                   15, queue, 2015);
             auto poll_msg = get_message<
                 i2c::messages::ConfigureSingleRegisterContinuousPolling>(queue);
             THEN("the top data members are correct") {
@@ -167,8 +177,10 @@ SCENARIO("Test the i2c poller command queue") {
 
             THEN("the transaction is correct and limited") {
                 REQUIRE(poll_msg.first.address == ADDRESS);
-                REQUIRE(poll_msg.first.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
-                REQUIRE(poll_msg.first.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(poll_msg.first.bytes_to_read ==
+                        i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(poll_msg.first.bytes_to_write ==
+                        i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(poll_msg.first.write_buffer == expected_write_buffer);
             }
             THEN("the id is passed along") {
@@ -183,7 +195,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -231,7 +244,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -245,8 +259,9 @@ SCENARIO("Test the i2c poller command queue") {
         }
         WHEN("we request a poll with the data overload") {
             uint32_t data_1 = 22, data_2 = 512;
-            poller.multi_register_poll(ADDRESS, data_1, i2c::messages::MAX_BUFFER_SIZE + 1, data_2, 2, 20, 15,
-                                       queue, 15);
+            poller.multi_register_poll(ADDRESS, data_1,
+                                       i2c::messages::MAX_BUFFER_SIZE + 1,
+                                       data_2, 2, 20, 15, queue, 15);
             auto poll_msg =
                 get_message<i2c::messages::MultiRegisterPollRead>(queue);
             THEN("the top level members are correct") {
@@ -256,13 +271,16 @@ SCENARIO("Test the i2c poller command queue") {
 
             THEN("the transactions are correct") {
                 REQUIRE(poll_msg.first.bytes_to_write == 4);
-                REQUIRE(poll_msg.first.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(poll_msg.first.bytes_to_read ==
+                        i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(0), u8(22), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(0),
+                                                        u8(22), u8(0)});
                 REQUIRE(poll_msg.second.bytes_to_write == 4);
                 REQUIRE(poll_msg.second.bytes_to_read == 2);
                 REQUIRE(poll_msg.second.write_buffer ==
-                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(2), u8(0), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(2),
+                                                        u8(0), u8(0)});
             }
             THEN("the id is passed through") {
                 REQUIRE(poll_msg.id.token == 15);
@@ -276,7 +294,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -323,7 +342,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -337,19 +357,23 @@ SCENARIO("Test the i2c poller command queue") {
         }
         WHEN("we request a poll with the data overload") {
             uint32_t data_1 = 22, data_2 = 512;
-            poller.continuous_multi_register_poll(ADDRESS, data_1, i2c::messages::MAX_BUFFER_SIZE + 1, data_2, 2,
-                                                  15, queue, 15);
+            poller.continuous_multi_register_poll(
+                ADDRESS, data_1, i2c::messages::MAX_BUFFER_SIZE + 1, data_2, 2,
+                15, queue, 15);
             auto poll_msg = get_message<
                 i2c::messages::ConfigureMultiRegisterContinuousPolling>(queue);
             THEN("the transactions are correct") {
                 REQUIRE(poll_msg.first.bytes_to_write == 4);
-                REQUIRE(poll_msg.first.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(poll_msg.first.bytes_to_read ==
+                        i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(0), u8(22), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(0),
+                                                        u8(22), u8(0)});
                 REQUIRE(poll_msg.second.bytes_to_write == 4);
                 REQUIRE(poll_msg.second.bytes_to_read == 2);
                 REQUIRE(poll_msg.second.write_buffer ==
-                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(2), u8(0), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(2),
+                                                        u8(0), u8(0)});
             }
             THEN("the top level members are correct") {
                 REQUIRE(poll_msg.delay_ms == 15);
@@ -366,7 +390,8 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0),
+                                                            u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {

--- a/i2c/tests/test_i2c_poller.cpp
+++ b/i2c/tests/test_i2c_poller.cpp
@@ -36,7 +36,7 @@ SCENARIO("Test the i2c poller command queue") {
                 REQUIRE(poll_msg.first.bytes_to_read == 4);
                 REQUIRE(poll_msg.first.bytes_to_write == 1);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        std::array{u8(5), u8(0), u8(0), u8(0), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(5), u8(0), u8(0), u8(0), u8(0)});
             }
             THEN("the id is defaulted") {
                 REQUIRE(poll_msg.id.token == 0);
@@ -50,7 +50,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -76,7 +76,7 @@ SCENARIO("Test the i2c poller command queue") {
                 REQUIRE(poll_msg.first.bytes_to_read == 5);
                 REQUIRE(poll_msg.first.bytes_to_write == 5);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        std::array{u8(0xc0), u8(0xff), u8(0xee), u8(0x44),
+                        i2c::messages::MaxMessageBuffer{u8(0xc0), u8(0xff), u8(0xee), u8(0x44),
                                    u8(0xd3)});
             }
             THEN("the id is passed along") {
@@ -91,7 +91,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -122,7 +122,7 @@ SCENARIO("Test the i2c poller command queue") {
                 REQUIRE(poll_msg.first.bytes_to_read == 4);
                 REQUIRE(poll_msg.first.bytes_to_write == 1);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        std::array{u8(5), u8(0), u8(0), u8(0), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(5), u8(0), u8(0), u8(0), u8(0)});
             }
             THEN("the id is passed through") {
                 REQUIRE(poll_msg.id.token == 15);
@@ -136,7 +136,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -162,7 +162,7 @@ SCENARIO("Test the i2c poller command queue") {
                 REQUIRE(poll_msg.first.bytes_to_read == 5);
                 REQUIRE(poll_msg.first.bytes_to_write == 5);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        std::array{u8(0xc0), u8(0xff), u8(0xee), u8(0x44),
+                        i2c::messages::MaxMessageBuffer{u8(0xc0), u8(0xff), u8(0xee), u8(0x44),
                                    u8(0xd3)});
             }
             THEN("the id is passed along") {
@@ -177,7 +177,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -225,7 +225,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -252,11 +252,11 @@ SCENARIO("Test the i2c poller command queue") {
                 REQUIRE(poll_msg.first.bytes_to_write == 4);
                 REQUIRE(poll_msg.first.bytes_to_read == 5);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        std::array{u8(0), u8(0), u8(0), u8(22), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(0), u8(22), u8(0)});
                 REQUIRE(poll_msg.second.bytes_to_write == 4);
                 REQUIRE(poll_msg.second.bytes_to_read == 2);
                 REQUIRE(poll_msg.second.write_buffer ==
-                        std::array{u8(0), u8(0), u8(2), u8(0), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(2), u8(0), u8(0)});
             }
             THEN("the id is passed through") {
                 REQUIRE(poll_msg.id.token == 15);
@@ -270,7 +270,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -317,7 +317,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {
@@ -339,11 +339,11 @@ SCENARIO("Test the i2c poller command queue") {
                 REQUIRE(poll_msg.first.bytes_to_write == 4);
                 REQUIRE(poll_msg.first.bytes_to_read == 5);
                 REQUIRE(poll_msg.first.write_buffer ==
-                        std::array{u8(0), u8(0), u8(0), u8(22), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(0), u8(22), u8(0)});
                 REQUIRE(poll_msg.second.bytes_to_write == 4);
                 REQUIRE(poll_msg.second.bytes_to_read == 2);
                 REQUIRE(poll_msg.second.write_buffer ==
-                        std::array{u8(0), u8(0), u8(2), u8(0), u8(0)});
+                        i2c::messages::MaxMessageBuffer{u8(0), u8(0), u8(2), u8(0), u8(0)});
             }
             THEN("the top level members are correct") {
                 REQUIRE(poll_msg.delay_ms == 15);
@@ -360,7 +360,7 @@ SCENARIO("Test the i2c poller command queue") {
                         .id = {.token = 1231, .is_completed_poll = false},
                         .bytes_read = 2,
                         .read_buffer =
-                            std::array{u8(1), u8(2), u8(0), u8(0), u8(0)},
+                            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(0), u8(0)},
                     };
                     static_cast<void>(poll_msg.response_writer.write(resp));
                     THEN("the response is passed along correctly") {

--- a/i2c/tests/test_i2c_task.cpp
+++ b/i2c/tests/test_i2c_task.cpp
@@ -23,7 +23,7 @@ SCENARIO("read and write data to the i2c task") {
 
         auto i2c_handler = i2c::tasks::I2CMessageHandler{sim_i2c};
 
-        std::array buffer{u8(1), u8(2), u8(3), u8(4), u8(5)};
+        auto buffer = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(3), u8(4), u8(5)};
         auto empty_txn = i2c::messages::Transaction{.address = 15,
                                                     .bytes_to_read = 0,
                                                     .bytes_to_write = 0,
@@ -59,7 +59,7 @@ SCENARIO("read and write data to the i2c task") {
                 "a response should have been enqueued with the mirrored data") {
                 auto resp = test_mocks::get_response(response_queue);
                 REQUIRE(resp.bytes_read == 0);
-                REQUIRE(resp.read_buffer == std::array<uint8_t, 5>{});
+                REQUIRE(resp.read_buffer == i2c::messages::MaxMessageBuffer{});
                 REQUIRE(resp.id == id);
             }
         }
@@ -102,7 +102,7 @@ SCENARIO("read and write data to the i2c task") {
             THEN("the response should be present and correct") {
                 auto resp = test_mocks::get_response(response_queue);
                 REQUIRE(resp.bytes_read == 3);
-                std::array check_buffer{u8(7), u8(9), u8(10), u8(0), u8(0)};
+                auto check_buffer=i2c::messages::MaxMessageBuffer{u8(7), u8(9), u8(10), u8(0), u8(0)};
                 REQUIRE(resp.read_buffer == check_buffer);
                 REQUIRE(resp.id == id);
             }
@@ -126,7 +126,7 @@ SCENARIO("read and write data to the i2c task") {
                 "a response should have been enqueued with the mirrored data") {
                 auto resp = test_mocks::get_response(response_queue);
                 REQUIRE(resp.bytes_read == 0);
-                REQUIRE(resp.read_buffer == std::array<uint8_t, 5>{});
+                REQUIRE(resp.read_buffer == i2c::messages::MaxMessageBuffer{});
                 REQUIRE(resp.id == id);
             }
         }

--- a/i2c/tests/test_i2c_task.cpp
+++ b/i2c/tests/test_i2c_task.cpp
@@ -23,7 +23,8 @@ SCENARIO("read and write data to the i2c task") {
 
         auto i2c_handler = i2c::tasks::I2CMessageHandler{sim_i2c};
 
-        auto buffer = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(3), u8(4), u8(5)};
+        auto buffer =
+            i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(3), u8(4), u8(5)};
         auto empty_txn = i2c::messages::Transaction{.address = 15,
                                                     .bytes_to_read = 0,
                                                     .bytes_to_write = 0,
@@ -102,7 +103,8 @@ SCENARIO("read and write data to the i2c task") {
             THEN("the response should be present and correct") {
                 auto resp = test_mocks::get_response(response_queue);
                 REQUIRE(resp.bytes_read == 3);
-                auto check_buffer=i2c::messages::MaxMessageBuffer{u8(7), u8(9), u8(10), u8(0), u8(0)};
+                auto check_buffer = i2c::messages::MaxMessageBuffer{
+                    u8(7), u8(9), u8(10), u8(0), u8(0)};
                 REQUIRE(resp.read_buffer == check_buffer);
                 REQUIRE(resp.id == id);
             }

--- a/i2c/tests/test_i2c_writer.cpp
+++ b/i2c/tests/test_i2c_writer.cpp
@@ -45,7 +45,7 @@ SCENARIO("Test the i2c command queue writer") {
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
                 auto compare = i2c::messages::MaxMessageBuffer{
-                    u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f), u8(0)};
+                    u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 4);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -60,7 +60,7 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, std::array{0x1, 0x02});
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 2);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -71,7 +71,7 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.writer == nullptr);
             }
         }
-        WHEN("we write a five byte buffer") {
+        WHEN("we write a full buffer") {
             writer.write(ADDRESS, std::array{u8(0x01), u8(0x02), u8(0x03),
                                              u8(0x04), u8(0x05)});
             auto msg = get_message(queue);
@@ -86,14 +86,17 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.writer == nullptr);
             }
         }
-        WHEN("we try and write a six byte buffer (too big)") {
-            writer.write(ADDRESS, std::array{u8(0x01), u8(0x02), u8(0x03),
-                                             u8(0x04), u8(0x05), u8(0x06)});
+        WHEN("we try and write a byte buffer that is too big") {
+            auto too_big = std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE + 2>{};
+            too_big.fill(0x12);
+            writer.write(ADDRESS, too_big);
+
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(0x5)};
+                auto compare = i2c::messages::MaxMessageBuffer{};
+                compare.fill(0x12);
                 REQUIRE(msg.transaction.write_buffer == compare);
-                REQUIRE(msg.transaction.bytes_to_write == 5);
+                REQUIRE(msg.transaction.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
             }
             THEN("the response is empty") {
@@ -105,8 +108,7 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, 0x23, 0xd34db33f);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x23), u8(0xd3), u8(0x4d), u8(0xb3),
-                                   u8(0x3f)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x23), u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -149,10 +151,10 @@ SCENARIO("Test the i2c command queue writer") {
             }
         }
         WHEN("we command a read of > max size") {
-            writer.read(0x1234, 6, response_queue);
+            writer.read(0x1234, i2c::messages::MAX_BUFFER_SIZE + 5, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is limited to max size") {
-                REQUIRE(msg.transaction.bytes_to_read == 5);
+                REQUIRE(msg.transaction.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
             }
         }
         WHEN("we specify a transaction token") {
@@ -272,17 +274,19 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.id.is_completed_poll == false);
             }
         }
-        WHEN("we try and write and read a six bytes (too big) ") {
+        WHEN("we try and write and read a buffer that is too big") {
+            auto too_big =std::array<uint8_t,i2c::messages::MAX_BUFFER_SIZE + 2>{};
+            too_big.fill(0x33);
             writer.transact(ADDRESS,
-                            std::array{u8(0x01), u8(0x02), u8(0x03), u8(0x04),
-                                       u8(0x05), u8(0x06)},
-                            6, response_queue);
+                            too_big,
+                            too_big.size(), response_queue);
             auto msg = get_message(queue);
             THEN("the transaction size is limited") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{};
+                compare.fill(0x33);
                 REQUIRE(msg.transaction.write_buffer == compare);
-                REQUIRE(msg.transaction.bytes_to_write == 5);
-                REQUIRE(msg.transaction.bytes_to_read == 5);
+                REQUIRE(msg.transaction.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(msg.transaction.address == ADDRESS);
             }
         }
@@ -328,17 +332,20 @@ SCENARIO("Test the i2c command queue writer") {
                 }
             }
         }
-        WHEN("we try and write and read six bytes (too big) ") {
+        WHEN("we try and write and read a buffer that is too big") {
+            auto too_big = std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE>{};
+            too_big.fill(0x11);
             writer.transact(
-                ADDRESS, 6,
-                i2c::messages::MaxMessageBuffer{u8(0x01), u8(0x02), u8(0x03), u8(0x04), u8(0x05)}, 6,
+                ADDRESS, too_big.size(),
+                too_big, too_big.size(),
                 {.token = 651, .is_completed_poll = true}, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction size is limited") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{};
+                compare.fill(0x11);
                 REQUIRE(msg.transaction.write_buffer == compare);
-                REQUIRE(msg.transaction.bytes_to_write == 5);
-                REQUIRE(msg.transaction.bytes_to_read == 5);
+                REQUIRE(msg.transaction.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(msg.transaction.address == ADDRESS);
             }
         }

--- a/i2c/tests/test_i2c_writer.cpp
+++ b/i2c/tests/test_i2c_writer.cpp
@@ -29,7 +29,7 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, static_cast<uint8_t>(0x05));
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x05), u8(0), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x05), u8(0), u8(0), u8(0), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 1);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -44,8 +44,8 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, static_cast<uint32_t>(0xd34db33f));
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f),
-                                   u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 4);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -60,7 +60,7 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, std::array{0x1, 0x02});
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x1), u8(0x2), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0), u8(0), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 2);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -76,7 +76,7 @@ SCENARIO("Test the i2c command queue writer") {
                                              u8(0x04), u8(0x05)});
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(0x5)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(0x5)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -91,7 +91,7 @@ SCENARIO("Test the i2c command queue writer") {
                                              u8(0x04), u8(0x05), u8(0x06)});
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(0x5)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(0x5)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -105,7 +105,7 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, 0x23, 0xd34db33f);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x23), u8(0xd3), u8(0x4d), u8(0xb3),
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x23), u8(0xd3), u8(0x4d), u8(0xb3),
                                    u8(0x3f)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
@@ -133,7 +133,7 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we try and write a response") {
-                    std::array check_buf{u8(1), u8(2), u8(3), u8(4), u8(5)};
+                    auto check_buf = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(3), u8(4), u8(5)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 25, .is_completed_poll = false},
@@ -171,7 +171,7 @@ SCENARIO("Test the i2c command queue writer") {
                             response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x05), u8(0), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x05), u8(0), u8(0), u8(0), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 1);
                 REQUIRE(msg.transaction.bytes_to_read == 4);
@@ -185,7 +185,7 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we write a response") {
-                    std::array response_buf{u8(1), u8(2), u8(0), u8(4), u8(10)};
+                    auto response_buf = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(4), u8(10)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 10, .is_completed_poll = false},
@@ -206,7 +206,7 @@ SCENARIO("Test the i2c command queue writer") {
                             response_queue, 25);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f),
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f),
                                    u8(0)};
 
                 REQUIRE(msg.transaction.write_buffer == compare);
@@ -223,7 +223,7 @@ SCENARIO("Test the i2c command queue writer") {
             writer.transact(ADDRESS, std::array{0x1, 0x02}, 1, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x1), u8(0x2), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0), u8(0), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 2);
                 REQUIRE(msg.transaction.bytes_to_read == 1);
@@ -237,7 +237,7 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we write a response") {
-                    std::array response_buf{u8(1), u8(2), u8(0), u8(4), u8(10)};
+                    auto response_buf = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(4), u8(10)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 10, .is_completed_poll = false},
@@ -260,7 +260,7 @@ SCENARIO("Test the i2c command queue writer") {
                 response_queue, 651);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
 
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
@@ -279,7 +279,7 @@ SCENARIO("Test the i2c command queue writer") {
                             6, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction size is limited") {
-                std::array compare{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
                 REQUIRE(msg.transaction.bytes_to_read == 5);
@@ -293,11 +293,11 @@ SCENARIO("Test the i2c command queue writer") {
         WHEN("we write a buffer and specify under the message size") {
             writer.transact(
                 ADDRESS, 3,
-                std::array{u8(0x01), u8(0x02), u8(0x03), u8(0x04), u8(0x05)}, 3,
+                i2c::messages::MaxMessageBuffer{u8(0x01), u8(0x02), u8(0x03), u8(0x04), u8(0x05)}, 3,
                 {.token = 651, .is_completed_poll = true}, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                std::array compare{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
 
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 3);
@@ -312,7 +312,7 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we write a response") {
-                    std::array response_buf{u8(1), u8(2), u8(0), u8(4), u8(10)};
+                    auto response_buf =i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(4), u8(10)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 10, .is_completed_poll = false},
@@ -331,11 +331,11 @@ SCENARIO("Test the i2c command queue writer") {
         WHEN("we try and write and read six bytes (too big) ") {
             writer.transact(
                 ADDRESS, 6,
-                std::array{u8(0x01), u8(0x02), u8(0x03), u8(0x04), u8(0x05)}, 6,
+                i2c::messages::MaxMessageBuffer{u8(0x01), u8(0x02), u8(0x03), u8(0x04), u8(0x05)}, 6,
                 {.token = 651, .is_completed_poll = true}, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction size is limited") {
-                std::array compare{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
                 REQUIRE(msg.transaction.bytes_to_read == 5);

--- a/i2c/tests/test_i2c_writer.cpp
+++ b/i2c/tests/test_i2c_writer.cpp
@@ -29,7 +29,8 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, static_cast<uint8_t>(0x05));
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x05), u8(0), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0x05), u8(0), u8(0), u8(0), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 1);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -60,7 +61,8 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, std::array{0x1, 0x02});
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2)};
+                auto compare =
+                    i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 2);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -76,7 +78,8 @@ SCENARIO("Test the i2c command queue writer") {
                                              u8(0x04), u8(0x05)});
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(0x5)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(0x5)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -87,7 +90,8 @@ SCENARIO("Test the i2c command queue writer") {
             }
         }
         WHEN("we try and write a byte buffer that is too big") {
-            auto too_big = std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE + 2>{};
+            auto too_big =
+                std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE + 2>{};
             too_big.fill(0x12);
             writer.write(ADDRESS, too_big);
 
@@ -96,7 +100,8 @@ SCENARIO("Test the i2c command queue writer") {
                 auto compare = i2c::messages::MaxMessageBuffer{};
                 compare.fill(0x12);
                 REQUIRE(msg.transaction.write_buffer == compare);
-                REQUIRE(msg.transaction.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_write ==
+                        i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
             }
             THEN("the response is empty") {
@@ -108,7 +113,8 @@ SCENARIO("Test the i2c command queue writer") {
             writer.write(ADDRESS, 0x23, 0xd34db33f);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x23), u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0x23), u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
                 REQUIRE(msg.transaction.bytes_to_read == 0);
@@ -135,7 +141,8 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we try and write a response") {
-                    auto check_buf = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(3), u8(4), u8(5)};
+                    auto check_buf = i2c::messages::MaxMessageBuffer{
+                        u8(1), u8(2), u8(3), u8(4), u8(5)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 25, .is_completed_poll = false},
@@ -151,10 +158,12 @@ SCENARIO("Test the i2c command queue writer") {
             }
         }
         WHEN("we command a read of > max size") {
-            writer.read(0x1234, i2c::messages::MAX_BUFFER_SIZE + 5, response_queue);
+            writer.read(0x1234, i2c::messages::MAX_BUFFER_SIZE + 5,
+                        response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is limited to max size") {
-                REQUIRE(msg.transaction.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_read ==
+                        i2c::messages::MAX_BUFFER_SIZE);
             }
         }
         WHEN("we specify a transaction token") {
@@ -173,7 +182,8 @@ SCENARIO("Test the i2c command queue writer") {
                             response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x05), u8(0), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0x05), u8(0), u8(0), u8(0), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 1);
                 REQUIRE(msg.transaction.bytes_to_read == 4);
@@ -187,7 +197,8 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we write a response") {
-                    auto response_buf = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(4), u8(10)};
+                    auto response_buf = i2c::messages::MaxMessageBuffer{
+                        u8(1), u8(2), u8(0), u8(4), u8(10)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 10, .is_completed_poll = false},
@@ -208,8 +219,8 @@ SCENARIO("Test the i2c command queue writer") {
                             response_queue, 25);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f),
-                                   u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0xd3), u8(0x4d), u8(0xb3), u8(0x3f), u8(0)};
 
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 4);
@@ -225,7 +236,8 @@ SCENARIO("Test the i2c command queue writer") {
             writer.transact(ADDRESS, std::array{0x1, 0x02}, 1, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0), u8(0), u8(0)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0x1), u8(0x2), u8(0), u8(0), u8(0)};
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 2);
                 REQUIRE(msg.transaction.bytes_to_read == 1);
@@ -239,7 +251,8 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we write a response") {
-                    auto response_buf = i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(4), u8(10)};
+                    auto response_buf = i2c::messages::MaxMessageBuffer{
+                        u8(1), u8(2), u8(0), u8(4), u8(10)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 10, .is_completed_poll = false},
@@ -262,7 +275,8 @@ SCENARIO("Test the i2c command queue writer") {
                 response_queue, 651);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
 
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 5);
@@ -275,18 +289,19 @@ SCENARIO("Test the i2c command queue writer") {
             }
         }
         WHEN("we try and write and read a buffer that is too big") {
-            auto too_big =std::array<uint8_t,i2c::messages::MAX_BUFFER_SIZE + 2>{};
+            auto too_big =
+                std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE + 2>{};
             too_big.fill(0x33);
-            writer.transact(ADDRESS,
-                            too_big,
-                            too_big.size(), response_queue);
+            writer.transact(ADDRESS, too_big, too_big.size(), response_queue);
             auto msg = get_message(queue);
             THEN("the transaction size is limited") {
                 auto compare = i2c::messages::MaxMessageBuffer{};
                 compare.fill(0x33);
                 REQUIRE(msg.transaction.write_buffer == compare);
-                REQUIRE(msg.transaction.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
-                REQUIRE(msg.transaction.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_write ==
+                        i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_read ==
+                        i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(msg.transaction.address == ADDRESS);
             }
         }
@@ -297,11 +312,13 @@ SCENARIO("Test the i2c command queue writer") {
         WHEN("we write a buffer and specify under the message size") {
             writer.transact(
                 ADDRESS, 3,
-                i2c::messages::MaxMessageBuffer{u8(0x01), u8(0x02), u8(0x03), u8(0x04), u8(0x05)}, 3,
-                {.token = 651, .is_completed_poll = true}, response_queue);
+                i2c::messages::MaxMessageBuffer{u8(0x01), u8(0x02), u8(0x03),
+                                                u8(0x04), u8(0x05)},
+                3, {.token = 651, .is_completed_poll = true}, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction is correct") {
-                auto compare = i2c::messages::MaxMessageBuffer{u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
+                auto compare = i2c::messages::MaxMessageBuffer{
+                    u8(0x1), u8(0x2), u8(0x3), u8(0x4), u8(5)};
 
                 REQUIRE(msg.transaction.write_buffer == compare);
                 REQUIRE(msg.transaction.bytes_to_write == 3);
@@ -316,7 +333,8 @@ SCENARIO("Test the i2c command queue writer") {
                 REQUIRE(msg.response_writer.queue_ref != nullptr);
                 REQUIRE(msg.response_writer.writer != nullptr);
                 AND_WHEN("we write a response") {
-                    auto response_buf =i2c::messages::MaxMessageBuffer{u8(1), u8(2), u8(0), u8(4), u8(10)};
+                    auto response_buf = i2c::messages::MaxMessageBuffer{
+                        u8(1), u8(2), u8(0), u8(4), u8(10)};
                     static_cast<void>(msg.response_writer.write(
                         i2c::messages::TransactionResponse{
                             .id = {.token = 10, .is_completed_poll = false},
@@ -333,19 +351,21 @@ SCENARIO("Test the i2c command queue writer") {
             }
         }
         WHEN("we try and write and read a buffer that is too big") {
-            auto too_big = std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE>{};
+            auto too_big =
+                std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE>{};
             too_big.fill(0x11);
-            writer.transact(
-                ADDRESS, too_big.size(),
-                too_big, too_big.size(),
-                {.token = 651, .is_completed_poll = true}, response_queue);
+            writer.transact(ADDRESS, too_big.size(), too_big, too_big.size(),
+                            {.token = 651, .is_completed_poll = true},
+                            response_queue);
             auto msg = get_message(queue);
             THEN("the transaction size is limited") {
                 auto compare = i2c::messages::MaxMessageBuffer{};
                 compare.fill(0x11);
                 REQUIRE(msg.transaction.write_buffer == compare);
-                REQUIRE(msg.transaction.bytes_to_write == i2c::messages::MAX_BUFFER_SIZE);
-                REQUIRE(msg.transaction.bytes_to_read == i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_write ==
+                        i2c::messages::MAX_BUFFER_SIZE);
+                REQUIRE(msg.transaction.bytes_to_read ==
+                        i2c::messages::MAX_BUFFER_SIZE);
                 REQUIRE(msg.transaction.address == ADDRESS);
             }
         }

--- a/include/eeprom/core/types.hpp
+++ b/include/eeprom/core/types.hpp
@@ -3,13 +3,13 @@
 namespace eeprom {
 namespace types {
 
-// 0-8192
-using address = uint16_t;
+// 0-255
+using address = uint8_t;
 
 // 0-32
 using data_length = uint8_t;
 
-constexpr data_length max_data_length = 32;
+constexpr data_length max_data_length = 8;
 
 using EepromData = std::array<uint8_t, max_data_length>;
 

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -14,5 +14,5 @@ class EEProm : public sensor_simulator::SensorType {
     }
 };
 
-}
-}  // namespace eeprom_simulator
+}  // namespace simulator
+}  // namespace eeprom

--- a/include/i2c/core/messages.hpp
+++ b/include/i2c/core/messages.hpp
@@ -9,7 +9,7 @@ namespace i2c {
 namespace messages {
 
 using std::size_t;
-static constexpr std::size_t MAX_BUFFER_SIZE = 5;
+static constexpr std::size_t MAX_BUFFER_SIZE = 9;
 using MaxMessageBuffer = std::array<uint8_t, MAX_BUFFER_SIZE>;
 
 /*

--- a/include/i2c/core/writer.hpp
+++ b/include/i2c/core/writer.hpp
@@ -50,7 +50,7 @@ class Writer {
     void write(uint16_t device_address, const DataBuffer& buf) {
         messages::MaxMessageBuffer max_buffer{};
         auto write_size = std::min(buf.size(), max_buffer.size());
-        std::copy_n(buf.cbegin(), write_size, max_buffer.begin());
+        std::copy_n(buf.begin(), write_size, max_buffer.begin());
         do_write(device_address, write_size, max_buffer);
     }
     template <typename Data>
@@ -150,7 +150,7 @@ class Writer {
                   ResponseQueue& response_queue, uint32_t transaction_id = 0) {
         messages::MaxMessageBuffer max_buffer{};
         auto write_size = std::min(buf.size(), max_buffer.size());
-        std::copy_n(buf.cbegin(), write_size, max_buffer.begin());
+        std::copy_n(buf.begin(), write_size, max_buffer.begin());
         transact(device_address, write_size, max_buffer, read_count,
                  messages::TransactionIdentifier{.token = transaction_id,
                                                  .is_completed_poll = false},

--- a/include/i2c/tests/mock_response_queue.hpp
+++ b/include/i2c/tests/mock_response_queue.hpp
@@ -20,7 +20,7 @@ auto get_response(Queue& queue) -> i2c::messages::TransactionResponse {
 }
 
 inline auto dummy_response(const i2c::messages::Transact& m,
-                           const std::array<uint8_t, 5>& resp = {})
+                           const std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE>& resp = {})
     -> i2c::messages::TransactionResponse {
     return i2c::messages::TransactionResponse{
         .id = m.id,

--- a/include/i2c/tests/mock_response_queue.hpp
+++ b/include/i2c/tests/mock_response_queue.hpp
@@ -35,8 +35,9 @@ template <typename Message>
 requires std::is_same_v<Message, i2c::messages::SingleRegisterPollRead> ||
     std::is_same_v<Message,
                    i2c::messages::ConfigureSingleRegisterContinuousPolling>
-inline auto dummy_single_response(const Message& msg, bool done = false,
-                                  const std::array<uint8_t, 5>& resp = {})
+inline auto dummy_single_response(
+    const Message& msg, bool done = false,
+    const i2c::messages::MaxMessageBuffer& resp = {})
     -> i2c::messages::TransactionResponse {
     auto id = msg.id;
     id.is_completed_poll = done;
@@ -48,9 +49,9 @@ template <typename Message>
 requires std::is_same_v<Message, i2c::messages::MultiRegisterPollRead> ||
     std::is_same_v<Message,
                    i2c::messages::ConfigureMultiRegisterContinuousPolling>
-inline auto dummy_multi_response(const Message& msg, std::size_t which,
-                                 bool done = false,
-                                 const std::array<uint8_t, 5>& resp = {}) {
+inline auto dummy_multi_response(
+    const Message& msg, std::size_t which, bool done = false,
+    const i2c::messages::MaxMessageBuffer& resp = {}) {
     auto id = msg.id;
     id.is_completed_poll = done;
     id.transaction_index = which;

--- a/include/i2c/tests/mock_response_queue.hpp
+++ b/include/i2c/tests/mock_response_queue.hpp
@@ -19,8 +19,9 @@ auto get_response(Queue& queue) -> i2c::messages::TransactionResponse {
     return std::get<i2c::messages::TransactionResponse>(empty_msg);
 }
 
-inline auto dummy_response(const i2c::messages::Transact& m,
-                           const std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE>& resp = {})
+inline auto dummy_response(
+    const i2c::messages::Transact& m,
+    const std::array<uint8_t, i2c::messages::MAX_BUFFER_SIZE>& resp = {})
     -> i2c::messages::TransactionResponse {
     return i2c::messages::TransactionResponse{
         .id = m.id,

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -129,8 +129,10 @@ SCENARIO("read capacitance sensor values") {
                 THEN(
                     "using the callback with +saturated data returns the "
                     "expected value") {
-                    std::array<uint8_t, 5> buffer_a = {0x7f, 0xff, 0, 0, 0};
-                    std::array<uint8_t, 5> buffer_b = {0xff, 0, 0, 0, 0};
+                    auto buffer_a =
+                        i2c::messages::MaxMessageBuffer{0x7f, 0xff, 0, 0, 0};
+                    auto buffer_b =
+                        i2c::messages::MaxMessageBuffer{0xff, 0, 0, 0, 0};
                     std::array<sensors::utils::TaskMessage, 4> responses{
                         test_mocks::launder_response(
                             read_message, response_queue,
@@ -166,8 +168,10 @@ SCENARIO("read capacitance sensor values") {
                 THEN(
                     "using the callback with -saturated data returns the "
                     "expected value") {
-                    std::array<uint8_t, 5> buffer_a = {0x80, 0x00, 0, 0, 0};
-                    std::array<uint8_t, 5> buffer_b = {0x00, 0, 0, 0, 0};
+                    auto buffer_a =
+                        i2c::messages::MaxMessageBuffer{0x80, 0x00, 0, 0, 0};
+                    auto buffer_b =
+                        i2c::messages::MaxMessageBuffer{0x00, 0, 0, 0, 0};
                     std::array<sensors::utils::TaskMessage, 4> responses{
                         test_mocks::launder_response(
                             read_message, response_queue,
@@ -211,8 +215,8 @@ SCENARIO("read capacitance sensor values") {
             can_messages::BaselineSensorRequest({}, capacitive_id, NUM_READS));
         WHEN("we call the capacitance handler") {
             sensor.handle_message(multi_read);
-            std::array<uint8_t, 5> buffer_a = {200, 80, 0, 0, 0};
-            std::array<uint8_t, 5> buffer_b = {100, 10, 0, 0, 0};
+            auto buffer_a = i2c::messages::MaxMessageBuffer{200, 80, 0, 0, 0};
+            auto buffer_b = i2c::messages::MaxMessageBuffer{100, 10, 0, 0, 0};
             auto read_message =
                 get_message<i2c::messages::MultiRegisterPollRead>(poller_queue);
             for (int i = 0; i < NUM_READS; i++) {
@@ -273,8 +277,8 @@ SCENARIO("capacitance callback tests") {
             REQUIRE(mock_hw.get_sync_reset_calls() == 1);
         }
         WHEN("it receives data under its threshold") {
-            std::array<uint8_t, 5> buffer_a = {0, 0, 0, 0, 0};
-            std::array<uint8_t, 5> buffer_b = {0, 0, 0, 0, 0};
+            auto buffer_a = i2c::messages::MaxMessageBuffer{0, 0, 0, 0, 0};
+            auto buffer_b = i2c::messages::MaxMessageBuffer{0, 0, 0, 0, 0};
             std::array tags{sensors::utils::ResponseTag::IS_PART_OF_POLL,
                             sensors::utils::ResponseTag::POLL_IS_CONTINUOUS};
             i2c::messages::TransactionResponse first{
@@ -304,8 +308,8 @@ SCENARIO("capacitance callback tests") {
             }
         }
         WHEN("it receives data over its threshold") {
-            std::array<uint8_t, 5> buffer_a = {0x7f, 0xff, 0, 0};
-            std::array<uint8_t, 5> buffer_b = {0xff, 0, 0, 0, 0};
+            auto buffer_a = i2c::messages::MaxMessageBuffer{0x7f, 0xff, 0, 0};
+            auto buffer_b = i2c::messages::MaxMessageBuffer{0xff, 0, 0, 0, 0};
             std::array tags{sensors::utils::ResponseTag::IS_PART_OF_POLL,
                             sensors::utils::ResponseTag::POLL_IS_CONTINUOUS};
             i2c::messages::TransactionResponse first{
@@ -351,8 +355,8 @@ SCENARIO("capacitance callback tests") {
         }
 
         WHEN("it receives data under its threshold") {
-            std::array<uint8_t, 5> buffer_a = {0, 0, 0, 0, 0};
-            std::array<uint8_t, 5> buffer_b = {0, 0, 0, 0, 0};
+            auto buffer_a = i2c::messages::MaxMessageBuffer{0, 0, 0, 0, 0};
+            auto buffer_b = i2c::messages::MaxMessageBuffer{0, 0, 0, 0, 0};
             std::array tags{sensors::utils::ResponseTag::IS_PART_OF_POLL,
                             sensors::utils::ResponseTag::POLL_IS_CONTINUOUS};
             i2c::messages::TransactionResponse first{
@@ -383,8 +387,9 @@ SCENARIO("capacitance callback tests") {
             }
         }
         WHEN("it receives data over its threshold") {
-            std::array<uint8_t, 5> buffer_a = {0x7f, 0xff, 0, 0, 0};
-            std::array<uint8_t, 5> buffer_b = {0xff, 0, 0, 0, 0};
+            auto buffer_a =
+                i2c::messages::MaxMessageBuffer{0x7f, 0xff, 0, 0, 0};
+            auto buffer_b = i2c::messages::MaxMessageBuffer{0xff, 0, 0, 0, 0};
             std::array tags{sensors::utils::ResponseTag::IS_PART_OF_POLL,
                             sensors::utils::ResponseTag::POLL_IS_CONTINUOUS};
             i2c::messages::TransactionResponse first{

--- a/sensors/tests/test_environment_sensor.cpp
+++ b/sensors/tests/test_environment_sensor.cpp
@@ -58,7 +58,8 @@ SCENARIO("read temperature and humidity values") {
                 }
                 THEN(
                     "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> my_buff = {250, 80, 0, 0, 0};
+                    auto my_buff =
+                        i2c::messages::MaxMessageBuffer{250, 80, 0, 0, 0};
                     auto response = test_mocks::launder_response(
                         transact_message, response_queue,
                         test_mocks::dummy_response(transact_message, my_buff));
@@ -98,7 +99,8 @@ SCENARIO("read temperature and humidity values") {
                 }
                 THEN(
                     "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> my_buff = {200, 0, 0, 0, 0};
+                    auto my_buff =
+                        i2c::messages::MaxMessageBuffer{200, 0, 0, 0, 0};
                     auto response = test_mocks::launder_response(
                         transact_message, response_queue,
                         test_mocks::dummy_response(transact_message, my_buff));

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -116,7 +116,8 @@ SCENARIO("read pressure sensor values") {
                 }
                 THEN(
                     "using the callback with data returns the expected value") {
-                    std::array<uint8_t, 5> buffer_a = {0, 8, 2, 8, 0};
+                    auto buffer_a =
+                        i2c::messages::MaxMessageBuffer{0, 8, 2, 8, 0};
                     auto response = test_mocks::launder_response(
                         read_message, response_queue,
                         test_mocks::dummy_single_response(read_message, true,


### PR DESCRIPTION
- eeprom word address is 8-bits not 16.
- increase i2c max message size to 9 from 5. (eeprom can write 9 byte messages)
- clean up tests to not hard code max message size. so if we have to change the max again we won't have to go through this kind of refactor again.