### PR TITLE
Enable data ready (#378)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ file(GLOB_RECURSE SOURCES_FOR_FORMAT
         ./i2c/*.hpp ./i2c/*.cpp
         ./sensors/*.hpp ./sensors/*.cpp
         ./spi/*.hpp ./spi/*.cpp
+        ./eeprom/*.hpp ./eeprom/*.cpp
         )
 
 # Targets for formatting. These are here rather than in individual target CMakeLists (e.g.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,6 @@ file(GLOB_RECURSE SOURCES_FOR_FORMAT
         ./i2c/*.hpp ./i2c/*.cpp
         ./sensors/*.hpp ./sensors/*.cpp
         ./spi/*.hpp ./spi/*.cpp
-        ./eeprom/*.hpp ./eeprom/*.cpp
         )
 
 # Targets for formatting. These are here rather than in individual target CMakeLists (e.g.

--- a/include/pipettes/core/interfaces.hpp
+++ b/include/pipettes/core/interfaces.hpp
@@ -4,8 +4,10 @@
 
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
 #include "motor-control/core/stepper_motor/tmc2160.hpp"
+#include "pipettes/core/interfaces.hpp"
 #include "pipettes/core/pipette_type.h"
 #include "pipettes/firmware/pipette_motor_hardware.hpp"
+#include "sensors/core/sensor_hardware_interface.hpp"
 
 namespace interfaces {
 
@@ -30,6 +32,15 @@ struct HighThroughputPipetteDriverHardware {
     TMC2130DriverConfig right_gear_motor;
     TMC2130DriverConfig left_gear_motor;
     TMC2160DriverConfig linear_motor;
+};
+
+struct HighThroughputSensorHardware {
+    sensors::hardware::SensorHardwareConfiguration primary;
+    sensors::hardware::SensorHardwareConfiguration secondary;
+};
+
+struct LowThroughputSensorHardware {
+    sensors::hardware::SensorHardwareConfiguration primary;
 };
 
 struct LowThroughputPipetteMotorHardware {
@@ -96,4 +107,40 @@ template <>
 auto motor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
     -> HighThroughputMotorConfigurations;
 
-}  // namespace interfaces
+template <PipetteType P>
+auto sensor_configurations()
+    -> std::enable_if_t<P == PipetteType::SINGLE_CHANNEL,
+                        LowThroughputSensorHardware>;
+
+template <PipetteType P>
+auto sensor_configurations()
+    -> std::enable_if_t<P == PipetteType::EIGHT_CHANNEL,
+                        LowThroughputSensorHardware>;
+
+template <PipetteType P>
+auto sensor_configurations()
+    -> std::enable_if_t<P == PipetteType::NINETY_SIX_CHANNEL,
+                        HighThroughputSensorHardware>;
+
+template <PipetteType P>
+auto sensor_configurations()
+    -> std::enable_if_t<P == PipetteType::THREE_EIGHTY_FOUR_CHANNEL,
+                        HighThroughputSensorHardware>;
+
+template <>
+auto sensor_configurations<PipetteType::SINGLE_CHANNEL>()
+    -> LowThroughputSensorHardware;
+
+template <>
+auto sensor_configurations<PipetteType::EIGHT_CHANNEL>()
+    -> LowThroughputSensorHardware;
+
+template <>
+auto sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
+    -> HighThroughputSensorHardware;
+
+template <>
+auto sensor_configurations<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
+    -> HighThroughputSensorHardware;
+
+};  // namespace interfaces

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -1,7 +1,15 @@
 #pragma once
 
+#include "common/firmware/gpio.hpp"
+
 namespace sensors {
 namespace hardware {
+
+struct SensorHardwareConfiguration {
+    gpio::PinConfig sync_in;
+    gpio::PinConfig sync_out;
+    gpio::PinConfig data_ready;
+};
 
 /** abstract sensor hardware device for a sync line */
 class SensorHardwareBase {
@@ -15,6 +23,7 @@ class SensorHardwareBase {
 
     virtual auto set_sync() -> void = 0;
     virtual auto reset_sync() -> void = 0;
+    virtual auto check_data_ready() -> bool = 0;
 };
 };  // namespace hardware
 };  // namespace sensors

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -6,6 +6,7 @@
 #include "common/core/logging.h"
 #include "i2c/core/messages.hpp"
 #include "sensors/core/mmr920C04.hpp"
