### PR TITLE
feat(motor-control): add tmc2160 motor control

### DIFF
--- a/include/motor-control/core/stepper_motor/tmc2160.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160.hpp
@@ -60,7 +60,7 @@ enum class Registers : uint8_t {
     PWM_SCALE = 0x71,
     PWM_AUTO = 0x72,
     LOST_STEPS = 0x73,
-}
+};
 
 inline auto is_valid_address(const uint8_t add) -> bool {
     switch (Registers(add)) {
@@ -164,8 +164,8 @@ struct __attribute__((packed, __may_alias__)) GStatus {
 };
 
 /**
-* This register sets the control current for holding and running.
-*/
+ * This register sets the control current for holding and running.
+ */
 struct __attribute__((packed, __may_alias__)) CurrentControl {
     static constexpr Registers address = Registers::IHOLD_IRUN;
     static constexpr bool writable = true;
@@ -182,8 +182,8 @@ struct __attribute__((packed, __may_alias__)) CurrentControl {
 };
 
 /**
-* This register scales the current set in ihold_irun.
-*/
+ * This register scales the current set in ihold_irun.
+ */
 struct __attribute__((packed, __may_alias__)) GlobalScaler {
     static constexpr Registers address = Registers::GLOBAL_SCALER;
     static constexpr bool writable = true;
@@ -298,7 +298,7 @@ struct __attribute__((packed, __may_alias__)) ChopConfig {
     uint32_t disfdcc : 1 = 0;
 
     // reserved, set to 0
-    uint32_t padding_1: 1 = 0;
+    uint32_t padding_1 : 1 = 0;
     /**
      * Chopper mode. 0 = standard mode, 1 = constant off-time with fast decay.
      */
@@ -309,7 +309,7 @@ struct __attribute__((packed, __may_alias__)) ChopConfig {
     uint32_t tbl : 2 = 2;
 
     // reserved, set to 0
-    uint32_t padding_2: 1 = 0;
+    uint32_t padding_2 : 1 = 0;
     /**
      * High velocity fullstep selection: Enables switching to fullstep when
      * VHIGH is exceeded. Only switches at 45º position.
@@ -502,7 +502,7 @@ struct TMC2160RegisterMap {
     CoolConfig coolconf = {};
     DriveStatus drvstatus = {};
     GStatus gstat = {};
-    GlobalScaler glob_scal = {};
+    GlobalScaler glob_scale = {};
 };
 
 // Registers are all 32 bits
@@ -510,7 +510,7 @@ using RegisterSerializedType = uint32_t;
 // Type definition to allow type aliasing for pointer dereferencing
 using RegisterSerializedTypeA = __attribute__((__may_alias__)) uint32_t;
 
-} // registers
+}  // namespace registers
 
 namespace configs {
 // R sense and VSF configuration
@@ -520,11 +520,11 @@ struct TMC2160MotorCurrentConfig {
 };
 
 struct TMC2160DriverConfig {
-    registers::TMC2130RegisterMap registers{};
-    TMC2130MotorCurrentConfig current_config{};
+    registers::TMC2160RegisterMap registers{};
+    TMC2160MotorCurrentConfig current_config{};
     spi::utils::ChipSelectInterface chip_select{};
 };
 
 }  // namespace configs
 
-} // tmc2160
+}  // namespace tmc2160

--- a/include/motor-control/core/stepper_motor/tmc2160.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160.hpp
@@ -1,0 +1,530 @@
+/**
+ * @file tmc2160.hpp
+ * @brief Contains register mapping information for the TMC2160 motor
+ * driver IC. See the datasheet for additional information.
+ *
+ * Datasheet:
+ * https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC2160A-datasheet_Rev1.06.pdf
+ *
+ *
+ */
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+
+#include "spi/core/utils.hpp"
+
+namespace tmc2160 {
+
+namespace registers {
+
+// Register mapping
+enum class Registers : uint8_t {
+    GCONF = 0x00,
+    GSTAT = 0x01,
+    IOIN = 0x04,
+    OTP_PROG = 0x06,
+    OTP_READ = 0x07,
+    FACTORY_CONF = 0x08,
+    SHORT_CONF = 0x09,
+    DRV_CONF = 0x0A,
+    GLOBAL_SCALER = 0x0B,
+    OFFSET_READ = 0x0C,
+    IHOLD_IRUN = 0x10,
+    TPOWERDOWN = 0x11,
+    TSTEP = 0x12,
+    TPWMTHRS = 0x13,
+    TCOOLTHRS = 0x14,
+    THIGH = 0x15,
+    XDIRECT = 0x2D,
+    VDCMIN = 0x33,
+    CHOPCONF = 0x6C,
+    COOLCONF = 0x6D,
+    DCCTRL = 0x6E,
+    DRVSTATUS = 0x6F,
+    PWMCONF = 0x70,
+    ENCM_CTRL = 0x72,
+    MSLUT_0 = 0x60,
+    MSLUT_1 = 0x61,
+    MSLUT_2 = 0x62,
+    MSLUT_3 = 0x63,
+    MSLUT_4 = 0x64,
+    MSLUT_5 = 0x65,
+    MSLUT_6 = 0x66,
+    MSLUT_7 = 0x67,
+    MSLUTSEL = 0x68,
+    MSLUTSTART = 0x69,
+    MSCNT = 0x6A,
+    MSCURACT = 0x6B,
+    PWM_SCALE = 0x71,
+    PWM_AUTO = 0x72,
+    LOST_STEPS = 0x73,
+}
+
+inline auto is_valid_address(const uint8_t add) -> bool {
+    switch (Registers(add)) {
+        case Registers::GCONF:
+        case Registers::GSTAT:
+        case Registers::IOIN:
+        case Registers::OTP_PROG:
+        case Registers::OTP_READ:
+        case Registers::FACTORY_CONF:
+        case Registers::SHORT_CONF:
+        case Registers::DRV_CONF:
+        case Registers::GLOBAL_SCALER:
+        case Registers::OFFSET_READ:
+        case Registers::IHOLD_IRUN:
+        case Registers::TPOWERDOWN:
+        case Registers::TPWMTHRS:
+        case Registers::TCOOLTHRS:
+        case Registers::THIGH:
+        case Registers::XDIRECT:
+        case Registers::VDCMIN:
+        case Registers::CHOPCONF:
+        case Registers::COOLCONF:
+        case Registers::DCCTRL:
+        case Registers::DRVSTATUS:
+        case Registers::PWMCONF:
+        case Registers::ENCM_CTRL:
+        case Registers::TSTEP:
+        case Registers::MSLUT_0:
+        case Registers::MSLUT_1:
+        case Registers::MSLUT_2:
+        case Registers::MSLUT_3:
+        case Registers::MSLUT_4:
+        case Registers::MSLUT_5:
+        case Registers::MSLUT_6:
+        case Registers::MSLUT_7:
+        case Registers::MSLUTSEL:
+        case Registers::MSLUTSTART:
+        case Registers::MSCNT:
+        case Registers::MSCURACT:
+        case Registers::PWM_SCALE:
+        case Registers::LOST_STEPS:
+            return true;
+    }
+    return false;
+}
+
+/** Template concept to constrain what structures encapsulate registers.*/
+template <typename Reg>
+concept TMC2160Register = requires(Reg& r, uint64_t value) {
+    // Struct has a valid register address
+    std::same_as<decltype(Reg::address), Registers&>;
+    // Struct has an integer with the total number of bits in a register.
+    // This is used to mask the 64-bit value before writing to the IC.
+    std::integral<decltype(Reg::value_mask)>;
+};
+
+template <typename Reg>
+concept WritableRegister = requires() {
+    {Reg::writable};
+};
+
+template <typename Reg>
+concept ReadableRegister = requires() {
+    {Reg::readable};
+};
+
+struct __attribute__((packed, __may_alias__)) GConfig {
+    static constexpr Registers address = Registers::GCONF;
+    static constexpr bool readable = true;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 17) - 1;
+
+    uint32_t recalibrate : 1 = 0;
+    uint32_t faststandstill : 1 = 0;
+    uint32_t en_pwm_mode : 1 = 0;
+    uint32_t multistep_filt : 1 = 0;  // MUST be 0
+    uint32_t shaft : 1 = 0;
+    uint32_t diag0_error : 1 = 0;
+    uint32_t diag0_otpw : 1 = 0;
+    uint32_t diag0_stall : 1 = 0;
+    uint32_t diag1_stall : 1 = 0;
+    uint32_t diag1_index : 1 = 0;
+    uint32_t diag1_onstate : 1 = 0;
+    uint32_t diag1_steps_skipped : 1 = 0;
+    uint32_t diag0_int_pushpull : 1 = 0;
+    uint32_t diag1_pushpull : 1 = 0;
+    uint32_t small_hysteresis : 1 = 0;
+    uint32_t stop_enable : 1 = 0;
+    uint32_t direct_mode : 1 = 0;
+    uint32_t test_mode : 1 = 0;  // MUST be 0
+};
+
+struct __attribute__((packed, __may_alias__)) GStatus {
+    static constexpr Registers address = Registers::GSTAT;
+    static constexpr bool readable = true;
+    static constexpr uint32_t value_mask = (1 << 3) - 1;
+
+    uint32_t reset : 1 = 0;
+    uint32_t driver_error : 1 = 0;
+    uint32_t uv_cp : 1 = 0;
+};
+
+/**
+* This register sets the control current for holding and running.
+*/
+struct __attribute__((packed, __may_alias__)) CurrentControl {
+    static constexpr Registers address = Registers::IHOLD_IRUN;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 20) - 1;
+
+    // Arbitrary scale from 0-31
+    uint32_t hold_current : 5 = 0;
+    uint32_t bit_padding_1 : 3 = 0;
+    // Arbitrary scale from 0-31
+    uint32_t run_current : 5 = 0;
+    uint32_t bit_padding_2 : 3 = 0;
+    // Motor powers down after (hold_current_delay * (2^18)) clock cycles
+    uint32_t hold_current_delay : 4 = 0;
+};
+
+/**
+* This register scales the current set in ihold_irun.
+*/
+struct __attribute__((packed, __may_alias__)) GlobalScaler {
+    static constexpr Registers address = Registers::GLOBAL_SCALER;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 8) - 1;
+
+    /**
+     * Global scaling of motor current. Multiplies to the current scaling.
+     *
+     * 0: Full Scale (or write 256)
+     * 1 … 31: Not allowed for operation
+     * 32 … 255: 32/256 … 255/256 of maximum current.
+     *
+     * Hint: Values >128 recommended for best results
+     */
+    uint32_t global_scaler : 8 = 0;
+};
+
+/**
+ * This is the time to delay between ending a movement and moving to power-down
+ * current. Scale goes up to "about 4 seconds"
+ */
+struct __attribute__((packed, __may_alias__)) PowerDownDelay {
+    static constexpr Registers address = Registers::TPOWERDOWN;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 8) - 1;
+
+    static constexpr double max_time = 4.0F;
+    static constexpr uint32_t max_val = 0xFF;
+    static constexpr uint32_t reset = 10;
+
+    [[nodiscard]] static auto reg_to_seconds(uint8_t reg) -> double {
+        return (static_cast<double>(reg) / static_cast<double>(max_val)) *
+               max_time;
+    }
+    static auto seconds_to_reg(double seconds) -> uint8_t {
+        if (seconds > max_time) {
+            return max_val;
+        }
+        return static_cast<uint32_t>((seconds / max_time) *
+                                     static_cast<double>(max_val));
+    }
+
+    uint32_t time : 8 = 0;
+};
+
+/**
+ * This is the threshold velocity for switching on smart energy coolStep
+ * and stallGuard.
+ */
+struct __attribute__((packed, __may_alias__)) TCoolThreshold {
+    static constexpr Registers address = Registers::TCOOLTHRS;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 20) - 1;
+
+    uint32_t threshold : 20 = 0;
+};
+
+/**
+ * This is the velocity threshold at which the controller will automatically
+ * move into a different chopper mode w/ fullstepping to maximize torque,
+ * applied whenever TSTEP < THIGH
+ */
+struct __attribute__((packed, __may_alias__)) THigh {
+    static constexpr Registers address = Registers::THIGH;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 20) - 1;
+
+    uint32_t threshold : 20 = 0;
+};
+
+/**
+ * The CHOPCONFIG register contains a number of configuration options for the
+ * Chopper control.
+ */
+struct __attribute__((packed, __may_alias__)) ChopConfig {
+    static constexpr Registers address = Registers::CHOPCONF;
+    static constexpr bool readable = true;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = 0x7FFFFFFF;
+
+    /** 0 = Driver disable
+     *  1 = "use only with TBL >= 2"
+     *  2...15 sets duration of slow decay phase:
+     * Nclk = 24 + 32 * TOFF
+     */
+    uint32_t toff : 4 = 0;
+
+    /**
+     * CHM = 0: sets hysteresis start value added to HEND
+     *  - Add 1,2,...,8 to hysteresis low value HEND
+     *
+     * CHM = 1: sets fast decay time, TFD :
+     *  - Nclk = 32*TFD
+     */
+    uint32_t hstrt : 3 = 0;
+    /**
+     * CHM = 0: Hysteresis is -3, -2, -1, ... 12. This is the hysteresis
+     * value used for the hysteresis chopper
+     *
+     * CHM = 1: Sine wave offset. 1/512 of the val gets added to abs of each
+     * sine wave entry
+     */
+    uint32_t hend : 4 = 0;
+    /**
+     * CHM = 1: MSB of fast decay time setting TFD
+     */
+    uint32_t fd3 : 1 = 0;
+    /**
+     * CHM = 1: Fast decay mode. Set to 1 to disable current comparator
+     * usage for termination of fast decay cycle.
+     */
+    uint32_t disfdcc : 1 = 0;
+
+    // reserved, set to 0
+    uint32_t padding_1: 1 = 0;
+    /**
+     * Chopper mode. 0 = standard mode, 1 = constant off-time with fast decay.
+     */
+    uint32_t chm : 1 = 0;
+    /**
+     * Blank Time Select. Sets comparator blank time to 16,24,36,54
+     */
+    uint32_t tbl : 2 = 2;
+
+    // reserved, set to 0
+    uint32_t padding_2: 1 = 0;
+    /**
+     * High velocity fullstep selection: Enables switching to fullstep when
+     * VHIGH is exceeded. Only switches at 45º position.
+     */
+    uint32_t vhighfs : 1 = 0;
+    /**
+     * High Velocity Chopper Mode: Enables switching to chm=1 and fd=0 when
+     * VHIGH is exceeded. If set, the TOFF setting automatically becomes
+     * doubled during high velocity operation.
+     */
+    uint32_t vhighchm : 1 = 0;
+    /**
+     * TPFD: Allows dampening of motor mid-range resonances.
+     * Passive fast decay time setting controls duration of the
+     * fast decay phase inserted after bridge polarity change
+     *
+     * 0 = disabled
+     *
+     * 1...15 Nclk = 128*TPFD
+     */
+    uint32_t tpfd : 4 = 0;
+    /**
+     * Microstep resolution:
+     *
+     * 0 = native 256 microstep setting
+     *
+     * 0b1...0b1000 = 128,64,32,16,8,4,2,FULLSTEP
+     *
+     * Reduced microstep resolution for STEP/DIR operation. Resolution gives
+     * the number of microstep entries per sine quarter wave.
+     */
+    uint32_t mres : 4 = 0;
+    /**
+     * Interpolation to 256 microsteps: If set, the actual MRES becomes
+     * extrapolated to 256 usteps for smoothest motor operation
+     */
+    uint32_t intpol : 1 = 0;
+    /**
+     * Enable double edge step pulses: If set, enable step impulse at each
+     * step edge to reduce step frequency requirement
+     */
+    uint32_t dedge : 1 = 0;
+    /**
+     * Short to GND protection disable:
+     *
+     * 0 = short to gnd protection on
+     *
+     * 1 = short to gnd protection disabled
+     */
+    uint32_t diss2g : 1 = 0;
+    /**
+     * Short to supply protection disable:
+     *
+     * 0 = short to vs protection on
+     *
+     * 1 = short to vs protection disabled
+     */
+    uint32_t diss2vs : 1 = 0;
+};
+
+/**
+ * COOLCONF contains information to configure the Coolstep and Smartguard (SG)
+ * features in the TMC2130
+ */
+struct __attribute__((packed, __may_alias__)) CoolConfig {
+    static constexpr Registers address = Registers::COOLCONF;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 25) - 1;
+
+    /**
+     * Minimum SG value for smart current control & smart current enable.
+     *
+     * If SG result falls below SEMIN*32, motor current increases to
+     * reduce motor load angle.
+     *
+     * 0 = smart current control coolStep OFF
+     *
+     * 1..15 = set threshold value
+     */
+    uint32_t semin : 4 = 0;
+    uint32_t padding_1 : 1 = 0;
+    /**
+     * Current up step width: Current increment steps per measured SG value:
+     *
+     * 1,2,4,8
+     */
+    uint32_t seup : 2 = 0;
+    uint32_t padding_2 : 1 = 0;
+    /**
+     * If the SG result is >= (SEMIN+SEMAX+1)*32, motor current decreases
+     * to save energy.
+     */
+    uint32_t semax : 4 = 0;
+    uint32_t padding_3 : 1 = 0;
+    /**
+     * Current down step speed:
+     *
+     * 0: for each 32 SG values, decrease by one
+     *
+     * 1: for each 8 SG values, decrease by one
+     *
+     * 2: for each 2 SG values, decrease by one
+     *
+     * 3: for each SG value, decrease by one
+     */
+    uint32_t sedn : 2 = 0;
+    /**
+     * Minimum current for smart current control:
+     *
+     * 0 = 1/2 of current setting in IRUN
+     *
+     * 1 = 1/4 of current setting in IRUN
+     */
+    uint32_t seimin : 1 = 0;
+    /**
+     * SG Threshold Value: This signed value controlls SG level for stall
+     * output and sets optimum measurement range for readout. A lower val
+     * gives a higher sensitivity. Zero is starting value working with most
+     * motors.
+     *
+     * -64 to +63: Higher value makes SG less sensitive and requires more
+     * torque to indicate a stall
+     */
+    int32_t sgt : 7 = 0;
+    uint32_t padding_4 : 1 = 0;
+    /**
+     * SG filter enable:
+     *
+     * 0 = standard mode, high time res for SG
+     *
+     * 1 = filtered mode, SG signal updated for each 4 full steps
+     */
+    uint32_t sfilt : 1 = 0;
+    uint32_t padding_5 : 1 = 0;
+};
+
+/**
+ * Holds error & stallguard information. Read only.
+ */
+struct __attribute__((packed, __may_alias__)) DriveStatus {
+    static constexpr Registers address = Registers::DRVSTATUS;
+    static constexpr bool readable = true;
+    static constexpr uint32_t value_mask = 0xFFFFFFFF;
+
+    // Stallguard2 Result, represents mechanical load.
+    // 0 is max load, 0x3FF is the max load.
+    uint32_t sg_result : 10 = 0;
+    // Reserved padding
+    uint32_t padding_0 : 2 = 0;
+    // short to supply indicator phase a
+    uint32_t s2vsa : 1 = 0;
+    // short to supply indicator phase b
+    uint32_t s2vsb : 1 = 0;
+    // stealth chop indicator
+    uint32_t stealth : 1 = 0;
+    // Fullstep-active indicator
+    uint32_t fsactive : 1 = 0;
+    // Actual motor current/ smart energy current.
+    // For monitoring function of automatic current scaling.
+    uint32_t cs_actual : 5 = 0;
+    // Rserved padding
+    uint32_t padding_1 : 3 = 0;
+    // Motor stall detected (sg_result = 0), or DcStep stall
+    // in DcStep mode.
+    uint32_t stallguard : 1 = 0;
+    // If 1, overtemp detected and driver is shut down.
+    uint32_t overtemp_flag : 1 = 0;
+    // If 1, pre-warning threshold for overtemp is exceeded.
+    uint32_t overtemp_prewarning_flag : 1 = 0;
+    // Short to ground in phase A
+    uint32_t s2ga : 1 = 0;
+    // Short to ground in phase B
+    uint32_t s2gb : 1 = 0;
+    // Open load in phase A
+    uint32_t ola : 1 = 0;
+    // Open load in phase B
+    uint32_t olb : 1 = 0;
+    // Standstill indicator. Occurs 2^20 clocks after last step.
+    uint32_t stst : 1 = 0;
+};
+
+// Encapsulates all of the registers that should be configured by software
+struct TMC2160RegisterMap {
+    GConfig gconfig = {};
+    CurrentControl ihold_irun = {};
+    PowerDownDelay tpowerdown = {};
+    TCoolThreshold tcoolthrs = {};
+    THigh thigh = {};
+    ChopConfig chopconf = {};
+    CoolConfig coolconf = {};
+    DriveStatus drvstatus = {};
+    GStatus gstat = {};
+    GlobalScaler glob_scal = {};
+};
+
+// Registers are all 32 bits
+using RegisterSerializedType = uint32_t;
+// Type definition to allow type aliasing for pointer dereferencing
+using RegisterSerializedTypeA = __attribute__((__may_alias__)) uint32_t;
+
+} // registers
+
+namespace configs {
+// R sense and VSF configuration
+struct TMC2160MotorCurrentConfig {
+    float r_sense;
+    float v_sf;
+};
+
+struct TMC2160DriverConfig {
+    registers::TMC2130RegisterMap registers{};
+    TMC2130MotorCurrentConfig current_config{};
+    spi::utils::ChipSelectInterface chip_select{};
+};
+
+}  // namespace configs
+
+} // tmc2160

