### PR TITLE
chore: store firmware artifacts from actions

### DIFF
--- a/.github/workflows/bootloader.yaml
+++ b/.github/workflows/bootloader.yaml
@@ -11,7 +11,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -25,7 +25,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/bootloader.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/bootloader.yaml
+++ b/.github/workflows/bootloader.yaml
@@ -6,27 +6,25 @@ on:
       - "common/**"
       - "include/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "bootloader/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "bootloader/**"
       - "common/**"
       - "include/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "bootloader/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/bootloader.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/can.yaml
+++ b/.github/workflows/can.yaml
@@ -9,7 +9,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -22,7 +22,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/can.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/can.yaml
+++ b/.github/workflows/can.yaml
@@ -5,25 +5,23 @@ on:
       - "can/**"
       - "include/can/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "can/**"
       - "include/can/**"
       - "include/common/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/can.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -9,7 +9,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -21,7 +21,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/common.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -5,24 +5,22 @@ on:
       - "common/**"
       - "include/common/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "common/**"
       - "include/common/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/common.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/eeprom.yaml
+++ b/.github/workflows/eeprom.yaml
@@ -15,7 +15,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -33,7 +33,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/eeprom.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/eeprom.yaml
+++ b/.github/workflows/eeprom.yaml
@@ -11,12 +11,11 @@ on:
       - "common/**"
       - "include/can/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "eeprom/**"
@@ -28,13 +27,12 @@ on:
       - "common/**"
       - "include/can/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/eeprom.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -14,7 +14,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -31,7 +31,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/gantry.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -68,6 +68,7 @@ jobs:
       - name: "Lint"
         run: cmake --build ./build-cross --target gantry-lint
       - name: "Upload proto artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "gantry-proto-${{github.ref_name}}"
@@ -75,6 +76,7 @@ jobs:
             build-cross/gantry/firmware/*-proto-image*.hex
             build-cross/gantry/firmware/gantry-*-proto
       - name: "Upload rev1 artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "gantry-rev1-${{github.ref_name}}"
@@ -82,6 +84,7 @@ jobs:
             build-cross/gantry/firmware/*-rev1-image*.hex
             build-cross/gantry/firmware/gantry-*-rev1
       - name: "Upload default artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "gantry-${{github.ref_name}}"
@@ -116,6 +119,7 @@ jobs:
       - name: 'Build Y simulator'
         run: cmake --build ./build-host --target gantry-y-simulator
       - name: "Upload simulator artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "gantry-simulators-${{github.ref_name}}"

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: 'Build Y simulator'
         run: cmake --build ./build-host --target gantry-y-simulator
       - name: "Upload simulator artifacts"
-        uses: actions/upload-artifacts@v3
+        uses: actions/upload-artifact@v3
         with:
           name: gantry-simulators
           path: |

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -64,9 +64,34 @@ jobs:
       - name: "Format"
         run: cmake --build ./build-cross --target gantry-format-ci
       - name: "Build"
-        run: cmake --build --preset=gantry
+        run: cmake --build --preset=gantry --target gantry-images gantry-exes
       - name: "Lint"
         run: cmake --build ./build-cross --target gantry-lint
+      - name: "Upload proto artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: gantry-proto
+          path: |
+            build-cross/gantry/firmware/*-proto-image*.hex
+            build-cross/gantry/firmware/gantry-*-proto
+      - name: "Upload rev1 artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: gantry-rev1
+          path: |
+            build-cross/gantry/firmware/*-rev1-image*.hex
+            build-cross/gantry/firmware/gantry-*-rev1
+      - name: "Upload default artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: gantry
+          path: |
+            build-cross/gantry/firmware/gantry-x
+            build-cross/gantry/firmware/gantry-y
+            build-cross/gantry/firmware/gantry-x-image.hex
+            build-cross/gantry/firmware/gantry-y-image.hex
+
+
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"
@@ -90,3 +115,9 @@ jobs:
         run: cmake --build ./build-host --target gantry-x-simulator
       - name: 'Build Y simulator'
         run: cmake --build ./build-host --target gantry-y-simulator
+      - name: "Upload simulator artifacts"
+        uses: actions/upload-artifacts@v3
+        with:
+          name: gantry-simulators
+          path: |
+            build-host/gantry/simulator/gantry-*-simulator

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -9,13 +9,12 @@ on:
       - "!include/pipettes/**"
       - "!include/head/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "gantry/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "gantry/**"
@@ -25,14 +24,13 @@ on:
       - "!include/pipettes/**"
       - "!include/head/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "gantry/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/gantry.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -70,21 +70,21 @@ jobs:
       - name: "Upload proto artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: gantry-proto
+          name: "gantry-proto-${{github.ref_name}}"
           path: |
             build-cross/gantry/firmware/*-proto-image*.hex
             build-cross/gantry/firmware/gantry-*-proto
       - name: "Upload rev1 artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: gantry-rev1
+          name: "gantry-rev1-${{github.ref_name}}"
           path: |
             build-cross/gantry/firmware/*-rev1-image*.hex
             build-cross/gantry/firmware/gantry-*-rev1
       - name: "Upload default artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: gantry
+          name: "gantry-${{github.ref_name}}"
           path: |
             build-cross/gantry/firmware/gantry-x
             build-cross/gantry/firmware/gantry-y
@@ -118,6 +118,6 @@ jobs:
       - name: "Upload simulator artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: gantry-simulators
+          name: "gantry-simulators-${{github.ref_name}}"
           path: |
             build-host/gantry/simulator/gantry-*-simulator

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: "Format"
         run: cmake --build ./build-cross --target gripper-format-ci
       - name: "Build"
-        run: cmake --build ./build-cross --target gripper gripper-image.hex
+        run: cmake --build ./build-cross --target gripper gripper-image-hex
       - name: "Lint"
         run: cmake --build ./build-cross --target gripper-lint
       - name: "Upload artifacts"

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -74,6 +74,7 @@ jobs:
       - name: "Lint"
         run: cmake --build ./build-cross --target gripper-lint
       - name: "Upload artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "gripper-${{github.ref_name}}"
@@ -102,6 +103,7 @@ jobs:
       - name: 'Build simulator'
         run: cmake --build ./build-host --target gripper-simulator
       - name: "Upload artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "gripper-simulator-${{github.ref_name}}"

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -70,9 +70,16 @@ jobs:
       - name: "Format"
         run: cmake --build ./build-cross --target gripper-format-ci
       - name: "Build"
-        run: cmake --build ./build-cross --target gripper
+        run: cmake --build ./build-cross --target gripper gripper-image.hex
       - name: "Lint"
         run: cmake --build ./build-cross --target gripper-lint
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "gripper"
+          path: |
+            build-cross/gripper/firmware/gripper
+            build-cross/gripper/firmware/gripper-image.hex
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"
@@ -94,3 +101,9 @@ jobs:
         run: cmake --build ./build-host --target gripper-build-and-test
       - name: 'Build simulator'
         run: cmake --build ./build-host --target gripper-simulator
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "gripper-simulator"
+          path: |
+            build-host/gripper/simulator/gripper-simulator

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -76,10 +76,10 @@ jobs:
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: "gripper"
+          name: "gripper-${{github.ref_name}}"
           path: |
             build-cross/gripper/firmware/gripper
-            build-cross/gripper/firmware/gripper-image-hex
+            build-cross/gripper/firmware/gripper-image.hex
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"
@@ -104,6 +104,6 @@ jobs:
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: "gripper-simulator"
+          name: "gripper-simulator-${{github.ref_name}}"
           path: |
             build-host/gripper/simulator/gripper-simulator

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -12,13 +12,12 @@ on:
       - "!include/gantry/**"
       - "!include/head/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "gripper/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "gripper/**"
@@ -31,14 +30,13 @@ on:
       - "!include/gantry/**"
       - "!include/head/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "gripper/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/gripper.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -79,7 +79,7 @@ jobs:
           name: "gripper"
           path: |
             build-cross/gripper/firmware/gripper
-            build-cross/gripper/firmware/gripper-image.hex
+            build-cross/gripper/firmware/gripper-image-hex
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -36,7 +36,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-      - ".github/workflows/head.yaml"
+      - ".github/workflows/gripper.yaml"
     paths_ignore:
       - "cmake/Arduino*"
     branches:

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -17,7 +17,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -37,7 +37,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/gripper.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -79,6 +79,7 @@ jobs:
             build-cross/head/firmware/head-proto
             build-cross/head/firmware/head-proto-image.hex
       - name: "Upload rev1 artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "head-rev1-${{github.ref_name}}"
@@ -86,6 +87,7 @@ jobs:
             build-cross/head/firmware/head-rev1
             build-cross/head/firmware/head-rev1-image.hex
       - name: "Upload default artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "head-${{github.ref_name}}"
@@ -114,6 +116,7 @@ jobs:
       - name: 'Build simulator'
         run: cmake --build ./build-host --target head-simulator
       - name: 'Upload artifacts'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "head-simulator-${{github.ref_name}}"

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -68,9 +68,30 @@ jobs:
       - name: "Format"
         run: cmake --build ./build-cross --target head-format-ci
       - name: "Build"
-        run: cmake --build ./build-cross --target head
+        run: cmake --build ./build-cross --target head-exes head-images
       - name: "Lint"
         run: cmake --build ./build-cross --target head-lint
+      - name: "Upload proto artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: head-proto
+          path: |
+            build-cross/head/firmware/head-proto
+            build-cross/head/firmware/head-proto-image.hex
+      - name: "Upload rev1 artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: head-rev1
+          path: |
+            build-cross/head/firmware/head-rev1
+            build-cross/head/firmware/head-rev1-image.hex
+      - name: "Upload default artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: head
+          path: |
+            build-cross/head/firmware/head
+            build-cross/head/firmware/head-image.hex
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"
@@ -92,3 +113,9 @@ jobs:
         run: cmake --build ./build-host --target head-build-and-test
       - name: 'Build simulator'
         run: cmake --build ./build-host --target head-simulator
+      - name: 'Upload artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: head-simulator
+          path: |
+            build-cross/head/firmware/head-simulator

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -11,13 +11,12 @@ on:
       - "!include/pipettes/**"
       - "!include/gantry/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "head/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "head/**"
@@ -29,14 +28,13 @@ on:
       - "!include/pipettes/**"
       - "!include/gantry/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "head/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/head.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -74,21 +74,21 @@ jobs:
       - name: "Upload proto artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: head-proto
+          name: "head-proto-${{github.ref_name}}"
           path: |
             build-cross/head/firmware/head-proto
             build-cross/head/firmware/head-proto-image.hex
       - name: "Upload rev1 artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: head-rev1
+          name: "head-rev1-${{github.ref_name}}"
           path: |
             build-cross/head/firmware/head-rev1
             build-cross/head/firmware/head-rev1-image.hex
       - name: "Upload default artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: head
+          name: "head-${{github.ref_name}}"
           path: |
             build-cross/head/firmware/head
             build-cross/head/firmware/head-image.hex
@@ -116,6 +116,6 @@ jobs:
       - name: 'Upload artifacts'
         uses: actions/upload-artifact@v3
         with:
-          name: head-simulator
+          name: "head-simulator-${{github.ref_name}}"
           path: |
             build-cross/head/simulator/head-simulator

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -118,4 +118,4 @@ jobs:
         with:
           name: head-simulator
           path: |
-            build-cross/head/firmware/head-simulator
+            build-cross/head/simulator/head-simulator

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -120,4 +120,4 @@ jobs:
         with:
           name: "head-simulator-${{github.ref_name}}"
           path: |
-            build-cross/head/simulator/head-simulator
+            build-host/head/simulator/head-simulator

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -70,6 +70,7 @@ jobs:
       - name: "Lint"
         run: cmake --build ./build-cross --target head-lint
       - name: "Upload proto artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "head-proto-${{github.ref_name}}"

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -16,7 +16,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -35,7 +35,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/head.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/i2c.yaml
+++ b/.github/workflows/i2c.yaml
@@ -11,7 +11,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -25,7 +25,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/i2c.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/i2c.yaml
+++ b/.github/workflows/i2c.yaml
@@ -5,14 +5,13 @@ on:
       - "i2c/**"
       - "include/i2c/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "include/common/**"
       - "common/**"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "i2c/**"
@@ -20,13 +19,12 @@ on:
       - "include/common/**"
       - "common/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/i2c.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/motorcontrol.yaml
+++ b/.github/workflows/motorcontrol.yaml
@@ -9,7 +9,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -21,7 +21,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/common.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/motorcontrol.yaml
+++ b/.github/workflows/motorcontrol.yaml
@@ -5,24 +5,22 @@ on:
       - "motor-control/**"
       - "include/motor-control/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "motor-control/**"
       - "include/motor-control/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/common.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: "Format"
         run: cmake --build --preset=pipettes --target pipettes-format-ci
       - name: "Build"
-        run: cmake --build --preset=pipettes --target pipettes pipettes-images
+        run: cmake --build --preset=pipettes --target pipettes pipettes-images-hex
       - name: "Lint Single Channel"
         run: cmake --build --preset=pipettes --target pipettes-single-lint
       - name: "Lint Multi Channel"

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -17,7 +17,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -37,7 +37,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/pipettes.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -70,11 +70,24 @@ jobs:
       - name: "Format"
         run: cmake --build --preset=pipettes --target pipettes-format-ci
       - name: "Build"
-        run: cmake --build --preset=pipettes --target pipettes
+        run: cmake --build --preset=pipettes --target pipettes pipettes-images
       - name: "Lint Single Channel"
         run: cmake --build --preset=pipettes --target pipettes-single-lint
       - name: "Lint Multi Channel"
         run: cmake --build --preset=pipettes --target pipettes-multi-lint
+      - name: "Upload artifacts"
+        using: actions/upload-artifact@v3
+        with:
+          name: "pipettes"
+          path: |
+            pipettes/firmware/pipettes-single
+            pipettes/firmware/pipettes-multi
+            pipettes/firmware/pipettes-96
+            pipettes/firmware/pipettes-384
+            pipettes/firmware/pipettes-single-image.hex
+            pipettes/firmware/pipettes-multi-image.hex
+            pipettes/firmware/pipettes-96-image.hex
+            pipettes/firmware/pipettes-384-image.hex
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"
@@ -102,4 +115,9 @@ jobs:
         run: cmake --build ./build-host --target pipettes-96-simulator
       - name: 'Build 384 simulator'
         run: cmake --build ./build-host --target pipettes-384-simulator
-
+      - name: "Upload artifacts"
+        using: actions/upload-artifact@v3
+        with:
+          name: "pipettes-simulators"
+          path: |
+            pipettes/simulator/pipettes-*-simulator

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -80,14 +80,14 @@ jobs:
         with:
           name: "pipettes"
           path: |
-            pipettes/firmware/pipettes-single
-            pipettes/firmware/pipettes-multi
-            pipettes/firmware/pipettes-96
-            pipettes/firmware/pipettes-384
-            pipettes/firmware/pipettes-single-image.hex
-            pipettes/firmware/pipettes-multi-image.hex
-            pipettes/firmware/pipettes-96-image.hex
-            pipettes/firmware/pipettes-384-image.hex
+            build-cross-pipettes/pipettes/firmware/pipettes-single
+            build-cross-pipettes/pipettes/firmware/pipettes-multi
+            build-cross-pipettes/pipettes/firmware/pipettes-96
+            build-cross-pipettes/pipettes/firmware/pipettes-384
+            build-cross-pipettes/pipettes/firmware/pipettes-single-image.hex
+            build-cross-pipettes/pipettes/firmware/pipettes-multi-image.hex
+            build-cross-pipettes/pipettes/firmware/pipettes-96-image.hex
+            build-cross-pipettes/pipettes/firmware/pipettes-384-image.hex
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"
@@ -120,4 +120,4 @@ jobs:
         with:
           name: "pipettes-simulators"
           path: |
-            pipettes/simulator/pipettes-*-simulator
+            build-host/pipettes/simulator/pipettes-*-simulator

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: "Lint Multi Channel"
         run: cmake --build --preset=pipettes --target pipettes-multi-lint
       - name: "Upload artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "pipettes-${{github.ref_name}}"
@@ -116,6 +117,7 @@ jobs:
       - name: 'Build 384 simulator'
         run: cmake --build ./build-host --target pipettes-384-simulator
       - name: "Upload artifacts"
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v3
         with:
           name: "pipettes-simulators-${{github.ref_name}}"

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -12,13 +12,12 @@ on:
       - "!include/head/**"
       - "i2c/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "pipettes/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "pipettes/**"
@@ -31,14 +30,13 @@ on:
       - "!include/gantry/**"
       - "!include/head/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "pipettes/CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/pipettes.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: "Lint Multi Channel"
         run: cmake --build --preset=pipettes --target pipettes-multi-lint
       - name: "Upload artifacts"
-        using: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: "pipettes"
           path: |
@@ -116,7 +116,7 @@ jobs:
       - name: 'Build 384 simulator'
         run: cmake --build ./build-host --target pipettes-384-simulator
       - name: "Upload artifacts"
-        using: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: "pipettes-simulators"
           path: |

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: "pipettes"
+          name: "pipettes-${{github.ref_name}}"
           path: |
             build-cross-pipettes/pipettes/firmware/pipettes-single
             build-cross-pipettes/pipettes/firmware/pipettes-multi
@@ -118,6 +118,6 @@ jobs:
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: "pipettes-simulators"
+          name: "pipettes-simulators-${{github.ref_name}}"
           path: |
             build-host/pipettes/simulator/pipettes-*-simulator

--- a/.github/workflows/sensors.yaml
+++ b/.github/workflows/sensors.yaml
@@ -12,12 +12,11 @@ on:
       - "common/**"
       - "include/can/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "include/motor-control/core/**"
@@ -30,13 +29,12 @@ on:
       - "common/**"
       - "include/can/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/sensors.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/.github/workflows/sensors.yaml
+++ b/.github/workflows/sensors.yaml
@@ -16,7 +16,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -35,7 +35,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/sensors.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/spi.yaml
+++ b/.github/workflows/spi.yaml
@@ -10,7 +10,7 @@ on:
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
   push:
     paths:
@@ -24,7 +24,7 @@ on:
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/spi.yaml"
-    paths_ignore:
+    paths-ignore:
       - "cmake/Arduino*"
     branches:
       - "*"

--- a/.github/workflows/spi.yaml
+++ b/.github/workflows/spi.yaml
@@ -6,12 +6,11 @@ on:
       - "common/**"
       - "include/spi/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
-    paths-ignore:
-      - "cmake/Arduino*"
   push:
     paths:
       - "spi/**"
@@ -19,13 +18,12 @@ on:
       - "include/spi/**"
       - "include/common/**"
       - "cmake/*"
+      - "!cmake/Arduino*"
       - "CMakeLists.txt"
       - "CMakePresets.json"
       - ".clang-format"
       - ".clang-tidy"
       - ".github/workflows/spi.yaml"
-    paths-ignore:
-      - "cmake/Arduino*"
     branches:
       - "*"
     tags:

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -82,6 +82,8 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         ${COMMON_EXECUTABLE_DIR}/system/iwdg.c
         )
 
+set(IMAGES)
+set(EXECUTABLES)
 foreach(REV IN LISTS REVISIONS)
   foreach(AXIS IN LISTS AXES)
     add_executable(gantry-${AXIS}-${REV}
@@ -89,7 +91,7 @@ foreach(REV IN LISTS REVISIONS)
             ${GANTRY_FW_LINTABLE_SRCS_${REV}}
           ${GANTRY_FW_NON_LINTABLE_SRCS}
           ${CMAKE_SOURCE_DIR}/gantry/firmware/axis_${AXIS}_hardware_config.c)
-
+    list(APPEND EXECUTABLES gantry-${AXIS}-${REV})
     target_gantry_core(gantry-${AXIS}-${REV} ${AXIS} ${REV})
     target_ot_motor_control(gantry-${AXIS}-${REV})
 
@@ -126,19 +128,17 @@ foreach(REV IN LISTS REVISIONS)
             CROSSCOMPILING_EMULATOR
             "${ARM_GDB};--command=${GDBINIT_FILE}")
 
-    add_custom_command(OUTPUT gantry-${AXIS}-${REV}.hex
-            COMMAND ${CROSS_OBJCOPY} ARGS gantry-${AXIS}-${REV} "-Oihex" gantry-${AXIS}-${REV}.hex
+    add_custom_target(gantry-${AXIS}-${REV}.hex
+            COMMAND ${CROSS_OBJCOPY} gantry-${AXIS}-${REV} "-Oihex" gantry-${AXIS}-${REV}.hex
             DEPENDS gantry-${AXIS}-${REV}
+            COMMENT "Building firmware hex image for ${AXIS}-${REV}"
             VERBATIM)
-    add_custom_target(gantry-${AXIS}-${REV}-hex ALL
-            DEPENDS gantry-${AXIS}-${REV}.hex)
 
-    add_custom_command(OUTPUT gantry-${AXIS}-${REV}.bin
-            COMMAND ${CROSS_OBJCOPY} ARGS gantry-${AXIS}-${REV} "-Obinary" gantry-${AXIS}-${REV}.bin
+    add_custom_target(gantry-${AXIS}-${REV}.bin
+            COMMAND ${CROSS_OBJCOPY} gantry-${AXIS}-${REV} "-Obinary" gantry-${AXIS}-${REV}.bin
             DEPENDS gantry-${AXIS}-${REV}
+            COMMENT "Building firmware binary image for ${AXIS}-${REV}"
             VERBATIM)
-    add_custom_target(gantry-${AXIS}-${REV}-bin ALL
-            DEPENDS gantry-${AXIS}-${REV}.bin)
 
     # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
     # arguable misuse of the concept) to the appropriate cross-gdb with
@@ -149,33 +149,41 @@ foreach(REV IN LISTS REVISIONS)
     add_custom_target(gantry-debug-${AXIS}-${REV}
             COMMAND gantry-${AXIS}-${REV}
             USES_TERMINAL
+            COMMENT "Running debugger for ${AXIS}-${REV}"
             )
 
     # Targets to create full image hex file containing both bootloader and application
-    add_custom_command(
-            OUTPUT gantry-${AXIS}-${REV}-image.hex
-            DEPENDS gantry-${AXIS}-${REV}-hex bootloader-gantry-${AXIS}-hex gantry-${AXIS}-${REV}.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex
-            COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py gantry-${AXIS}-${REV}-image.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex gantry-${AXIS}-${REV}.hex
-            VERBATIM)
-    add_custom_target(gantry-${AXIS}-${REV}-image-hex ALL
-            DEPENDS gantry-${AXIS}-${REV}-image.hex)
-
+    add_custom_target(
+            gantry-${AXIS}-${REV}-image.hex ALL
+            ${CMAKE_SOURCE_DIR}/hex_combine.py gantry-${AXIS}-${REV}-image.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex gantry-${AXIS}-${REV}.hex
+            DEPENDS gantry-${AXIS}-${REV}.hex bootloader-gantry-${AXIS}-hex gantry-${AXIS}-${REV}.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex
+            VERBATIM
+            COMMENT "Building combined bootloader and firmware for ${AXIS}-${REV}")
+    list(APPEND IMAGES gantry-${AXIS}-${REV}-image.hex)
     # Targets to flash bootloader and firmware
     add_custom_target(gantry-${AXIS}-${REV}-flash
-            COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/gantry-${AXIS}-${REV}-image.hex;reset;exit"
+            "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/gantry-${AXIS}-${REV}-image.hex;reset;exit"
             VERBATIM
             COMMENT "Flashing gantry ${AXIS} ${REV}"
-            DEPENDS gantry-${AXIS}-${REV}-image-hex)
+            DEPENDS gantry-${AXIS}-${REV}-image.hex)
   endforeach()
 endforeach()
 
 #default targets
 foreach(AXIS IN LISTS AXES)
-  add_custom_target(gantry-${AXIS}-image-hex DEPENDS gantry-${AXIS}-${DEFAULT_REVISION}-image-hex)
+  add_custom_target(gantry-${AXIS}-image.hex
+      ${CMAKE_COMMAND} -E copy gantry-${AXIS}-${DEFAULT_REVISION}-image.hex gantry-${AXIS}-image.hex
+      DEPENDS gantry-${AXIS}-${DEFAULT_REVISION}-image.hex)
+  list(APPEND IMAGES gantry-${AXIS}-image.hex)
   add_custom_target(gantry-debug-${AXIS} DEPENDS gantry-debug-${AXIS}-${DEFAULT_REVISION})
-  add_custom_target(gantry-${AXIS} DEPENDS gantry-${AXIS}-${DEFAULT_REVISION})
+  add_custom_target(gantry-${AXIS}
+      COMMAND ${CMAKE_COMMAND} -E copy gantry-${AXIS}-${DEFAULT_REVISION} gantry-${AXIS}
+      DEPENDS gantry-${AXIS}-${DEFAULT_REVISION})
+  list(APPEND EXECUTABLES gantry-${AXIS})
   add_custom_target(gantry-${AXIS}-flash DEPENDS gantry-${AXIS}-${DEFAULT_REVISION}-flash)
 endforeach()
+add_custom_target(gantry-images DEPENDS ${IMAGES})
+add_custom_target(gantry-exes DEPENDS ${EXECUTABLES})
 find_package(Clang)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -81,9 +81,8 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         ${COMMON_EXECUTABLE_DIR}/system/app_update.c
         ${COMMON_EXECUTABLE_DIR}/system/iwdg.c
         )
-
 set(IMAGES)
-set(EXECUTABLES)
+set(EXES)
 foreach(REV IN LISTS REVISIONS)
   foreach(AXIS IN LISTS AXES)
     add_executable(gantry-${AXIS}-${REV}
@@ -91,7 +90,7 @@ foreach(REV IN LISTS REVISIONS)
             ${GANTRY_FW_LINTABLE_SRCS_${REV}}
           ${GANTRY_FW_NON_LINTABLE_SRCS}
           ${CMAKE_SOURCE_DIR}/gantry/firmware/axis_${AXIS}_hardware_config.c)
-    list(APPEND EXECUTABLES gantry-${AXIS}-${REV})
+    list(APPEND EXES gantry-${AXIS}-${REV})
     target_gantry_core(gantry-${AXIS}-${REV} ${AXIS} ${REV})
     target_ot_motor_control(gantry-${AXIS}-${REV})
 
@@ -128,17 +127,19 @@ foreach(REV IN LISTS REVISIONS)
             CROSSCOMPILING_EMULATOR
             "${ARM_GDB};--command=${GDBINIT_FILE}")
 
-    add_custom_target(gantry-${AXIS}-${REV}.hex
-            COMMAND ${CROSS_OBJCOPY} gantry-${AXIS}-${REV} "-Oihex" gantry-${AXIS}-${REV}.hex
+    add_custom_command(OUTPUT gantry-${AXIS}-${REV}.hex
+            COMMAND ${CROSS_OBJCOPY} ARGS gantry-${AXIS}-${REV} "-Oihex" gantry-${AXIS}-${REV}.hex
             DEPENDS gantry-${AXIS}-${REV}
-            COMMENT "Building firmware hex image for ${AXIS}-${REV}"
             VERBATIM)
+    add_custom_target(gantry-${AXIS}-${REV}-hex ALL
+            DEPENDS gantry-${AXIS}-${REV}.hex)
 
-    add_custom_target(gantry-${AXIS}-${REV}.bin
-            COMMAND ${CROSS_OBJCOPY} gantry-${AXIS}-${REV} "-Obinary" gantry-${AXIS}-${REV}.bin
+    add_custom_command(OUTPUT gantry-${AXIS}-${REV}.bin
+            COMMAND ${CROSS_OBJCOPY} ARGS gantry-${AXIS}-${REV} "-Obinary" gantry-${AXIS}-${REV}.bin
             DEPENDS gantry-${AXIS}-${REV}
-            COMMENT "Building firmware binary image for ${AXIS}-${REV}"
             VERBATIM)
+    add_custom_target(gantry-${AXIS}-${REV}-bin ALL
+            DEPENDS gantry-${AXIS}-${REV}.bin)
 
     # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
     # arguable misuse of the concept) to the appropriate cross-gdb with
@@ -149,41 +150,44 @@ foreach(REV IN LISTS REVISIONS)
     add_custom_target(gantry-debug-${AXIS}-${REV}
             COMMAND gantry-${AXIS}-${REV}
             USES_TERMINAL
-            COMMENT "Running debugger for ${AXIS}-${REV}"
             )
 
     # Targets to create full image hex file containing both bootloader and application
-    add_custom_target(
-            gantry-${AXIS}-${REV}-image.hex ALL
-            ${CMAKE_SOURCE_DIR}/hex_combine.py gantry-${AXIS}-${REV}-image.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex gantry-${AXIS}-${REV}.hex
-            DEPENDS gantry-${AXIS}-${REV}.hex bootloader-gantry-${AXIS}-hex gantry-${AXIS}-${REV}.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex
-            VERBATIM
-            COMMENT "Building combined bootloader and firmware for ${AXIS}-${REV}")
+    add_custom_command(
+            OUTPUT gantry-${AXIS}-${REV}-image.hex
+            DEPENDS gantry-${AXIS}-${REV}-hex bootloader-gantry-${AXIS}-hex gantry-${AXIS}-${REV}.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex
+            COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py gantry-${AXIS}-${REV}-image.hex $<TARGET_FILE_DIR:bootloader-gantry-${AXIS}>/bootloader-gantry-${AXIS}.hex gantry-${AXIS}-${REV}.hex
+            VERBATIM)
+    add_custom_target(gantry-${AXIS}-${REV}-image-hex ALL
+            DEPENDS gantry-${AXIS}-${REV}-image.hex)
     list(APPEND IMAGES gantry-${AXIS}-${REV}-image.hex)
+
     # Targets to flash bootloader and firmware
     add_custom_target(gantry-${AXIS}-${REV}-flash
-            "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/gantry-${AXIS}-${REV}-image.hex;reset;exit"
+            COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/gantry-${AXIS}-${REV}-image.hex;reset;exit"
             VERBATIM
             COMMENT "Flashing gantry ${AXIS} ${REV}"
-            DEPENDS gantry-${AXIS}-${REV}-image.hex)
+            DEPENDS gantry-${AXIS}-${REV}-image-hex)
   endforeach()
 endforeach()
 
 #default targets
 foreach(AXIS IN LISTS AXES)
-  add_custom_target(gantry-${AXIS}-image.hex
-      ${CMAKE_COMMAND} -E copy gantry-${AXIS}-${DEFAULT_REVISION}-image.hex gantry-${AXIS}-image.hex
-      DEPENDS gantry-${AXIS}-${DEFAULT_REVISION}-image.hex)
-  list(APPEND IMAGES gantry-${AXIS}-image.hex)
+  add_custom_command(OUTPUT gantry-${AXIS}-image.hex
+      COMMAND ${CMAKE_COMMAND} -E copy gantry-${AXIS}-${DEFAULT_REVISION}-image.hex gantry-${AXIS}-image.hex
+      DEPENDS gantry-${AXIS}-${DEFAULT_REVISION}-image-hex)
+  add_custom_target(gantry-${AXIS}-image-hex DEPENDS gantry-${AXIS}-image.hex)
+  list(APPEND IMAGES gantry-${AXIS}-image-hex)
   add_custom_target(gantry-debug-${AXIS} DEPENDS gantry-debug-${AXIS}-${DEFAULT_REVISION})
   add_custom_target(gantry-${AXIS}
-      COMMAND ${CMAKE_COMMAND} -E copy gantry-${AXIS}-${DEFAULT_REVISION} gantry-${AXIS}
+      ${CMAKE_COMMAND} -E copy gantry-${AXIS}-${DEFAULT_REVISION} gantry-${AXIS}
       DEPENDS gantry-${AXIS}-${DEFAULT_REVISION})
-  list(APPEND EXECUTABLES gantry-${AXIS})
+  list(APPEND EXES gantry-${AXIS})
   add_custom_target(gantry-${AXIS}-flash DEPENDS gantry-${AXIS}-${DEFAULT_REVISION}-flash)
 endforeach()
+
 add_custom_target(gantry-images DEPENDS ${IMAGES})
-add_custom_target(gantry-exes DEPENDS ${EXECUTABLES})
+add_custom_target(gantry-exes DEPENDS ${EXES})
 find_package(Clang)
 
 # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -107,15 +107,20 @@ find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
         PATHS "${CrossGCC_BINDIR}"
         NO_DEFAULT_PATH
         REQUIRED)
-add_custom_target(gripper.hex
-        ${CROSS_OBJCOPY} gripper "-Oihex" gripper.hex
+add_custom_command(OUTPUT gripper.hex
+        COMMAND ${CROSS_OBJCOPY} ARGS gripper "-Oihex" gripper.hex
         DEPENDS gripper
         VERBATIM)
+add_custom_target(gripper-hex ALL
+        DEPENDS gripper.hex)
 
-add_custom_target(gripper.bin
-        ${CROSS_OBJCOPY} gripper "-Obinary" gripper.bin
+add_custom_command(OUTPUT gripper.bin
+        COMMAND ${CROSS_OBJCOPY} ARGS gripper "-Obinary" gripper.bin
         DEPENDS gripper
         VERBATIM)
+add_custom_target(gripper-bin ALL
+        DEPENDS gripper.bin)
+
 
 find_package(Clang)
 
@@ -153,11 +158,13 @@ add_custom_target(gripper-debug
         )
 
 # Targets to create full image hex file containing both bootloader and application
-add_custom_target(
-        gripper-image.hex
-        ${CMAKE_SOURCE_DIR}/hex_combine.py gripper-image.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex gripper.hex
-        DEPENDS gripper.hex bootloader-gripper-hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
+add_custom_command(
+        OUTPUT gripper-image.hex
+        DEPENDS gripper-hex bootloader-gripper-hex gripper.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
+        COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py gripper-image.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex gripper.hex
         VERBATIM)
+add_custom_target(gripper-image-hex ALL
+        DEPENDS gripper-image.hex)
 
 set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32G491RETx/stm32g4discovery.cfg")
 
@@ -166,4 +173,4 @@ add_custom_target(gripper-flash
         COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/gripper-image.hex;reset;exit"
         VERBATIM
         COMMENT "Flashing board"
-        DEPENDS gripper-image.hex)
+        DEPENDS gripper-image-hex)

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -107,20 +107,15 @@ find_program(CROSS_OBJCOPY "${CrossGCC_TRIPLE}-objcopy"
         PATHS "${CrossGCC_BINDIR}"
         NO_DEFAULT_PATH
         REQUIRED)
-add_custom_command(OUTPUT gripper.hex
-        COMMAND ${CROSS_OBJCOPY} ARGS gripper "-Oihex" gripper.hex
+add_custom_target(gripper.hex
+        ${CROSS_OBJCOPY} gripper "-Oihex" gripper.hex
         DEPENDS gripper
         VERBATIM)
-add_custom_target(gripper-hex ALL
-        DEPENDS gripper.hex)
 
-add_custom_command(OUTPUT gripper.bin
-        COMMAND ${CROSS_OBJCOPY} ARGS gripper "-Obinary" gripper.bin
+add_custom_target(gripper.bin
+        ${CROSS_OBJCOPY} gripper "-Obinary" gripper.bin
         DEPENDS gripper
         VERBATIM)
-add_custom_target(gripper-bin ALL
-        DEPENDS gripper.bin)
-
 
 find_package(Clang)
 
@@ -158,13 +153,11 @@ add_custom_target(gripper-debug
         )
 
 # Targets to create full image hex file containing both bootloader and application
-add_custom_command(
-        OUTPUT gripper-image.hex
+add_custom_target(
+        gripper-image.hex
+        ${CMAKE_SOURCE_DIR}/hex_combine.py gripper-image.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex gripper.hex
         DEPENDS gripper-hex bootloader-gripper-hex gripper.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
-        COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py gripper-image.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex gripper.hex
         VERBATIM)
-add_custom_target(gripper-image-hex ALL
-        DEPENDS gripper-image.hex)
 
 set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32G491RETx/stm32g4discovery.cfg")
 

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -156,7 +156,7 @@ add_custom_target(gripper-debug
 add_custom_target(
         gripper-image.hex
         ${CMAKE_SOURCE_DIR}/hex_combine.py gripper-image.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex gripper.hex
-        DEPENDS gripper.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
+        DEPENDS gripper.hex bootloader-gripper-hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
         VERBATIM)
 
 set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32G491RETx/stm32g4discovery.cfg")

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -156,7 +156,7 @@ add_custom_target(gripper-debug
 add_custom_target(
         gripper-image.hex
         ${CMAKE_SOURCE_DIR}/hex_combine.py gripper-image.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex gripper.hex
-        DEPENDS gripper-hex bootloader-gripper-hex gripper.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
+        DEPENDS gripper.hex $<TARGET_FILE_DIR:bootloader-gripper>/bootloader-gripper.hex
         VERBATIM)
 
 set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32G491RETx/stm32g4discovery.cfg")
@@ -166,4 +166,4 @@ add_custom_target(gripper-flash
         COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/gripper-image.hex;reset;exit"
         VERBATIM
         COMMENT "Flashing board"
-        DEPENDS gripper-image-hex)
+        DEPENDS gripper-image.hex)

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -67,7 +67,8 @@ add_executable(head-rev1
         ${HEAD_FW_LINTABLE_SRCS}
         ${HEAD_FW_NON_LINTABLE_SRCS})
 target_head_core_rev1(head-rev1)
-
+set(IMAGES)
+set(EXES head-proto head-rev1)
 
 foreach(REVISION_TARGET IN LISTS REVISIONS )
   target_ot_motor_control(${REVISION_TARGET})
@@ -105,21 +106,15 @@ foreach(REVISION_TARGET IN LISTS REVISIONS )
           CROSSCOMPILING_EMULATOR
           "${ARM_GDB};--command=${CMAKE_BINARY_DIR}/common/firmware/STM32G491RETx/gdbinit")
 
-  add_custom_command(OUTPUT ${REVISION_TARGET}.hex
-          COMMAND ${CROSS_OBJCOPY} ARGS ${REVISION_TARGET} "-Oihex" ${REVISION_TARGET}.hex
+  add_custom_target(${REVISION_TARGET}.hex
+          ${CROSS_OBJCOPY} ${REVISION_TARGET} "-Oihex" ${REVISION_TARGET}.hex
           DEPENDS ${REVISION_TARGET}
           VERBATIM)
 
-  add_custom_target(${REVISION_TARGET}-hex ALL
-          DEPENDS ${REVISION_TARGET}.hex)
-
-  add_custom_command(OUTPUT ${REVISION_TARGET}.bin
-          COMMAND ${CROSS_OBJCOPY} ARGS ${REVISION_TARGET} "-Obinary" ${REVISION_TARGET}.bin
+  add_custom_target(${REVISION_TARGET}.bin
+          ${CROSS_OBJCOPY} ${REVISION_TARGET} "-Obinary" ${REVISION_TARGET}.bin
           DEPENDS ${REVISION_TARGET}
           VERBATIM)
-
-  add_custom_target(${REVISION_TARGET}-bin ALL
-          DEPENDS ${REVISION_TARGET}.bin)
 
   # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
   # arguable misuse of the concept) to the appropriate cross-gdb with
@@ -133,28 +128,34 @@ foreach(REVISION_TARGET IN LISTS REVISIONS )
           )
 
   # Targets to create full image hex file containing both bootloader and application
-  add_custom_command(
-          OUTPUT ${REVISION_TARGET}-image.hex
-          DEPENDS ${REVISION_TARGET}-hex bootloader-head-hex ${REVISION_TARGET}.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex
-          COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py ${REVISION_TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex ${REVISION_TARGET}.hex
+  add_custom_target(
+          ${REVISION_TARGET}-image.hex
+          ${CMAKE_SOURCE_DIR}/hex_combine.py ${REVISION_TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex ${REVISION_TARGET}.hex
+          DEPENDS ${REVISION_TARGET}.hex bootloader-head-hex ${REVISION_TARGET}.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex
           VERBATIM)
-  add_custom_target(${REVISION_TARGET}-image-hex ALL
-          DEPENDS ${REVISION_TARGET}-image.hex)
+  list(APPEND IMAGES ${REVISION_TARGET}-image.hex)
 
   # Targets to flash bootloader and firmware
   add_custom_target(${REVISION_TARGET}-flash
           COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/${REVISION_TARGET}-image.hex;reset;exit"
           VERBATIM
           COMMENT "Flashing board"
-          DEPENDS ${REVISION_TARGET}-image-hex)
+          DEPENDS ${REVISION_TARGET}-image.hex)
 endforeach()
 
 # Default targets
-add_custom_target(head-image-hex DEPENDS ${DEFAULT_REVISION}-image-hex)
+add_custom_target(head-image.hex
+  ${CMAKE_COMMAND} -E copy ${DEFAULT_REVISION}-image.hex head-image.hex
+  DEPENDS ${DEFAULT_REVISION}-image.hex
+  )
+add_custom_target(head
+  ${CMAKE_COMMAND} -E copy ${DEFAULT_REVISION} head
+  DEPENDS ${DEFAULT_REVISION})
 add_custom_target(head-debug DEPENDS ${DEFAULT_REVISION}-debug)
-add_custom_target(head DEPENDS ${DEFAULT_REVISION})
-add_custom_target(head-flash DEPENDS ${DEFAULT_REVISION}-flash)
 
+add_custom_target(head-flash DEPENDS ${DEFAULT_REVISION}-flash)
+add_custom_target(head-images DEPENDS head-image.hex ${IMAGES})
+add_custom_target(head-exes DEPENDS head ${EXES})
 
 target_include_directories(STM32G4xx_Drivers_Head
         PUBLIC .)

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -163,8 +163,8 @@ add_custom_command(OUTPUT head-image.hex
 )
 add_custom_target(head-image-hex DEPENDS head-image.hex)
 add_custom_target(head-flash DEPENDS ${DEFAULT_REVISION}-flash)
-add_custom_target(head-exes DEPENDS ${EXES})
-add_custom_target(head-images DEPENDS ${IMAGES})
+add_custom_target(head-exes DEPENDS head ${EXES})
+add_custom_target(head-images DEPENDS head-image-hex ${IMAGES})
 
 target_include_directories(STM32G4xx_Drivers_Head
         PUBLIC .)

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -68,7 +68,7 @@ add_executable(head-rev1
         ${HEAD_FW_NON_LINTABLE_SRCS})
 target_head_core_rev1(head-rev1)
 set(IMAGES)
-set(EXES head-proto head-rev1)
+set(EXES)
 
 foreach(REVISION_TARGET IN LISTS REVISIONS )
   target_ot_motor_control(${REVISION_TARGET})
@@ -105,16 +105,24 @@ foreach(REVISION_TARGET IN LISTS REVISIONS )
           PROPERTIES
           CROSSCOMPILING_EMULATOR
           "${ARM_GDB};--command=${CMAKE_BINARY_DIR}/common/firmware/STM32G491RETx/gdbinit")
+  list(APPEND EXES ${REVISION_TARGET})
 
-  add_custom_target(${REVISION_TARGET}.hex
-          ${CROSS_OBJCOPY} ${REVISION_TARGET} "-Oihex" ${REVISION_TARGET}.hex
+  add_custom_command(OUTPUT ${REVISION_TARGET}.hex
+          COMMAND ${CROSS_OBJCOPY} ARGS ${REVISION_TARGET} "-Oihex" ${REVISION_TARGET}.hex
           DEPENDS ${REVISION_TARGET}
           VERBATIM)
 
-  add_custom_target(${REVISION_TARGET}.bin
-          ${CROSS_OBJCOPY} ${REVISION_TARGET} "-Obinary" ${REVISION_TARGET}.bin
+  add_custom_target(${REVISION_TARGET}-hex ALL
+          DEPENDS ${REVISION_TARGET}.hex)
+  list(APPEND IMAGES ${REVISION_TARGET}-hex)
+
+  add_custom_command(OUTPUT ${REVISION_TARGET}.bin
+          COMMAND ${CROSS_OBJCOPY} ARGS ${REVISION_TARGET} "-Obinary" ${REVISION_TARGET}.bin
           DEPENDS ${REVISION_TARGET}
           VERBATIM)
+
+  add_custom_target(${REVISION_TARGET}-bin ALL
+          DEPENDS ${REVISION_TARGET}.bin)
 
   # Runs cross-gdb (since CMAKE_CROSSCOMPILING_EMULATOR is set in an
   # arguable misuse of the concept) to the appropriate cross-gdb with
@@ -128,34 +136,35 @@ foreach(REVISION_TARGET IN LISTS REVISIONS )
           )
 
   # Targets to create full image hex file containing both bootloader and application
-  add_custom_target(
-          ${REVISION_TARGET}-image.hex
-          ${CMAKE_SOURCE_DIR}/hex_combine.py ${REVISION_TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex ${REVISION_TARGET}.hex
-          DEPENDS ${REVISION_TARGET}.hex bootloader-head-hex ${REVISION_TARGET}.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex
+  add_custom_command(
+          OUTPUT ${REVISION_TARGET}-image.hex
+          DEPENDS ${REVISION_TARGET}-hex bootloader-head-hex ${REVISION_TARGET}.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex
+          COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py ${REVISION_TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-head>/bootloader-head.hex ${REVISION_TARGET}.hex
           VERBATIM)
-  list(APPEND IMAGES ${REVISION_TARGET}-image.hex)
+  add_custom_target(${REVISION_TARGET}-image-hex ALL
+          DEPENDS ${REVISION_TARGET}-image.hex)
 
   # Targets to flash bootloader and firmware
   add_custom_target(${REVISION_TARGET}-flash
           COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/${REVISION_TARGET}-image.hex;reset;exit"
           VERBATIM
           COMMENT "Flashing board"
-          DEPENDS ${REVISION_TARGET}-image.hex)
+          DEPENDS ${REVISION_TARGET}-image-hex)
 endforeach()
 
 # Default targets
-add_custom_target(head-image.hex
-  ${CMAKE_COMMAND} -E copy ${DEFAULT_REVISION}-image.hex head-image.hex
-  DEPENDS ${DEFAULT_REVISION}-image.hex
-  )
+add_custom_target(head-debug DEPENDS ${DEFAULT_REVISION}-debug)
 add_custom_target(head
   ${CMAKE_COMMAND} -E copy ${DEFAULT_REVISION} head
   DEPENDS ${DEFAULT_REVISION})
-add_custom_target(head-debug DEPENDS ${DEFAULT_REVISION}-debug)
-
+add_custom_command(OUTPUT head-image.hex
+  COMMAND ${CMAKE_COMMAND} -E copy ${DEFAULT_REVISION}-image.hex head-image.hex
+  DEPENDS ${DEFAULT_REVISION}-image-hex
+)
+add_custom_target(head-image-hex DEPENDS head-image.hex)
 add_custom_target(head-flash DEPENDS ${DEFAULT_REVISION}-flash)
-add_custom_target(head-images DEPENDS head-image.hex ${IMAGES})
-add_custom_target(head-exes DEPENDS head ${EXES})
+add_custom_target(head-exes DEPENDS ${EXES})
+add_custom_target(head-images DEPENDS ${IMAGES})
 
 target_include_directories(STM32G4xx_Drivers_Head
         PUBLIC .)

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -8,7 +8,7 @@ add_STM32L5_freertos("Pipettes")
 set(COMMON_EXECUTABLE_DIR "${CMAKE_SOURCE_DIR}/common/firmware")
 
 set(CAN_FW_DIR "${CMAKE_SOURCE_DIR}/can/firmware")
-
+set(IMAGES)
 
 # Add source files that should be checked by clang-tidy here
 set(PIPETTE_FW_LINTABLE_SRCS
@@ -66,7 +66,6 @@ find_program(ARM_GDB
 find_package(Clang)
 
 add_custom_target(pipettes)
-add_custom_target(pipettes-images)
 
 function(add_pipettes_executable TARGET)
     add_executable(${TARGET}
@@ -127,14 +126,19 @@ function(add_pipettes_executable TARGET)
             PATHS "${CrossGCC_BINDIR}"
             NO_DEFAULT_PATH
             REQUIRED)
-    add_custom_target(${TARGET}.hex
-            ${CROSS_OBJCOPY} ${TARGET} "-Oihex" ${TARGET}.hex
+    add_custom_command(OUTPUT ${TARGET}.hex
+            COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET} "-Oihex" ${TARGET}.hex
             DEPENDS ${TARGET}
             VERBATIM)
-    add_custom_target(${TARGET}.bin
-            ${CROSS_OBJCOPY} ${TARGET} "-Obinary" ${TARGET}.bin
+    add_custom_target(${TARGET}-hex ALL
+            DEPENDS ${TARGET}.hex)
+
+    add_custom_command(OUTPUT ${TARGET}.bin
+            COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET} "-Obinary" ${TARGET}.bin
             DEPENDS ${TARGET}
             VERBATIM)
+    add_custom_target(${TARGET}-bin ALL
+            DEPENDS ${TARGET}.bin)
 
     # # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
     # # which is a catch-all static analyzer/linter
@@ -169,10 +173,14 @@ function(add_pipettes_executable TARGET)
 
 
     # Targets to create full image hex file containing both bootloader and application
-    add_custom_target(${TARGET}-image.hex
-        ${CMAKE_SOURCE_DIR}/hex_combine.py ${TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
-        DEPENDS ${TARGET}.hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
-        VERBATIM)
+    add_custom_command(
+            OUTPUT ${TARGET}-image.hex
+            DEPENDS ${TARGET}-hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
+            COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py ${TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
+            VERBATIM)
+    add_custom_target(${TARGET}-image-hex ALL
+            DEPENDS ${TARGET}-image.hex)
+    list(APPEND IMAGES ${TARGET}-image-hex)
 
     set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32L562RETx/stm32l5discovery.cfg")
 
@@ -181,11 +189,11 @@ function(add_pipettes_executable TARGET)
             COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}-image.hex;reset;exit"
             VERBATIM
             COMMENT "Flashing board"
-            DEPENDS ${TARGET}-image.hex)
+            DEPENDS ${TARGET}-image-hex)
 
     add_dependencies(pipettes ${TARGET})
-    add_dependencies(pipettes-images ${TARGET}-image.hex)
 endfunction()
+add_custom_target(pipettes-images-hex DEPENDS ${IMAGES})
 
 add_pipettes_executable(pipettes-single)
 add_pipettes_executable(pipettes-multi)

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -171,7 +171,7 @@ function(add_pipettes_executable TARGET)
     # Targets to create full image hex file containing both bootloader and application
     add_custom_target(${TARGET}-image.hex
         ${CMAKE_SOURCE_DIR}/hex_combine.py ${TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
-        DEPENDS ${TARGET}-hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
+        DEPENDS ${TARGET}.hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
         VERBATIM)
 
     set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32L562RETx/stm32l5discovery.cfg")
@@ -181,7 +181,7 @@ function(add_pipettes_executable TARGET)
             COMMAND "${OpenOCD_EXECUTABLE}" "-f" "${DISCO_FILE}" "-c" "program ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}-image.hex;reset;exit"
             VERBATIM
             COMMENT "Flashing board"
-            DEPENDS ${TARGET}-image-hex)
+            DEPENDS ${TARGET}-image.hex)
 
     add_dependencies(pipettes ${TARGET})
     add_dependencies(pipettes-images ${TARGET}-image.hex)

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -66,6 +66,7 @@ find_program(ARM_GDB
 find_package(Clang)
 
 add_custom_target(pipettes)
+add_custom_target(pipettes-images)
 
 function(add_pipettes_executable TARGET)
     add_executable(${TARGET}
@@ -126,19 +127,14 @@ function(add_pipettes_executable TARGET)
             PATHS "${CrossGCC_BINDIR}"
             NO_DEFAULT_PATH
             REQUIRED)
-    add_custom_command(OUTPUT ${TARGET}.hex
-            COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET} "-Oihex" ${TARGET}.hex
+    add_custom_target(${TARGET}.hex
+            ${CROSS_OBJCOPY} ${TARGET} "-Oihex" ${TARGET}.hex
             DEPENDS ${TARGET}
             VERBATIM)
-    add_custom_target(${TARGET}-hex ALL
-            DEPENDS ${TARGET}.hex)
-
-    add_custom_command(OUTPUT ${TARGET}.bin
-            COMMAND ${CROSS_OBJCOPY} ARGS ${TARGET} "-Obinary" ${TARGET}.bin
+    add_custom_target(${TARGET}.bin
+            ${CROSS_OBJCOPY} ${TARGET} "-Obinary" ${TARGET}.bin
             DEPENDS ${TARGET}
             VERBATIM)
-    add_custom_target(${TARGET}-bin ALL
-            DEPENDS ${TARGET}.bin)
 
     # # runs clang-tidy https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html
     # # which is a catch-all static analyzer/linter
@@ -173,14 +169,10 @@ function(add_pipettes_executable TARGET)
 
 
     # Targets to create full image hex file containing both bootloader and application
-    add_custom_command(
-            OUTPUT ${TARGET}-image.hex
-            DEPENDS ${TARGET}-hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
-            COMMAND ${CMAKE_SOURCE_DIR}/hex_combine.py ${TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
-            VERBATIM)
-    add_custom_target(${TARGET}-image-hex ALL
-            DEPENDS ${TARGET}-image.hex)
-
+    add_custom_target(${TARGET}-image.hex
+        ${CMAKE_SOURCE_DIR}/hex_combine.py ${TARGET}-image.hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
+        DEPENDS ${TARGET}-hex bootloader-pipettes-hex $<TARGET_FILE_DIR:bootloader-pipettes>/bootloader-pipettes.hex ${TARGET}.hex
+        VERBATIM)
 
     set(DISCO_FILE "${COMMON_EXECUTABLE_DIR}/STM32L562RETx/stm32l5discovery.cfg")
 
@@ -192,6 +184,7 @@ function(add_pipettes_executable TARGET)
             DEPENDS ${TARGET}-image-hex)
 
     add_dependencies(pipettes ${TARGET})
+    add_dependencies(pipettes-images ${TARGET}-image.hex)
 endfunction()
 
 add_pipettes_executable(pipettes-single)


### PR DESCRIPTION
Refactor cmake targets to provide default-named outputs for all projects as well as revision and variant outputs. We can then store those outputs in github actions storage so we can distribute and store controlled outputs rather than dev builds.