### PR TITLE
chore(sensors, can): add sensor ids to can messages

### DIFF
--- a/gripper/core/tasks.cpp
+++ b/gripper/core/tasks.cpp
@@ -43,9 +43,10 @@ void gripper_tasks::start_tasks(
     i2c3_task_client.set_queue(&i2c3_task.get_queue());
     queues.i2c3_queue = &i2c3_task.get_queue();
 
-    auto& eeprom_task = eeprom_task_builder.start(5, "eeprom", i2c3_task_client,
-                                                  eeprom_hw_iface);
-    tasks.eeprom_task = &eeprom_task;
+    auto& eeprom_task =
+        eeprom_task_builder
+            .start(5, "eeprom", i2c3_task_client, eeprom_hw_iface)
+                tasks.eeprom_task = &eeprom_task;
     queues.eeprom_queue = &eeprom_task.get_queue();
 
     z_tasks::start_task(z_motor, spi_device, driver_configs, tasks);

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -163,4 +163,11 @@ enum class PipetteTipActionType {
     drop = 0x1,
 };
 
+/**
+ * Sensor Ids.
+ * Not to be confused with SensorType. This is the ID value that separate
+ * two or more of the same type of sensor within a system.
+ */
+enum class SensorId { S0 = 0x0, S1 = 0x1 };
+
 }  // namespace can::ids

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -550,13 +550,14 @@ struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> ReadFromSensorRequest {
         uint8_t sensor = 0;
-        uint8_t id = 0;
+        uint8_t sensor_id = 0;
         uint8_t offset_reading = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
-        body = bit_utils::bytes_to_int(body, limit, id);
+        body = bit_utils::bytes_to_int(body, limit, sensor_id);
         body = bit_utils::bytes_to_int(body, limit, offset_reading);
-        return ReadFromSensorRequest{
-            .sensor = sensor, .id = id, .offset_reading = offset_reading};
+        return ReadFromSensorRequest{.sensor = sensor,
+                                     .sensor_id = sensor_id,
+                                     .offset_reading = offset_reading};
     }
 
     auto operator==(const ReadFromSensorRequest& other) const -> bool = default;
@@ -564,22 +565,22 @@ struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
 
 struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
     uint8_t sensor;
-    uint8_t id;
+    uint8_t sensor_id;
     uint16_t data;
     uint8_t reg_address;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> WriteToSensorRequest {
         uint8_t sensor = 0;
-        uint8_t id = 0;
+        uint8_t sensor_id = 0;
         uint16_t data = 0;
         uint8_t reg_address = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
-        body = bit_utils::bytes_to_int(body, limit, id);
+        body = bit_utils::bytes_to_int(body, limit, sensor_id);
         body = bit_utils::bytes_to_int(body, limit, data);
         body = bit_utils::bytes_to_int(body, limit, reg_address);
         return WriteToSensorRequest{.sensor = sensor,
-                                    .id = id,
+                                    .sensor_id = sensor_id,
                                     .data = data,
                                     .reg_address = reg_address};
     }
@@ -589,19 +590,20 @@ struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
 
 struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
     uint8_t sensor = 0;
-    uint8_t id = 0;
+    uint8_t sensor_id = 0;
     uint8_t sample_rate = 1;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> BaselineSensorRequest {
         uint8_t sensor = 0;
-        uint8_t id = 0;
+        uint8_t sensor_id = 0;
         uint8_t sample_rate = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
-        body = bit_utils::bytes_to_int(body, limit, id);
+        body = bit_utils::bytes_to_int(body, limit, sensor_id);
         body = bit_utils::bytes_to_int(body, limit, sample_rate);
-        return BaselineSensorRequest{
-            .sensor = sensor, .id = id, .sample_rate = sample_rate};
+        return BaselineSensorRequest{.sensor = sensor,
+                                     .sensor_id = sensor_id,
+                                     .sample_rate = sample_rate};
     }
 
     auto operator==(const BaselineSensorRequest& other) const -> bool = default;
@@ -609,14 +611,15 @@ struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
 
 struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
     can::ids::SensorType sensor{};
-    uint8_t id = 0;
+    can::ids::SensorId sensor_id{};
     int32_t sensor_data = 0;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
-        iter = bit_utils::int_to_bytes(id, iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
+                                       limit);
         iter = bit_utils::int_to_bytes(sensor_data, iter, limit);
         return iter - body;
     }
