### PR TITLE
fix(spi): set a timeout and retries on commands to write to the spi queue

### DIFF
--- a/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
@@ -62,15 +62,14 @@ class TMC2130 {
         auto response = false;
 
         // setting a 10 ms timeout and 3 repeats.
-        for (int i=3; i>0; i--) {
-            response = _spi_manager.write(
-                converted_addr, command_data, _task_queue, _cs_intf, 10);
+        for (int i = 3; i > 0; i--) {
+            response = _spi_manager.write(converted_addr, command_data,
+                                          _task_queue, _cs_intf, 10);
             if (response) {
                 i = 0;
             }
         }
         return response;
-
     }
 
     /**

--- a/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
@@ -59,8 +59,18 @@ class TMC2130 {
 
     auto write(Registers addr, uint32_t command_data) -> bool {
         auto converted_addr = static_cast<uint8_t>(addr);
-        return _spi_manager.write(converted_addr, command_data, _task_queue,
-                                  _cs_intf);
+        auto response = false;
+
+        // setting a 10 ms timeout and 3 repeats.
+        for (int i=3; i>0; i--) {
+            response = _spi_manager.write(
+                converted_addr, command_data, _task_queue, _cs_intf, 10);
+            if (response) {
+                i = 0;
+            }
+        }
+        return response;
+
     }
 
     /**

--- a/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
@@ -59,8 +59,16 @@ class TMC2160 {
 
     auto write(Registers addr, uint32_t command_data) -> bool {
         auto converted_addr = static_cast<uint8_t>(addr);
-        return _spi_manager.write(converted_addr, command_data, _task_queue,
-                                  _cs_intf);
+        auto response = false;
+        // setting a 10 ms timeout and 3 repeats.
+        for (int i=3; i>0; i--) {
+            response = _spi_manager.write(
+                converted_addr, command_data, _task_queue, _cs_intf, 10);
+            if (response) {
+                i = 0;
+            }
+        }
+        return response;
     }
 
     /**

--- a/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
@@ -61,9 +61,9 @@ class TMC2160 {
         auto converted_addr = static_cast<uint8_t>(addr);
         auto response = false;
         // setting a 10 ms timeout and 3 repeats.
-        for (int i=3; i>0; i--) {
-            response = _spi_manager.write(
-                converted_addr, command_data, _task_queue, _cs_intf, 10);
+        for (int i = 3; i > 0; i--) {
+            response = _spi_manager.write(converted_addr, command_data,
+                                          _task_queue, _cs_intf, 10);
             if (response) {
                 i = 0;
             }

--- a/include/spi/core/writer.hpp
+++ b/include/spi/core/writer.hpp
@@ -77,7 +77,8 @@ class Writer {
      */
     template <OriginatingResponseQueue RQType>
     auto write(uint8_t register_addr, uint32_t command_data,
-               RQType& response_queue, utils::ChipSelectInterface cs_intf)
+               RQType& response_queue, utils::ChipSelectInterface cs_intf,
+               uint8_t timeout_ms = 1)
         -> bool {
         auto txBuffer = build_message(register_addr, spi::hardware::Mode::WRITE,
                                       command_data);
@@ -89,7 +90,7 @@ class Writer {
             .id = _transaction_id,
             .transaction = {.txBuffer = txBuffer, .cs_interface = cs_intf},
             .response_writer = ResponseWriter(response_queue)};
-        return queue->try_write(message);
+        return queue->try_write(message, timeout_ms);
     }
 
   private:

--- a/include/spi/core/writer.hpp
+++ b/include/spi/core/writer.hpp
@@ -78,8 +78,7 @@ class Writer {
     template <OriginatingResponseQueue RQType>
     auto write(uint8_t register_addr, uint32_t command_data,
                RQType& response_queue, utils::ChipSelectInterface cs_intf,
-               uint8_t timeout_ms = 1)
-        -> bool {
+               uint8_t timeout_ms = 1) -> bool {
         auto txBuffer = build_message(register_addr, spi::hardware::Mode::WRITE,
                                       command_data);
         TransactionIdentifier _transaction_id{

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -29,6 +29,8 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+
+        HAL_GPIO_WritePin(GPIOC, GPIO_InitStruct.Pin, GPIO_PIN_SET);
     }
 }
 


### PR DESCRIPTION
## Overview

The 96 channel has 3 motors all on the same spi bus. We were seeing an issue where the motor drivers weren't getting fully configured most likely because the queue was being overwritten by the three different motor driver tasks.

This PR adds in a timeout and retries to the spi write command in both motor drivers.

## Requirements

- [ ] Test on hardware with logic analyzer