### PR TITLE
chore(can): generate can timings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,clang-analyzer-*,bugprone-*,-bugprone-branch-clone,cppcoreguidelines-*,-cppcoreguidelines-non-private-member-variables-in-classes,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-avoid-non-const-global-variables,misc-*,-misc-non-private-member-variables-in-classes,-misc-unused-parameters,modernize-*,readability-*,-readability-magic-numbers,performance-*,-performance-no-int-to-ptr,-readability-named-parameter,'
+Checks:          '-*,clang-analyzer-*,bugprone-*,-bugprone-branch-clone,cppcoreguidelines-*,-cppcoreguidelines-non-private-member-variables-in-classes,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-avoid-non-const-global-variables,misc-*,-misc-non-private-member-variables-in-classes,-misc-unused-parameters,modernize-*,readability-*,-readability-magic-numbers,performance-*,-performance-no-int-to-ptr,-readability-named-parameter,-readability-static-accessed-through-instance'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*/.*hpp'
 AnalyzeTemporaryDtors: false

--- a/bootloader/firmware/main.c
+++ b/bootloader/firmware/main.c
@@ -1,7 +1,6 @@
 #include "platform_specific_hal_conf.h"
 #include "platform_specific_hal.h"
 #include "common/core/app_update.h"
-#include "common/firmware/can.h"
 #include "common/firmware/errors.h"
 #include "common/firmware/clocking.h"
 #include "common/firmware/iwdg.h"
@@ -11,7 +10,7 @@
 #include "bootloader/core/updater.h"
 #include "bootloader/firmware/system.h"
 #include "bootloader/firmware/crc32.h"
-
+#include "bootloader/firmware/can.h"
 /**
  * The CAN handle.
  */

--- a/bootloader/firmware/stm32G4/can.c
+++ b/bootloader/firmware/stm32G4/can.c
@@ -1,4 +1,4 @@
-#include "common/firmware/can.h"
+#include "bootloader/firmware/can.h"
 
 /**
  * Initialize a connection to FDCAN1

--- a/bootloader/firmware/stm32L5/can.c
+++ b/bootloader/firmware/stm32L5/can.c
@@ -1,4 +1,4 @@
-#include "common/firmware/can.h"
+#include "bootloader/firmware/can.h"
 
 
 /**

--- a/can/firmware/hal_can.c
+++ b/can/firmware/hal_can.c
@@ -41,11 +41,11 @@ static void * message_callback_data = NULL;
 /**
  * Start CAN
  */
