### PR TITLE
fix(i2c): restrict the message queue size

### DIFF
--- a/i2c/tests/test_i2c_poll_task.cpp
+++ b/i2c/tests/test_i2c_poll_task.cpp
@@ -411,7 +411,6 @@ SCENARIO("test the limited-count i2c poller") {
         }
     }
 }
-}
 
 SCENARIO("test the ongoing i2c polling") {
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};


### PR DESCRIPTION
## Overview

In reality, message queues are restricted to a certain size. Some of the tests around polling relied
on the fact that dequeue (the simulation queue backing) does not have a set size. This PR restricts
that size to the default queue size (10) which also happens to be the poll count size.

@sfoster1 let me know if this keeps the intent of the test correctly.