### PR TITLE
fix(gripper): direction & v ref calculations

### DIFF
--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -47,7 +47,7 @@ class MotorDriverMessageHandler {
     }
 
     void handle(const can_messages::SetBrushedMotorVrefRequest& m) {
-        auto val = fixed_point_to_float(m.v_ref, 15);
+        auto val = fixed_point_to_float(m.v_ref, 16);
         LOG("Received set motor reference voltage request,  vref=%f", val);
         driver.set_reference_voltage(val);
     }

--- a/motor-control/firmware/brushed_motor/brushed_motor_driver_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_driver_hardware.cpp
@@ -10,6 +10,7 @@ bool BrushedMotorDriver::stop_digital_analog_converter() {
     return motor_hardware_stop_dac(dac.dac_handle, dac.channel);
 }
 bool BrushedMotorDriver::set_reference_voltage(float val) {
+    conf.vref = val;
     auto vref_val =
         static_cast<uint32_t>(val * DAC_DATA_MULTIPLIER / VOLTAGE_REFERENCE);
     return motor_hardware_set_dac_value(dac.dac_handle, dac.channel,

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -6,13 +6,13 @@
 using namespace motor_hardware;
 
 void BrushedMotorHardware::positive_direction() {
-    motor_hardware_stop_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
-    motor_hardware_start_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
+    motor_hardware_stop_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
+    motor_hardware_start_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
 }
 
 void BrushedMotorHardware::negative_direction() {
-    motor_hardware_start_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
-    motor_hardware_stop_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
+    motor_hardware_start_pwm(pins.pwm_2.tim, pins.pwm_2.channel);
+    motor_hardware_stop_pwm(pins.pwm_1.tim, pins.pwm_1.channel);
 }
 
 void BrushedMotorHardware::start_timer_interrupt() {


### PR DESCRIPTION
Some small fixes to enable the gripper motor to grip correctly on the OT3: I was wrong about the directions and used the wrong fixed point index for calculating the brushed motor VREF.