### PR TITLE
feat(sensors): add autothreshold

### DIFF
--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -8,6 +8,7 @@
 #include "common/core/logging.h"
 #include "sensors/core/fdc1004.hpp"
 #include "sensors/core/sensor_hardware_interface.hpp"
+#include "sensors/core/utils.hpp"
 
 namespace sensors {
 namespace tasks {
@@ -72,10 +73,15 @@ struct ReadCapacitanceCallback {
         }
         auto capacitance = convert_capacitance(measurement, number_of_reads,
                                                current_offset_pf);
-        auto message = can_messages::ReadFromSensorResponse{
-            .sensor = SensorType::capacitive,
-            .sensor_data = convert_to_fixed_point(capacitance, 15)};
-        can_client.send_can_message(can_ids::NodeId::host, message);
+        if (utils::tag_in_token(m.id.token,
+                                utils::ResponseTag::IS_THRESHOLD_SENSE)) {
+            set_threshold(capacitance + 1);
+        } else {
+            auto message = can_messages::ReadFromSensorResponse{
+                .sensor = SensorType::capacitive,
+                .sensor_data = convert_to_fixed_point(capacitance, 15)};
+            can_client.send_can_message(can_ids::NodeId::host, message);
+        }
         auto new_offset = update_offset(capacitance, current_offset_pf);
         set_offset(new_offset);
     }
@@ -119,6 +125,10 @@ struct ReadCapacitanceCallback {
 
     auto set_threshold(float threshold_pf) -> void {
         zero_threshold_pf = threshold_pf;
+        auto message = can_messages::SensorThresholdResponse{
+            .sensor = SensorType::capacitive,
+            .threshold = convert_to_fixed_point(zero_threshold_pf, 15)};
+        can_client.send_can_message(can_ids::NodeId::host, message);
     }
 
     [[nodiscard]] auto get_threshold() const -> float {

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -167,8 +167,11 @@ class CapacitiveMessageHandler {
     SensorHardwareBase &hardware;
     CanClient &can_client;
     OwnQueue &own_queue;
-    ReadCapacitanceCallback<CanClient, I2CQueueWriter> capacitance_handler;
     bool is_initialized = false;
+
+  public:
+    // Kept public for testability
+    ReadCapacitanceCallback<CanClient, I2CQueueWriter> capacitance_handler;
 };
 
 /**

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -118,13 +118,21 @@ class CapacitiveMessageHandler {
     void visit(can_messages::SetSensorThresholdRequest &m) {
         LOG("Received request to set threshold to %d from %d sensor",
             m.threshold, m.sensor);
-        capacitance_handler.set_threshold(
-            fixed_point_to_float(m.threshold, 15));
-        auto message = can_messages::SensorThresholdResponse{
-            .sensor = SensorType::capacitive,
-            .threshold = convert_to_fixed_point(
-                capacitance_handler.get_threshold(), 15)};
-        can_client.send_can_message(can_ids::NodeId::host, message);
+        if (m.threshold != 0) {
+            capacitance_handler.set_threshold(
+                fixed_point_to_float(m.threshold, 15));
+        } else {
+            capacitance_handler.reset_limited();
+            capacitance_handler.set_number_of_reads(10);
+            std::array tags{utils::ResponseTag::IS_PART_OF_POLL,
+                            utils::ResponseTag::IS_BASELINE,
+                            utils::ResponseTag::IS_THRESHOLD_SENSE};
+            poller.multi_register_poll(
+                ADDRESS, MSB_MEASUREMENT_1, 2, LSB_MEASUREMENT_1, 2,
+                uint16_t(10), DELAY, own_queue,
+                utils::build_id(ADDRESS, MSB_MEASUREMENT_1,
+                                utils::byte_from_tags(tags)));
+        }
     }
 
     void visit(can_messages::BindSensorOutputRequest &m) {

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -41,6 +41,7 @@ enum class ResponseTag : size_t {
     IS_PART_OF_POLL = 0,
     IS_BASELINE = 1,
     POLL_IS_CONTINUOUS = 2,
+    IS_THRESHOLD_SENSE = 4,
 };
 
 [[nodiscard]] constexpr auto byte_from_tag(ResponseTag tag) -> uint8_t {

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -407,6 +407,7 @@ SCENARIO("capacitance callback tests") {
             second.id.transaction_index = 1;
             second.read_buffer = buffer_b;
             callback_host.set_threshold(10);
+            can_queue.reset();
             callback_host.handle_ongoing_response(first);
             callback_host.handle_ongoing_response(second);
             THEN("it should not send can messages") {
@@ -418,6 +419,142 @@ SCENARIO("capacitance callback tests") {
                 // this call is still the one from setting up
                 // when we started the bind
                 REQUIRE(mock_hw.get_sync_reset_calls() == 1);
+            }
+        }
+    }
+}
+
+SCENARIO("threshold configuration") {
+    test_mocks::MockSensorHardware mock_hw{};
+    test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
+    test_mocks::MockMessageQueue<i2c::poller::TaskMessage> poller_queue{};
+
+    test_mocks::MockMessageQueue<message_writer_task::TaskMessage> can_queue{};
+    test_mocks::MockMessageQueue<sensors::utils::TaskMessage>
+        capacitive_queue{};
+
+    i2c::writer::TaskMessage empty_msg{};
+    i2c::poller::TaskMessage empty_poll_msg{};
+
+    test_mocks::MockI2CResponseQueue response_queue{};
+    auto queue_client =
+        mock_client::QueueClient{.capacitive_sensor_queue = &capacitive_queue};
+    auto writer = i2c::writer::Writer<test_mocks::MockMessageQueue>{};
+    auto poller = i2c::poller::Poller<test_mocks::MockMessageQueue>{};
+    queue_client.set_queue(&can_queue);
+    writer.set_queue(&i2c_queue);
+    poller.set_queue(&poller_queue);
+
+    auto sensor = sensors::tasks::CapacitiveMessageHandler{
+        writer, poller, mock_hw, queue_client, response_queue};
+
+    GIVEN("A request to set an autothreshold") {
+        int NUM_READS = 10;
+        auto autothreshold =
+            sensors::utils::TaskMessage(can_messages::SetSensorThresholdRequest(
+                {}, static_cast<uint8_t>(can_ids::SensorType::capacitive), 0));
+        WHEN("the message is received") {
+            sensor.handle_message(autothreshold);
+            THEN("the poller queue is populated with a poll request") {
+                REQUIRE(poller_queue.get_size() == 1);
+            }
+            AND_WHEN("we read the messages from the queue") {
+                auto read_message =
+                    get_message<i2c::messages::MultiRegisterPollRead>(
+                        poller_queue);
+
+                THEN("The write and read command addresses are correct") {
+                    REQUIRE(read_message.first.address ==
+                            sensors::fdc1004::ADDRESS);
+                    REQUIRE(read_message.first.write_buffer[0] ==
+                            sensors::fdc1004::MSB_MEASUREMENT_1);
+                    REQUIRE(read_message.first.bytes_to_write == 1);
+                    REQUIRE(read_message.second.address ==
+                            sensors::fdc1004::ADDRESS);
+                    REQUIRE(read_message.second.write_buffer[0] ==
+                            sensors::fdc1004::LSB_MEASUREMENT_1);
+                    REQUIRE(read_message.second.bytes_to_write == 1);
+                    REQUIRE(read_message.delay_ms == 20);
+                    REQUIRE(read_message.polling == NUM_READS);
+                }
+                AND_WHEN("using the callback with data") {
+                    auto buffer_a =
+                        i2c::messages::MaxMessageBuffer{0x7f, 0xff, 0, 0, 0};
+                    auto buffer_b =
+                        i2c::messages::MaxMessageBuffer{0xff, 0, 0, 0, 0};
+                    for (int i = 0; i < NUM_READS - 1; i++) {
+                        auto response_a = sensors::utils::TaskMessage(
+                            test_mocks::launder_response(
+                                read_message, response_queue,
+                                test_mocks::dummy_multi_response(
+                                    read_message, 0, false, buffer_a)));
+                        sensor.handle_message(response_a);
+                        auto response_b = sensors::utils::TaskMessage(
+                            test_mocks::launder_response(
+                                read_message, response_queue,
+                                test_mocks::dummy_multi_response(
+                                    read_message, 1, false, buffer_b)));
+                        sensor.handle_message(response_b);
+                    }
+                    auto final_response_a = sensors::utils::TaskMessage(
+                        test_mocks::launder_response(
+                            read_message, response_queue,
+                            test_mocks::dummy_multi_response(read_message, 0,
+                                                             true, buffer_a)));
+                    auto final_response_b = sensors::utils::TaskMessage(
+                        test_mocks::launder_response(
+                            read_message, response_queue,
+                            test_mocks::dummy_multi_response(read_message, 1,
+                                                             true, buffer_b)));
+                    sensor.handle_message(final_response_a);
+                    sensor.handle_message(final_response_b);
+                    THEN("the threshold is set to the proper value") {
+                        REQUIRE(sensor.capacitance_handler.get_threshold() ==
+                                16);
+                    }
+                    THEN(
+                        "a message is sent on can informing that the threshold "
+                        "is set") {
+                        REQUIRE(can_queue.get_size() == 1);
+                        message_writer_task::TaskMessage can_msg{};
+                        can_queue.try_read(&can_msg);
+
+                        auto response_msg =
+                            std::get<can_messages::SensorThresholdResponse>(
+                                can_msg.message);
+                        float check_data = signed_fixed_point_to_float(
+                            response_msg.threshold, 15);
+                        // the average value + 1
+                        float expected = 16;
+                        REQUIRE(check_data == Approx(expected).epsilon(1e-4));
+                    }
+                }
+            }
+        }
+    }
+
+    GIVEN("A request to set a specific threshold") {
+        auto specific_threshold =
+            sensors::utils::TaskMessage(can_messages::SetSensorThresholdRequest(
+                {}, static_cast<uint8_t>(can_ids::SensorType::capacitive),
+                convert_to_fixed_point(10, 15)));
+        WHEN("the message is received") {
+            sensor.handle_message(specific_threshold);
+
+            THEN("the sensor should send a response with the same threshold") {
+                REQUIRE(can_queue.get_size() == 1);
+                message_writer_task::TaskMessage can_response{};
+                REQUIRE(can_queue.try_read(&can_response) == true);
+                auto threshold_response =
+                    std::get<can_messages::SensorThresholdResponse>(
+                        can_response.message);
+                REQUIRE(threshold_response.sensor ==
+                        can_ids::SensorType::capacitive);
+                REQUIRE(threshold_response.threshold ==
+                        convert_to_fixed_point(10, 15));
+            }
+            THEN("the sensor's threshold should be set") {
+                REQUIRE(sensor.capacitance_handler.get_threshold() == 10);
             }
         }
     }


### PR DESCRIPTION
The capacitive sensor on the pipette is extremely sensitive to its immediate environment. We probably want to zero out the ambient capacitance when it is close to, but not yet touching, whatever it's going to sense.

We could do that today by commanding a reading via can from python; getting the reading back; and then commanding a threshold based on that reading via can. We could also send a command that tells the pipette to take a reading and then use that reading as a new threshold, and we'll save some back-and-forth.

Todo: tests, better use of the message including specifying an offset amount. Required for https://github.com/Opentrons/opentrons/pull/10067