+#include "sensors/core/sensor_hardware_interface.hpp"
 #include "sensors/core/sensors.hpp"
 
 namespace sensors {
@@ -27,11 +28,13 @@ template <class I2CQueueWriter, class I2CQueuePoller,
 class MMR92C04 {
   public:
     MMR92C04(I2CQueueWriter &writer, I2CQueuePoller &poller,
-             CanClient &can_client, OwnQueue &own_queue)
+             CanClient &can_client, OwnQueue &own_queue,
+             sensors::hardware::SensorHardwareBase &hardware)
         : writer(writer),
           poller(poller),
           can_client(can_client),
-          own_queue(own_queue) {}
+          own_queue(own_queue),
+          hardware(hardware) {}
 
     /**
      * @brief Check if the MMR92C04 has been initialized.
@@ -257,6 +260,7 @@ class MMR92C04 {
     I2CQueuePoller &poller;
     CanClient &can_client;
     OwnQueue &own_queue;
+    hardware::SensorHardwareBase &hardware;
 
     template <mmr920C04::MMR920C04Register Reg>
     requires registers::WritableRegister<Reg>

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -116,9 +116,6 @@ class PressureSensorTask {
     ~PressureSensorTask() = default;
 
     /**
-/home/caila/ot3-firmware/sensors/tests/test_pressure_sensor.cpp:18:6: note:
-constraints not satisfied
-
      * Task entry point.
      */
     template <message_writer_task::TaskClient CanClient>

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -17,10 +17,11 @@ template <class I2CQueueWriter, class I2CQueuePoller,
           message_writer_task::TaskClient CanClient, class OwnQueue>
 class PressureMessageHandler {
   public:
-    explicit PressureMessageHandler(I2CQueueWriter &i2c_writer,
-                                    I2CQueuePoller &i2c_poller,
-                                    CanClient &can_client, OwnQueue &own_queue)
-        : driver{i2c_writer, i2c_poller, can_client, own_queue} {}
+    explicit PressureMessageHandler(
+        I2CQueueWriter &i2c_writer, I2CQueuePoller &i2c_poller,
+        CanClient &can_client, OwnQueue &own_queue,
+        sensors::hardware::SensorHardwareBase &hardware)
+        : driver{i2c_writer, i2c_poller, can_client, own_queue, hardware} {}
     PressureMessageHandler(const PressureMessageHandler &) = delete;
     PressureMessageHandler(const PressureMessageHandler &&) = delete;
     auto operator=(const PressureMessageHandler &)
@@ -115,14 +116,18 @@ class PressureSensorTask {
     ~PressureSensorTask() = default;
 
     /**
+/home/caila/ot3-firmware/sensors/tests/test_pressure_sensor.cpp:18:6: note:
+constraints not satisfied
+
      * Task entry point.
      */
     template <message_writer_task::TaskClient CanClient>
-    [[noreturn]] void operator()(i2c::writer::Writer<QueueImpl> *writer,
-                                 i2c::poller::Poller<QueueImpl> *poller,
-                                 CanClient *can_client) {
-        auto handler =
-            PressureMessageHandler{*writer, *poller, *can_client, get_queue()};
+    [[noreturn]] void operator()(
+        i2c::writer::Writer<QueueImpl> *writer,
+        i2c::poller::Poller<QueueImpl> *poller, CanClient *can_client,
+        sensors::hardware::SensorHardwareBase *hardware) {
+        auto handler = PressureMessageHandler{*writer, *poller, *can_client,
+                                              get_queue(), *hardware};
         handler.initialize();
         utils::TaskMessage message{};
         for (;;) {

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -12,7 +12,7 @@ class SensorHardware : public SensorHardwareBase {
     auto set_sync() -> void override { gpio::set(hardware.sync_out); }
     auto reset_sync() -> void override { gpio::reset(hardware.sync_out); }
     auto check_data_ready() -> bool override {
-        return gpio::is_set(hardware.sync_in);
+        return gpio::is_set(hardware.data_ready);
     }
     sensors::hardware::SensorHardwareConfiguration hardware;
 };

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -1,16 +1,21 @@
 #pragma once
 
-#include "common/firmware/gpio.hpp"
 #include "sensors/core/sensor_hardware_interface.hpp"
 
 namespace sensors {
 namespace hardware {
+
 class SensorHardware : public SensorHardwareBase {
   public:
-    explicit SensorHardware(gpio::PinConfig sync) : sync_pin(sync) {}
-    auto set_sync() -> void override { gpio::set(sync_pin); }
-    auto reset_sync() -> void override { gpio::reset(sync_pin); }
-    gpio::PinConfig sync_pin;
+    SensorHardware(sensors::hardware::SensorHardwareConfiguration hardware)
+        : hardware(hardware) {}
+    auto set_sync() -> void override { gpio::set(hardware.sync_out); }
+    auto reset_sync() -> void override { gpio::reset(hardware.sync_out); }
+    auto check_data_ready() -> bool override {
+        return gpio::is_set(hardware.sync_in);
+    }
+    sensors::hardware::SensorHardwareConfiguration hardware;
 };
+
 };  // namespace hardware
 };  // namespace sensors

--- a/include/sensors/simulation/hardware.hpp
+++ b/include/sensors/simulation/hardware.hpp
@@ -8,6 +8,9 @@ class SimulatedSensorHardware : public SensorHardwareBase {
   public:
     auto set_sync() -> void override {}
     auto reset_sync() -> void override {}
+    auto check_data_ready() -> bool override { return true; }
+
+  private:
 };
 };  // namespace hardware
 };  // namespace sensors

--- a/include/sensors/tests/mock_hardware.hpp
+++ b/include/sensors/tests/mock_hardware.hpp
@@ -12,13 +12,15 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
         sync_state = false;
         sync_reset_calls++;
     }
-
+    auto check_data_ready() -> bool override { return data_ready; }
+    auto change_data_ready_value(bool value) -> void { data_ready = value; }
     auto get_sync_state_mock() const -> bool { return sync_state; }
     auto get_sync_set_calls() const -> uint32_t { return sync_set_calls; }
     auto get_sync_reset_calls() const -> uint32_t { return sync_reset_calls; }
 
   private:
     bool sync_state = false;
+    bool data_ready = false;
     uint32_t sync_set_calls = 0;
     uint32_t sync_reset_calls = 0;
 };

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -31,7 +31,8 @@ void sensor_tasks::start_tasks(
     auto& environment_sensor_task = environment_sensor_task_builder.start(
         5, "enviro sensor", i2c1_task_client, queues);
     auto& pressure_sensor_task = pressure_sensor_task_builder.start(
-        5, "pressure sensor", i2c1_task_client, i2c1_poller_client, queues);
+        5, "pressure sensor", i2c1_task_client, i2c1_poller_client, queues,
+        sensor_hardware);
     auto& capacitive_sensor_task = capacitive_sensor_task_builder.start(
         5, "capacitive sensor", i2c1_task_client, i2c1_poller_client,
         sensor_hardware, queues);

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -68,7 +68,6 @@ static PipetteHardwarePin get_gpio_lt(PipetteHardwareDevice device) {
     }
 }
 
-
 static uint16_t get_spi_pins_lt(GPIO_TypeDef* for_handle) {
     /*
      * SPI Bus 2

--- a/pipettes/firmware/hardware_config.h
+++ b/pipettes/firmware/hardware_config.h
@@ -10,7 +10,8 @@ typedef struct {
 typedef enum {
     pipette_hardware_device_LED_drive,
     pipette_hardware_device_sync_in,
-    pipette_hardware_device_sync_out
+    pipette_hardware_device_sync_out,
+    pipette_hardware_device_data_ready,
 }PipetteHardwareDevice;
 
 uint16_t pipette_hardware_spi_pins(const PipetteType pipette_type, GPIO_TypeDef* which_handle);

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -299,17 +299,17 @@ auto interfaces::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
             .sync_in =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOB,
-                 .pin = GPIO_PIN_7,
+                 .pin = GPIO_PIN_5,
                  .active_setting = GPIO_PIN_RESET},
             .sync_out =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOB,
-                 .pin = GPIO_PIN_6,
+                 .pin = GPIO_PIN_4,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOB,
-                 .pin = GPIO_PIN_5,
+                 .port = GPIOC,
+                 .pin = GPIO_PIN_9,
                  .active_setting = GPIO_PIN_RESET},
         }};
     return pins;
@@ -325,17 +325,17 @@ auto interfaces::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
             .sync_in =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOB,
-                 .pin = GPIO_PIN_7,
+                 .pin = GPIO_PIN_5,
                  .active_setting = GPIO_PIN_RESET},
             .sync_out =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOB,
-                 .pin = GPIO_PIN_6,
+                 .pin = GPIO_PIN_4,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOB,
-                 .pin = GPIO_PIN_5,
+                 .port = GPIOC,
+                 .pin = GPIO_PIN_9,
                  .active_setting = GPIO_PIN_RESET},
         }};
     return pins;

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -290,3 +290,137 @@ auto interfaces::motor_configurations<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
     return interfaces::HighThroughputMotorConfigurations{
         .hardware_pins = pins, .driver_configs = configs};
 }
+
+template <>
+auto interfaces::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
+    -> interfaces::LowThroughputSensorHardware {
+    auto pins = interfaces::LowThroughputSensorHardware{
+        .primary = sensors::hardware::SensorHardwareConfiguration{
+            .sync_in =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_7,
+                 .active_setting = GPIO_PIN_RESET},
+            .sync_out =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_6,
+                 .active_setting = GPIO_PIN_RESET},
+            .data_ready =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_5,
+                 .active_setting = GPIO_PIN_RESET},
+        }};
+    return pins;
+}
+
+// TODO (06/02/22 CM): change up the hardware grouping to accommodate both
+//  pressure sensors on the EIGHT CHANNEL pipette
+template <>
+auto interfaces::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
+    -> interfaces::LowThroughputSensorHardware {
+    auto pins = interfaces::LowThroughputSensorHardware{
+        .primary = sensors::hardware::SensorHardwareConfiguration{
+            .sync_in =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_7,
+                 .active_setting = GPIO_PIN_RESET},
+            .sync_out =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_6,
+                 .active_setting = GPIO_PIN_RESET},
+            .data_ready =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_5,
+                 .active_setting = GPIO_PIN_RESET},
+        }};
+    return pins;
+}
+
+template <>
+auto interfaces::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
+    -> interfaces::HighThroughputSensorHardware {
+    auto pins = interfaces::HighThroughputSensorHardware{
+        .primary =
+            sensors::hardware::SensorHardwareConfiguration{
+                .sync_in =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_4,
+                     .active_setting = GPIO_PIN_RESET},
+                .sync_out =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_5,
+                     .active_setting = GPIO_PIN_RESET},
+                .data_ready =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_15,
+                     .active_setting = GPIO_PIN_RESET},
+            },
+        .secondary = sensors::hardware::SensorHardwareConfiguration{
+            .sync_in =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_4,
+                 .active_setting = GPIO_PIN_RESET},
+            .sync_out =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_5,
+                 .active_setting = GPIO_PIN_RESET},
+            .data_ready =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOA,
+                 .pin = GPIO_PIN_8,
+                 .active_setting = GPIO_PIN_RESET},
+        }};
+    return pins;
+}
+
+template <>
+auto interfaces::sensor_configurations<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
+    -> interfaces::HighThroughputSensorHardware {
+    auto pins = interfaces::HighThroughputSensorHardware{
+        .primary =
+            sensors::hardware::SensorHardwareConfiguration{
+                .sync_in =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_4,
+                     .active_setting = GPIO_PIN_RESET},
+                .sync_out =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_5,
+                     .active_setting = GPIO_PIN_RESET},
+                .data_ready =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_15,
+                     .active_setting = GPIO_PIN_RESET},
+            },
+        .secondary = sensors::hardware::SensorHardwareConfiguration{
+            .sync_in =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_4,
+                 .active_setting = GPIO_PIN_RESET},
+            .sync_out =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_5,
+                 .active_setting = GPIO_PIN_RESET},
+            .data_ready =
+                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOA,
+                 .pin = GPIO_PIN_8,
+                 .active_setting = GPIO_PIN_RESET},
+        }};
+    return pins;
+}

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -106,16 +106,10 @@ extern "C" void gear_callback() {
     // TODO implement the motor handler for the 96 channel
 }
 
-static sensors::hardware::SensorHardware pins_for_sensor_lt(gpio::PinConfig{
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    .port = GPIOB,
-    .pin = GPIO_PIN_4,
-    .active_setting = GPIO_PIN_RESET});
-static sensors::hardware::SensorHardware pins_for_sensor_96(gpio::PinConfig{
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    .port = GPIOB,
-    .pin = GPIO_PIN_5,
-    .active_setting = GPIO_PIN_RESET});
+static auto pins_for_sensor = interfaces::sensor_configurations<PIPETTE_TYPE>();
+
+auto sensor_hardware =
+    sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
 // Unfortunately, these numbers need to be literals or defines
 // to get the compile-time checks to work so we can't actually
@@ -141,7 +135,7 @@ auto initialize_motor_tasks(
                               peripheral_tasks::get_i2c3_client(),
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
-                              pins_for_sensor_96, id, eeprom_hardware_iface);
+                              sensor_hardware, id, eeprom_hardware_iface);
 
     initialize_linear_timer(plunger_callback);
     initialize_gear_timer(gear_callback);
@@ -159,7 +153,7 @@ auto initialize_motor_tasks(
                               peripheral_tasks::get_i2c3_client(),
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
-                              pins_for_sensor_lt, id, eeprom_hardware_iface);
+                              sensor_hardware, id, eeprom_hardware_iface);
 
     initialize_linear_timer(plunger_callback);
     linear_motor_tasks::start_tasks(

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -121,6 +121,45 @@ void sync_drive_gpio_init() {
     HAL_GPIO_WritePin(sync_out_hardware.port, sync_out_hardware.pin, GPIO_PIN_SET);
 }
 
+void data_ready_gpio_init() {
+    PipetteType pipette_type = get_pipette_type();
+    PipetteHardwarePin hardware;
+    if (pipette_type == SINGLE_CHANNEL || pipette_type == EIGHT_CHANNEL)
+    {
+        hardware =
+            pipette_hardware_get_gpio(
+                pipette_type, pipette_hardware_device_data_ready);
+    }
+    else {
+        hardware =
+            pipette_hardware_get_gpio(
+        pipette_type, pipette_hardware_device_data_ready);
+        PipetteHardwarePin hardware_rear =
+        pipette_hardware_get_gpio(
+            pipette_type, pipette_hardware_device_data_ready);
+
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        /*Configure GPIO pin*/
+        GPIO_InitTypeDef GPIO_InitStruct = {0};
+        GPIO_InitStruct.Pin = hardware_rear.pin;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Pull = GPIO_PULLUP;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        HAL_GPIO_Init(hardware.port, &GPIO_InitStruct);
+    }
+
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+
+    /*Configure GPIO pin*/
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = hardware.pin;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Pull = GPIO_PULLUP;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    HAL_GPIO_Init(hardware.port, &GPIO_InitStruct);
+}
+
 int tip_present() {
     return HAL_GPIO_ReadPin(GPIOA, GPIO_PIN_10) == GPIO_PIN_SET;
 }

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -11,6 +11,7 @@
 #include "sensors/core/mmr920C04.hpp"
 #include "sensors/core/tasks/pressure_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
