### PR TITLE
refactor(i2c): I2c read register

### DIFF
--- a/i2c/tests/test_i2c_writer.cpp
+++ b/i2c/tests/test_i2c_writer.cpp
@@ -171,6 +171,21 @@ SCENARIO("Test the i2c command queue writer") {
             auto msg = get_message(queue);
             THEN("the token is used") { REQUIRE(msg.id.token == 52); }
         }
+        WHEN("we command a read from a specified register") {
+            writer.read(0x4321, 3, 5,
+                        response_queue);
+            auto msg = get_message(queue);
+            THEN("the transaction contains a write portion for the address") {
+                REQUIRE(msg.transaction.bytes_to_write==1);
+                REQUIRE(msg.transaction.write_buffer[0]==3);
+            }
+            THEN("the device address is set") {
+                REQUIRE(msg.transaction.address == 0x4321);
+            }
+            THEN("the read count is set") {
+                REQUIRE(msg.transaction.bytes_to_read==5);
+            }
+        }
     }
 
     GIVEN("a desire to transact") {

--- a/i2c/tests/test_i2c_writer.cpp
+++ b/i2c/tests/test_i2c_writer.cpp
@@ -172,18 +172,17 @@ SCENARIO("Test the i2c command queue writer") {
             THEN("the token is used") { REQUIRE(msg.id.token == 52); }
         }
         WHEN("we command a read from a specified register") {
-            writer.read(0x4321, 3, 5,
-                        response_queue);
+            writer.read(0x4321, 3, 5, response_queue);
             auto msg = get_message(queue);
             THEN("the transaction contains a write portion for the address") {
-                REQUIRE(msg.transaction.bytes_to_write==1);
-                REQUIRE(msg.transaction.write_buffer[0]==3);
+                REQUIRE(msg.transaction.bytes_to_write == 1);
+                REQUIRE(msg.transaction.write_buffer[0] == 3);
             }
             THEN("the device address is set") {
                 REQUIRE(msg.transaction.address == 0x4321);
             }
             THEN("the read count is set") {
-                REQUIRE(msg.transaction.bytes_to_read==5);
+                REQUIRE(msg.transaction.bytes_to_read == 5);
             }
         }
     }

--- a/include/i2c/core/writer.hpp
+++ b/include/i2c/core/writer.hpp
@@ -105,6 +105,29 @@ class Writer {
         queue->try_write(message);
     }
 
+    /**
+     * A single read from a register or memory address
+     * @tparam RQType response queue type
+     * @param device_address the i2c device address
+     * @param address register/address to read from
+     * @param read_bytes number of bytes to read
+     * @param response_queue queue to respond to
+     * @param id optional transaction id returned in response.
+     */
+    template <messages::I2CResponseQueue RQType>
+    void read(uint16_t device_address, uint8_t address, std::size_t read_bytes,
+              RQType& response_queue, uint32_t id = 0) {
+        messages::Transact message{
+            .transaction = {.address = device_address,
+                            .bytes_to_read =
+                                std::min(read_bytes, messages::MAX_BUFFER_SIZE),
+                            .bytes_to_write = 1,
+                            .write_buffer{address}},
+            .id = {.token = id, .is_completed_poll = false},
+            .response_writer = messages::ResponseWriter(response_queue)};
+        queue->try_write(message);
+    }
+
     /*
      * A full read+write transaction on the i2c bus.
      *


### PR DESCRIPTION
`i2c::writer::Writer` has a `write` method that accepts a register address. This is a nice convenience for writing a buffer to a device that expects the first byte of a transaction to be a memory or register address.

This PR adds the `read` equivalent. When using this method, a transaction is created that initially writes a single byte address followed by a read.
