### PR TITLE
refactor(eeprom): CAN messages support 16-bit messaging.

### DIFF
--- a/include/eeprom/core/serial_number.hpp
+++ b/include/eeprom/core/serial_number.hpp
@@ -57,8 +57,8 @@ class SerialNumberAccessor {
      * Write serial number to eeprom
      */
     auto write(const SerialNumberType& sn) -> void {
-        auto amount_to_write = std::min(static_cast<types::data_length>(sn.size()),
-                                        types::max_data_length);
+        auto amount_to_write = std::min(
+            static_cast<types::data_length>(sn.size()), types::max_data_length);
         auto write = types::EepromData{};
         std::copy_n(sn.cbegin(), amount_to_write, write.begin());
 

--- a/include/eeprom/core/serial_number.hpp
+++ b/include/eeprom/core/serial_number.hpp
@@ -44,7 +44,7 @@ class SerialNumberAccessor {
      */
     auto start_read() -> void {
         auto amount_to_read = std::min(
-            static_cast<types::address>(addresses::serial_number_length),
+            static_cast<types::data_length>(addresses::serial_number_length),
             types::max_data_length);
         eeprom_client.send_eeprom_queue(eeprom::message::ReadEepromMessage{
             .memory_address = addresses::serial_number_address_begin,
@@ -57,7 +57,7 @@ class SerialNumberAccessor {
      * Write serial number to eeprom
      */
     auto write(const SerialNumberType& sn) -> void {
-        auto amount_to_write = std::min(static_cast<types::address>(sn.size()),
+        auto amount_to_write = std::min(static_cast<types::data_length>(sn.size()),
                                         types::max_data_length);
         auto write = types::EepromData{};
         std::copy_n(sn.cbegin(), amount_to_write, write.begin());

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -135,10 +135,12 @@ class EEPromMessageHandler {
         // The transaction will write the memory address, then read the
         // data.
         auto write_buffer = i2c::messages::MaxMessageBuffer{};
-        // TODO (amit, 2022-05-31): Current board revisions' eeprom has 8-bit addressing.
+        // TODO (amit, 2022-05-31): Current board revisions' eeprom has 8-bit
+        // addressing.
         //  To use the newer 16-bit addressing, remove this static_cast.
         auto address = static_cast<uint8_t>(m.memory_address);
-        static_cast<void>(bit_utils::int_to_bytes(address, write_buffer.begin(), write_buffer.end()));
+        static_cast<void>(bit_utils::int_to_bytes(address, write_buffer.begin(),
+                                                  write_buffer.end()));
 
         auto transaction =
             i2c::messages::Transaction{.address = types::DEVICE_ADDRESS,

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -134,11 +134,17 @@ class EEPromMessageHandler {
 
         // The transaction will write the memory address, then read the
         // data.
+        auto write_buffer = i2c::messages::MaxMessageBuffer{};
+        // TODO (amit, 2022-05-31): Current board revisions' eeprom has 8-bit addressing.
+        //  To use the newer 16-bit addressing, remove this static_cast.
+        auto address = static_cast<uint8_t>(m.memory_address);
+        static_cast<void>(bit_utils::int_to_bytes(address, write_buffer.begin(), write_buffer.end()));
+
         auto transaction =
             i2c::messages::Transaction{.address = types::DEVICE_ADDRESS,
                                        .bytes_to_read = m.length,
-                                       .bytes_to_write = 1,
-                                       .write_buffer{m.memory_address}};
+                                       .bytes_to_write = sizeof(address),
+                                       .write_buffer{write_buffer}};
         // The transaction identifier uses the token returned from id_map.add
         auto transaction_id =
             i2c::messages::TransactionIdentifier{.token = token.value()};

--- a/include/eeprom/core/types.hpp
+++ b/include/eeprom/core/types.hpp
@@ -3,8 +3,8 @@
 namespace eeprom {
 namespace types {
 
-// 0-255
-using address = uint8_t;
+// 0-65535
+using address = uint16_t;
 
 // 0-8
 using data_length = uint8_t;


### PR DESCRIPTION
FW companion to https://github.com/Opentrons/opentrons/pull/10540

New revs have eeprom that supports 16-bit address. This allows sending 16-bit addresses over CAN, but still uses 8-bit addressing. There's a TODO for how to change.