### PR TITLE
refactor(tmc2160): modify how we scale current on the tmc2160 motor driver

### DIFF
--- a/include/motor-control/core/stepper_motor/tmc2160.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160.hpp
@@ -199,6 +199,19 @@ struct __attribute__((packed, __may_alias__)) GlobalScaler {
      * Hint: Values >128 recommended for best results
      */
     uint32_t global_scaler : 8 = 0;
+
+    static constexpr uint32_t minimum_value = 32;
+
+    auto check_operational_value() -> void {
+        // The minimum operational value (aside from zero) is 32.
+        // We should make sure that we aren't setting this register
+        // below 32 before writing it over spi.
+        if (global_scaler != 0) {
+            if (global_scaler < minimum_value) {
+                global_scaler = minimum_value;
+            }
+        }
+    }
 };
 
 /**

--- a/include/motor-control/core/stepper_motor/tmc2160.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160.hpp
@@ -201,12 +201,13 @@ struct __attribute__((packed, __may_alias__)) GlobalScaler {
     uint32_t global_scaler : 8 = 0;
 
     static constexpr uint32_t minimum_value = 32;
+    static constexpr uint32_t full_scale = 0;
 
-    auto check_operational_value() -> void {
+    auto clamp_value() -> void {
         // The minimum operational value (aside from zero) is 32.
         // We should make sure that we aren't setting this register
         // below 32 before writing it over spi.
-        if (global_scaler != 0) {
+        if (global_scaler != full_scale) {
             if (global_scaler < minimum_value) {
                 global_scaler = minimum_value;
             }

--- a/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
@@ -15,7 +15,6 @@
 #include "spi/core/utils.hpp"
 #include "spi/core/writer.hpp"
 #include "tmc2160.hpp"
-#include "common/core/logging.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
@@ -384,25 +383,30 @@ class TMC2160 {
         /*
          * From the datasheet (page 62):
          *
-         * For best precision of current setting, it is advised to measure and fine tune the current in the application.
-         * Choose the sense resistors to the next value covering the desired motor current.
-         * Set IRUN to 31 corresponding 100% of the desired motor current and fine-tune motor current using GLOBALSCALER.
-         * IHOLD should be set to a nominal value of 16.
+         * For best precision of current setting, it is advised to measure and
+         * fine tune the current in the application. Choose the sense resistors
+         * to the next value covering the desired motor current. Set IRUN to 31
+         * corresponding 100% of the desired motor current and fine-tune motor
+         * current using GLOBALSCALER. IHOLD should be set to a nominal value
+         * of 16.
          *
          * CURRENT_SCALE_RATIO = run_current_scale + 1 / 32 (should always be 1)
          * INV_SQRT_TWO = 1 / sqrt(2)
          * RMS_CURRENT_RATIO = full scale voltage / resistence
-         * GLOBALSCALAR = (256.0 * CURRENT)/ (CURRENT_SCALE_RATIO*INV_SQRT_TWO*RMS_CURRENT_RATIO)
+         * GLOBALSCALAR = (256.0 * CURRENT)/
+         * (CURRENT_SCALE_RATIO*INV_SQRT_TWO*RMS_CURRENT_RATIO)
          */
         constexpr auto INV_SQRT_TWO = 1.0 / sqrt2;
         constexpr auto GLOB_SCALE_MAX = 256.0;
         auto CURRENT_SCALE_RATIO = (_registers.ihold_irun.run_current + 1) / 32;
         auto RMS_CURRENT_RATIO = _current_config.v_sf / _current_config.r_sense;
-        auto FLOAT_CONSTANT =
-            static_cast<float>(GLOB_SCALE_MAX/(INV_SQRT_TWO * CURRENT_SCALE_RATIO * RMS_CURRENT_RATIO));
+        auto FLOAT_CONSTANT = static_cast<float>(
+            GLOB_SCALE_MAX /
+            (INV_SQRT_TWO * CURRENT_SCALE_RATIO * RMS_CURRENT_RATIO));
         auto fixed_point_constant = static_cast<uint32_t>(
             FLOAT_CONSTANT * static_cast<float>(1LL << 16));
-        uint64_t global_scalar = static_cast<uint64_t>(fixed_point_constant) * static_cast<uint64_t>(c);
+        uint64_t global_scalar = static_cast<uint64_t>(fixed_point_constant) *
+                                 static_cast<uint64_t>(c);
         return static_cast<uint32_t>(global_scalar >> 32) - 1;
     }
 

