### PR TITLE
feat(pipettes): add additional basic timer for the gear motors

### DIFF
--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -30,6 +30,7 @@ set(PIPETTE_FW_NON_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
     ${CMAKE_CURRENT_SOURCE_DIR}/motor_encoder_hardware.c
     ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/motor_timer_hardware.c
     ${CMAKE_CURRENT_SOURCE_DIR}/mount_detect_hardware.c
     ${CMAKE_CURRENT_SOURCE_DIR}/hardware_config.c
     ${COMMON_EXECUTABLE_DIR}/errors/errors.c

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -33,6 +33,7 @@
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "motor_encoder_hardware.h"
 #include "motor_hardware.h"
+#include "motor_timer_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
 #pragma GCC diagnostic pop
 
@@ -107,6 +108,10 @@ static auto driver_configs = interfaces::driver_config_by_axis(PIPETTE_TYPE);
 
 extern "C" void plunger_callback() { plunger_interrupt.run_interrupt(); }
 
+extern "C" void gear_callback() {
+    // TODO implement the motor handler for the 96 channel
+}
+
 static sensors::hardware::SensorHardware pins_for_sensor_lt(gpio::PinConfig{
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
     .port = GPIOB,
@@ -137,7 +142,10 @@ auto main() -> int {
 
     app_update_clear_flags();
 
-    initialize_timer(plunger_callback);
+    initialize_linear_timer(plunger_callback);
+    if (PIPETTE_TYPE == NINETY_SIX_CHANNEL) {
+        initialize_gear_timer(gear_callback);
+    }
 
     can_start();
 

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -5,9 +5,6 @@
 #include "hardware_config.h"
 
 
-TIM_HandleTypeDef htim7;
-static motor_interrupt_callback plunger_callback = NULL;
-
 void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     if (hspi->Instance == SPI2) {
@@ -132,44 +129,3 @@ HAL_StatusTypeDef initialize_spi(void) {
     return HAL_SPI_Init(&hspi2);
 }
 
-void MX_TIM7_Init(void) {
-    TIM_MasterConfigTypeDef sMasterConfig = {0};
-
-    htim7.Instance = TIM7;
-    htim7.Init.Prescaler = 499;
-    htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim7.Init.Period = 1;
-    htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
-    if (HAL_TIM_Base_Init(&htim7) != HAL_OK) {
-        Error_Handler();
-    }
-    sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
-    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
-    if (HAL_TIMEx_MasterConfigSynchronization(&htim7, &sMasterConfig) !=
-        HAL_OK) {
-        Error_Handler();
-    }
-}
-
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
-    // Check which version of the timer triggered this callback
-    if ((htim == &htim7) && plunger_callback) {
-        plunger_callback();
-    }
-}
-
-void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim) {
-    if (htim == &htim7) {
-        /* Peripheral clock enable */
-        __HAL_RCC_TIM7_CLK_ENABLE();
-
-        /* TIM7 interrupt Init */
-        HAL_NVIC_SetPriority(TIM7_IRQn, 6, 0);
-        HAL_NVIC_EnableIRQ(TIM7_IRQn);
-    }
-}
-
-void initialize_timer(motor_interrupt_callback callback) {
-    plunger_callback = callback;
-    MX_TIM7_Init();
-}

--- a/pipettes/firmware/motor_hardware.h
+++ b/pipettes/firmware/motor_hardware.h
@@ -7,10 +7,6 @@ extern "C" {
 #endif  // __cplusplus
 
 extern SPI_HandleTypeDef hspi2;
-extern TIM_HandleTypeDef htim7;
-
-typedef void (*motor_interrupt_callback)();
-void initialize_timer(motor_interrupt_callback);
 HAL_StatusTypeDef initialize_spi(void);
 void motor_driver_CLK_gpio_init();
 

--- a/pipettes/firmware/motor_timer_hardware.c
+++ b/pipettes/firmware/motor_timer_hardware.c
@@ -1,0 +1,87 @@
+#include "common/firmware/errors.h"
+#include "stm32l5xx_hal.h"
+
+#include "motor_timer_hardware.h"
+#include "pipettes/core/pipette_type.h"
+
+
+TIM_HandleTypeDef htim7;
+TIM_HandleTypeDef htim6;
+static linear_motor_interrupt_callback plunger_callback = NULL;
+static gear_motor_interrupt_callback gear_callback = NULL;
+
+
+void MX_TIM7_Init(void) {
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+
+    htim7.Instance = TIM7;
+    htim7.Init.Prescaler = 499;
+    htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim7.Init.Period = 1;
+    htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
+    if (HAL_TIM_Base_Init(&htim7) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim7, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+}
+
+void MX_TIM6_Init(void) {
+    TIM_MasterConfigTypeDef sMasterConfig = {0};
+
+    htim6.Instance = TIM6;
+    htim6.Init.Prescaler = 499;
+    htim6.Init.CounterMode = TIM_COUNTERMODE_UP;
+    htim6.Init.Period = 1;
+    htim6.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
+    if (HAL_TIM_Base_Init(&htim6) != HAL_OK) {
+        Error_Handler();
+    }
+    sMasterConfig.MasterOutputTrigger = TIM_TRGO_UPDATE;
+    sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
+    if (HAL_TIMEx_MasterConfigSynchronization(&htim6, &sMasterConfig) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+}
+
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
+    // Check which version of the timer triggered this callback
+    if ((htim == &htim7) && plunger_callback) {
+        plunger_callback();
+    } else if ((htim == &htim6) && gear_callback) {
+        gear_callback();
+    }
+}
+
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim) {
+    if (htim == &htim7) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM7_CLK_ENABLE();
+
+        /* TIM7 interrupt Init */
+        HAL_NVIC_SetPriority(TIM7_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM7_IRQn);
+    } else if (htim == &htim6) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM6_CLK_ENABLE();
+
+        /* TIM7 interrupt Init */
+        HAL_NVIC_SetPriority(TIM6_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM6_IRQn);
+    }
+}
+
+void initialize_linear_timer(linear_motor_interrupt_callback callback) {
+    plunger_callback = callback;
+    MX_TIM7_Init();
+}
+
+void initialize_gear_timer(gear_motor_interrupt_callback callback) {
+    gear_callback = callback;
+    MX_TIM6_Init();
+}

--- a/pipettes/firmware/motor_timer_hardware.h
+++ b/pipettes/firmware/motor_timer_hardware.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "platform_specific_hal_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+extern TIM_HandleTypeDef htim7;
+extern TIM_HandleTypeDef htim6;
+
+typedef void (*linear_motor_interrupt_callback)();
+typedef void (*gear_motor_interrupt_callback)();
+void initialize_linear_timer(linear_motor_interrupt_callback);
+void initialize_gear_timer(gear_motor_interrupt_callback);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/pipettes/firmware/stm32l5xx_it.c
+++ b/pipettes/firmware/stm32l5xx_it.c
@@ -37,6 +37,7 @@
 DMA_HandleTypeDef hdma_spi1_tx;
 DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim7;
+extern TIM_HandleTypeDef htim6;
 /******************************************************************************/
 /*            Cortex-M33 Processor Exceptions Handlers                         */
 /******************************************************************************/
@@ -143,6 +144,11 @@ void FDCAN1_IT0_IRQHandler(void) { HAL_FDCAN_IRQHandler(can_get_device_handle())
  * @brief This function handles TIM7 global interrupt.
  */
 void TIM7_IRQHandler(void) { HAL_TIM_IRQHandler(&htim7); }
+
+/**
+ * @brief This function handles TIM6 global interrupt.
+ */
+void TIM6_IRQHandler(void) { HAL_TIM_IRQHandler(&htim6); }
 /**
  * @}
  */


### PR DESCRIPTION
## Overview
Closes RET-915 and is related to RET-916. First small step in enabled 3 motors on the 96 channel.

## Notes

I chose to use the other basic timer for now. We might want to re-evaluate the types of timers we use more closely depending on each timers individual application.