@@ -627,23 +630,23 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
 struct SetSensorThresholdRequest
     : BaseMessage<MessageId::set_sensor_threshold_request> {
     can::ids::SensorType sensor;
-    uint8_t id;
+    can::ids::SensorId sensor_id;
     int32_t threshold;
     can::ids::SensorThresholdMode mode;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SetSensorThresholdRequest {
         uint8_t sensor = 0;
-        uint8_t id = 0;
+        uint8_t sensor_id = 0;
         int32_t threshold = 0;
         uint8_t mode = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
-        body = bit_utils::bytes_to_int(body, limit, id);
+        body = bit_utils::bytes_to_int(body, limit, sensor_id);
         body = bit_utils::bytes_to_int(body, limit, threshold);
         body = bit_utils::bytes_to_int(body, limit, mode);
         return SetSensorThresholdRequest{
             .sensor = static_cast<can::ids::SensorType>(sensor),
-            .id = id,
+            .sensor_id = static_cast<can::ids::SensorId>(sensor_id),
             .threshold = threshold,
             .mode = static_cast<can::ids::SensorThresholdMode>(mode)};
     }
@@ -655,7 +658,7 @@ struct SetSensorThresholdRequest
 struct SensorThresholdResponse
     : BaseMessage<MessageId::set_sensor_threshold_response> {
     can::ids::SensorType sensor{};
-    uint8_t id = 0;
+    can::ids::SensorId sensor_id{};
     int32_t threshold = 0;
     can::ids::SensorThresholdMode mode{};
 
@@ -663,7 +666,8 @@ struct SensorThresholdResponse
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
-        iter = bit_utils::int_to_bytes(id, iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
+                                       limit);
         iter = bit_utils::int_to_bytes(threshold, iter, limit);
         iter = bit_utils::int_to_bytes(static_cast<uint8_t>(mode), iter, limit);
         return iter - body;
@@ -803,19 +807,20 @@ struct SetSerialNumber : BaseMessage<MessageId::set_serial_number> {
 struct SensorDiagnosticRequest
     : BaseMessage<MessageId::sensor_diagnostic_request> {
     uint8_t sensor;
-    uint8_t id;
+    uint8_t sensor_id;
     uint8_t reg_address;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SensorDiagnosticRequest {
         uint8_t sensor = 0;
-        uint8_t id = 0;
+        uint8_t sensor_id = 0;
         uint8_t reg_address = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
-        body = bit_utils::bytes_to_int(body, limit, id);
+        body = bit_utils::bytes_to_int(body, limit, sensor_id);
         body = bit_utils::bytes_to_int(body, limit, reg_address);
-        return SensorDiagnosticRequest{
-            .sensor = sensor, .id = id, .reg_address = reg_address};
+        return SensorDiagnosticRequest{.sensor = sensor,
+                                       .sensor_id = sensor_id,
+                                       .reg_address = reg_address};
     }
 
     auto operator==(const SensorDiagnosticRequest& other) const
@@ -825,7 +830,7 @@ struct SensorDiagnosticRequest
 struct SensorDiagnosticResponse
     : BaseMessage<MessageId::sensor_diagnostic_response> {
     can::ids::SensorType sensor;
-    uint8_t id;
+    can::ids::SensorId sensor_id;
     uint8_t reg_address;
     uint32_t data;
 
@@ -833,7 +838,8 @@ struct SensorDiagnosticResponse
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
-        iter = bit_utils::int_to_bytes(id, iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
+                                       limit);
         iter = bit_utils::int_to_bytes(reg_address, iter, limit);
         iter = bit_utils::int_to_bytes(data, iter, limit);
         return iter - body;
@@ -865,7 +871,7 @@ struct PipetteInfoResponse : BaseMessage<MessageId::pipette_info_response> {
 struct BindSensorOutputRequest
     : BaseMessage<MessageId::bind_sensor_output_request> {
     can::ids::SensorType sensor;
-    uint8_t id;
+    can::ids::SensorId sensor_id;
     uint8_t binding;  // a bitfield of can::ids::SensorOutputBinding
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -878,7 +884,7 @@ struct BindSensorOutputRequest
         body = bit_utils::bytes_to_int(body, limit, _binding);
         return BindSensorOutputRequest{
             .sensor = static_cast<can::ids::SensorType>(_sensor),
-            .id = _id,
+            .sensor_id = static_cast<can::ids::SensorId>(_id),
             .binding = _binding};
     }
 
@@ -889,14 +895,15 @@ struct BindSensorOutputRequest
 struct BindSensorOutputResponse
     : BaseMessage<MessageId::bind_sensor_output_response> {
     can::ids::SensorType sensor{};
-    uint8_t id;
+    can::ids::SensorId sensor_id{};
     uint8_t binding{};  // a bitfield of can::ids::SensorOutputBinding
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
-        iter = bit_utils::int_to_bytes(id, iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
+                                       limit);
         iter = bit_utils::int_to_bytes(binding, iter, limit);
         return iter - body;
     }
@@ -968,7 +975,7 @@ struct TipActionResponse
 struct PeripheralStatusRequest
     : BaseMessage<MessageId::peripheral_status_request> {
     can::ids::SensorType sensor;
-    uint8_t id;
+    can::ids::SensorId sensor_id;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> PeripheralStatusRequest {
@@ -977,7 +984,8 @@ struct PeripheralStatusRequest
         body = bit_utils::bytes_to_int(body, limit, _sensor);
         body = bit_utils::bytes_to_int(body, limit, _id);
         return PeripheralStatusRequest{
-            .sensor = static_cast<can::ids::SensorType>(_sensor), .id = _id};
+            .sensor = static_cast<can::ids::SensorType>(_sensor),
+            .sensor_id = static_cast<can::ids::SensorId>(_id)};
     }
     auto operator==(const PeripheralStatusRequest& other) const
         -> bool = default;
@@ -986,14 +994,15 @@ struct PeripheralStatusRequest
 struct PeripheralStatusResponse
     : BaseMessage<MessageId::peripheral_status_response> {
     can::ids::SensorType sensor;
-    uint8_t id;
+    can::ids::SensorId sensor_id;
     uint8_t status;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
-        iter = bit_utils::int_to_bytes(id, body, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), body,
+                                       limit);
         iter = bit_utils::int_to_bytes(status, body, limit);
         return iter - body;
     }

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -544,16 +544,19 @@ struct FirmwareUpdateStatusResponse
 
 struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
     uint8_t sensor = 0;
+    uint8_t sensor_id = 0;
     uint8_t offset_reading = 0;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> ReadFromSensorRequest {
         uint8_t sensor = 0;
+        uint8_t id = 0;
         uint8_t offset_reading = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, id);
         body = bit_utils::bytes_to_int(body, limit, offset_reading);
-        return ReadFromSensorRequest{.sensor = sensor,
-                                     .offset_reading = offset_reading};
+        return ReadFromSensorRequest{
+            .sensor = sensor, .id = id, .offset_reading = offset_reading};
     }
 
     auto operator==(const ReadFromSensorRequest& other) const -> bool = default;
@@ -561,19 +564,24 @@ struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
 
 struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
     uint8_t sensor;
+    uint8_t id;
     uint16_t data;
     uint8_t reg_address;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> WriteToSensorRequest {
         uint8_t sensor = 0;
+        uint8_t id = 0;
         uint16_t data = 0;
         uint8_t reg_address = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, id);
         body = bit_utils::bytes_to_int(body, limit, data);
         body = bit_utils::bytes_to_int(body, limit, reg_address);
-        return WriteToSensorRequest{
-            .sensor = sensor, .data = data, .reg_address = reg_address};
+        return WriteToSensorRequest{.sensor = sensor,
+                                    .id = id,
+                                    .data = data,
+                                    .reg_address = reg_address};
     }
 
     auto operator==(const WriteToSensorRequest& other) const -> bool = default;
@@ -581,16 +589,19 @@ struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
 
 struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
     uint8_t sensor = 0;
+    uint8_t id = 0;
     uint8_t sample_rate = 1;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> BaselineSensorRequest {
         uint8_t sensor = 0;
+        uint8_t id = 0;
         uint8_t sample_rate = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, id);
         body = bit_utils::bytes_to_int(body, limit, sample_rate);
-        return BaselineSensorRequest{.sensor = sensor,
-                                     .sample_rate = sample_rate};
+        return BaselineSensorRequest{
+            .sensor = sensor, .id = id, .sample_rate = sample_rate};
     }
 
     auto operator==(const BaselineSensorRequest& other) const -> bool = default;
@@ -598,12 +609,14 @@ struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
 
 struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
     can::ids::SensorType sensor{};
+    uint8_t id = 0;
     int32_t sensor_data = 0;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
+        iter = bit_utils::int_to_bytes(id, iter, limit);
         iter = bit_utils::int_to_bytes(sensor_data, iter, limit);
         return iter - body;
     }
@@ -614,19 +627,23 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
 struct SetSensorThresholdRequest
     : BaseMessage<MessageId::set_sensor_threshold_request> {
     can::ids::SensorType sensor;
+    uint8_t id;
     int32_t threshold;
     can::ids::SensorThresholdMode mode;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SetSensorThresholdRequest {
         uint8_t sensor = 0;
+        uint8_t id = 0;
         int32_t threshold = 0;
         uint8_t mode = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, id);
         body = bit_utils::bytes_to_int(body, limit, threshold);
         body = bit_utils::bytes_to_int(body, limit, mode);
         return SetSensorThresholdRequest{
             .sensor = static_cast<can::ids::SensorType>(sensor),
+            .id = id,
             .threshold = threshold,
             .mode = static_cast<can::ids::SensorThresholdMode>(mode)};
     }
@@ -638,6 +655,7 @@ struct SetSensorThresholdRequest
 struct SensorThresholdResponse
     : BaseMessage<MessageId::set_sensor_threshold_response> {
     can::ids::SensorType sensor{};
+    uint8_t id = 0;
     int32_t threshold = 0;
     can::ids::SensorThresholdMode mode{};
 
@@ -645,6 +663,7 @@ struct SensorThresholdResponse
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
+        iter = bit_utils::int_to_bytes(id, iter, limit);
         iter = bit_utils::int_to_bytes(threshold, iter, limit);
         iter = bit_utils::int_to_bytes(static_cast<uint8_t>(mode), iter, limit);
         return iter - body;
@@ -784,16 +803,19 @@ struct SetSerialNumber : BaseMessage<MessageId::set_serial_number> {
 struct SensorDiagnosticRequest
     : BaseMessage<MessageId::sensor_diagnostic_request> {
     uint8_t sensor;
+    uint8_t id;
     uint8_t reg_address;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SensorDiagnosticRequest {
         uint8_t sensor = 0;
+        uint8_t id = 0;
         uint8_t reg_address = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, id);
         body = bit_utils::bytes_to_int(body, limit, reg_address);
-        return SensorDiagnosticRequest{.sensor = sensor,
-                                       .reg_address = reg_address};
+        return SensorDiagnosticRequest{
+            .sensor = sensor, .id = id, .reg_address = reg_address};
     }
 
     auto operator==(const SensorDiagnosticRequest& other) const
@@ -803,6 +825,7 @@ struct SensorDiagnosticRequest
 struct SensorDiagnosticResponse
     : BaseMessage<MessageId::sensor_diagnostic_response> {
     can::ids::SensorType sensor;
+    uint8_t id;
     uint8_t reg_address;
     uint32_t data;
 
@@ -810,6 +833,7 @@ struct SensorDiagnosticResponse
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
+        iter = bit_utils::int_to_bytes(id, iter, limit);
         iter = bit_utils::int_to_bytes(reg_address, iter, limit);
         iter = bit_utils::int_to_bytes(data, iter, limit);
         return iter - body;
@@ -841,16 +865,20 @@ struct PipetteInfoResponse : BaseMessage<MessageId::pipette_info_response> {
 struct BindSensorOutputRequest
     : BaseMessage<MessageId::bind_sensor_output_request> {
     can::ids::SensorType sensor;
+    uint8_t id;
     uint8_t binding;  // a bitfield of can::ids::SensorOutputBinding
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> BindSensorOutputRequest {
         uint8_t _sensor = 0;
+        uint8_t _id = 0;
         uint8_t _binding = 0;
         body = bit_utils::bytes_to_int(body, limit, _sensor);
+        body = bit_utils::bytes_to_int(body, limit, _id);
         body = bit_utils::bytes_to_int(body, limit, _binding);
         return BindSensorOutputRequest{
             .sensor = static_cast<can::ids::SensorType>(_sensor),
+            .id = _id,
             .binding = _binding};
     }
 
@@ -861,12 +889,14 @@ struct BindSensorOutputRequest
 struct BindSensorOutputResponse
     : BaseMessage<MessageId::bind_sensor_output_response> {
     can::ids::SensorType sensor{};
+    uint8_t id;
     uint8_t binding{};  // a bitfield of can::ids::SensorOutputBinding
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
+        iter = bit_utils::int_to_bytes(id, iter, limit);
         iter = bit_utils::int_to_bytes(binding, iter, limit);
         return iter - body;
     }
@@ -938,13 +968,16 @@ struct TipActionResponse
 struct PeripheralStatusRequest
     : BaseMessage<MessageId::peripheral_status_request> {
     can::ids::SensorType sensor;
+    uint8_t id;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> PeripheralStatusRequest {
         uint8_t _sensor = 0;
+        uint8_t _id = 0;
         body = bit_utils::bytes_to_int(body, limit, _sensor);
+        body = bit_utils::bytes_to_int(body, limit, _id);
         return PeripheralStatusRequest{
-            .sensor = static_cast<can::ids::SensorType>(_sensor)};
+            .sensor = static_cast<can::ids::SensorType>(_sensor), .id = _id};
     }
     auto operator==(const PeripheralStatusRequest& other) const
         -> bool = default;
@@ -953,12 +986,14 @@ struct PeripheralStatusRequest
 struct PeripheralStatusResponse
     : BaseMessage<MessageId::peripheral_status_response> {
     can::ids::SensorType sensor;
+    uint8_t id;
     uint8_t status;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), body, limit);
+        iter = bit_utils::int_to_bytes(id, body, limit);
         iter = bit_utils::int_to_bytes(status, body, limit);
         return iter - body;
     }

--- a/include/common/core/freertos_task.hpp
+++ b/include/common/core/freertos_task.hpp
@@ -83,13 +83,15 @@ template <uint32_t StackDepth,
                                           // reified type - a queue type like
                                           // FreeRTOSQueue. Its argument is a
                                           // reified type.
-          typename TaskObj>
+          typename TaskObj,
+          typename... TaskCtorArgs>
 // The complexity of the templating here is required because we don't want the
 // task classes or includes to have to deal with FreeRTOS - we want to leave the
 // exact type of queue, for instance, a template as long as we can. This class
 // is the place where we finally specify the type of queue.
 struct TaskStarter {
-    TaskStarter() : task_entry{queue}, task{task_entry} {}
+    TaskStarter(TaskCtorArgs... args)
+        : task_entry(queue, args...), task(task_entry) {}
     TaskStarter(const TaskStarter&) = delete;
     auto operator=(const TaskStarter&) -> TaskStarter& = delete;
     TaskStarter(TaskStarter&&) = delete;

--- a/include/gripper/core/tasks.hpp
+++ b/include/gripper/core/tasks.hpp
@@ -55,7 +55,9 @@ struct QueueClient : can::message_writer::MessageWriter {
 
     void send_eeprom_queue(const eeprom::task::TaskMessage& m);
 
-    void send_capacitive_sensor_queue(const sensors::utils::TaskMessage& m);
+    void send_capacitive_sensor_queue_s0(const sensors::utils::TaskMessage& m);
+    
+    void send_capacitive_sensor_queue_s1(const sensors::utils::TaskMessage& m);
 
     void send_environment_sensor_queue(const sensors::utils::TaskMessage& m);
 
@@ -77,7 +79,9 @@ struct QueueClient : can::message_writer::MessageWriter {
     freertos_message_queue::FreeRTOSMessageQueue<eeprom::task::TaskMessage>*
         eeprom_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<sensors::utils::TaskMessage>*
-        capacitive_sensor_queue{nullptr};
+        capacitive_sensor_queue_s0{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<sensors::utils::TaskMessage>*
+        capacitive_sensor_queue_s1{nullptr};
 };
 
 /**
@@ -123,8 +127,11 @@ struct AllTask {
     eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
         eeprom_task{nullptr};
     sensors::tasks::CapacitiveSensorTask<
-        freertos_message_queue::FreeRTOSMessageQueue>* capacitive_sensor_task{
-        nullptr};
+        freertos_message_queue::FreeRTOSMessageQueue>*
+        capacitive_sensor_task_s0{nullptr};
+    sensors::tasks::CapacitiveSensorTask<
+        freertos_message_queue::FreeRTOSMessageQueue>*
+        capacitive_sensor_task_s1{nullptr};
 };
 
 /**

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -48,8 +48,11 @@ struct Tasks {
         freertos_message_queue::FreeRTOSMessageQueue>* environment_sensor_task{
         nullptr};
     sensors::tasks::CapacitiveSensorTask<
-        freertos_message_queue::FreeRTOSMessageQueue>* capacitive_sensor_task{
-        nullptr};
+        freertos_message_queue::FreeRTOSMessageQueue>*
+        capacitive_sensor_task_s0{nullptr};
+    sensors::tasks::CapacitiveSensorTask<
+        freertos_message_queue::FreeRTOSMessageQueue>*
+        capacitive_sensor_task_s1{nullptr};
     sensors::tasks::PressureSensorTask<
         freertos_message_queue::FreeRTOSMessageQueue>* pressure_sensor_task{
         nullptr};
@@ -65,7 +68,10 @@ struct QueueClient : can::message_writer::MessageWriter {
 
     void send_environment_sensor_queue(const sensors::utils::TaskMessage& m);
 
-    void send_capacitive_sensor_queue(const sensors::utils::TaskMessage& m);
+    void send_capacitive_sensor_queue_s0(const sensors::utils::TaskMessage& m);
+
+    // TODO: implement s1 capacitive sensor for pipettes
+    void send_capacitive_sensor_queue_s1(const sensors::utils::TaskMessage&) {}
 
     void send_pressure_sensor_queue(const sensors::utils::TaskMessage& m);
 
@@ -74,7 +80,7 @@ struct QueueClient : can::message_writer::MessageWriter {
     freertos_message_queue::FreeRTOSMessageQueue<sensors::utils::TaskMessage>*
         environment_sensor_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<sensors::utils::TaskMessage>*
-        capacitive_sensor_queue{nullptr};
+        capacitive_sensor_queue_s0{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<sensors::utils::TaskMessage>*
         pressure_sensor_queue{nullptr};
 };

--- a/include/sensors/core/message_handlers/sensors.hpp
+++ b/include/sensors/core/message_handlers/sensors.hpp
@@ -27,30 +27,37 @@ class SensorHandler {
     void visit(const std::monostate &) {}
 
     void visit(const can::messages::SetSensorThresholdRequest &m) {
-        send_to_queue(can::ids::SensorType(m.sensor), m);
+        send_to_queue(can::ids::SensorType(m.sensor),
+                      can::ids::SensorId(m.sensor_id), m);
     }
 
     void visit(const can::messages::BaselineSensorRequest &m) {
-        send_to_queue(can::ids::SensorType(m.sensor), m);
+        send_to_queue(can::ids::SensorType(m.sensor),
+                      can::ids::SensorId(m.sensor_id), m);
     }
 
     void visit(const can::messages::WriteToSensorRequest &m) {
-        send_to_queue(can::ids::SensorType(m.sensor), m);
+        send_to_queue(can::ids::SensorType(m.sensor),
+                      can::ids::SensorId(m.sensor_id), m);
     }
 
     void visit(const can::messages::ReadFromSensorRequest &m) {
-        send_to_queue(can::ids::SensorType(m.sensor), m);
+        send_to_queue(can::ids::SensorType(m.sensor),
+                      can::ids::SensorId(m.sensor_id), m);
     }
 
     void visit(const can::messages::BindSensorOutputRequest &m) {
-        send_to_queue(can::ids::SensorType(m.sensor), m);
+        send_to_queue(can::ids::SensorType(m.sensor),
+                      can::ids::SensorId(m.sensor_id), m);
     }
 
     void visit(const can::messages::PeripheralStatusRequest &m) {
-        send_to_queue(can::ids::SensorType(m.sensor), m);
+        send_to_queue(can::ids::SensorType(m.sensor),
+                      can::ids::SensorId(m.sensor_id), m);
     }
 
-    void send_to_queue(can::ids::SensorType type, const utils::TaskMessage &m) {
+    void send_to_queue(can::ids::SensorType type, can::ids::SensorId id,
+                       const utils::TaskMessage &m) {
         switch (type) {
             case can::ids::SensorType::temperature: {
                 client.send_environment_sensor_queue(m);
@@ -61,7 +68,15 @@ class SensorHandler {
                 break;
             }
             case can::ids::SensorType::capacitive: {
-                client.send_capacitive_sensor_queue(m);
+                switch (id) {
+                    case can::ids::SensorId::S1: {
+                        client.send_capacitive_sensor_queue_s1(m);
+                        break;
+                    }
+                    default:
+                        client.send_capacitive_sensor_queue_s0(m);
+                        break;
+                }
                 break;
             }
             case can::ids::SensorType::pressure: {

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -27,7 +27,7 @@ struct ReadCapacitanceCallback {
   public:
     ReadCapacitanceCallback(CanClient &can_client, I2CQueueWriter &i2c_writer,
                             hardware::SensorHardwareBase &hardware,
-                            can::ids::SensorId id)
+                            can::ids::SensorId &id)
         : can_client{can_client},
           i2c_writer{i2c_writer},
           hardware{hardware},

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -155,7 +155,7 @@ class EnvironmentSensorTask {
     using Messages = utils::TaskMessage;
     using QueueType = QueueImpl<utils::TaskMessage>;
     EnvironmentSensorTask(QueueType &queue, can::ids::SensorId id)
-        : queue{queue}, id{id} {}
+        : queue{queue}, sensor_id{id} {}
     EnvironmentSensorTask(const EnvironmentSensorTask &c) = delete;
     EnvironmentSensorTask(const EnvironmentSensorTask &&c) = delete;
     auto operator=(const EnvironmentSensorTask &c) = delete;
@@ -169,7 +169,7 @@ class EnvironmentSensorTask {
     [[noreturn]] void operator()(i2c::writer::Writer<QueueImpl> *writer,
                                  CanClient *can_client) {
         auto handler = EnvironmentSensorMessageHandler(*writer, *can_client,
-                                                       get_queue(), id);
+                                                       get_queue(), sensor_id);
         handler.initialize();
         utils::TaskMessage message{};
         for (;;) {
@@ -183,7 +183,7 @@ class EnvironmentSensorTask {
 
   private:
     QueueType &queue;
-    can::ids::SensorId id;
+    can::ids::SensorId sensor_id;
 };
 };  // namespace tasks
 

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -29,12 +29,14 @@ class MMR92C04 {
   public:
     MMR92C04(I2CQueueWriter &writer, I2CQueuePoller &poller,
              CanClient &can_client, OwnQueue &own_queue,
-             sensors::hardware::SensorHardwareBase &hardware)
+             sensors::hardware::SensorHardwareBase &hardware,
+             const can::ids::SensorId &id)
         : writer(writer),
           poller(poller),
           can_client(can_client),
           own_queue(own_queue),
-          hardware(hardware) {}
+          hardware(hardware),
+          sensor_id(id) {}
 
     /**
      * @brief Check if the MMR92C04 has been initialized.
@@ -47,7 +49,7 @@ class MMR92C04 {
         return _registers;
     }
 
-    auto get_sensor_id() -> SensorType { return SensorType::pressure; }
+    auto get_sensor_type() -> SensorType { return SensorType::pressure; }
 
     auto get_host_id() -> NodeId { return NodeId::host; }
 
@@ -179,7 +181,7 @@ class MMR92C04 {
         auto pressure =
             mmr920C04::Pressure::to_pressure(_registers.pressure.reading);
         auto message = can::messages::ReadFromSensorResponse{
-            .sensor = get_sensor_id(), .sensor_data = pressure};
+            .sensor = get_sensor_type(), .sensor_data = pressure};
         can_client.send_can_message(get_host_id(), message);
     }
 
@@ -187,7 +189,7 @@ class MMR92C04 {
         auto pressure = mmr920C04::LowPassPressure::to_pressure(
             _registers.low_pass_pressure.reading);
         auto message = can::messages::ReadFromSensorResponse{
-            .sensor = get_sensor_id(), .sensor_data = pressure};
+            .sensor = get_sensor_type(), .sensor_data = pressure};
         can_client.send_can_message(get_host_id(), message);
     }
 
@@ -195,27 +197,32 @@ class MMR92C04 {
         auto temperature = mmr920C04::Temperature::to_temperature(
             _registers.low_pass_pressure.reading);
         auto message = can::messages::ReadFromSensorResponse{
-            .sensor = get_sensor_id(), .sensor_data = temperature};
+            .sensor = get_sensor_type(), .sensor_data = temperature};
         can_client.send_can_message(get_host_id(), message);
     }
 
     auto send_status() -> void {
         auto status = mmr920C04::Status::to_status(_registers.status.reading);
         auto message = can::messages::ReadFromSensorResponse{
-            .sensor = get_sensor_id(),
+            .sensor = get_sensor_type(),
+            .sensor_id = sensor_id,
             .sensor_data = static_cast<int32_t>(status)};
         can_client.send_can_message(get_host_id(), message);
     }
 
     auto send_threshold() -> void {
         auto message = can::messages::SensorThresholdResponse{
-            .sensor = get_sensor_id(), .threshold = get_threshold()};
+            .sensor = get_sensor_type(),
+            .sensor_id = sensor_id,
+            .threshold = get_threshold()};
         can_client.send_can_message(get_host_id(), message);
     }
 
     auto send_peripheral_response() -> void {
-        auto message = can::messages::PeripheralStatusResponse{
-            .sensor = get_sensor_id(), .status = initialized()};
+        auto message =
+            can::messages::PeripheralStatusResponse{.sensor = get_sensor_type(),
+                                                    .sensor_id = sensor_id,
+                                                    .status = initialized()};
         can_client.send_can_message(get_host_id(), message);
     }
 
@@ -261,6 +268,7 @@ class MMR92C04 {
     CanClient &can_client;
     OwnQueue &own_queue;
     hardware::SensorHardwareBase &hardware;
+    const can::ids::SensorId &sensor_id;
 
     template <mmr920C04::MMR920C04Register Reg>
     requires registers::WritableRegister<Reg>

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -20,8 +20,9 @@ class PressureMessageHandler {
     explicit PressureMessageHandler(
         I2CQueueWriter &i2c_writer, I2CQueuePoller &i2c_poller,
         CanClient &can_client, OwnQueue &own_queue,
-        sensors::hardware::SensorHardwareBase &hardware)
-        : driver{i2c_writer, i2c_poller, can_client, own_queue, hardware} {}
+        sensors::hardware::SensorHardwareBase &hardware,
+        const can::ids::SensorId &id)
+        : driver{i2c_writer, i2c_poller, can_client, own_queue, hardware, id} {}
     PressureMessageHandler(const PressureMessageHandler &) = delete;
     PressureMessageHandler(const PressureMessageHandler &&) = delete;
     auto operator=(const PressureMessageHandler &)
@@ -122,9 +123,10 @@ class PressureSensorTask {
     [[noreturn]] void operator()(
         i2c::writer::Writer<QueueImpl> *writer,
         i2c::poller::Poller<QueueImpl> *poller, CanClient *can_client,
-        sensors::hardware::SensorHardwareBase *hardware) {
-        auto handler = PressureMessageHandler{*writer, *poller, *can_client,
-                                              get_queue(), *hardware};
+        sensors::hardware::SensorHardwareBase *hardware,
+        const can::ids::SensorId *id) {
+        auto handler = PressureMessageHandler{
+            *writer, *poller, *can_client, get_queue(), *hardware, *id};
         handler.initialize();
         utils::TaskMessage message{};
         for (;;) {

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -109,7 +109,8 @@ class PressureSensorTask {
   public:
     using Messages = utils::TaskMessage;
     using QueueType = QueueImpl<utils::TaskMessage>;
-    PressureSensorTask(QueueType &queue) : queue{queue} {}
+    PressureSensorTask(QueueType &queue, can::ids::SensorId id)
+        : queue{queue}, sensor_id{id} {}
     PressureSensorTask(const PressureSensorTask &c) = delete;
     PressureSensorTask(const PressureSensorTask &&c) = delete;
     auto operator=(const PressureSensorTask &c) = delete;
@@ -123,10 +124,9 @@ class PressureSensorTask {
     [[noreturn]] void operator()(
         i2c::writer::Writer<QueueImpl> *writer,
         i2c::poller::Poller<QueueImpl> *poller, CanClient *can_client,
-        sensors::hardware::SensorHardwareBase *hardware,
-        const can::ids::SensorId *id) {
+        sensors::hardware::SensorHardwareBase *hardware) {
         auto handler = PressureMessageHandler{
-            *writer, *poller, *can_client, get_queue(), *hardware, *id};
+            *writer, *poller, *can_client, get_queue(), *hardware, sensor_id};
         handler.initialize();
         utils::TaskMessage message{};
         for (;;) {
@@ -140,6 +140,7 @@ class PressureSensorTask {
 
   private:
     QueueType &queue;
+    can::ids::SensorId sensor_id;
 };
 }  // namespace tasks
 }  // namespace sensors

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -30,7 +30,7 @@ using TaskMessage = typename ::utils::VariantCat<
  */
 template <typename Client>
 concept TaskClient = requires(Client client, const TaskMessage& m) {
-    {client.send_capacitive_sensor_queue(m)};
+    {client.send_capacitive_sensor_queue_s0(m)};
 };
 
 enum class BitMode : uint8_t { LSB = 0x0, MSB = 0x1 };

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -10,13 +10,15 @@ static auto eeprom_task_builder =
     freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
 
 static auto environment_sensor_task_builder =
-    freertos_task::TaskStarter<512, sensors::tasks::EnvironmentSensorTask>(
-        can::ids::SensorId::S0);
+    freertos_task::TaskStarter<512, sensors::tasks::EnvironmentSensorTask,
+                               can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto capacitive_sensor_task_builder =
-    freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask>{};
+    freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
+                               can::ids::SensorId>(can::ids::SensorId::S0);
 static auto pressure_sensor_task_builder =
-    freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask>{};
+    freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,
+                               can::ids::SensorId>(can::ids::SensorId::S0);
 
 void sensor_tasks::start_tasks(
     sensor_tasks::CanWriterTask& can_writer,
@@ -35,10 +37,10 @@ void sensor_tasks::start_tasks(
         5, "enviro sensor", i2c1_task_client, queues);
     auto& pressure_sensor_task = pressure_sensor_task_builder.start(
         5, "pressure sensor", i2c1_task_client, i2c1_poller_client, queues,
-        sensor_hardware, can::ids::SensorId::S0);
+        sensor_hardware);
     auto& capacitive_sensor_task = capacitive_sensor_task_builder.start(
         5, "capacitive sensor", i2c1_task_client, i2c1_poller_client,
-        sensor_hardware, queues, can::ids::SensorId::S0);
+        sensor_hardware, queues);
 
     tasks.eeprom_task = &eeprom_task;
     tasks.environment_sensor_task = &environment_sensor_task;

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -13,9 +13,10 @@ static auto environment_sensor_task_builder =
     freertos_task::TaskStarter<512, sensors::tasks::EnvironmentSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
-static auto capacitive_sensor_task_builder =
+static auto capacitive_sensor_task_builder_s0 =
     freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
+
 static auto pressure_sensor_task_builder =
     freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
@@ -38,19 +39,19 @@ void sensor_tasks::start_tasks(
     auto& pressure_sensor_task = pressure_sensor_task_builder.start(
         5, "pressure sensor", i2c1_task_client, i2c1_poller_client, queues,
         sensor_hardware);
-    auto& capacitive_sensor_task = capacitive_sensor_task_builder.start(
-        5, "capacitive sensor", i2c1_task_client, i2c1_poller_client,
+    auto& capacitive_sensor_task_s0 = capacitive_sensor_task_builder_s0.start(
+        5, "capacitive sensor s0", i2c1_task_client, i2c1_poller_client,
         sensor_hardware, queues);
 
     tasks.eeprom_task = &eeprom_task;
     tasks.environment_sensor_task = &environment_sensor_task;
-    tasks.capacitive_sensor_task = &capacitive_sensor_task;
+    tasks.capacitive_sensor_task_s0 = &capacitive_sensor_task_s0;
     tasks.pressure_sensor_task = &pressure_sensor_task;
 
     queues.set_queue(&can_writer.get_queue());
     queues.eeprom_queue = &eeprom_task.get_queue();
     queues.environment_sensor_queue = &environment_sensor_task.get_queue();
-    queues.capacitive_sensor_queue = &capacitive_sensor_task.get_queue();
+    queues.capacitive_sensor_queue_s0 = &capacitive_sensor_task_s0.get_queue();
     queues.pressure_sensor_queue = &pressure_sensor_task.get_queue();
 }
 
@@ -69,9 +70,9 @@ void sensor_tasks::QueueClient::send_environment_sensor_queue(
     environment_sensor_queue->try_write(m);
 }
 
-void sensor_tasks::QueueClient::send_capacitive_sensor_queue(
+void sensor_tasks::QueueClient::send_capacitive_sensor_queue_s0(
     const sensors::utils::TaskMessage& m) {
-    capacitive_sensor_queue->try_write(m);
+    capacitive_sensor_queue_s0->try_write(m);
 }
 
 void sensor_tasks::QueueClient::send_pressure_sensor_queue(

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -1,5 +1,6 @@
 #include "pipettes/core/sensor_tasks.hpp"
 
+#include "can/core/ids.hpp"
 #include "common/core/freertos_task.hpp"
 
 static auto tasks = sensor_tasks::Tasks{};
@@ -9,7 +10,9 @@ static auto eeprom_task_builder =
     freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
 
 static auto environment_sensor_task_builder =
-    freertos_task::TaskStarter<512, sensors::tasks::EnvironmentSensorTask>{};
+    freertos_task::TaskStarter<512, sensors::tasks::EnvironmentSensorTask>(
+        can::ids::SensorId::S0);
+
 static auto capacitive_sensor_task_builder =
     freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask>{};
 static auto pressure_sensor_task_builder =
@@ -32,10 +35,10 @@ void sensor_tasks::start_tasks(
         5, "enviro sensor", i2c1_task_client, queues);
     auto& pressure_sensor_task = pressure_sensor_task_builder.start(
         5, "pressure sensor", i2c1_task_client, i2c1_poller_client, queues,
-        sensor_hardware);
+        sensor_hardware, can::ids::SensorId::S0);
     auto& capacitive_sensor_task = capacitive_sensor_task_builder.start(
         5, "capacitive sensor", i2c1_task_client, i2c1_poller_client,
-        sensor_hardware, queues);
+        sensor_hardware, queues, can::ids::SensorId::S0);
 
     tasks.eeprom_task = &eeprom_task;
     tasks.environment_sensor_task = &environment_sensor_task;


### PR DESCRIPTION
Sometimes we have multiples of the same type of sensor present in a subsystem and we need separate sensor IDs to differentiate them.