--- a/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
@@ -391,10 +391,12 @@ class TMC2160 {
          * of 16.
          *
          * CURRENT_SCALE_RATIO = run_current_scale + 1 / 32 (should always be 1)
-         * INV_SQRT_TWO = 1 / sqrt(2)
          * RMS_CURRENT_RATIO = full scale voltage / resistence
-         * GLOBALSCALAR = (256.0 * CURRENT)/
-         * (CURRENT_SCALE_RATIO*INV_SQRT_TWO*RMS_CURRENT_RATIO)
+         * GLOB_FROM_CURRENT = 256.0 * sqrt(2)
+         * GLOBALSCALAR_CONSTANT = GLOB_FROM_CURRENT / (CURRENT_SCALE_RATIO *
+         * RMS_CURRENT_RATIO)
+         *
+         * new_scalar = current * GLOBALSCALAR_CONSTANT
          */
         constexpr auto GLOB_FROM_CURRENT = 256.0 * sqrt2;
         float CURRENT_SCALE_RATIO =

--- a/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
@@ -397,9 +397,11 @@ class TMC2160 {
          * (CURRENT_SCALE_RATIO*INV_SQRT_TWO*RMS_CURRENT_RATIO)
          */
         constexpr auto GLOB_FROM_CURRENT = 256.0 * sqrt2;
-        float CURRENT_SCALE_RATIO = (_registers.ihold_irun.run_current + 1.0) / 32.0;
+        float CURRENT_SCALE_RATIO =
+            (_registers.ihold_irun.run_current + 1.0) / 32.0;
         auto RMS_CURRENT_RATIO = _current_config.v_sf / _current_config.r_sense;
-        auto GLOBAL_SCALE_CONSTANT = GLOB_FROM_CURRENT / (CURRENT_SCALE_RATIO * RMS_CURRENT_RATIO);
+        auto GLOBAL_SCALE_CONSTANT =
+            GLOB_FROM_CURRENT / (CURRENT_SCALE_RATIO * RMS_CURRENT_RATIO);
         auto fixed_point_constant = static_cast<uint32_t>(
             GLOBAL_SCALE_CONSTANT * static_cast<float>(1LL << 16));
         uint64_t global_scaler = static_cast<uint64_t>(fixed_point_constant) *

--- a/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160_driver.hpp
@@ -379,6 +379,14 @@ class TMC2160 {
 
     [[nodiscard]] auto convert_to_tmc2160_current_value(uint32_t c) const
         -> uint32_t {
+        /*
+         * From the datasheet (page 62):
+         *
+         * For best precision of current setting, it is advised to measure and fine tune the current in the application.
+         * Choose the sense resistors to the next value covering the desired motor current.
+         * Set IRUN to 31 corresponding 100% of the desired motor current and fine-tune motor current using GLOBALSCALER.
+         * IHOLD should be set to a nominal value of 16.
+         */
         constexpr auto SQRT_TWO = sqrt2;
         uint32_t CURR_GLOB_SCALE = _registers.glob_scale.global_scaler;
         auto GLOB_SCALE = static_cast<float>(CURR_GLOB_SCALE) / 256.0;

--- a/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
@@ -103,14 +103,13 @@ class MotorDriverMessageHandler {
             m.hold_current, m.run_current);
 
         if (m.hold_current != 0U) {
-            driver.get_register_map().ihold_irun.hold_current =
+            driver.get_register_map().glob_scale.global_scaler =
                 driver.convert_to_tmc2160_current_value(m.hold_current);
-        };
-        if (m.run_current != 0U) {
-            driver.get_register_map().ihold_irun.run_current =
+        } else if (m.run_current != 0U) {
+            driver.get_register_map().glob_scale.global_scaler =
                 driver.convert_to_tmc2160_current_value(m.run_current);
         }
-        driver.set_current_control(driver.get_register_map().ihold_irun);
+        driver.set_glob_scaler(driver.get_register_map().glob_scale);
     }
 
     tmc2160::driver::TMC2160<Writer, TaskQueue> driver;

--- a/motor-control/tests/test_motor_driver.cpp
+++ b/motor-control/tests/test_motor_driver.cpp
@@ -161,19 +161,25 @@ TEST_CASE("Setup a tmc2160 motor driver") {
             constexpr uint32_t one_amp = 1 << 16;
             constexpr uint32_t global_scaler_1amps = 110;
             auto register_config = subject.driver_config.registers;
-            REQUIRE(subject.driver.get_register_map()
-                        .glob_scale.global_scaler ==
-                    register_config.glob_scale.global_scaler);
+            REQUIRE(
+                subject.driver.get_register_map().glob_scale.global_scaler ==
+                register_config.glob_scale.global_scaler);
             THEN("The global scaler value is correct") {
-                auto two_amps_gs = subject.driver.convert_to_tmc2160_current_value(two_amps);
+                auto two_amps_gs =
+                    subject.driver.convert_to_tmc2160_current_value(two_amps);
                 REQUIRE(two_amps_gs == global_scaler_2amps);
-                auto one_amps_gs = subject.driver.convert_to_tmc2160_current_value(one_amp);
+                auto one_amps_gs =
+                    subject.driver.convert_to_tmc2160_current_value(one_amp);
                 REQUIRE(one_amps_gs == global_scaler_1amps);
             }
-            AND_THEN("Set the value to 32 if global scaler is calculated to be below 32") {
+            AND_THEN(
+                "Set the value to 32 if global scaler is calculated to be "
+                "below 32") {
                 subject.driver.get_register_map().glob_scale.global_scaler = 1;
-                subject.driver.set_glob_scaler(subject.driver.get_register_map().glob_scale);
-                REQUIRE(subject.driver.get_register_map().glob_scale.global_scaler == 32);
+                subject.driver.set_glob_scaler(
+                    subject.driver.get_register_map().glob_scale);
+                REQUIRE(subject.driver.get_register_map()
+                            .glob_scale.global_scaler == 32);
             }
         }
     }

--- a/motor-control/tests/test_motor_driver.cpp
+++ b/motor-control/tests/test_motor_driver.cpp
@@ -56,8 +56,8 @@ struct TMC2160Container {
     spi::writer::Writer<test_mocks::MockMessageQueue> spi_writer{};
     tmc2160::configs::TMC2160DriverConfig driver_config{
         .registers = {.gconfig = {.en_pwm_mode = 1},
-                      .ihold_irun = {.hold_current = 0x2,
-                                     .run_current = 0x2,
+                      .ihold_irun = {.hold_current = 16,
+                                     .run_current = 31,
                                      .hold_current_delay = 0x7},
                       .tpowerdown = {},
                       .tcoolthrs = {.threshold = 0},
@@ -151,6 +151,29 @@ TEST_CASE("Setup a tmc2160 motor driver") {
                 REQUIRE(subject.driver.get_register_map()
                             .glob_scale.global_scaler ==
                         register_config.glob_scale.global_scaler);
+            }
+        }
+
+        WHEN("Changing the current") {
+            constexpr uint32_t two_amps = 2 << 16;
+            constexpr uint32_t global_scaler_2amps = 221;
+
+            constexpr uint32_t one_amp = 1 << 16;
+            constexpr uint32_t global_scaler_1amps = 110;
+            auto register_config = subject.driver_config.registers;
+            REQUIRE(subject.driver.get_register_map()
+                        .glob_scale.global_scaler ==
+                    register_config.glob_scale.global_scaler);
+            THEN("The global scaler value is correct") {
+                auto two_amps_gs = subject.driver.convert_to_tmc2160_current_value(two_amps);
+                REQUIRE(two_amps_gs == global_scaler_2amps);
+                auto one_amps_gs = subject.driver.convert_to_tmc2160_current_value(one_amp);
+                REQUIRE(one_amps_gs == global_scaler_1amps);
+            }
+            AND_THEN("Set the value to 32 if global scaler is calculated to be below 32") {
+                subject.driver.get_register_map().glob_scale.global_scaler = 1;
+                subject.driver.set_glob_scaler(subject.driver.get_register_map().glob_scale);
+                REQUIRE(subject.driver.get_register_map().glob_scale.global_scaler == 32);
             }
         }
     }

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -13,8 +13,8 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
         default:
             return tmc2160::configs::TMC2160DriverConfig{
                 .registers = {.gconfig = {.en_pwm_mode = 1},
-                              .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x19,
+                              .ihold_irun = {.hold_current = 16,
+                                             .run_current = 31,
                                              .hold_current_delay = 0x7},
                               .tpowerdown = {},
                               .tcoolthrs = {.threshold = 0},


### PR DESCRIPTION
## Overview

The datasheet for the 2160 driver suggests that current be scaled based on the global scalar as
opposed to calculated the value of IRUN Or IHOLD directly. I think we probably need to dig a bit
deeper into stealthchop, whenever we want to actually configure it properly, because there were some
warnings around changing the global scalar while using this feature.