+#include "sensors/tests/mock_hardware.hpp"
 
 template <typename Message, typename Queue>
 requires std::constructible_from<i2c::poller::TaskMessage, Message>
@@ -34,6 +35,7 @@ SCENARIO("read pressure sensor values") {
     test_mocks::MockMessageQueue<message_writer_task::TaskMessage> can_queue{};
     test_mocks::MockMessageQueue<sensors::utils::TaskMessage> pressure_queue{};
     test_mocks::MockI2CResponseQueue response_queue{};
+    test_mocks::MockSensorHardware mock_hw{};
 
     i2c::writer::TaskMessage empty_msg{};
     i2c::poller::TaskMessage empty_poll_msg{};
@@ -46,7 +48,7 @@ SCENARIO("read pressure sensor values") {
     poller.set_queue(&i2c_poll_queue);
 
     auto sensor = sensors::tasks::PressureMessageHandler{
-        writer, poller, queue_client, response_queue};
+        writer, poller, queue_client, response_queue, mock_hw};
     constexpr uint8_t pressure_id = 0x4;
     constexpr uint8_t pressure_temperature_id = 0x5;
 


### PR DESCRIPTION
This pr adds hardware support for the data ready pins on the pipette main boards, but does not check that pin's value or incorporate it into the pressure sensor reads. That will be done in a follow-up pr.