### PR TITLE
fix(eeprom): eeprom debugging

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -202,7 +202,7 @@ SCENARIO("message serializing works") {
         }
 
         WHEN("serialized into too large a buffer") {
-            auto arr = std::array<uint8_t, 10>{};
+            auto arr = std::array<uint8_t, ReadFromEEPromResponse::SIZE + 5>{};
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is written into the buffer.") {
                 REQUIRE(arr[0] == 13);
@@ -216,7 +216,9 @@ SCENARIO("message serializing works") {
                 REQUIRE(arr[8] == 0x0);
                 REQUIRE(arr[9] == 0x0);
             }
-            THEN("size is correct") { REQUIRE(size == 10); }
+            THEN("size is correct") {
+                REQUIRE(size == ReadFromEEPromResponse::SIZE);
+            }
         }
     }
 }

--- a/gripper/firmware/i2c_setup.c
+++ b/gripper/firmware/i2c_setup.c
@@ -69,7 +69,7 @@ void eeprom_write_protect_init(void) {
     /*Configure GPIO pin : C12 */
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     GPIO_InitStruct.Pin = EEPROM_GPIO_PIN;
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     HAL_GPIO_Init(EEPROM_GPIO_BANK, &GPIO_InitStruct);
 }
@@ -79,14 +79,14 @@ void eeprom_write_protect_init(void) {
  * @brief enable writing to the eeprom.
  */
 void enable_eeprom_write() {
-    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_RESET);
 }
 
 /**
  * @brief disable writing to the eeprom.
  */
 void disable_eeprom_write() {
-    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_SET);
 }
 
 

--- a/gripper/firmware/main.cpp
+++ b/gripper/firmware/main.cpp
@@ -75,6 +75,9 @@ auto main() -> int {
     i2c_setup(&i2c_handles);
     i2c_comms3.set_handle(i2c_handles.i2c3);
 
+    // write protect the eeprom.
+    disable_eeprom_write();
+
     can_start(can_bit_timings.clock_divider, can_bit_timings.segment_1_quanta,
               can_bit_timings.segment_2_quanta,
               can_bit_timings.max_sync_jump_width);

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -175,6 +175,8 @@ struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
     eeprom::types::address address;
     eeprom::types::data_length data_length;
     eeprom::types::EepromData data;
+    static constexpr uint8_t SIZE =
+        sizeof(address) + sizeof(data_length) + eeprom::types::max_data_length;
 
     /**
      * Create a response message from iterator
@@ -205,7 +207,10 @@ struct ReadFromEEPromResponse : BaseMessage<MessageId::read_eeprom_response> {
             std::min(data_length,
                      static_cast<eeprom::types::data_length>(limit - iter)),
             iter);
-        return limit - body;
+
+        // The size is the fixed size of the message or the supplied buffer
+        // size. Whichever is smaller.
+        return std::min(static_cast<uint8_t>(limit - body), SIZE);
     }
     auto operator==(const ReadFromEEPromResponse& other) const
         -> bool = default;

--- a/include/i2c/firmware/i2c.h
+++ b/include/i2c/firmware/i2c.h
@@ -24,9 +24,16 @@ bool hal_i2c_master_receive(HAL_I2C_HANDLE handle, uint16_t dev_address, uint8_t
 HAL_I2C_HANDLE MX_I2C1_Init();
 HAL_I2C_HANDLE MX_I2C3_Init();
 int data_ready();
-void enable_eeprom();
-void disable_eeprom();
 
+/**
+ * enable writing to the eeprom.
+ */
+void enable_eeprom_write();
+
+/**
+ * disable writing to the eeprom.
+ */
+void disable_eeprom_write();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/pipettes/firmware/i2c_setup.c
+++ b/pipettes/firmware/i2c_setup.c
@@ -14,7 +14,7 @@ static I2C_HandleTypeDef hi2c3;
 void eeprom_write_gpio_init() {
     PipetteType pipette_type = get_pipette_type();
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     if (pipette_type == NINETY_SIX_CHANNEL) {
         __HAL_RCC_GPIOA_CLK_ENABLE();
@@ -138,12 +138,26 @@ int data_ready() {
     return HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_9) == GPIO_PIN_SET;
 }
 
-void enable_eeprom() {
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_SET);
+/**
+ * @brief enable writing to the eeprom.
+ */
+void enable_eeprom_write() {
+    if (get_pipette_type() == NINETY_SIX_CHANNEL) {
+        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_RESET);
+    } else {
+        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_RESET);
+    }
 }
 
-void disable_eeprom() {
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_RESET);
+/**
+ * @brief disable writing to the eeprom.
+ */
+void disable_eeprom_write() {
+    if (get_pipette_type() == NINETY_SIX_CHANNEL) {
+        HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_SET);
+    } else {
+        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_SET);
+    }
 }
 
 void i2c_setup(I2CHandlerStruct* temp_struct) {

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -60,9 +60,9 @@ class EEPromHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
   public:
     void set_write_protect(bool enable) final {
         if (enable) {
-            disable_eeprom();
+            disable_eeprom_write();
         } else {
-            enable_eeprom();
+            enable_eeprom_write();
         }
     }
 };
@@ -167,6 +167,9 @@ auto main() -> int {
     i2c_setup(&i2chandler_struct);
     i2c_comms3.set_handle(i2chandler_struct.i2c3);
     i2c_comms1.set_handle(i2chandler_struct.i2c1);
+
+    // Write protect the eeprom
+    disable_eeprom_write();
 
     if (initialize_spi() != HAL_OK) {
         Error_Handler();


### PR DESCRIPTION
Results from debugging eeprom on pipette and gripper.

- pin settings weren't right
- write protect is active high
- read response was needlessly large