--- a/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
@@ -1,0 +1,441 @@
+/**
+ * @file tmc2130.hpp
+ * @brief Interface to control a TMC2130 IC
+ */
+#pragma once
+
+#include <cmath>
+#include <concepts>
+#include <cstdint>
+#include <functional>
+#include <numbers>
+#include <optional>
+
+#include "common/core/bit_utils.hpp"
+#include "spi/core/utils.hpp"
+#include "spi/core/writer.hpp"
+#include "tmc2160.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
+namespace tmc2130 {
+
+namespace driver {
+
+using namespace std::numbers;
+using namespace spi::writer;
+using namespace tmc2160::registers;
+using namespace tmc2160::configs;
+
+template <class Writer, class TaskQueue>
+class TMC2160 {
+  public:
+    /**
+     *
+     * @param[spi_manager] The
+     * @param[task_queue]
+     * @param[conf]
+     */
+    TMC2160(Writer& spi_manager, TaskQueue& task_queue,
+            TMC2160DriverConfig& conf)
+        : _registers(conf.registers),
+          _current_config(conf.current_config),
+          _spi_manager(spi_manager),
+          _cs_intf(conf.chip_select),
+          _task_queue(task_queue),
+          _initialized(false) {}
+
+    TMC2160(const TMC2160& c) = delete;
+    TMC2160(const TMC2160&& c) = delete;
+    auto operator=(const TMC2160& c) = delete;
+    auto operator=(const TMC2160&& c) = delete;
+    ~TMC2160() = default;
+
+    auto read(Registers addr, uint32_t command_data) -> void {
+        auto converted_addr = static_cast<uint8_t>(addr);
+        _spi_manager.read(converted_addr, command_data, _task_queue, _cs_intf);
+    }
+
+    auto write(Registers addr, uint32_t command_data) -> bool {
+        auto converted_addr = static_cast<uint8_t>(addr);
+        return _spi_manager.write(converted_addr, command_data, _task_queue,
+                                  _cs_intf);
+    }
+
+    /**
+     *
+     * @return True if configurations were successfully writen to the spi task
+     * queue and false otherwise.
+     */
+    auto write_config() -> bool {
+        if (!set_gconf(_registers.gconfig)) {
+            return false;
+        }
+        if (!set_current_control(_registers.ihold_irun)) {
+            return false;
+        }
+        if (!set_power_down_delay(
+            PowerDownDelay::reg_to_seconds(_registers.tpowerdown.time))) {
+            return false;
+        }
+        if (!set_cool_threshold(_registers.tcoolthrs)) {
+            return false;
+        }
+        if (!set_thigh(_registers.thigh)) {
+            return false;
+        }
+        if (!set_chop_config(_registers.chopconf)) {
+            return false;
+        }
+        if (!set_cool_config(_registers.coolconf)) {
+            return false;
+        }
+        if (!set_glob_scaler(_registers.glob_scale)) {
+            return false;
+        }
+        _initialized = true;
+        return true;
+    }
+
+    /**
+ * @brief Check if the TMC2130 has been initialized.
+ * @return true if the registers have been written at least once,
+ * false otherwise.
+ */
+    [[nodiscard]] auto initialized() const -> bool { return _initialized; }
+
+    auto handle_spi_read(Registers addr,
+                         const spi::utils::MaxMessageBuffer& rxBuffer)
+    -> uint32_t {
+        uint32_t response = 0;
+        const auto* iter = rxBuffer.cbegin();                      // NOLINT
+        iter = bit_utils::bytes_to_int(iter + 1, rxBuffer.cend(),  // NOLINT
+                                       response);
+        switch (addr) {
+            case Registers::GCONF:
+                update_gconf(response);
+                return response;
+            case Registers::GSTAT:
+                update_gstatus(response);
+                return response;
+            case Registers::CHOPCONF:
+                update_chop_config(response);
+                return response;
+            case Registers::DRVSTATUS:
+                update_driver_status(response);
+                return response;
+            default:
+                return response;
+        }
+    }
+
+    auto handle_spi_write_failure(Registers addr) -> void {
+        // If we fail to set the given register,
+        // we should set the value to zero again
+        // and treat the driver as uninitialized.
+        _initialized = false;
+        switch (addr) {
+            case Registers::GCONF:
+                update_gconf(0);
+            case Registers::GSTAT:
+                update_gconf(0);
+            case Registers::CHOPCONF:
+                update_gconf(0);
+            case Registers::DRVSTATUS:
+                update_gconf(0);
+            default:
+                break;
+        }
+    }
+
+    // FUNCTIONS TO SET INDIVIDUAL REGISTERS
+
+    /**
+     * @brief Update GCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_gconf(GConfig reg) -> bool {
+        reg.enc_commutation = 0;
+        reg.test_mode = 0;
+        if (set_register(reg)) {
+            _registers.gconfig = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update IHOLDIRUN register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_current_control(CurrentControl reg) -> bool {
+        reg.bit_padding_1 = 0;
+        reg.bit_padding_2 = 0;
+        if (set_register(reg)) {
+            _registers.ihold_irun = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Update TPOWERDOWN register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_power_down_delay(double time) -> bool {
+        PowerDownDelay temp_reg = {.time =
+        PowerDownDelay::seconds_to_reg(time)};
+        if (set_register(temp_reg)) {
+            _registers.tpowerdown = temp_reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update TCOOLTHRSH register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_cool_threshold(TCoolThreshold reg) -> bool {
+        if (set_register(reg)) {
+            _registers.tcoolthrs = reg;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * @brief Update THIGH register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_thigh(THigh reg) -> bool {
+        if (set_register(reg)) {
+            _registers.thigh = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update CHOPCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_chop_config(ChopConfig reg) -> bool {
+        if (set_register(reg)) {
+            _registers.chopconf = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update COOLCONF register
+     * @param reg New configuration register to set
+     * @param policy Instance of abstraction policy to use
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_cool_config(CoolConfig reg) -> bool {
+        // Assert that bits that MUST be 0 are actually 0
+        reg.padding_1 = 0;
+        reg.padding_2 = 0;
+        reg.padding_3 = 0;
+        reg.padding_4 = 0;
+        if (set_register(reg)) {
+            _registers.coolconf = reg;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Update GlobalScaler register
+     * @param reg New configuration register to set
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_glob_scaler(GlobalScaler reg) -> bool {
+        if (set_register(reg)) {
+            _registers.glob_scale = reg;
+            return true;
+        }
+        return false;
+    }
+
+    [[nodiscard]] auto get_glob_scaler() -> std::optional<GlobalScaler> {
+        return _registers.glob_scale;
+    }
+
+    /**
+     * @brief Get the current GlobalScaler register value. This register can
+     * be read, so this function gets it from the actual device.
+     */
+    auto update_glob_scaler(uint32_t data) -> void {
+        auto ret = read_register<GConfig>(data);
+        if (ret.has_value()) {
+            _registers.gconfig = ret.value();
+        }
+    }
+
+    /**
+     * @brief Get the current GCONF register status. This register can
+     * be read, so this function gets it from the actual device.
+     */
+    [[nodiscard]] auto get_gconf() -> std::optional<GConfig> {
+        return _registers.gconfig;
+    }
+
+    auto update_gconf(uint32_t data) -> void {
+        auto ret = read_register<GConfig>(data);
+        if (ret.has_value()) {
+            _registers.gconfig = ret.value();
+        }
+    }
+
+    /**
+     * @brief Get the general status register
+     */
+    [[nodiscard]] auto get_gstatus() -> GStatus {
+        if (bool(_registers.gstat)) {
+            return _registers.gstat;
+        }
+        return GStatus{.driver_error = 1};
+    }
+
+    /**
+     * @brief Update the general status register
+     */
+    auto update_gstatus(uint32_t data) -> void {
+        auto ret = read_register<GStatus>(data);
+        if (ret.has_value()) {
+            _registers.gstat = ret.value();
+        }
+    }
+    /**
+     * @brief Get the current CHOPCONF register status. This register can
+     * be read, so this function gets it from the actual device.
+     */
+    [[nodiscard]] auto get_chop_config() -> std::optional<ChopConfig> {
+        return _registers.chopconf;
+    }
+
+    /**
+     * @brief Update the current CHOPCONF register status.
+     */
+    auto update_chop_config(uint32_t data) -> void {
+        auto ret = read_register<ChopConfig>(data);
+        if (ret.has_value()) {
+            _registers.chopconf = ret.value();
+        }
+    }
+
+    /**
+     * @brief Get the current DRV_STATUS register reading. Contains
+     * information on the current error & stallguard status of the IC.
+     * @return The register, or nothing if the register couldn't be read.
+     */
+    [[nodiscard]] auto get_driver_status() -> std::optional<DriveStatus> {
+        return _registers.drvstatus;
+    }
+
+    /**
+     * @brief Get the current DRV_STATUS register reading. Contains
+     * information on the current error & stallguard status of the IC.
+     * @return The register, or nothing if the register couldn't be read.
+     */
+    auto update_driver_status(uint32_t data) -> void {
+        auto ret = read_register<DriveStatus>(data);
+        if (ret.has_value()) {
+            _registers.drvstatus = ret.value();
+        }
+    }
+
+    /**
+     * @brief Get the register map
+     */
+    [[nodiscard]] auto get_register_map() -> TMC2130RegisterMap& {
+        return _registers;
+    }
+
+    [[nodiscard]] auto convert_to_tmc2160_current_value(uint32_t c) const
+    -> uint32_t {
+        constexpr auto SQRT_TWO = sqrt2;
+        constexpr auto CURR_GLOB_SCALE = *reinterpret_cast<RegisterSerializedTypeA*>(&_registers.glob_scale);
+        constexpr auto GLOB_SCALE = static_cast<float>(CURR_GLOB_SCALE) / 256.0
+        auto FLOAT_CONSTANT = static_cast<float>(
+            SQRT_TWO * 32.0 * (_current_config.r_sense) /
+            _current_config.v_sf * GLOB_SCALE);
+        auto fixed_point_constant = static_cast<uint32_t>(
+            FLOAT_CONSTANT * static_cast<float>(1LL << 16));
+        uint64_t val = static_cast<uint64_t>(fixed_point_constant) *
+                       static_cast<uint64_t>(c);
+        auto new_val = static_cast<uint32_t>(val >> 32);
+        return new_val - 1;
+    }
+
+
+  private:
+    /**
+     * @brief Set a register on the TMC2130
+     *
+     * @tparam Reg The type of register to set
+     * @tparam Policy Abstraction class for actual writing
+     * @param[in] policy Instance of the abstraction policy to use
+     * @param[in] reg The register to write
+     * @return True if the register could be written, false otherwise.
+     * Attempts to write to an unwirteable register will throw a static
+     * assertion.
+     */
+    template <TMC2130Register Reg>
+    requires WritableRegister<Reg>
+    auto set_register(Reg& reg) -> bool {
+        // Ignore the typical linter warning because we're only using
+        // this on __packed structures that mimic hardware registers
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto value = *reinterpret_cast<RegisterSerializedTypeA*>(&reg);
+        value &= Reg::value_mask;
+        return write(Reg::address, value);
+    }
+    /**
+     * @brief Read a register on the TMC2130
+     *
+     * @tparam Reg The type of register to read
+     * @tparam Policy Abstraction class for actual writing
+     * @param[in] policy Instance of the abstraction policy to use
+     * @return The contents of the register, or nothing if the register
+     * can't be read.
+     */
+    template <TMC2130Register Reg>
+    requires ReadableRegister<Reg>
+    auto read_register(uint32_t data) -> std::optional<Reg> {
+        using RT = std::optional<RegisterSerializedType>;
+        using RG = std::optional<Reg>;
+
+        auto ret = RT(data);
+        if (!ret.has_value()) {
+            return RG();
+        }
+        // Ignore the typical linter warning because we're only using
+        // this on __packed structures that mimic hardware registers
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        return RG(*reinterpret_cast<Reg*>(&ret.value()));
+    }
+
+    TMC2160RegisterMap _registers = {};
+    TMC2160MotorCurrentConfig _current_config = {};
+    Writer& _spi_manager;
+    spi::utils::ChipSelectInterface _cs_intf;
+    TaskQueue& _task_queue;
+    bool _initialized;
+
+
+}

--- a/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <variant>
+
+#include "can/core/can_writer_task.hpp"
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+#include "common/core/logging.h"
+#include "common/core/message_utils.hpp"
+#include "motor-control/core/stepper_motor/tmc2160.hpp"
+#include "motor-control/core/stepper_motor/tmc2160_driver.hpp"
+#include "motor-control/core/tasks/messages.hpp"
+#include "spi/core/messages.hpp"
+
+namespace tmc2160 {
+
+namespace tasks {
+
+using SpiResponseMessage = std::tuple<spi::messages::TransactResponse>;
+using CanMessageTuple = std::tuple<can_messages::ReadMotorDriverRegister,
+    can_messages::SetupRequest,
+    can_messages::WriteMotorDriverRegister,
+    can_messages::WriteMotorCurrentRequest>;
+using CanMessage =
+typename ::utils::TuplesToVariants<std::tuple<std::monostate>,
+    CanMessageTuple>::type;
+using TaskMessage = typename ::utils::VariantCat<
+    std::variant<std::monostate>,
+    typename ::utils::TuplesToVariants<CanMessageTuple,
+        SpiResponseMessage>::type>::type;
+
+/**
+ * The handler of motor driver messages
+ */
+template <class Writer, message_writer_task::TaskClient CanClient,
+    class TaskQueue>
+class MotorDriverMessageHandler {
+  public:
+    MotorDriverMessageHandler(Writer& writer, CanClient& can_client,
+                              TaskQueue& task_queue,
+                              tmc2160::configs::TMC2130DriverConfig& configs)
+        : driver(writer, task_queue, configs), can_client(can_client) {}
+    MotorDriverMessageHandler(const MotorDriverMessageHandler& c) = delete;
+    MotorDriverMessageHandler(const MotorDriverMessageHandler&& c) = delete;
+    auto operator=(const MotorDriverMessageHandler& c) = delete;
+    auto operator=(const MotorDriverMessageHandler&& c) = delete;
+    ~MotorDriverMessageHandler() = default;
+
+    /**
+     * Called upon arrival of new message
+     * @param message
+     */
+    void handle_message(const TaskMessage& message) {
+        std::visit([this](auto m) { this->handle(m); }, message);
+    }
+
+  private:
+    void handle(const std::monostate m) { static_cast<void>(m); }
+
+    void handle(const spi::messages::TransactResponse& m) {
+        if (m.id.command_type ==
+            static_cast<uint8_t>(spi::hardware::Mode::WRITE) &&
+            !m.success) {
+            driver.handle_spi_write_failure(tmc2130::registers::Registers(
+                static_cast<uint8_t>(m.id.token)));
+        } else if (m.id.command_type ==
+                   static_cast<uint8_t>(spi::hardware::Mode::READ)) {
+            auto data = driver.handle_spi_read(
+                tmc2130::registers::Registers(static_cast<uint8_t>(m.id.token)),
+                m.rxBuffer);
+            can_messages::ReadMotorDriverRegisterResponse response_msg{
+                .reg_address = static_cast<uint8_t>(m.id.token),
+                .data = data,
+            };
+            can_client.send_can_message(can_ids::NodeId::host, response_msg);
+        }
+    }
+
+    void handle(const can_messages::SetupRequest& m) {
+        LOG("Received motor setup request");
+        driver.write_config();
+    }
+
+    void handle(const can_messages::WriteMotorDriverRegister& m) {
+        LOG("Received write motor driver request: addr=%d, data=%d",
+            m.reg_address, m.data);
+        if (tmc2160::registers::is_valid_address(m.reg_address)) {
+            driver.write(tmc2160::registers::Registers(m.reg_address), m.data);
+        }
+    }
+
+    void handle(const can_messages::ReadMotorDriverRegister& m) {
+        LOG("Received read motor driver request: addr=%d", m.reg_address);
+        uint32_t data = 0;
+        if (tmc2160::registers::is_valid_address(m.reg_address)) {
+            driver.read(tmc2160::registers::Registers(m.reg_address), data);
+        }
+    }
+
+    void handle(const can_messages::WriteMotorCurrentRequest& m) {
+        LOG("Received write motor current request: hold_current=%d, "
+            "run_current=%d",
+            m.hold_current, m.run_current);
+
+        if (m.hold_current != 0U) {
+            driver.get_register_map().ihold_irun.hold_current =
+                driver.convert_to_tmc2160_current_value(m.hold_current);
+        };
+        if (m.run_current != 0U) {
+            driver.get_register_map().ihold_irun.run_current =
+                driver.convert_to_tmc2160_current_value(m.run_current);
+        }
+        driver.set_current_control(driver.get_register_map().ihold_irun);
+    }
+
+    tmc2160::driver::TMC2160<Writer, TaskQueue> driver;
+    CanClient& can_client;
+};
+
+/**
+ * The task type.
+ */
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
+class MotorDriverTask {
+  public:
+    using Messages = TaskMessage;
+    using QueueType = QueueImpl<TaskMessage>;
+    MotorDriverTask(QueueType& queue) : queue{queue} {}
+    MotorDriverTask(const MotorDriverTask& c) = delete;
+    MotorDriverTask(const MotorDriverTask&& c) = delete;
+    auto operator=(const MotorDriverTask& c) = delete;
+    auto operator=(const MotorDriverTask&& c) = delete;
+    ~MotorDriverTask() = default;
+
+    /**
+     * Task entry point.
+     */
+
+    template <message_writer_task::TaskClient CanClient,
+        class MotorDriverConfigs, class SpiWriter>
+    [[noreturn]] void operator()(MotorDriverConfigs* configs,
+                                 CanClient* can_client, SpiWriter* writer) {
+        auto handler = MotorDriverMessageHandler(*writer, *can_client,
+                                                 get_queue(), *configs);
+        TaskMessage message{};
+        for (;;) {
+            if (queue.try_read(&message, queue.max_delay)) {
+                handler.handle_message(message);
+            }
+        }
+    }
+
+    [[nodiscard]] auto get_queue() const -> QueueType& { return queue; }
+
+  private:
+    QueueType& queue;
+};
+
+/**
+ * Concept describing a class that can message this task.
+ * @tparam Client
+ */
+template <typename Client>
+concept TaskClient = requires(Client client, const TaskMessage& m) {
+    {client.send_motor_driver_queue(m)};
+};
+
+}  // namespace tasks
+
+}  // namespace tmc2130

--- a/motor-control/tests/test_motor_driver.cpp
+++ b/motor-control/tests/test_motor_driver.cpp
@@ -2,7 +2,10 @@
 #include "common/tests/mock_message_queue.hpp"
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
 #include "motor-control/core/stepper_motor/tmc2130_driver.hpp"
+#include "motor-control/core/stepper_motor/tmc2160.hpp"
+#include "motor-control/core/stepper_motor/tmc2160_driver.hpp"
 #include "motor-control/core/tasks/tmc2130_motor_driver_task.hpp"
+#include "motor-control/core/tasks/tmc2160_motor_driver_task.hpp"
 #include "spi/core/tasks/spi_task.hpp"
 #include "spi/core/writer.hpp"
 
@@ -59,6 +62,67 @@ TEST_CASE("Setup a tmc2130 motor driver") {
                         register_config.chopconf.mres);
                 REQUIRE(subject.get_register_map().coolconf.sgt ==
                         register_config.coolconf.sgt);
+            }
+        }
+    }
+}
+
+TEST_CASE("Setup a tmc2160 motor driver") {
+    test_mocks::MockMessageQueue<tmc2160::tasks::TaskMessage> resp_queue{};
+    test_mocks::MockMessageQueue<spi::tasks::TaskMessage> spi_queue{};
+    auto spi_writer = spi::writer::Writer<test_mocks::MockMessageQueue>{};
+    spi_writer.set_queue(&spi_queue);
+    tmc2160::configs::TMC2160DriverConfig driver_config{
+        .registers = {.gconfig = {.en_pwm_mode = 1},
+                      .ihold_irun = {.hold_current = 0x2,
+                                     .run_current = 0x2,
+                                     .hold_current_delay = 0x7},
+                      .tpowerdown = {},
+                      .tcoolthrs = {.threshold = 0},
+                      .thigh = {.threshold = 0xFFFFF},
+                      .chopconf = {.toff = 0x5,
+                                   .hstrt = 0x5,
+                                   .hend = 0x3,
+                                   .tbl = 0x2,
+                                   .mres = 0x3},
+                      .coolconf = {.sgt = 0b110},
+                      .glob_scale = {.global_scaler = 112}},
+        .current_config = {
+            .r_sense = 0.1,
+            .v_sf = 0.325,
+        }};
+
+    auto subject =
+        tmc2160::driver::TMC2160{spi_writer, resp_queue, driver_config};
+
+    GIVEN("a tmc2160 motor driver") {
+        WHEN("Setup is called") {
+            subject.write_config();
+            THEN("Registers have the configured values.") {
+                auto register_config = driver_config.registers;
+                REQUIRE(subject.get_gconf().value().en_pwm_mode ==
+                        register_config.gconfig.en_pwm_mode);
+                REQUIRE(subject.get_register_map().ihold_irun.hold_current ==
+                        register_config.ihold_irun.hold_current);
+                REQUIRE(subject.get_register_map().ihold_irun.run_current ==
+                        register_config.ihold_irun.run_current);
+                REQUIRE(
+                    subject.get_register_map().ihold_irun.hold_current_delay ==
+                    register_config.ihold_irun.hold_current_delay);
+                REQUIRE(subject.get_chop_config().value().toff ==
+                        register_config.chopconf.toff);
+                REQUIRE(subject.get_chop_config().value().hstrt ==
+                        register_config.chopconf.hstrt);
+                REQUIRE(subject.get_chop_config().value().hend ==
+                        register_config.chopconf.hend);
+                REQUIRE(subject.get_chop_config().value().tbl ==
+                        register_config.chopconf.tbl);
+                REQUIRE(subject.get_chop_config().value().mres ==
+                        register_config.chopconf.mres);
+                REQUIRE(subject.get_register_map().coolconf.sgt ==
+                        register_config.coolconf.sgt);
+                REQUIRE(subject.get_register_map().glob_scale.global_scaler ==
+                        register_config.glob_scale.global_scaler);
             }
         }
     }


### PR DESCRIPTION
## Overview

Closes RET-915. Adds in a basic setup for the `tmc2160` driver. For now it follows the `tmc2130` driver very closely. Both files should probably be refactored at some point to reduce the amount of functions in each driver.

## Follow-ups

These tasks will be used in a follow-up PR implementing [Handle multiple motors for pick up tip](https://opentrons.atlassian.net/browse/RET-916)