-void can_start() {
+void can_start(uint8_t clock_divider, uint8_t segment_1_tqs, uint8_t segment_2_tqs, uint8_t max_sync_jump_width) {
     mutex = xSemaphoreCreateMutexStatic(&mutex_data);
 
     // TODO (al, 2021-11-18): error returns?
-    MX_FDCAN1_Init(&fdcan1);
+    MX_FDCAN1_Init(&fdcan1, clock_divider, segment_1_tqs, segment_2_tqs, max_sync_jump_width);
 
     HAL_FDCAN_ActivateNotification(&fdcan1, FDCAN_IT_RX_FIFO0_NEW_MESSAGE | FDCAN_IT_RX_FIFO1_NEW_MESSAGE,0);
 

--- a/can/tests/CMakeLists.txt
+++ b/can/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
         test_can_message_buffer.cpp
         test_dispatch.cpp
         test_arbitration_id.cpp
+        test_bit_timings.cpp
 )
 
 target_include_directories(can PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/can/tests/test_bit_timings.cpp
+++ b/can/tests/test_bit_timings.cpp
@@ -1,0 +1,59 @@
+#include "can/core/bit_timings.hpp"
+#include "catch2/catch.hpp"
+
+SCENARIO("bit timing properties") {
+    WHEN("testing standard G4 properties") {
+        auto timings =
+            can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
+        THEN("the time quantum is 47ns") {
+            REQUIRE(timings.actual_time_quantum == 47);
+        }
+        THEN("the bitrate is 250kbaud") {
+            REQUIRE(timings.actual_bitrate == 250312);
+        }
+        THEN("the segment 1 block is 73 quanta") {
+            REQUIRE(timings.segment_1_quanta == 73);
+        }
+        THEN("the segment 2 block is 11 quantua") {
+            REQUIRE(timings.segment_2_quanta == 11);
+        }
+        THEN("the sync jump width is 1 quantum") {
+            REQUIRE(timings.max_sync_jump_width == 1);
+        }
+        THEN("the segment blocks add up to the right time") {
+            REQUIRE(static_cast<uint32_t>(
+                        static_cast<double>(can::bit_timings::NS_PER_S) /
+                        static_cast<double>((timings.segment_1_quanta +
+                                             timings.segment_2_quanta + 1) *
+                                            timings.actual_time_quantum)) ==
+                    timings.actual_bitrate);
+        }
+    }
+    WHEN("testing standard L5 properties") {
+        auto timings =
+            can::bit_timings::BitTimings<110000000, 50, 250000, 882>{};
+        THEN("the time quantum is 50ns") {
+            REQUIRE(timings.actual_time_quantum == 45);
+        }
+        THEN("the bitrate is 250kbaud") {
+            REQUIRE(timings.actual_bitrate == 252525);
+        }
+        THEN("the segment 1 block is 75 quanta") {
+            REQUIRE(timings.segment_1_quanta == 76);
+        }
+        THEN("the segment 2 block is 11 quanta") {
+            REQUIRE(timings.segment_2_quanta == 11);
+        }
+        THEN("the sync jump width is 1 quantum") {
+            REQUIRE(timings.max_sync_jump_width == 1);
+        }
+        THEN("the segment blocks add to the right time") {
+            REQUIRE(static_cast<uint32_t>(
+                        static_cast<double>(can::bit_timings::NS_PER_S) /
+                        static_cast<double>((timings.segment_1_quanta +
+                                             timings.segment_2_quanta + 1) *
+                                            timings.actual_time_quantum)) ==
+                    timings.actual_bitrate);
+        }
+    }
+}

--- a/can/tests/test_bit_timings.cpp
+++ b/can/tests/test_bit_timings.cpp
@@ -1,21 +1,30 @@
 #include "can/core/bit_timings.hpp"
 #include "catch2/catch.hpp"
 
+using can::bit_timings::KHZ;
+using can::bit_timings::MHZ;
+
 SCENARIO("bit timing properties") {
     WHEN("testing standard G4 properties") {
         auto timings =
-            can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
-        THEN("the time quantum is 47ns") {
-            REQUIRE(timings.actual_time_quantum == 47);
+            can::bit_timings::BitTimings<85 * MHZ, 240, 250 * KHZ, 883>{};
+        THEN("the clock divider is 20") {
+            REQUIRE(timings.clock_divider == 20);
+        }
+        THEN("the time quantum is 235ns") {
+            REQUIRE(timings.actual_time_quantum == 235);
+        }
+        THEN("there are 17 time quanta in a bit") {
+            REQUIRE(timings.total_time_quanta == 17);
         }
         THEN("the bitrate is 250kbaud") {
             REQUIRE(timings.actual_bitrate == 250312);
         }
         THEN("the segment 1 block is 73 quanta") {
-            REQUIRE(timings.segment_1_quanta == 73);
+            REQUIRE(timings.segment_1_quanta == 14);
         }
-        THEN("the segment 2 block is 11 quantua") {
-            REQUIRE(timings.segment_2_quanta == 11);
+        THEN("the segment 2 block is 11 quanta") {
+            REQUIRE(timings.segment_2_quanta == 2);
         }
         THEN("the sync jump width is 1 quantum") {
             REQUIRE(timings.max_sync_jump_width == 1);
@@ -31,18 +40,24 @@ SCENARIO("bit timing properties") {
     }
     WHEN("testing standard L5 properties") {
         auto timings =
-            can::bit_timings::BitTimings<110000000, 50, 250000, 882>{};
+            can::bit_timings::BitTimings<110 * MHZ, 455, 275330, 875>{};
+        THEN("the clock divider is 50") {
+            REQUIRE(timings.clock_divider == 50);
+        }
         THEN("the time quantum is 50ns") {
-            REQUIRE(timings.actual_time_quantum == 45);
+            REQUIRE(timings.actual_time_quantum == 454);
         }
         THEN("the bitrate is 250kbaud") {
-            REQUIRE(timings.actual_bitrate == 252525);
+            REQUIRE(timings.actual_bitrate == 275330);
         }
-        THEN("the segment 1 block is 75 quanta") {
-            REQUIRE(timings.segment_1_quanta == 76);
+        THEN("there are 8 time quanta in a bit") {
+            REQUIRE(timings.total_time_quanta == 8);
         }
-        THEN("the segment 2 block is 11 quanta") {
-            REQUIRE(timings.segment_2_quanta == 11);
+        THEN("the segment 1 block is 6 quanta") {
+            REQUIRE(timings.segment_1_quanta == 6);
+        }
+        THEN("the segment 2 block is 1 quantum") {
+            REQUIRE(timings.segment_2_quanta == 1);
         }
         THEN("the sync jump width is 1 quantum") {
             REQUIRE(timings.max_sync_jump_width == 1);

--- a/gantry/firmware/can.c
+++ b/gantry/firmware/can.c
@@ -6,7 +6,12 @@
  * @param handle Pointer to an FDCAN handle
  * @return HAL_OK on success
  */
-HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
+HAL_StatusTypeDef MX_FDCAN1_Init(
+    FDCAN_HandleTypeDef* handle,
+    uint8_t clock_divider,
+    uint8_t segment_1_tqs,
+    uint8_t segment_2_tqs,
+    uint8_t max_sync_jump_width) {
     handle->Instance = FDCAN1;
     handle->Init.ClockDivider = FDCAN_CLOCK_DIV1;
     handle->Init.FrameFormat = FDCAN_FRAME_FD_NO_BRS;
@@ -14,14 +19,14 @@ HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
     handle->Init.AutoRetransmission = ENABLE;
     handle->Init.TransmitPause = DISABLE;
     handle->Init.ProtocolException = DISABLE;
-    handle->Init.NominalPrescaler = 20;
-    handle->Init.NominalSyncJumpWidth = 2;
-    handle->Init.NominalTimeSeg1 = 14;
-    handle->Init.NominalTimeSeg2 = 2;
-    handle->Init.DataPrescaler = 20;
-    handle->Init.DataSyncJumpWidth = 1;
-    handle->Init.DataTimeSeg1 = 14;
-    handle->Init.DataTimeSeg2 = 1;
+    handle->Init.NominalPrescaler = clock_divider;
+    handle->Init.NominalSyncJumpWidth = max_sync_jump_width;
+    handle->Init.NominalTimeSeg1 = segment_1_tqs;
+    handle->Init.NominalTimeSeg2 = segment_2_tqs;
+    handle->Init.DataPrescaler = clock_divider;
+    handle->Init.DataSyncJumpWidth = max_sync_jump_width;
+    handle->Init.DataTimeSeg1 = segment_1_tqs;
+    handle->Init.DataTimeSeg2 = segment_2_tqs;
     handle->Init.StdFiltersNbr = 20;
     handle->Init.ExtFiltersNbr = 20;
     handle->Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -205,6 +205,8 @@ static motor_handler::MotorInterruptHandler motor_interrupt(
  */
 extern "C" void call_motor_handler(void) { motor_interrupt.run_interrupt(); }
 
+// For the exact timing values these generate see
+// can/tests/test_bit_timings.cpp
 static constexpr auto can_bit_timings =
     can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
 

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -205,10 +205,25 @@ static motor_handler::MotorInterruptHandler motor_interrupt(
  */
 extern "C" void call_motor_handler(void) { motor_interrupt.run_interrupt(); }
 
+// Unfortunately, these numbers need to be literals or defines
+// to get the compile-time checks to work so we can't actually
+// correctly rely on the hal to get these numbers - they need
+// to be checked against current configuration. However, they are
+// - clock input is 85MHz assuming the CAN is clocked from PCLK1
+// which has a clock divider of 2, and the system clock is 170MHZ
+// - 240ns requested time quantum yields a 235ns actual
+// - 250KHz bitrate requested yields 250312KHz actual
+// - 88.3% sample point
+// Should drive
+// segment 1 = 14 quanta
+// segment 2 = 2 quanta
+
 // For the exact timing values these generate see
 // can/tests/test_bit_timings.cpp
+
 static constexpr auto can_bit_timings =
-    can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
+    can::bit_timings::BitTimings<85 * can::bit_timings::MHZ, 240,
+                                 250 * can::bit_timings::KHZ, 883>{};
 
 void interfaces::initialize() {
     // Initialize SPI

--- a/gantry/firmware/interfaces.cpp
+++ b/gantry/firmware/interfaces.cpp
@@ -1,5 +1,6 @@
 #include "gantry/core/interfaces.hpp"
 
+#include "can/core/bit_timings.hpp"
 #include "can/firmware/hal_can.h"
 #include "can/firmware/hal_can_bus.hpp"
 #include "common/core/freertos_message_queue.hpp"
@@ -204,6 +205,9 @@ static motor_handler::MotorInterruptHandler motor_interrupt(
  */
 extern "C" void call_motor_handler(void) { motor_interrupt.run_interrupt(); }
 
+static constexpr auto can_bit_timings =
+    can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
+
 void interfaces::initialize() {
     // Initialize SPI
     if (initialize_spi(get_axis_type()) != HAL_OK) {
@@ -213,7 +217,9 @@ void interfaces::initialize() {
     initialize_timer(call_motor_handler);
 
     // Start the can bus
-    can_start();
+    can_start(can_bit_timings.clock_divider, can_bit_timings.segment_1_quanta,
+              can_bit_timings.segment_2_quanta,
+              can_bit_timings.max_sync_jump_width);
 
     iWatchdog.start(6);
 }

--- a/gripper/firmware/can.c
+++ b/gripper/firmware/can.c
@@ -6,7 +6,12 @@
  * @param handle Pointer to an FDCAN handle
  * @return HAL_OK on success
  */
-HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
+HAL_StatusTypeDef MX_FDCAN1_Init(
+    FDCAN_HandleTypeDef* handle,
+    uint8_t clock_divider,
+    uint8_t segment_1_tqs,
+    uint8_t segment_2_tqs,
+    uint8_t max_sync_jump_width) {
     handle->Instance = FDCAN1;
     handle->Init.ClockDivider = FDCAN_CLOCK_DIV1;
     handle->Init.FrameFormat = FDCAN_FRAME_FD_NO_BRS;
@@ -14,14 +19,14 @@ HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
     handle->Init.AutoRetransmission = ENABLE;
     handle->Init.TransmitPause = DISABLE;
     handle->Init.ProtocolException = DISABLE;
-    handle->Init.NominalPrescaler = 20;
-    handle->Init.NominalSyncJumpWidth = 2;
-    handle->Init.NominalTimeSeg1 = 14;
-    handle->Init.NominalTimeSeg2 = 2;
-    handle->Init.DataPrescaler = 20;
-    handle->Init.DataSyncJumpWidth = 1;
-    handle->Init.DataTimeSeg1 = 14;
-    handle->Init.DataTimeSeg2 = 1;
+    handle->Init.NominalPrescaler = clock_divider;
+    handle->Init.NominalSyncJumpWidth = max_sync_jump_width;
+    handle->Init.NominalTimeSeg1 = segment_1_tqs;
+    handle->Init.NominalTimeSeg2 = segment_2_tqs;
+    handle->Init.DataPrescaler = clock_divider;
+    handle->Init.DataSyncJumpWidth = max_sync_jump_width;
+    handle->Init.DataTimeSeg1 = segment_1_tqs;
+    handle->Init.DataTimeSeg2 = segment_2_tqs;
     handle->Init.StdFiltersNbr = 20;
     handle->Init.ExtFiltersNbr = 20;
     handle->Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;

--- a/gripper/firmware/main.cpp
+++ b/gripper/firmware/main.cpp
@@ -21,6 +21,8 @@ static auto iWatchdog = iwdg::IndependentWatchDog{};
  * The can bus.
  */
 static auto canbus = hal_can_bus::HalCanBus(can_get_device_handle());
+// For the exact timing values these generate see
+// can/tests/test_bit_timings.cpp
 static constexpr auto can_bit_timings =
     can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
 

--- a/gripper/firmware/main.cpp
+++ b/gripper/firmware/main.cpp
@@ -21,10 +21,24 @@ static auto iWatchdog = iwdg::IndependentWatchDog{};
  * The can bus.
  */
 static auto canbus = hal_can_bus::HalCanBus(can_get_device_handle());
+// Unfortunately, these numbers need to be literals or defines
+// to get the compile-time checks to work so we can't actually
+// correctly rely on the hal to get these numbers - they need
+// to be checked against current configuration. However, they are
+// - clock input is 85MHz assuming the CAN is clocked from PCLK1
+// which has a clock divider of 2, and the system clock is 170MHZ
+// - 240ns requested time quantum yields a 235ns actual
+// - 250KHz bitrate requested yields 250312KHz actual
+// - 88.3% sample point
+// Should drive
+// segment 1 = 14 quanta
+// segment 2 = 2 quanta
+//
 // For the exact timing values these generate see
 // can/tests/test_bit_timings.cpp
 static constexpr auto can_bit_timings =
-    can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
+    can::bit_timings::BitTimings<85 * can::bit_timings::MHZ, 240,
+                                 250 * can::bit_timings::KHZ, 883>{};
 
 auto main() -> int {
     HardwareInit();

--- a/gripper/firmware/main.cpp
+++ b/gripper/firmware/main.cpp
@@ -6,6 +6,7 @@
 #include "system_stm32g4xx.h"
 // clang-format on
 
+#include "can/core/bit_timings.hpp"
 #include "can/firmware/hal_can.h"
 #include "can/firmware/hal_can_bus.hpp"
 #include "common/core/app_update.h"
@@ -20,6 +21,8 @@ static auto iWatchdog = iwdg::IndependentWatchDog{};
  * The can bus.
  */
 static auto canbus = hal_can_bus::HalCanBus(can_get_device_handle());
+static constexpr auto can_bit_timings =
+    can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
 
 auto main() -> int {
     HardwareInit();
@@ -31,7 +34,9 @@ auto main() -> int {
     z_motor_iface::initialize();
     grip_motor_iface::initialize();
 
-    can_start();
+    can_start(can_bit_timings.clock_divider, can_bit_timings.segment_1_quanta,
+              can_bit_timings.segment_2_quanta,
+              can_bit_timings.max_sync_jump_width);
 
     gripper_tasks::start_tasks(canbus, z_motor_iface::get_z_motor(),
                                grip_motor_iface::get_grip_motor(),

--- a/head/firmware/can.c
+++ b/head/firmware/can.c
@@ -6,7 +6,12 @@
  * @param handle Pointer to an FDCAN handle
  * @return HAL_OK on success
  */
-HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
+HAL_StatusTypeDef MX_FDCAN1_Init(
+    FDCAN_HandleTypeDef* handle,
+    uint8_t clock_divider,
+    uint8_t segment_1_tqs,
+    uint8_t segment_2_tqs,
+    uint8_t max_sync_jump_width) {
     handle->Instance = FDCAN1;
     handle->Init.ClockDivider = FDCAN_CLOCK_DIV1;
     handle->Init.FrameFormat = FDCAN_FRAME_FD_NO_BRS;
@@ -14,14 +19,14 @@ HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
     handle->Init.AutoRetransmission = ENABLE;
     handle->Init.TransmitPause = DISABLE;
     handle->Init.ProtocolException = DISABLE;
-    handle->Init.NominalPrescaler = 20;
-    handle->Init.NominalSyncJumpWidth = 2;
-    handle->Init.NominalTimeSeg1 = 14;
-    handle->Init.NominalTimeSeg2 = 2;
-    handle->Init.DataPrescaler = 20;
-    handle->Init.DataSyncJumpWidth = 1;
-    handle->Init.DataTimeSeg1 = 14;
-    handle->Init.DataTimeSeg2 = 1;
+    handle->Init.NominalPrescaler = clock_divider;
+    handle->Init.NominalSyncJumpWidth = max_sync_jump_width;
+    handle->Init.NominalTimeSeg1 = segment_1_tqs;
+    handle->Init.NominalTimeSeg2 = segment_2_tqs;
+    handle->Init.DataPrescaler = clock_divider;
+    handle->Init.DataSyncJumpWidth = max_sync_jump_width;
+    handle->Init.DataTimeSeg1 = segment_1_tqs;
+    handle->Init.DataTimeSeg2 = segment_2_tqs;
     handle->Init.StdFiltersNbr = 20;
     handle->Init.ExtFiltersNbr = 20;
     handle->Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -256,14 +256,18 @@ auto timer_for_notifier = freertos_timer::FreeRTOSTimer(
 // to be checked against current configuration. However, they are
 // - clock input is 85MHz assuming the CAN is clocked from PCLK1
 // which has a clock divider of 2, and the system clock is 170MHZ
-// - 50ns time quantum to match host
-// - 250KHz bitrate
-// - 88.2% (.882*255) sample point
+// - 240ns requested time quantum yields a 235ns actual
+// - 250KHz bitrate requested yields 250312KHz actual
+// - 88.3% sample point
+// Should drive
+// segment 1 = 14 quanta
+// segment 2 = 2 quanta
 
 // For the exact timing values these generate see
 // can/tests/test_bit_timings.cpp
 static constexpr auto can_bit_timings =
-    can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
+    can::bit_timings::BitTimings<85 * can::bit_timings::MHZ, 240,
+                                 250 * can::bit_timings::KHZ, 883>{};
 
 auto main() -> int {
     HardwareInit();

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -19,6 +19,7 @@
 #include "stm32g4xx_hal_conf.h"
 #include "utility_hardware.h"
 #pragma GCC diagnostic pop
+#include "can/core/bit_timings.hpp"
 #include "can/firmware/hal_can_bus.hpp"
 #include "common/core/freertos_timer.hpp"
 #include "common/firmware/clocking.h"
@@ -249,6 +250,19 @@ auto timer_for_notifier = freertos_timer::FreeRTOSTimer(
     }),
     100);
 
+// Unfortunately, these numbers need to be literals or defines
+// to get the compile-time checks to work so we can't actually
+// correctly rely on the hal to get these numbers - they need
+// to be checked against current configuration. However, they are
+// - clock input is 85MHz assuming the CAN is clocked from PCLK1
+// which has a clock divider of 2, and the system clock is 170MHZ
+// - 50ns time quantum to match host
+// - 250KHz bitrate
+// - 88.2% (.882*255) sample point
+
+static constexpr auto can_bit_timings =
+    can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
+
 auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
@@ -266,7 +280,9 @@ auto main() -> int {
 
     utility_gpio_init();
 
-    can_start();
+    can_start(can_bit_timings.clock_divider, can_bit_timings.segment_1_quanta,
+              can_bit_timings.segment_2_quanta,
+              can_bit_timings.max_sync_jump_width);
 
     head_tasks::start_tasks(can_bus_1, motor_left.motion_controller,
                             motor_right.motion_controller, psd, spi_comms2,

--- a/head/firmware/main.cpp
+++ b/head/firmware/main.cpp
@@ -260,6 +260,8 @@ auto timer_for_notifier = freertos_timer::FreeRTOSTimer(
 // - 250KHz bitrate
 // - 88.2% (.882*255) sample point
 
+// For the exact timing values these generate see
+// can/tests/test_bit_timings.cpp
 static constexpr auto can_bit_timings =
     can::bit_timings::BitTimings<85000000, 50, 250000, 882>{};
 
@@ -279,7 +281,6 @@ auto main() -> int {
     }
 
     utility_gpio_init();
-
     can_start(can_bit_timings.clock_divider, can_bit_timings.segment_1_quanta,
               can_bit_timings.segment_2_quanta,
               can_bit_timings.max_sync_jump_width);

--- a/include/bootloader/firmware/can.h
+++ b/include/bootloader/firmware/can.h
@@ -1,0 +1,24 @@
+#ifndef __CAN_H__
+#define __CAN_H__
+
+#include "platform_specific_hal_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+
+/**
+ * Initializa FDCAN1
+ *
+ * @param handle Pointer to a FDCAN_HandleTypeDef
+ * @return HAL_OK on success
+ */
+HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef * handle);
+
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif // __cplusplus
+
+#endif  // __CAN_H__

--- a/include/can/core/bit_timings.hpp
+++ b/include/can/core/bit_timings.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstdint>
+
+namespace can {
+namespace bit_timings {
+
+static constexpr uint32_t NS_PER_S = 1000 * 1000 * 1000;
+
+template <uint32_t can_clock_hz, uint32_t time_quantum_ns>
+consteval auto get_clock_divider() -> uint8_t {
+    static_assert(can_clock_hz != 0, "clock must not be 0");
+    static_assert(time_quantum_ns != 0, "quantum time must not be 0");
+    constexpr auto clockdivider =
+        static_cast<uint32_t>((static_cast<uint64_t>(can_clock_hz) *
+                               static_cast<uint64_t>(time_quantum_ns)) /
+                              NS_PER_S);
+    static_assert(clockdivider != 0,
+                  "Cannot accomplish this quantum at this clock (too slow)");
+    static_assert(clockdivider < 256,
+                  "Cannot accomplish this quantum at this clock (too fast)");
+    return clockdivider;
+}
+
+template <uint32_t can_clock_hz, uint32_t clockdiv, uint32_t time_quantum_ns>
+consteval auto get_actual_time_quantum() -> uint32_t {
+    static_assert(can_clock_hz != 0);
+    constexpr auto actual_time_quantum = NS_PER_S / (can_clock_hz / clockdiv);
+    static_assert(
+        actual_time_quantum < (time_quantum_ns + (time_quantum_ns >> 3)),
+        "Time quantum >12% too high");
+    static_assert(
+        actual_time_quantum > (time_quantum_ns - (time_quantum_ns >> 3)),
+        "Time quantum >12% too low");
+    return actual_time_quantum;
+}
+
+template <uint32_t total_time_quanta, uint32_t actual_time_quantum,
+          uint32_t bitrate_hz>
+consteval auto get_actual_bitrate() -> uint32_t {
+    constexpr auto actual_bitrate =
+        NS_PER_S / (total_time_quanta * actual_time_quantum);
+    static_assert(actual_bitrate > (bitrate_hz + (bitrate_hz >> 3)),
+                  "Bitrate >12% too high");
+    static_assert(actual_bitrate < (bitrate_hz - (bitrate_hz >> 3)),
+                  "Bitrate >12% too low");
+    return actual_bitrate;
+}
+
+template <uint32_t bitrate_hz, uint32_t time_quantum_ns>
+consteval auto get_total_time_quanta() -> uint32_t {
+    return NS_PER_S / (bitrate_hz * time_quantum_ns);
+}
+
+static constexpr uint16_t SAMPLE_POINT_MAX = 1000;
+
+template <uint32_t total_time_quanta, uint16_t sample_point_ratio>
+consteval auto get_segment_1_quanta() -> uint32_t {
+    static_assert(sample_point_ratio < 1000,
+                  "sample point ratio should be in (1, 1000) and will be "
+                  "evaluated as sample_point_ratio / 1000");
+    return static_cast<uint32_t>((total_time_quanta * sample_point_ratio) /
+                                 SAMPLE_POINT_MAX) -
+           1;
+}
+
+template <uint32_t total_time_quanta, uint16_t sample_point_ratio>
+consteval auto get_segment_2_quanta() -> uint8_t {
+    static_assert(sample_point_ratio < 1000,
+                  "sample point ratio should be in (1, 1000) and will be "
+                  "evaluated as sample_point_ratio / 1000");
+    constexpr auto segment_1_quanta =
+        get_segment_1_quanta<total_time_quanta, sample_point_ratio>();
+    constexpr auto try_segment_2_quanta = static_cast<uint32_t>(
+        (total_time_quanta * (SAMPLE_POINT_MAX - sample_point_ratio)) /
+        SAMPLE_POINT_MAX);
+    return (
+        ((segment_1_quanta + try_segment_2_quanta) < (total_time_quanta + 1))
+            ? (try_segment_2_quanta + 1)
+            : try_segment_2_quanta);
+}
+
+template <uint32_t can_clock_hz, uint32_t time_quantum_ns, uint32_t bitrate_hz,
+          uint16_t sample_point_ratio>
+struct BitTimings {
+    static constexpr uint8_t clock_divider =
+        get_clock_divider<can_clock_hz, time_quantum_ns>();
+    static constexpr uint32_t actual_time_quantum =
+        get_actual_time_quantum<can_clock_hz, clock_divider, time_quantum_ns>();
+    static constexpr uint32_t total_time_quanta =
+        get_total_time_quanta<bitrate_hz, actual_time_quantum>();
+    static constexpr uint32_t actual_bitrate =
+        get_actual_bitrate<total_time_quanta, actual_time_quantum,
+                           bitrate_hz>();
+    static constexpr uint8_t segment_1_quanta =
+        get_segment_1_quanta<total_time_quanta, sample_point_ratio>();
+    static constexpr uint8_t segment_2_quanta =
+        get_segment_2_quanta<total_time_quanta, sample_point_ratio>();
+    static constexpr uint8_t max_sync_jump_width = segment_2_quanta;
+};
+
+};  // namespace bit_timings
+};  // namespace can

--- a/include/can/core/bit_timings.hpp
+++ b/include/can/core/bit_timings.hpp
@@ -5,6 +5,7 @@
 namespace can {
 namespace bit_timings {
 
+// helper functions and values for calculating bit timings
 static constexpr uint32_t NS_PER_S = 1000 * 1000 * 1000;
 
 template <uint32_t can_clock_hz, uint32_t time_quantum_ns>
@@ -26,6 +27,7 @@ template <uint32_t can_clock_hz, uint32_t clockdiv, uint32_t time_quantum_ns>
 consteval auto get_actual_time_quantum() -> uint32_t {
     static_assert(can_clock_hz != 0);
     constexpr auto actual_time_quantum = NS_PER_S / (can_clock_hz / clockdiv);
+    // fails if the predicate is false (time quantum is outside bounds)
     static_assert(
         actual_time_quantum < (time_quantum_ns + (time_quantum_ns >> 3)),
         "Time quantum >12% too high");
@@ -40,9 +42,11 @@ template <uint32_t total_time_quanta, uint32_t actual_time_quantum,
 consteval auto get_actual_bitrate() -> uint32_t {
     constexpr auto actual_bitrate =
         NS_PER_S / (total_time_quanta * actual_time_quantum);
-    static_assert(actual_bitrate > (bitrate_hz + (bitrate_hz >> 3)),
+    // note: this logic may look backward but it's because assert fails
+    // and prints the message if the predicate is _false_
+    static_assert(actual_bitrate < (bitrate_hz + (bitrate_hz >> 3)),
                   "Bitrate >12% too high");
-    static_assert(actual_bitrate < (bitrate_hz - (bitrate_hz >> 3)),
+    static_assert(actual_bitrate > (bitrate_hz - (bitrate_hz >> 3)),
                   "Bitrate >12% too low");
     return actual_bitrate;
 }
@@ -80,23 +84,67 @@ consteval auto get_segment_2_quanta() -> uint8_t {
             : try_segment_2_quanta);
 }
 
+/*
+** Generate can bit timing configuration values that are compatible with the
+** ST HAL based on both device-specific factors and well known CANbus
+*parameters.
+**
+** @tparam can_clock_hz The speed of the clock that drives the CANbus
+*peripheral,
+** in Hz. Unfortunately, to keep this compile-time computable, it must be
+*written
+** down directly based on understanding of the clock configuration.
+**
+** @tparam time_quantum_ns The desired time quantum to configure, in ns. The
+*exact
+** value may be impossible to achieve based on available clock division factors.
+** The actual quantum time used is available as the actual_time_quantum static
+** member. Compilation will fail if the actual time quantum is different from
+** the requested by more than 12%.
+**
+** @tparam bitrate_hz The desired bitrate of the CANbus, in hz (or, really,
+*baud).
+** This may not be achievable based on the exact time quantum calculated; if it
+** diverges by more than 12%, compilation will fail. The generated value may be
+** accessed from the static member actual_bitrate.
+**
+** @tparam sample_point_ratio The desired location of the CAN protocol sample
+** point. This is in parts-per-thousand, unitless.
+**
+** @tparam sync_jump_width The value to use for sync jump width, in time quanta.
+*/
+
 template <uint32_t can_clock_hz, uint32_t time_quantum_ns, uint32_t bitrate_hz,
-          uint16_t sample_point_ratio>
+          uint16_t sample_point_ratio, uint8_t sync_jump_width = 1>
 struct BitTimings {
+    constexpr BitTimings() {
+        static_cast<void>(actual_bitrate);
+        static_cast<void>(actual_time_quantum);
+    }
+    // The clock divider to set for the time quantum generator.
     static constexpr uint8_t clock_divider =
         get_clock_divider<can_clock_hz, time_quantum_ns>();
+    // The actual length of the time quantum based on the input clock and
+    // divider, in nanoseconds.
     static constexpr uint32_t actual_time_quantum =
         get_actual_time_quantum<can_clock_hz, clock_divider, time_quantum_ns>();
+    // The total number of time quanta in a bit.
     static constexpr uint32_t total_time_quanta =
         get_total_time_quanta<bitrate_hz, actual_time_quantum>();
+    // The actual bitrate in Hz based on the time quantum length.
     static constexpr uint32_t actual_bitrate =
         get_actual_bitrate<total_time_quanta, actual_time_quantum,
                            bitrate_hz>();
+    // The number of time quanta in protocol propagation segment +
+    // protocol segment 1 (the ST hal does not differentiate these two)
     static constexpr uint8_t segment_1_quanta =
         get_segment_1_quanta<total_time_quanta, sample_point_ratio>();
+    // The number of time quanta in protocol segment 2
     static constexpr uint8_t segment_2_quanta =
         get_segment_2_quanta<total_time_quanta, sample_point_ratio>();
-    static constexpr uint8_t max_sync_jump_width = segment_2_quanta;
+    // The max allowable sync jump width for clock skew synchronization in
+    // time quanta.
+    static constexpr uint8_t max_sync_jump_width = sync_jump_width;
 };
 
 };  // namespace bit_timings

--- a/include/can/core/bit_timings.hpp
+++ b/include/can/core/bit_timings.hpp
@@ -4,6 +4,9 @@
 
 namespace can {
 namespace bit_timings {
+// Useful for writing large clean frequencies and keeping them readable
+static constexpr uint32_t MHZ = 1000 * 1000;
+static constexpr uint32_t KHZ = 1000;
 
 // helper functions and values for calculating bit timings
 static constexpr uint32_t NS_PER_S = 1000 * 1000 * 1000;
@@ -79,7 +82,7 @@ consteval auto get_segment_2_quanta() -> uint8_t {
         (total_time_quanta * (SAMPLE_POINT_MAX - sample_point_ratio)) /
         SAMPLE_POINT_MAX);
     return (
-        ((segment_1_quanta + try_segment_2_quanta) < (total_time_quanta + 1))
+        ((segment_1_quanta + try_segment_2_quanta) < (total_time_quanta - 1))
             ? (try_segment_2_quanta + 1)
             : try_segment_2_quanta);
 }

--- a/include/can/firmware/hal_can.h
+++ b/include/can/firmware/hal_can.h
@@ -16,10 +16,12 @@ typedef void(*can_message_callback)(void* cb_data, uint32_t identifier, uint8_t*
  */
 typedef void * HAL_CAN_HANDLE;
 
+
+
 /**
  * Start CAN.
  */
-void can_start();
+void can_start(uint8_t clock_divider, uint8_t segment_1_tqs, uint8_t segment_2_tqs, uint8_t max_sync_jump_width);
 
 
 /**

--- a/include/common/firmware/can.h
+++ b/include/common/firmware/can.h
@@ -12,9 +12,13 @@ extern "C" {
  * Initializa FDCAN1
  *
  * @param handle Pointer to a FDCAN_HandleTypeDef
+ * @param clock_divider Clock divider for canbus peripheral
+ * @param segment_1_tqs Time quanta for the phase 1 segment
+ * @param segment_2_tqs Time quanta for the phase 2 segment
+ * @param max_sync_jump_width Max jump width for auto resync
  * @return HAL_OK on success
  */
-HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef * handle);
+HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef * handle, uint8_t clock_divider, uint8_t segment_1_tqs, uint8_t segment_2_tqs, uint8_t max_sync_jump_width);
 
 
 #ifdef __cplusplus

--- a/pipettes/firmware/can.c
+++ b/pipettes/firmware/can.c
@@ -7,7 +7,12 @@
  * @param handle Pointer to an FDCAN handle
  * @return HAL_OK on success
  */
-HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
+HAL_StatusTypeDef MX_FDCAN1_Init(
+    FDCAN_HandleTypeDef* handle,
+    uint8_t clock_divider,
+    uint8_t segment_1_tqs,
+    uint8_t segment_2_tqs,
+    uint8_t max_sync_jump_width) {
     handle->Instance = FDCAN1;
     handle->Init.ClockDivider = FDCAN_CLOCK_DIV1;
     handle->Init.FrameFormat = FDCAN_FRAME_FD_NO_BRS;
@@ -15,14 +20,14 @@ HAL_StatusTypeDef MX_FDCAN1_Init(FDCAN_HandleTypeDef* handle) {
     handle->Init.AutoRetransmission = ENABLE;
     handle->Init.TransmitPause = DISABLE;
     handle->Init.ProtocolException = DISABLE;
-    handle->Init.NominalPrescaler = 50;
-    handle->Init.NominalSyncJumpWidth = 2;
-    handle->Init.NominalTimeSeg1 = 6;
-    handle->Init.NominalTimeSeg2 = 1;
-    handle->Init.DataPrescaler = 50;
-    handle->Init.DataSyncJumpWidth = 1;
-    handle->Init.DataTimeSeg1 = 6;
-    handle->Init.DataTimeSeg2 = 1;
+    handle->Init.NominalPrescaler = clock_divider,
+    handle->Init.NominalSyncJumpWidth = max_sync_jump_width;
+    handle->Init.NominalTimeSeg1 = segment_1_tqs;
+    handle->Init.NominalTimeSeg2 = segment_2_tqs;
+    handle->Init.DataPrescaler = clock_divider;
+    handle->Init.DataSyncJumpWidth = max_sync_jump_width;
+    handle->Init.DataTimeSeg1 = segment_1_tqs;
+    handle->Init.DataTimeSeg2 = segment_2_tqs;
     handle->Init.StdFiltersNbr = 20;
     handle->Init.ExtFiltersNbr = 20;
     handle->Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -5,6 +5,7 @@
 
 // clang-format on
 
+#include "can/core/bit_timings.hpp"
 #include "can/core/ids.hpp"
 #include "can/firmware/hal_can_bus.hpp"
 #include "common/core/app_update.h"
@@ -118,6 +119,9 @@ static sensors::hardware::SensorHardware pins_for_sensor_96(gpio::PinConfig{
     .pin = GPIO_PIN_5,
     .active_setting = GPIO_PIN_RESET});
 
+static constexpr auto can_bit_timings =
+    can::bit_timings::BitTimings<110000000, 50, 250000, 882>{};
+
 auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
@@ -139,7 +143,9 @@ auto main() -> int {
 
     initialize_timer(plunger_callback);
 
-    can_start();
+    can_start(can_bit_timings.clock_divider, can_bit_timings.segment_1_quanta,
+              can_bit_timings.segment_2_quanta,
+              can_bit_timings.max_sync_jump_width);
 
     pipettes_tasks::start_tasks(
         can_bus_1, pipette_motor.motion_controller, i2c_comms3, i2c_comms1,

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -119,10 +119,23 @@ static sensors::hardware::SensorHardware pins_for_sensor_96(gpio::PinConfig{
     .pin = GPIO_PIN_5,
     .active_setting = GPIO_PIN_RESET});
 
+// Unfortunately, these numbers need to be literals or defines
+// to get the compile-time checks to work so we can't actually
+// correctly rely on the hal to get these numbers - they need
+// to be checked against current configuration. However, they are
+// - clock input is 110MHz assuming the CAN is clocked from sysclk
+// - 455ns requested time quantum yields a 454ns actual
+// - 275.33KHz bitrate
+// - 87.5% sample point
+// Should drive
+// segment 1 = 8 quanta
+// segment 2 = 1 quantum
+
 // For the exact timing values these generate see
 // can/tests/test_bit_timings.cpp
 static constexpr auto can_bit_timings =
-    can::bit_timings::BitTimings<110000000, 50, 250000, 882>{};
+    can::bit_timings::BitTimings<110 * can::bit_timings::MHZ, 455, 275330,
+                                 875>{};
 
 auto main() -> int {
     HardwareInit();

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -119,6 +119,8 @@ static sensors::hardware::SensorHardware pins_for_sensor_96(gpio::PinConfig{
     .pin = GPIO_PIN_5,
     .active_setting = GPIO_PIN_RESET});
 
+// For the exact timing values these generate see
+// can/tests/test_bit_timings.cpp
 static constexpr auto can_bit_timings =
     can::bit_timings::BitTimings<110000000, 50, 250000, 882>{};
 


### PR DESCRIPTION
CANbus bit timings are a complicated thing. They depend on four different parameters. All four of the parameters we were using in the firmware were different from what the host system uses in linux, and were all just written down in a way that made it really non-obvious what they meant.

This makes the non-obviousness different by calculating those values from named parameters with units and with compile-time range and correctness checks.

After this PR, the bit timings used by the controllers will be identical to what they were before, but they'll now be generated and tied in with actual canbus canonical parameters. The next step is to change them to more useful values.

This supercedes #346 