### PR TITLE
chore(i2c): Writer returns try_write result

### DIFF
--- a/include/i2c/core/writer.hpp
+++ b/include/i2c/core/writer.hpp
@@ -47,30 +47,30 @@ class Writer {
      * Writes do not incur transaction responses.
      * */
     template <std::ranges::range DataBuffer>
-    void write(uint16_t device_address, const DataBuffer& buf) {
+    auto write(uint16_t device_address, const DataBuffer& buf) -> bool {
         messages::MaxMessageBuffer max_buffer{};
         auto write_size = std::min(buf.size(), max_buffer.size());
         std::copy_n(buf.begin(), write_size, max_buffer.begin());
-        do_write(device_address, write_size, max_buffer);
+        return do_write(device_address, write_size, max_buffer);
     }
     template <typename Data>
     requires std::is_integral_v<Data>
-    void write(uint16_t device_address, Data data) {
+    auto write(uint16_t device_address, Data data) -> bool {
         messages::MaxMessageBuffer max_buffer{};
         static_cast<void>(bit_utils::int_to_bytes(data, max_buffer.begin(),
                                                   max_buffer.end()));
-        do_write(device_address, sizeof(data), max_buffer);
+        return do_write(device_address, sizeof(data), max_buffer);
     }
     template <typename Data>
     requires std::is_integral_v<Data>
-    void write(uint16_t device_address, uint8_t reg, Data data) {
+    auto write(uint16_t device_address, uint8_t reg, Data data) -> bool {
         messages::MaxMessageBuffer max_buffer{};
         auto* iter = max_buffer.begin();
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         *iter++ = reg;
         static_cast<void>(
             bit_utils::int_to_bytes(data, iter, max_buffer.end()));
-        do_write(device_address, sizeof(data) + 1, max_buffer);
+        return do_write(device_address, sizeof(data) + 1, max_buffer);
     }
 
     /**
@@ -92,8 +92,8 @@ class Writer {
      * once the transaction completes.
      */
     template <messages::I2CResponseQueue RQType>
-    void read(uint16_t device_address, std::size_t read_bytes,
-              RQType& response_queue, uint32_t id = 0) {
+    auto read(uint16_t device_address, std::size_t read_bytes,
+              RQType& response_queue, uint32_t id = 0) -> bool {
         messages::Transact message{
             .transaction = {.address = device_address,
                             .bytes_to_read =
@@ -102,7 +102,7 @@ class Writer {
                             .write_buffer{}},
             .id = {.token = id, .is_completed_poll = false},
             .response_writer = messages::ResponseWriter(response_queue)};
-        queue->try_write(message);
+        return queue->try_write(message);
     }
 
     /**
@@ -115,8 +115,8 @@ class Writer {
      * @param id optional transaction id returned in response.
      */
     template <messages::I2CResponseQueue RQType>
-    void read(uint16_t device_address, uint8_t address, std::size_t read_bytes,
-              RQType& response_queue, uint32_t id = 0) {
+    auto read(uint16_t device_address, uint8_t address, std::size_t read_bytes,
+              RQType& response_queue, uint32_t id = 0) -> bool {
         messages::Transact message{
             .transaction = {.address = device_address,
                             .bytes_to_read =
@@ -125,7 +125,7 @@ class Writer {
                             .write_buffer{address}},
             .id = {.token = id, .is_completed_poll = false},
             .response_writer = messages::ResponseWriter(response_queue)};
-        queue->try_write(message);
+        return queue->try_write(message);
     }
 
     /*
@@ -169,36 +169,40 @@ class Writer {
      */
     template <std::ranges::range DataBuf,
               messages::I2CResponseQueue ResponseQueue>
-    void transact(uint16_t device_address, DataBuf buf, std::size_t read_count,
-                  ResponseQueue& response_queue, uint32_t transaction_id = 0) {
+    auto transact(uint16_t device_address, DataBuf buf, std::size_t read_count,
+                  ResponseQueue& response_queue, uint32_t transaction_id = 0)
+        -> bool {
         messages::MaxMessageBuffer max_buffer{};
         auto write_size = std::min(buf.size(), max_buffer.size());
         std::copy_n(buf.begin(), write_size, max_buffer.begin());
-        transact(device_address, write_size, max_buffer, read_count,
-                 messages::TransactionIdentifier{.token = transaction_id,
-                                                 .is_completed_poll = false},
-                 response_queue);
+        return transact(
+            device_address, write_size, max_buffer, read_count,
+            messages::TransactionIdentifier{.token = transaction_id,
+                                            .is_completed_poll = false},
+            response_queue);
     }
 
     template <typename Data, messages::I2CResponseQueue ResponseQueue>
     requires std::is_integral_v<Data>
-    void transact(uint16_t device_address, Data data, std::size_t read_count,
-                  ResponseQueue& response_queue, uint32_t transaction_id = 0) {
+    auto transact(uint16_t device_address, Data data, std::size_t read_count,
+                  ResponseQueue& response_queue, uint32_t transaction_id = 0)
+        -> bool {
         messages::MaxMessageBuffer max_buffer{};
         static_cast<void>(bit_utils::int_to_bytes(data, max_buffer.begin(),
                                                   max_buffer.end()));
-        transact(device_address, sizeof(data), max_buffer, read_count,
-                 messages::TransactionIdentifier{.token = transaction_id,
-                                                 .is_completed_poll = false},
-                 response_queue);
+        return transact(
+            device_address, sizeof(data), max_buffer, read_count,
+            messages::TransactionIdentifier{.token = transaction_id,
+                                            .is_completed_poll = false},
+            response_queue);
     }
 
     template <typename ResponseQueue>
-    void transact(uint16_t device_address, std::size_t write_bytes,
+    auto transact(uint16_t device_address, std::size_t write_bytes,
                   const messages::MaxMessageBuffer& buf, std::size_t read_bytes,
                   messages::TransactionIdentifier id,
-                  ResponseQueue& response_queue) {
-        transact(
+                  ResponseQueue& response_queue) -> bool {
+        return transact(
             messages::Transaction{
                 .address = device_address,
                 .bytes_to_read =
@@ -209,10 +213,10 @@ class Writer {
     }
 
     template <typename ResponseQueue>
-    void transact(const messages::Transaction& txn,
+    auto transact(const messages::Transaction& txn,
                   const messages::TransactionIdentifier& id,
-                  ResponseQueue& response_queue) {
-        queue->try_write(messages::Transact{
+                  ResponseQueue& response_queue) -> bool {
+        return queue->try_write(messages::Transact{
             .transaction = txn,
             .id = id,
             .response_writer = messages::ResponseWriter(response_queue)});
@@ -221,9 +225,9 @@ class Writer {
     void set_queue(QueueType* q) { queue = q; }
 
   private:
-    void do_write(uint16_t address, std::size_t write_bytes,
-                  const messages::MaxMessageBuffer& buf) {
-        queue->try_write(messages::Transact{
+    auto do_write(uint16_t address, std::size_t write_bytes,
+                  const messages::MaxMessageBuffer& buf) -> bool {
+        return queue->try_write(messages::Transact{
             .transaction = {.address = address,
                             .bytes_to_read = 0,
                             .bytes_to_write = std::min(write_bytes, buf.size()),

--- a/include/spi/core/writer.hpp
+++ b/include/spi/core/writer.hpp
@@ -62,8 +62,7 @@ class Writer {
         queue->try_write(message);
 
         message.id.requires_response = true;
-        queue->try_write(message);
-        return true;
+        return queue->try_write(message);
     }
 
     /**
@@ -90,8 +89,7 @@ class Writer {
             .id = _transaction_id,
             .transaction = {.txBuffer = txBuffer, .cs_interface = cs_intf},
             .response_writer = ResponseWriter(response_queue)};
-        queue->try_write(message);
-        return true;
+        return queue->try_write(message);
     }
 
   private:


### PR DESCRIPTION
for clients keeping track of transactions, it's nice to know whether the transaction made it to the i2c queue.