### PR TITLE
feat(gripper,pipettes): read serial number from eeprom

### DIFF
--- a/eeprom/tests/CMakeLists.txt
+++ b/eeprom/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
         test_message_handler.cpp
         test_eeprom_task.cpp
         test_hardware_iface.cpp
+        test_serial_number.cpp
 )
 
 target_include_directories(eeprom PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -1,6 +1,5 @@
 #include "catch2/catch.hpp"
 #include "eeprom/core/serial_number.hpp"
-//#include "eeprom/core/addresses.hpp"
 #include <vector>
 
 
@@ -14,7 +13,7 @@ struct MockEEPromTaskClient {
 };
 
 
-struct MockListener {
+struct MockListener: serial_number::ReadListener {
     void on_read(const serial_number::SerialNumberType& sn) {this->sn = sn; call_count++;}
     serial_number::SerialNumberType sn{};
     int call_count{0};

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -77,19 +77,16 @@ SCENARIO("Reading serial number") {
         WHEN("the read completes") {
             auto sn = serial_number::SerialNumberType{8, 7, 6, 5, 4, 3, 2, 1};
 
-            for (auto m = queue_client.messages.cbegin();
-                 m < queue_client.messages.cend(); m++) {
-                auto read_message = std::get<message::ReadEepromMessage>(*m);
-                auto data = types::EepromData{};
-                std::copy_n(sn.cbegin() + read_message.memory_address,
-                            read_message.length, data.begin());
+            auto read_message = std::get<message::ReadEepromMessage>(queue_client.messages[0]);
+            auto data = types::EepromData{};
+            std::copy_n(sn.cbegin() + read_message.memory_address,
+                        read_message.length, data.begin());
 
-                read_message.callback(
-                    {.memory_address = read_message.memory_address,
-                     .length = read_message.length,
-                     .data = data},
-                    read_message.callback_param);
-            }
+            read_message.callback(
+                {.memory_address = read_message.memory_address,
+                 .length = read_message.length,
+                 .data = data},
+                read_message.callback_param);
 
             THEN("then the listener is called once") {
                 REQUIRE(read_listener.call_count == 1);

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -14,18 +14,21 @@ struct MockEEPromTaskClient {
 
 
 struct MockListener {
-    void on_read(const serial_number::SerialNumberType&) {}
+    void on_read(const serial_number::SerialNumberType& sn) {this->sn = sn; call_count++;}
+    serial_number::SerialNumberType sn{};
+    int call_count{0};
 };
 
 
 SCENARIO("Writing serial number") {
-    auto queue_client =MockEEPromTaskClient{};
+    auto queue_client = MockEEPromTaskClient{};
     auto read_listener = MockListener{};
     auto subject =
         serial_number::SerialNumberAccessor{queue_client, read_listener};
 
     GIVEN("A serial number to write") {
-        auto data = serial_number::SerialNumberType{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+        auto data = serial_number::SerialNumberType{1, 2, 3, 4,  5,  6,
+                                                    7, 8, 9, 10, 11, 12};
 
         WHEN("the writing serial number") {
             subject.write(data);
@@ -33,18 +36,29 @@ SCENARIO("Writing serial number") {
             THEN("there are two eeprom writes") {
                 REQUIRE(queue_client.messages.size() == 2);
 
-                auto write_message = std::get<message::WriteEepromMessage>(queue_client.messages[0]);
-                REQUIRE(write_message.memory_address==0);
-                REQUIRE(write_message.length==8);
-                REQUIRE(write_message.data==types::EepromData{1, 2, 3, 4, 5, 6, 7, 8});
+                auto write_message = std::get<message::WriteEepromMessage>(
+                    queue_client.messages[0]);
+                REQUIRE(write_message.memory_address == 0);
+                REQUIRE(write_message.length == 8);
+                REQUIRE(write_message.data ==
+                        types::EepromData{1, 2, 3, 4, 5, 6, 7, 8});
 
-                write_message = std::get<message::WriteEepromMessage>(queue_client.messages[1]);
-                REQUIRE(write_message.memory_address==8);
-                REQUIRE(write_message.length==4);
-                REQUIRE(write_message.data==types::EepromData{9, 10, 11, 12});
+                write_message = std::get<message::WriteEepromMessage>(
+                    queue_client.messages[1]);
+                REQUIRE(write_message.memory_address == 8);
+                REQUIRE(write_message.length == 4);
+                REQUIRE(write_message.data == types::EepromData{9, 10, 11, 12});
             }
         }
     }
+}
+
+
+SCENARIO("Reading serial number") {
+    auto queue_client =MockEEPromTaskClient{};
+    auto read_listener = MockListener{};
+    auto subject =
+        serial_number::SerialNumberAccessor{queue_client, read_listener};
 
     GIVEN("A request to read the serial number") {
         WHEN("reading the serial number") {
@@ -53,17 +67,40 @@ SCENARIO("Writing serial number") {
             THEN("there are two eeprom reads") {
                 REQUIRE(queue_client.messages.size() == 2);
 
-                auto write_message = std::get<message::ReadEepromMessage>(queue_client.messages[0]);
-                REQUIRE(write_message.memory_address==0);
-                REQUIRE(write_message.length==8);
-                REQUIRE(write_message.callback_param == &subject);
+                auto read_message = std::get<message::ReadEepromMessage>(queue_client.messages[0]);
+                REQUIRE(read_message.memory_address==0);
+                REQUIRE(read_message.length==8);
+                REQUIRE(read_message.callback_param == &subject);
 
-                write_message = std::get<message::ReadEepromMessage>(queue_client.messages[1]);
-                REQUIRE(write_message.memory_address==8);
-                REQUIRE(write_message.length==4);
-                REQUIRE(write_message.callback_param == &subject);
+                read_message = std::get<message::ReadEepromMessage>(queue_client.messages[1]);
+                REQUIRE(read_message.memory_address==8);
+                REQUIRE(read_message.length==4);
+                REQUIRE(read_message.callback_param == &subject);
             }
         }
     }
 
+    GIVEN("A request to read the serial number") {
+        subject.start_read();
+
+        WHEN("the read completes") {
+            auto sn = serial_number::SerialNumberType{12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+
+            for (auto m = queue_client.messages.cbegin(); m < queue_client.messages.cend(); m++) {
+                auto read_message = std::get<message::ReadEepromMessage>(*m);
+                auto data = types::EepromData{};
+                std::copy_n(sn.cbegin() + read_message.memory_address, read_message.length, data.begin());
+
+                read_message.callback({
+                    .memory_address=read_message.memory_address,
+                        .length=read_message.length,
+                    .data=data}, read_message.callback_param);
+            }
+
+            THEN("then the listener is called once") {
+                REQUIRE(read_listener.call_count == 1);
+                REQUIRE(read_listener.sn == sn);
+            }
+        }
+    }
 }

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -1,0 +1,42 @@
+#include "catch2/catch.hpp"
+#include "eeprom/core/serial_number.hpp"
+#include <vector>
+
+
+using namespace eeprom;
+
+struct MockEEPromTaskClient {
+    void send_eeprom_queue(const task::TaskMessage& m) {
+        messages.push_back(m);
+    }
+    std::vector<task::TaskMessage> messages{};
+};
+
+
+SCENARIO("Writing serial number") {
+    auto queue_client =MockEEPromTaskClient{};
+    auto subject =
+        serial_number::SerialNumberAccessor{queue_client};
+
+    GIVEN("A serial number to write") {
+        auto data = serial_number::SerialNumberType{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+        WHEN("the writing serial number") {
+            subject.write(data);
+
+            THEN("there are two eeprom writes") {
+                REQUIRE(queue_client.messages.size() == 2);
+
+                auto write_message = std::get<message::WriteEepromMessage>(queue_client.messages[0]);
+                REQUIRE(write_message.memory_address==0);
+                REQUIRE(write_message.length==8);
+                REQUIRE(write_message.data==types::EepromData{1, 2, 3, 4, 5, 6, 7, 8});
+
+                write_message = std::get<message::WriteEepromMessage>(queue_client.messages[1]);
+                REQUIRE(write_message.memory_address==8);
+                REQUIRE(write_message.length==4);
+                REQUIRE(write_message.data==types::EepromData{9, 10, 11, 12});
+            }
+        }
+    }
+}

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -39,4 +39,25 @@ SCENARIO("Writing serial number") {
             }
         }
     }
+
+    GIVEN("A request to read the serial number") {
+        WHEN("reading the serial number") {
+            subject.start_read();
+
+            THEN("there are two eeprom reads") {
+                REQUIRE(queue_client.messages.size() == 2);
+
+                auto write_message = std::get<message::ReadEepromMessage>(queue_client.messages[0]);
+                REQUIRE(write_message.memory_address==0);
+                REQUIRE(write_message.length==8);
+                REQUIRE(write_message.callback_param == &subject);
+
+                write_message = std::get<message::ReadEepromMessage>(queue_client.messages[1]);
+                REQUIRE(write_message.memory_address==8);
+                REQUIRE(write_message.length==4);
+                REQUIRE(write_message.callback_param == &subject);
+            }
+        }
+    }
+
 }

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -13,10 +13,16 @@ struct MockEEPromTaskClient {
 };
 
 
+struct MockListener {
+    void on_read(const serial_number::SerialNumberType&) {}
+};
+
+
 SCENARIO("Writing serial number") {
     auto queue_client =MockEEPromTaskClient{};
+    auto read_listener = MockListener{};
     auto subject =
-        serial_number::SerialNumberAccessor{queue_client};
+        serial_number::SerialNumberAccessor{queue_client, read_listener};
 
     GIVEN("A serial number to write") {
         auto data = serial_number::SerialNumberType{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -77,7 +77,8 @@ SCENARIO("Reading serial number") {
         WHEN("the read completes") {
             auto sn = serial_number::SerialNumberType{8, 7, 6, 5, 4, 3, 2, 1};
 
-            auto read_message = std::get<message::ReadEepromMessage>(queue_client.messages[0]);
+            auto read_message =
+                std::get<message::ReadEepromMessage>(queue_client.messages[0]);
             auto data = types::EepromData{};
             std::copy_n(sn.cbegin() + read_message.memory_address,
                         read_message.length, data.begin());

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -39,7 +39,7 @@ SCENARIO("Writing serial number") {
                 auto write_message = std::get<message::WriteEepromMessage>(
                     queue_client.messages[0]);
                 REQUIRE(write_message.memory_address == addresses::serial_number_address_begin);
-                REQUIRE(write_message.length == data.size());
+                REQUIRE(write_message.length == types::max_data_length);
                 REQUIRE(write_message.data ==
                         types::EepromData{1, 2, 3, 4, 5, 6, 7, 8});
             }
@@ -63,7 +63,7 @@ SCENARIO("Reading serial number") {
 
                 auto read_message = std::get<message::ReadEepromMessage>(queue_client.messages[0]);
                 REQUIRE(read_message.memory_address==addresses::serial_number_address_begin);
-                REQUIRE(read_message.length==addresses::serial_number_length);
+                REQUIRE(read_message.length==types::max_data_length);
                 REQUIRE(read_message.callback_param == &subject);
             }
         }

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -1,7 +1,7 @@
-#include "catch2/catch.hpp"
-#include "eeprom/core/serial_number.hpp"
 #include <vector>
 
+#include "catch2/catch.hpp"
+#include "eeprom/core/serial_number.hpp"
 
 using namespace eeprom;
 
@@ -12,13 +12,14 @@ struct MockEEPromTaskClient {
     std::vector<task::TaskMessage> messages{};
 };
 
-
-struct MockListener: serial_number::ReadListener {
-    void on_read(const serial_number::SerialNumberType& sn) {this->sn = sn; call_count++;}
+struct MockListener : serial_number::ReadListener {
+    void on_read(const serial_number::SerialNumberType& sn) {
+        this->sn = sn;
+        call_count++;
+    }
     serial_number::SerialNumberType sn{};
     int call_count{0};
 };
-
 
 SCENARIO("Writing serial number") {
     auto queue_client = MockEEPromTaskClient{};
@@ -27,8 +28,7 @@ SCENARIO("Writing serial number") {
         serial_number::SerialNumberAccessor{queue_client, read_listener};
 
     GIVEN("A serial number to write") {
-        auto data = serial_number::SerialNumberType{1, 2, 3, 4,  5,  6,
-                                                    7, 8};
+        auto data = serial_number::SerialNumberType{1, 2, 3, 4, 5, 6, 7, 8};
 
         WHEN("the writing serial number") {
             subject.write(data);
@@ -38,7 +38,8 @@ SCENARIO("Writing serial number") {
 
                 auto write_message = std::get<message::WriteEepromMessage>(
                     queue_client.messages[0]);
-                REQUIRE(write_message.memory_address == addresses::serial_number_address_begin);
+                REQUIRE(write_message.memory_address ==
+                        addresses::serial_number_address_begin);
                 REQUIRE(write_message.length == types::max_data_length);
                 REQUIRE(write_message.data ==
                         types::EepromData{1, 2, 3, 4, 5, 6, 7, 8});
@@ -47,9 +48,8 @@ SCENARIO("Writing serial number") {
     }
 }
 
-
 SCENARIO("Reading serial number") {
-    auto queue_client =MockEEPromTaskClient{};
+    auto queue_client = MockEEPromTaskClient{};
     auto read_listener = MockListener{};
     auto subject =
         serial_number::SerialNumberAccessor{queue_client, read_listener};
@@ -61,9 +61,11 @@ SCENARIO("Reading serial number") {
             THEN("there is an eeprom read") {
                 REQUIRE(queue_client.messages.size() == 1);
 
-                auto read_message = std::get<message::ReadEepromMessage>(queue_client.messages[0]);
-                REQUIRE(read_message.memory_address==addresses::serial_number_address_begin);
-                REQUIRE(read_message.length==types::max_data_length);
+                auto read_message = std::get<message::ReadEepromMessage>(
+                    queue_client.messages[0]);
+                REQUIRE(read_message.memory_address ==
+                        addresses::serial_number_address_begin);
+                REQUIRE(read_message.length == types::max_data_length);
                 REQUIRE(read_message.callback_param == &subject);
             }
         }
@@ -75,15 +77,18 @@ SCENARIO("Reading serial number") {
         WHEN("the read completes") {
             auto sn = serial_number::SerialNumberType{8, 7, 6, 5, 4, 3, 2, 1};
 
-            for (auto m = queue_client.messages.cbegin(); m < queue_client.messages.cend(); m++) {
+            for (auto m = queue_client.messages.cbegin();
+                 m < queue_client.messages.cend(); m++) {
                 auto read_message = std::get<message::ReadEepromMessage>(*m);
                 auto data = types::EepromData{};
-                std::copy_n(sn.cbegin() + read_message.memory_address, read_message.length, data.begin());
+                std::copy_n(sn.cbegin() + read_message.memory_address,
+                            read_message.length, data.begin());
 
-                read_message.callback({
-                    .memory_address=read_message.memory_address,
-                        .length=read_message.length,
-                    .data=data}, read_message.callback_param);
+                read_message.callback(
+                    {.memory_address = read_message.memory_address,
+                     .length = read_message.length,
+                     .data = data},
+                    read_message.callback_param);
             }
 
             THEN("then the listener is called once") {

--- a/gripper/core/can_tasks.cpp
+++ b/gripper/core/can_tasks.cpp
@@ -25,7 +25,7 @@ static auto can_brushed_motion_handler =
 static auto can_brushed_move_group_handler =
     move_group_handler::BrushedMoveGroupHandler{g_queues};
 static auto gripper_info_handler =
-    gripper_info::GripperInfoMessageHandler{main_queues};
+    gripper_info::GripperInfoMessageHandler{main_queues, main_queues};
 
 /** Handler of system messages. */
 static auto system_message_handler = system_handler::SystemMessageHandler{

--- a/gripper/core/can_tasks.cpp
+++ b/gripper/core/can_tasks.cpp
@@ -1,21 +1,7 @@
 #include <span>
 
-#include "can/core/can_bus.hpp"
-#include "can/core/can_writer_task.hpp"
-#include "can/core/dispatch.hpp"
-#include "can/core/freertos_can_dispatch.hpp"
-#include "can/core/message_handlers/motion.hpp"
-#include "can/core/message_handlers/motor.hpp"
-#include "can/core/message_handlers/move_group.hpp"
-#include "can/core/message_handlers/system.hpp"
-#include "common/core/freertos_task.hpp"
-#include "common/core/logging.h"
-#include "common/core/version.h"
 #include "eeprom/core/message_handler.hpp"
 #include "gripper/core/can_task.hpp"
-#include "gripper/core/gripper_info.hpp"
-#include "gripper/core/interfaces.hpp"
-#include "gripper/core/tasks.hpp"
 
 using namespace can_dispatch;
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -8,8 +8,8 @@
 #include "can/core/ids.hpp"
 #include "common/core/bit_utils.hpp"
 #include "common/core/version.h"
-#include "eeprom/core/types.hpp"
 #include "eeprom/core/serial_number.hpp"
+#include "eeprom/core/types.hpp"
 #include "parse.hpp"
 
 namespace can_messages {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -803,7 +803,7 @@ using PipetteInfoRequest = Empty<MessageId::pipette_info_request>;
 struct PipetteInfoResponse : BaseMessage<MessageId::pipette_info_response> {
     uint16_t name;
     uint16_t model;
-    std::array<char, 12> serial{};
+    eeprom::serial_number::SerialNumberType serial{};
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -9,6 +9,7 @@
 #include "common/core/bit_utils.hpp"
 #include "common/core/version.h"
 #include "eeprom/core/types.hpp"
+#include "eeprom/core/serial_number.hpp"
 #include "parse.hpp"
 
 namespace can_messages {
@@ -744,7 +745,7 @@ using GripperInfoRequest = Empty<MessageId::gripper_info_request>;
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct GripperInfoResponse : BaseMessage<MessageId::gripper_info_response> {
     uint16_t model;
-    std::array<char, 12> serial{};
+    eeprom::serial_number::SerialNumberType serial{};
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "types.hpp"
+
+namespace eeprom {
+namespace addresses {
+
+constexpr types::data_length serial_number_length = 12;
+constexpr types::address serial_number_address_begin = 0;
+constexpr types::address serial_number_address_end = serial_number_address_begin + serial_number_length;
+
+
+}
+}

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -5,7 +5,7 @@
 namespace eeprom {
 namespace addresses {
 
-constexpr types::data_length serial_number_length = 8;
+constexpr types::data_length serial_number_length = 12;
 constexpr types::address serial_number_address_begin = 0;
 constexpr types::address serial_number_address_end = serial_number_address_begin + serial_number_length;
 

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -7,8 +7,8 @@ namespace addresses {
 
 constexpr types::data_length serial_number_length = 12;
 constexpr types::address serial_number_address_begin = 0;
-constexpr types::address serial_number_address_end = serial_number_address_begin + serial_number_length;
+constexpr types::address serial_number_address_end =
+    serial_number_address_begin + serial_number_length;
 
-
-}
-}
+}  // namespace addresses
+}  // namespace eeprom

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -5,7 +5,7 @@
 namespace eeprom {
 namespace addresses {
 
-constexpr types::data_length serial_number_length = 12;
+constexpr types::data_length serial_number_length = 8;
 constexpr types::address serial_number_address_begin = 0;
 constexpr types::address serial_number_address_end = serial_number_address_begin + serial_number_length;
 

--- a/include/eeprom/core/serial_number.hpp
+++ b/include/eeprom/core/serial_number.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "task.hpp"
-#include <cstdint>
 #include <array>
+#include <cstdint>
+
+#include "task.hpp"
 #include "types.hpp"
 
 namespace eeprom {
@@ -12,21 +13,26 @@ constexpr auto SERIAL_NUMBER_LENGTH = 12;
 
 using SerialNumberType = std::array<uint8_t, SERIAL_NUMBER_LENGTH>;
 
-
 template <task::TaskClient EEPromTaskClient>
 class SerialNumberAccessor {
   public:
-    explicit SerialNumberAccessor(EEPromTaskClient& eeprom_client) : eeprom_client{eeprom_client} {}
+    explicit SerialNumberAccessor(EEPromTaskClient& eeprom_client)
+        : eeprom_client{eeprom_client} {}
 
     /**
      * Begin a read of the serial number.
      */
     auto start_read() -> void {
-//        auto msg = eeprom::message::ReadEepromMessage{
-//            .memory_address = can_msg.address,
-//            .length = can_msg.data_length,
-//            .callback = callback,
-//            .callback_param = this};
+        eeprom_client.send_eeprom_queue(
+            eeprom::message::ReadEepromMessage{.memory_address = 0,
+                                               .length = types::max_data_length,
+                                               .callback = callback,
+                                               .callback_param = this});
+        eeprom_client.send_eeprom_queue(eeprom::message::ReadEepromMessage{
+            .memory_address = 8,
+            .length = types::max_data_length - 4,
+            .callback = callback,
+            .callback_param = this});
     }
 
     /**
@@ -37,25 +43,26 @@ class SerialNumberAccessor {
         auto second_write = types::EepromData{};
 
         std::copy_n(sn.cbegin(), first_write.size(), first_write.begin());
-        std::copy_n(sn.cbegin() + first_write.size(), sn.size() - first_write.size(), second_write.begin());
+        std::copy_n(sn.cbegin() + first_write.size(),
+                    sn.size() - first_write.size(), second_write.begin());
 
         eeprom_client.send_eeprom_queue(
-         eeprom::message::WriteEepromMessage{
-            .memory_address = 0,
-            .length = first_write.size(),
-            .data = first_write});
+            eeprom::message::WriteEepromMessage{.memory_address = 0,
+                                                .length = first_write.size(),
+                                                .data = first_write});
 
-        eeprom_client.send_eeprom_queue(
-            eeprom::message::WriteEepromMessage{
-                .memory_address = first_write.size(),
-                .length = static_cast<types::data_length>(sn.size() - first_write.size()),
-                .data = second_write});
+        eeprom_client.send_eeprom_queue(eeprom::message::WriteEepromMessage{
+            .memory_address = first_write.size(),
+            .length =
+                static_cast<types::data_length>(sn.size() - first_write.size()),
+            .data = second_write});
     }
 
   private:
+    static void callback(const eeprom::message::EepromMessage&, void*) {}
     EEPromTaskClient& eeprom_client;
     SerialNumberType serial_number{};
 };
 
-}
-}
+}  // namespace serial_number
+}  // namespace eeprom

--- a/include/eeprom/core/serial_number.hpp
+++ b/include/eeprom/core/serial_number.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "task.hpp"
+#include <cstdint>
+#include <array>
+#include "types.hpp"
+
+namespace eeprom {
+namespace serial_number {
+
+constexpr auto SERIAL_NUMBER_LENGTH = 12;
+
+using SerialNumberType = std::array<uint8_t, SERIAL_NUMBER_LENGTH>;
+
+
+template <task::TaskClient EEPromTaskClient>
+class SerialNumberAccessor {
+  public:
+    explicit SerialNumberAccessor(EEPromTaskClient& eeprom_client) : eeprom_client{eeprom_client} {}
+
+    /**
+     * Begin a read of the serial number.
+     */
+    auto start_read() -> void {
+//        auto msg = eeprom::message::ReadEepromMessage{
+//            .memory_address = can_msg.address,
+//            .length = can_msg.data_length,
+//            .callback = callback,
+//            .callback_param = this};
+    }
+
+    /**
+     * Write serial number to eeprom
+     */
+    auto write(const SerialNumberType& sn) -> void {
+        auto first_write = types::EepromData{};
+        auto second_write = types::EepromData{};
+
+        std::copy_n(sn.cbegin(), first_write.size(), first_write.begin());
+        std::copy_n(sn.cbegin() + first_write.size(), sn.size() - first_write.size(), second_write.begin());
+
+        eeprom_client.send_eeprom_queue(
+         eeprom::message::WriteEepromMessage{
+            .memory_address = 0,
+            .length = first_write.size(),
+            .data = first_write});
+
+        eeprom_client.send_eeprom_queue(
+            eeprom::message::WriteEepromMessage{
+                .memory_address = first_write.size(),
+                .length = static_cast<types::data_length>(sn.size() - first_write.size()),
+                .data = second_write});
+    }
+
+  private:
+    EEPromTaskClient& eeprom_client;
+    SerialNumberType serial_number{};
+};
+
+}
+}

--- a/include/eeprom/core/serial_number.hpp
+++ b/include/eeprom/core/serial_number.hpp
@@ -18,6 +18,12 @@ using SerialNumberType = std::array<uint8_t, addresses::serial_number_length>;
  */
 class ReadListener {
   public:
+    ReadListener() = default;
+    ReadListener(const ReadListener&) = default;
+    auto operator=(const ReadListener&) -> ReadListener& = default;
+    ReadListener(ReadListener&&) noexcept = default;
+    auto operator=(ReadListener&&) noexcept -> ReadListener& = default;
+
     virtual ~ReadListener() = default;
     virtual void on_read(const SerialNumberType&) = 0;
 };
@@ -83,6 +89,7 @@ class SerialNumberAccessor {
     static void callback(const eeprom::message::EepromMessage& msg,
                          void* param) {
         auto* self =
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             reinterpret_cast<SerialNumberAccessor<EEPromTaskClient>*>(param);
         self->callback(msg);
     }

--- a/include/eeprom/core/serial_number.hpp
+++ b/include/eeprom/core/serial_number.hpp
@@ -18,7 +18,7 @@ using SerialNumberType = std::array<uint8_t, addresses::serial_number_length>;
  */
 class ReadListener {
   public:
-    virtual ~ReadListener() =default;
+    virtual ~ReadListener() = default;
     virtual void on_read(const SerialNumberType&) = 0;
 };
 
@@ -83,8 +83,7 @@ class SerialNumberAccessor {
     static void callback(const eeprom::message::EepromMessage& msg,
                          void* param) {
         auto* self =
-            reinterpret_cast<SerialNumberAccessor<EEPromTaskClient>*>(
-                param);
+            reinterpret_cast<SerialNumberAccessor<EEPromTaskClient>*>(param);
         self->callback(msg);
     }
 

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -51,7 +51,8 @@ using BrushedMoveGroupDispatchTarget = can_dispatch::DispatchParseTarget<
     can_messages::ExecuteMoveGroupRequest, can_messages::GetMoveGroupRequest,
     can_messages::GripperGripRequest, can_messages::GripperHomeRequest>;
 using GripperInfoDispatchTarget = can_dispatch::DispatchParseTarget<
-    gripper_info::GripperInfoMessageHandler<gripper_tasks::QueueClient, gripper_tasks::QueueClient>,
+    gripper_info::GripperInfoMessageHandler<gripper_tasks::QueueClient,
+                                            gripper_tasks::QueueClient>,
     can_messages::GripperInfoRequest>;
 
 auto constexpr reader_message_buffer_size = 1024;

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -51,7 +51,7 @@ using BrushedMoveGroupDispatchTarget = can_dispatch::DispatchParseTarget<
     can_messages::ExecuteMoveGroupRequest, can_messages::GetMoveGroupRequest,
     can_messages::GripperGripRequest, can_messages::GripperHomeRequest>;
 using GripperInfoDispatchTarget = can_dispatch::DispatchParseTarget<
-    gripper_info::GripperInfoMessageHandler<gripper_tasks::QueueClient>,
+    gripper_info::GripperInfoMessageHandler<gripper_tasks::QueueClient, gripper_tasks::QueueClient>,
     can_messages::GripperInfoRequest>;
 
 auto constexpr reader_message_buffer_size = 1024;

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -5,8 +5,8 @@
 #include "can/core/message_handlers/motor.hpp"
 #include "can/core/message_handlers/move_group.hpp"
 #include "can/core/message_handlers/system.hpp"
-#include "gripper/core/gripper_info.hpp"
 #include "common/core/freertos_message_queue.hpp"
+#include "gripper/core/gripper_info.hpp"
 #include "gripper/core/tasks.hpp"
 
 namespace can_bus {

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
-#include "can/core/can_writer_task.hpp"
 #include "can/core/freertos_can_dispatch.hpp"
 #include "can/core/message_handlers/motion.hpp"
 #include "can/core/message_handlers/motor.hpp"
 #include "can/core/message_handlers/move_group.hpp"
 #include "can/core/message_handlers/system.hpp"
-#include "common/core/freertos_message_queue.hpp"
 #include "gripper/core/gripper_info.hpp"
+#include "common/core/freertos_message_queue.hpp"
 #include "gripper/core/tasks.hpp"
-#include "motor-control/core/stepper_motor/motor.hpp"
 
 namespace can_bus {
 class CanBus;

--- a/include/gripper/core/gripper_info.hpp
+++ b/include/gripper/core/gripper_info.hpp
@@ -8,42 +8,30 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
+#include "eeprom/core/serial_number.hpp"
 
 namespace gripper_info {
 using namespace can_ids;
 using namespace can_messages;
 
-struct GripperInfo {
-    uint16_t model;
-    std::array<char, 12> serial;
-};
 
 /**
  * A HandlesMessages implementing class that will respond to system messages.
  *
  * @tparam CanClient can writer task client
+ * @tparam EEPromClient eeprom task client
  */
-template <message_writer_task::TaskClient CanClient>
-class GripperInfoMessageHandler {
+template <message_writer_task::TaskClient CanClient, eeprom::task::TaskClient EEPromClient>
+class GripperInfoMessageHandler : eeprom::serial_number::ReadListener {
   public:
     /**
      * Constructor
      *
      * @param writer A message writer for sending the response
+     * @param eeprom_client An eeprom task client
      */
-    explicit GripperInfoMessageHandler(CanClient &writer)
-        : GripperInfoMessageHandler(
-              writer, GripperInfo{.model = 1,
-                                  .serial = std::array{'2', '0', '2', '2', '0',
-                                                       '4', '2', '1', 'A', '0',
-                                                       '5', '\0'}}) {}
-    GripperInfoMessageHandler(CanClient &writer,
-                              const GripperInfo &gripper_info)
-        : writer(writer), response{.model = gripper_info.model} {
-        std::copy_n(
-            gripper_info.serial.cbegin(),
-            std::min(gripper_info.serial.size(), response.serial.size()),
-            response.serial.begin());
+    explicit GripperInfoMessageHandler(CanClient &writer, EEPromClient &eeprom_client)
+        : writer{writer}, serial_number_accessor{eeprom_client, *this} {
     }
     GripperInfoMessageHandler(const GripperInfoMessageHandler &) = delete;
     GripperInfoMessageHandler(const GripperInfoMessageHandler &&) = delete;
@@ -51,7 +39,7 @@ class GripperInfoMessageHandler {
         -> GripperInfoMessageHandler & = delete;
     auto operator=(const GripperInfoMessageHandler &&)
         -> GripperInfoMessageHandler && = delete;
-    ~GripperInfoMessageHandler() = default;
+    ~GripperInfoMessageHandler() final = default;
 
     using MessageType = std::variant<std::monostate, GripperInfoRequest>;
 
@@ -63,14 +51,22 @@ class GripperInfoMessageHandler {
         std::visit([this](auto o) { this->visit(o); }, m);
     }
 
+    /**
+     * A serial number read has completed.
+     * @param sn Serial number
+     */
+    void on_read(const eeprom::serial_number::SerialNumberType& sn) final {
+        writer.send_can_message(can_ids::NodeId::host, GripperInfoResponse{.model=1, .serial=sn});
+    }
+
   private:
     void visit(std::monostate &) {}
 
     void visit(GripperInfoRequest &) {
-        writer.send_can_message(can_ids::NodeId::host, response);
+        serial_number_accessor.start_read();
     }
 
     CanClient &writer;
-    can_messages::GripperInfoResponse response;
+    eeprom::serial_number::SerialNumberAccessor<EEPromClient> serial_number_accessor;
 };
 };  // namespace gripper_info

--- a/include/gripper/core/gripper_info.hpp
+++ b/include/gripper/core/gripper_info.hpp
@@ -14,14 +14,14 @@ namespace gripper_info {
 using namespace can_ids;
 using namespace can_messages;
 
-
 /**
  * A HandlesMessages implementing class that will respond to system messages.
  *
  * @tparam CanClient can writer task client
  * @tparam EEPromClient eeprom task client
  */
-template <message_writer_task::TaskClient CanClient, eeprom::task::TaskClient EEPromClient>
+template <message_writer_task::TaskClient CanClient,
+          eeprom::task::TaskClient EEPromClient>
 class GripperInfoMessageHandler : eeprom::serial_number::ReadListener {
   public:
     /**
@@ -30,9 +30,9 @@ class GripperInfoMessageHandler : eeprom::serial_number::ReadListener {
      * @param writer A message writer for sending the response
      * @param eeprom_client An eeprom task client
      */
-    explicit GripperInfoMessageHandler(CanClient &writer, EEPromClient &eeprom_client)
-        : writer{writer}, serial_number_accessor{eeprom_client, *this} {
-    }
+    explicit GripperInfoMessageHandler(CanClient &writer,
+                                       EEPromClient &eeprom_client)
+        : writer{writer}, serial_number_accessor{eeprom_client, *this} {}
     GripperInfoMessageHandler(const GripperInfoMessageHandler &) = delete;
     GripperInfoMessageHandler(const GripperInfoMessageHandler &&) = delete;
     auto operator=(const GripperInfoMessageHandler &)
@@ -55,18 +55,18 @@ class GripperInfoMessageHandler : eeprom::serial_number::ReadListener {
      * A serial number read has completed.
      * @param sn Serial number
      */
-    void on_read(const eeprom::serial_number::SerialNumberType& sn) final {
-        writer.send_can_message(can_ids::NodeId::host, GripperInfoResponse{.model=1, .serial=sn});
+    void on_read(const eeprom::serial_number::SerialNumberType &sn) final {
+        writer.send_can_message(can_ids::NodeId::host,
+                                GripperInfoResponse{.model = 1, .serial = sn});
     }
 
   private:
     void visit(std::monostate &) {}
 
-    void visit(GripperInfoRequest &) {
-        serial_number_accessor.start_read();
-    }
+    void visit(GripperInfoRequest &) { serial_number_accessor.start_read(); }
 
     CanClient &writer;
-    eeprom::serial_number::SerialNumberAccessor<EEPromClient> serial_number_accessor;
+    eeprom::serial_number::SerialNumberAccessor<EEPromClient>
+        serial_number_accessor;
 };
 };  // namespace gripper_info

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -56,7 +56,7 @@ using SensorDispatchTarget = can_dispatch::DispatchParseTarget<
     can_messages::BindSensorOutputRequest>;
 
 using PipetteInfoDispatchTarget = can_dispatch::DispatchParseTarget<
-    pipette_info::PipetteInfoMessageHandler<central_tasks::QueueClient>,
+    pipette_info::PipetteInfoMessageHandler<central_tasks::QueueClient, sensor_tasks::QueueClient>,
     can_messages::PipetteInfoRequest>;
 
 using EEPromDispatchTarget = can_dispatch::DispatchParseTarget<

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -56,7 +56,8 @@ using SensorDispatchTarget = can_dispatch::DispatchParseTarget<
     can_messages::BindSensorOutputRequest>;
 
 using PipetteInfoDispatchTarget = can_dispatch::DispatchParseTarget<
-    pipette_info::PipetteInfoMessageHandler<central_tasks::QueueClient, sensor_tasks::QueueClient>,
+    pipette_info::PipetteInfoMessageHandler<central_tasks::QueueClient,
+                                            sensor_tasks::QueueClient>,
     can_messages::PipetteInfoRequest>;
 
 using EEPromDispatchTarget = can_dispatch::DispatchParseTarget<

--- a/include/pipettes/core/pipette_info.hpp
+++ b/include/pipettes/core/pipette_info.hpp
@@ -38,7 +38,8 @@ uint16_t get_model();
  * @tparam CanClient can writer task client
  * @tparam EEPromClient eeprom task client
  */
-template <message_writer_task::TaskClient CanClient, eeprom::task::TaskClient EEPromClient>
+template <message_writer_task::TaskClient CanClient,
+          eeprom::task::TaskClient EEPromClient>
 class PipetteInfoMessageHandler : eeprom::serial_number::ReadListener {
   public:
     /**
@@ -47,9 +48,9 @@ class PipetteInfoMessageHandler : eeprom::serial_number::ReadListener {
      * @param writer A message writer for sending the response
      * @param eeprom_client An eeprom task client
      */
-    explicit PipetteInfoMessageHandler(CanClient &writer, EEPromClient &eeprom_client)
-        : writer(writer), serial_number_accessor{eeprom_client, *this} {
-    }
+    explicit PipetteInfoMessageHandler(CanClient &writer,
+                                       EEPromClient &eeprom_client)
+        : writer(writer), serial_number_accessor{eeprom_client, *this} {}
     PipetteInfoMessageHandler(const PipetteInfoMessageHandler &) = delete;
     PipetteInfoMessageHandler(const PipetteInfoMessageHandler &&) = delete;
     auto operator=(const PipetteInfoMessageHandler &)
@@ -68,16 +69,18 @@ class PipetteInfoMessageHandler : eeprom::serial_number::ReadListener {
         std::visit([this](auto o) { this->visit(o); }, m);
     }
 
-    void on_read(const eeprom::serial_number::SerialNumberType& sn) final {
-        writer.send_can_message(can_ids::NodeId::host, can_messages::PipetteInfoResponse{.name=static_cast<uint16_t>(get_name()),.model=get_model(),  .serial=sn});
+    void on_read(const eeprom::serial_number::SerialNumberType &sn) final {
+        writer.send_can_message(can_ids::NodeId::host,
+                                can_messages::PipetteInfoResponse{
+                                    .name = static_cast<uint16_t>(get_name()),
+                                    .model = get_model(),
+                                    .serial = sn});
     }
 
   private:
     void visit(std::monostate &) {}
 
-    void visit(PipetteInfoRequest &) {
-        serial_number_accessor.start_read();
-    }
+    void visit(PipetteInfoRequest &) { serial_number_accessor.start_read(); }
 
     CanClient &writer;
     eeprom::serial_number::SerialNumberAccessor<EEPromClient>

--- a/pipettes/core/can_task_high_throughput.cpp
+++ b/pipettes/core/can_task_high_throughput.cpp
@@ -36,7 +36,7 @@ static auto sensor_handler =
     sensors::handlers::SensorHandler{sensor_queue_client};
 
 static auto pipette_info_handler =
-    pipette_info::PipetteInfoMessageHandler{central_queue_client};
+    pipette_info::PipetteInfoMessageHandler{central_queue_client, sensor_queue_client};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target =

--- a/pipettes/core/can_task_high_throughput.cpp
+++ b/pipettes/core/can_task_high_throughput.cpp
@@ -35,8 +35,8 @@ static auto system_message_handler = system_handler::SystemMessageHandler{
 static auto sensor_handler =
     sensors::handlers::SensorHandler{sensor_queue_client};
 
-static auto pipette_info_handler =
-    pipette_info::PipetteInfoMessageHandler{central_queue_client, sensor_queue_client};
+static auto pipette_info_handler = pipette_info::PipetteInfoMessageHandler{
+    central_queue_client, sensor_queue_client};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target =

--- a/pipettes/core/can_task_low_throughput.cpp
+++ b/pipettes/core/can_task_low_throughput.cpp
@@ -34,7 +34,7 @@ static auto sensor_handler =
     sensors::handlers::SensorHandler{sensor_queue_client};
 
 static auto pipette_info_handler =
-    pipette_info::PipetteInfoMessageHandler{central_queue_client};
+    pipette_info::PipetteInfoMessageHandler{central_queue_client, sensor_queue_client};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target =

--- a/pipettes/core/can_task_low_throughput.cpp
+++ b/pipettes/core/can_task_low_throughput.cpp
@@ -33,8 +33,8 @@ static auto system_message_handler = system_handler::SystemMessageHandler{
 static auto sensor_handler =
     sensors::handlers::SensorHandler{sensor_queue_client};
 
-static auto pipette_info_handler =
-    pipette_info::PipetteInfoMessageHandler{central_queue_client, sensor_queue_client};
+static auto pipette_info_handler = pipette_info::PipetteInfoMessageHandler{
+    central_queue_client, sensor_queue_client};
 
 /** The connection between the motor handler and message buffer */
 static auto motor_dispatch_target =


### PR DESCRIPTION
We read the serial number from the eeprom.

The eeprom on these boards is can only read 8 bytes at a time. Rather than supporting a 12-byte serial number by doing two reads, we'll just use 8 bytes. No need to write throwaway code.