### PR TITLE
chore(i2c): add i2c::transaction::IdMap

### DIFF
--- a/i2c/tests/CMakeLists.txt
+++ b/i2c/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
         test_i2c_poller.cpp
         test_i2c_task.cpp
         test_i2c_poll_impl.cpp
+        test_transaction.cpp
 )
 
 target_include_directories(i2c PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/i2c/tests/test_transaction.cpp
+++ b/i2c/tests/test_transaction.cpp
@@ -1,72 +1,59 @@
 #include "catch2/catch.hpp"
 #include "i2c/core/transaction.hpp"
 
-
 SCENARIO("id map") {
     GIVEN("an IdMap object with capacity of 1") {
         auto subject = i2c::transaction::IdMap<int, 1>{};
 
         WHEN("adding an entry") {
             auto id = subject.add(2);
-            THEN("an id is returned") {
-                REQUIRE(id);
-            }
+            THEN("an id is returned") { REQUIRE(id); }
         }
 
         WHEN("adding too many entries") {
             auto id1 = subject.add(2);
             auto id2 = subject.add(2);
-            THEN("first id is good") {
-                REQUIRE(id1);
-            }
-            THEN("second id is not set") {
-                REQUIRE(!id2);
-            }
+            THEN("first id is good") { REQUIRE(id1); }
+            THEN("second id is not set") { REQUIRE(!id2); }
         }
 
         WHEN("adding then clearing an entry") {
             auto id = subject.add(52);
             auto value = subject.remove(id.value());
             THEN("the value is returned by clear") {
-                REQUIRE(value.value()==52);
+                REQUIRE(value.value() == 52);
             }
         }
 
         WHEN("remove a non existent id") {
             auto value = subject.remove(0);
-            THEN("the return is not set") {
-                REQUIRE(!value);
-            }
+            THEN("the return is not set") { REQUIRE(!value); }
         }
 
         WHEN("removing out of range") {
             auto value = subject.remove(10020);
-            THEN("the return is not set") {
-                REQUIRE(!value);
-            }
+            THEN("the return is not set") { REQUIRE(!value); }
         }
     }
 
     GIVEN("an IdMap object") {
         auto subject = i2c::transaction::IdMap<int, 5>{};
 
-        THEN("the count is 0") {
-            REQUIRE(subject.count()==0);
-        }
+        THEN("the count is 0") { REQUIRE(subject.count() == 0); }
 
         WHEN("adding two entries") {
             auto id1 = subject.add(2);
             auto id2 = subject.add(2);
 
-            THEN("the count is 2") { REQUIRE(subject.count()==2); }
+            THEN("the count is 2") { REQUIRE(subject.count() == 2); }
             WHEN("removing one") {
                 subject.remove(id2.value());
-                THEN("the count is 1") { REQUIRE(subject.count()==1); }
+                THEN("the count is 1") { REQUIRE(subject.count() == 1); }
             }
             WHEN("removing another both") {
                 subject.remove(id2.value());
                 subject.remove(id1.value());
-                THEN("the count is 0") { REQUIRE(subject.count()==0); }
+                THEN("the count is 0") { REQUIRE(subject.count() == 0); }
             }
         }
     }

--- a/i2c/tests/test_transaction.cpp
+++ b/i2c/tests/test_transaction.cpp
@@ -1,0 +1,73 @@
+#include "catch2/catch.hpp"
+#include "i2c/core/transaction.hpp"
+
+
+SCENARIO("id map") {
+    GIVEN("an IdMap object with capacity of 1") {
+        auto subject = i2c::transaction::IdMap<int, 1>{};
+
+        WHEN("adding an entry") {
+            auto id = subject.add(2);
+            THEN("an id is returned") {
+                REQUIRE(id);
+            }
+        }
+
+        WHEN("adding too many entries") {
+            auto id1 = subject.add(2);
+            auto id2 = subject.add(2);
+            THEN("first id is good") {
+                REQUIRE(id1);
+            }
+            THEN("second id is not set") {
+                REQUIRE(!id2);
+            }
+        }
+
+        WHEN("adding then clearing an entry") {
+            auto id = subject.add(52);
+            auto value = subject.remove(id.value());
+            THEN("the value is returned by clear") {
+                REQUIRE(value.value()==52);
+            }
+        }
+
+        WHEN("remove a non existent id") {
+            auto value = subject.remove(0);
+            THEN("the return is not set") {
+                REQUIRE(!value);
+            }
+        }
+
+        WHEN("removing out of range") {
+            auto value = subject.remove(10020);
+            THEN("the return is not set") {
+                REQUIRE(!value);
+            }
+        }
+    }
+
+    GIVEN("an IdMap object") {
+        auto subject = i2c::transaction::IdMap<int, 5>{};
+
+        THEN("the count is 0") {
+            REQUIRE(subject.count()==0);
+        }
+
+        WHEN("adding two entries") {
+            auto id1 = subject.add(2);
+            auto id2 = subject.add(2);
+
+            THEN("the count is 2") { REQUIRE(subject.count()==2); }
+            WHEN("removing one") {
+                subject.remove(id2.value());
+                THEN("the count is 1") { REQUIRE(subject.count()==1); }
+            }
+            WHEN("removing another both") {
+                subject.remove(id2.value());
+                subject.remove(id1.value());
+                THEN("the count is 0") { REQUIRE(subject.count()==0); }
+            }
+        }
+    }
+}

--- a/include/i2c/core/transaction.hpp
+++ b/include/i2c/core/transaction.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <array>
+#include <optional>
+#include <variant>
+
+namespace i2c {
+namespace transaction {
+
+/**
+ * A class that maps i2c transaction ids to arbitrary objects. This class is not
+ * reentrant.
+ *
+ * @tparam Entry The type mapped to a transaction id
+ * @tparam MAX_SIZE The maximum number of entries in the collection
+ */
+template <typename Entry, std::size_t MAX_SIZE>
+class IdMap {
+  public:
+    /**
+     * Add an entry to the collection
+     * @param t Entry
+     * @return returns an optional containing the id on success. No id if
+     * collection is full.
+     */
+    auto add(const Entry& t) -> std::optional<uint32_t> {
+        auto iter = std::find_if(
+            transactions.begin(), transactions.end(),
+            [](auto& i) { return std::holds_alternative<std::monostate>(i); });
+        if (iter != std::end(transactions)) {
+            *iter = t;
+            return iter - transactions.begin();
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Remove mapping from the collection.
+     * @param id the id returned from add
+     * @return The existing entry if it exists
+     */
+    auto remove(uint32_t id) -> std::optional<Entry> {
+        if (static_cast<std::size_t>(id) < transactions.size()) {
+            auto i = transactions[id];
+            if (std::holds_alternative<Entry>(i)) {
+                auto transaction = std::get<Entry>(i);
+                transactions[id] = std::monostate{};
+                return transaction;
+            }
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Get the number of mappings.
+     * @return the count.
+     */
+    auto count() -> int {
+        return std::count_if(
+            transactions.begin(), transactions.end(),
+            [](auto& i) { return !std::holds_alternative<std::monostate>(i); });
+    }
+
+  private:
+    using Transaction = std::variant<std::monostate, Entry>;
+    using Transactions = std::array<Transaction, MAX_SIZE>;
+    Transactions transactions{};
+};
+
+}  // namespace transaction
+}  // namespace i2c


### PR DESCRIPTION
A class that makes maps transaction id to some arbitrary data.

Will be useful for correlating transaction responses in Eeprom task and perhaps others. 

i2c writer transactions contain a `token` field. This is a `uint32_t` that is meant to connect the `TransactionResponse` to the sent `Transaction`. Some users of the i2c write may want to store some arbitrary data about a transaction when it's sent and use it when processing the response.

For example, the Eeprom task will store the eeprom memory address read from and some pointers for returning responses to the reader. This data will be associated with the `token` sent in the Transaction and  looked up when the TransactionResponse message arrives.

Not used anywhere but tests, yet.
