### PR TITLE
feat(can): blink leds when there is a canbus error

### DIFF
--- a/can/firmware/hal_can_bus.cpp
+++ b/can/firmware/hal_can_bus.cpp
@@ -1,6 +1,43 @@
 #include "can/firmware/hal_can_bus.hpp"
 
+#include "common/firmware/gpio.hpp"
+
 using namespace hal_can_bus;
+
+void HalCanBus::hal_state_callback(void* data, hal_can_state_t state) {
+    if (data == nullptr) {
+        return;
+    }
+    auto* slf = static_cast<HalCanBus*>(data);
+
+    if (slf->indicator.port == nullptr) {
+        return;
+    }
+    switch (state) {
+        case HAL_CAN_STATE_ERROR_PASSIVE:
+            slf->indicator_timer.update_period_from_isr(
+                BLINK_HALF_PERIOD_ERROR_PASSIVE_MS);
+            break;
+        case HAL_CAN_STATE_ERROR_ACTIVE:
+            slf->indicator_timer.update_period_from_isr(
+                BLINK_HALF_PERIOD_ERROR_ACTIVE_MS);
+            break;
+        case HAL_CAN_STATE_BUS_OFF:
+            slf->indicator_timer.stop_from_isr();
+            gpio::reset(slf->indicator);
+            break;
+    }
+}
+
+void HalCanBus::handle_timer() {
+    if (indicator.port != nullptr) {
+        if (gpio::is_set(indicator)) {
+            gpio::reset(indicator);
+        } else {
+            gpio::set(indicator);
+        }
+    }
+}
 
 void HalCanBus::set_incoming_message_callback(
     void* cb_data, IncomingMessageCallback callback) {

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -54,11 +54,7 @@ struct motion_controller::HardwareConfig motor_pins {
             .port = GPIOC,
             .pin = GPIO_PIN_7,
             .active_setting = GPIO_PIN_SET},
-    .led = {
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-        .port = GPIOC,
-        .pin = GPIO_PIN_6,
-        .active_setting = GPIO_PIN_RESET},
+    .led = {},
 };
 
 /**

--- a/include/can/core/bit_timings.hpp
+++ b/include/can/core/bit_timings.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <concepts>
 #include <cstdint>
+#include <type_traits>
 
 namespace can {
 namespace bit_timings {
@@ -149,6 +151,16 @@ struct BitTimings {
     // time quanta.
     static constexpr uint8_t max_sync_jump_width = sync_jump_width;
 };
+
+template <typename BT>
+concept BitTimingSpec =
+    std::is_same_v<std::remove_cvref_t<decltype(BT::clock_divider)>, uint8_t> &&
+    std::is_same_v<std::remove_cvref_t<decltype(BT::segment_1_quanta)>,
+                   uint8_t> &&
+    std::is_same_v<std::remove_cvref_t<decltype(BT::segment_2_quanta)>,
+                   uint8_t> &&
+    std::is_same_v<std::remove_cvref_t<decltype(BT::max_sync_jump_width)>,
+                   uint8_t>;
 
 };  // namespace bit_timings
 };  // namespace can

--- a/include/can/firmware/hal_can.h
+++ b/include/can/firmware/hal_can.h
@@ -7,6 +7,19 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * Canbus protocol states
+ */
+typedef enum {
+  HAL_CAN_STATE_ERROR_ACTIVE,
+  HAL_CAN_STATE_ERROR_PASSIVE,
+  HAL_CAN_STATE_BUS_OFF
+} hal_can_state_t;
+
+/**
+ * State indication callback
+ */
+typedef void(*can_state_callback)(void* cb_data, hal_can_state_t new_state);
+/**
  * Receive message callback.
  */
 typedef void(*can_message_callback)(void* cb_data, uint32_t identifier, uint8_t* data, uint8_t length);
@@ -67,6 +80,16 @@ void can_send_message(HAL_CAN_HANDLE handle, uint32_t arbitration_id, uint8_t* b
  */
 void can_add_filter(HAL_CAN_HANDLE handle, uint32_t index, CanFilterType type, CanFilterConfig config,
                     uint32_t val1, uint32_t val2);
+
+/**
+ * Register a callback function to handle a change in the CAN hardware state.
+ *
+ * This is called from an ISR
+ *
+ * @param cb_data a value that will be passed to the callback function.
+ * @param callback a callback function.
+ */
+void can_register_state_callback(void * cb_data, can_state_callback callback);
 
 
 

--- a/include/can/firmware/hal_can_bus.hpp
+++ b/include/can/firmware/hal_can_bus.hpp
@@ -35,7 +35,6 @@ class HalCanBus : public CanBus {
     template <can::bit_timings::BitTimingSpec TimingsT>
     void start(TimingsT timings) {
         if (indicator.port != nullptr) {
-            indicator_timer.update_period(BLINK_HALF_PERIOD_ERROR_ACTIVE_MS);
             indicator_timer.start();
         }
         can_start(timings.clock_divider, timings.segment_1_quanta,


### PR DESCRIPTION
By adding interrupt handling that queries the protocol status of the FDCAN peripheral and adding LEDs to the firmware c++ hal can bus, we can add (or, well, steal from the motors) LEDs that blink when the canbus changes state. For now,
- Slow blink (~2Hz) when the bus is in ERROR_ACTIVE, which it should be all the time
- Fast blink (~10Hz) when the bus is in ERROR_PASSIVE, when it's gotten a lot of errors but can still transmit
- On solid when the bus is off because it saw too many errors.

We can merge this whenever (doesn't have to wait for the canbus timings to get merged) but we'll need to rebase on main first.