### PR TITLE
feat(sensors): Allow setting an offset to autothreshold

### DIFF
--- a/generate_header.py
+++ b/generate_header.py
@@ -57,6 +57,7 @@ def generate_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
         write_enum_cpp(constants_mod.ToolType, output)
         write_enum_cpp(constants_mod.SensorType, output)
         write_enum_cpp(constants_mod.SensorOutputBinding, output)
+        write_enum_cpp(constants_mod.SensorThresholdMode, output)
 
 
 def write_enum_cpp(e: Type[Enum], output: io.StringIO) -> None:

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -152,4 +152,10 @@ enum class SensorOutputBinding {
     report = 0x2,
 };
 
+/** How a sensor's threshold should be interpreted. */
+enum class SensorThresholdMode {
+    absolute = 0x0,
+    auto_baseline = 0x1,
+};
+
 }  // namespace can_ids

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -613,17 +613,22 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
 
 struct SetSensorThresholdRequest
     : BaseMessage<MessageId::set_sensor_threshold_request> {
-    uint8_t sensor;
+    can_ids::SensorType sensor;
     int32_t threshold;
+    can_ids::SensorThresholdMode mode;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SetSensorThresholdRequest {
         uint8_t sensor = 0;
         int32_t threshold = 0;
+        uint8_t mode = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, threshold);
-        return SetSensorThresholdRequest{.sensor = sensor,
-                                         .threshold = threshold};
+        body = bit_utils::bytes_to_int(body, limit, mode);
+        return SetSensorThresholdRequest{
+            .sensor = static_cast<can_ids::SensorType>(sensor),
+            .threshold = threshold,
+            .mode = static_cast<can_ids::SensorThresholdMode>(mode)};
     }
 
     auto operator==(const SetSensorThresholdRequest& other) const
@@ -634,12 +639,14 @@ struct SensorThresholdResponse
     : BaseMessage<MessageId::set_sensor_threshold_response> {
     can_ids::SensorType sensor{};
     int32_t threshold = 0;
+    can_ids::SensorThresholdMode mode{};
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
         iter = bit_utils::int_to_bytes(threshold, iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(mode), iter, limit);
         return iter - body;
     }
     auto operator==(const SensorThresholdResponse& other) const

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -118,15 +118,17 @@ class CapacitiveMessageHandler {
     void visit(can_messages::SetSensorThresholdRequest &m) {
         LOG("Received request to set threshold to %d from %d sensor",
             m.threshold, m.sensor);
-        if (m.threshold != 0) {
+        if (m.mode == can_ids::SensorThresholdMode::absolute) {
             capacitance_handler.set_threshold(
-                fixed_point_to_float(m.threshold, 15));
+                fixed_point_to_float(m.threshold, 15), m.mode);
         } else {
             capacitance_handler.reset_limited();
             capacitance_handler.set_number_of_reads(10);
             std::array tags{utils::ResponseTag::IS_PART_OF_POLL,
                             utils::ResponseTag::IS_BASELINE,
                             utils::ResponseTag::IS_THRESHOLD_SENSE};
+            capacitance_handler.prime_autothreshold(
+                fixed_point_to_float(m.threshold, 15));
             poller.multi_register_poll(
                 ADDRESS, MSB_MEASUREMENT_1, 2, LSB_MEASUREMENT_1, 2,
                 uint16_t(10), DELAY, own_queue,


### PR DESCRIPTION
We shouldn't hardcode the offset we set when we do an autothreshold; we should allow it to be specified from canbus. This adds a new field to the threshold messages that specifies the mode of the threshold. 