### PR TITLE
fix(gripper): fix motor interrupt handler & switch dir pins

### DIFF
--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -17,12 +17,12 @@ struct motor_hardware::BrushedHardwareConfig brushed_motor_pins {
     .pwm_1 =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .tim = &htim1,
+            .tim = &htim3,
             .channel = TIM_CHANNEL_1},
     .pwm_2 =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .tim = &htim3,
+            .tim = &htim1,
             .channel = TIM_CHANNEL_1},
     .enable =
         {  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -6,20 +6,20 @@
 using namespace motor_hardware;
 
 void BrushedMotorHardware::positive_direction() {
-    motor_hardware_start_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
-    motor_hardware_stop_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
-}
-
-void BrushedMotorHardware::negative_direction() {
     motor_hardware_stop_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
     motor_hardware_start_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
 }
 
+void BrushedMotorHardware::negative_direction() {
+    motor_hardware_start_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
+    motor_hardware_stop_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
+}
+
 void BrushedMotorHardware::start_timer_interrupt() {
-    motor_hardware_start_timer(pins.pwm_1.tim);  // start base timer
+    motor_hardware_start_timer(pins.pwm_2.tim);  // start base timer
 }
 void BrushedMotorHardware::stop_timer_interrupt() {
-    motor_hardware_stop_timer(pins.pwm_1.tim);  // stop base timer
+    motor_hardware_stop_timer(pins.pwm_2.tim);  // stop base timer
 }
 
 void BrushedMotorHardware::activate_motor() { gpio::set(pins.enable); }


### PR DESCRIPTION
The pins for the brushed motor direction were incorrect. This PR also fixes the logic in the motor interrupt handler so it actually behaves correctly (only monitor the limit switch when the axis is homing).