### PR TITLE
Ryan g++12 test fixes

### DIFF
--- a/i2c/simulation/i2c_sim.cpp
+++ b/i2c/simulation/i2c_sim.cpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <vector>
+#include <algorithm>
 
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.h"

--- a/i2c/simulation/i2c_sim.cpp
+++ b/i2c/simulation/i2c_sim.cpp
@@ -1,8 +1,8 @@
 #include "i2c/simulation/i2c_sim.hpp"
 
+#include <algorithm>
 #include <map>
 #include <vector>
-#include <algorithm>
 
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.h"

--- a/include/can/tests/mock_message_buffer.hpp
+++ b/include/can/tests/mock_message_buffer.hpp
@@ -44,7 +44,8 @@ struct MockMessageBuffer {
 
     template <typename Iter, typename Limit>
     auto receive(Iter iter, Limit limit, uint32_t timeout) -> std::size_t {
-        auto buffer_length = std::min((size_t)(limit - iter), size_t(buff.size()));
+        auto buffer_length =
+            std::min((size_t)(limit - iter), size_t(buff.size()));
         auto read_iter = buff.begin();
         for (size_t i = 0; i < buffer_length; i++) {
             *(iter++) = *(read_iter++);

--- a/include/can/tests/mock_message_buffer.hpp
+++ b/include/can/tests/mock_message_buffer.hpp
@@ -44,9 +44,9 @@ struct MockMessageBuffer {
 
     template <typename Iter, typename Limit>
     auto receive(Iter iter, Limit limit, uint32_t timeout) -> std::size_t {
-        auto buffer_length = limit - iter;
+        auto buffer_length = std::min((size_t)(limit - iter), size_t(buff.size()));
         auto read_iter = buff.begin();
-        for (int i = 0; i < buffer_length; i++) {
+        for (size_t i = 0; i < buffer_length; i++) {
             *(iter++) = *(read_iter++);
         }
         this->timeout = timeout;

--- a/include/motor-control/core/stepper_motor/tmc2130.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130.hpp
@@ -98,7 +98,10 @@ template <typename Reg>
 // Struct has a valid register address
 // Struct has an integer with the total number of bits in a register.
 // This is used to mask the 64-bit value before writing to the IC.
-concept TMC2130Register = std::same_as<std::remove_cvref_t<decltype(Reg::address)>, std::remove_cvref_t<Registers&>> && std::integral<decltype(Reg::value_mask)>;
+concept TMC2130Register =
+    std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
+                 std::remove_cvref_t<Registers&>> &&
+    std::integral<decltype(Reg::value_mask)>;
 
 template <typename Reg>
 concept WritableRegister = requires() {

--- a/include/motor-control/core/stepper_motor/tmc2130.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130.hpp
@@ -95,13 +95,10 @@ inline auto is_valid_address(const uint8_t add) -> bool {
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
-concept TMC2130Register = requires(Reg& r, uint64_t value) {
-    // Struct has a valid register address
-    std::same_as<decltype(Reg::address), Registers&>;
-    // Struct has an integer with the total number of bits in a register.
-    // This is used to mask the 64-bit value before writing to the IC.
-    std::integral<decltype(Reg::value_mask)>;
-};
+// Struct has a valid register address
+// Struct has an integer with the total number of bits in a register.
+// This is used to mask the 64-bit value before writing to the IC.
+concept TMC2130Register = std::same_as<std::remove_cvref_t<decltype(Reg::address)>, std::remove_cvref_t<Registers&>> && std::integral<decltype(Reg::value_mask)>;
 
 template <typename Reg>
 concept WritableRegister = requires() {

--- a/include/motor-control/core/stepper_motor/tmc2160.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160.hpp
@@ -112,8 +112,10 @@ template <typename Reg>
 // Struct has a valid register address
 // Struct has an integer with the total number of bits in a register.
 // This is used to mask the 64-bit value before writing to the IC.
-concept TMC2160Register = std::same_as<std::remove_cvref_t<decltype(Reg::address)>, std::remove_cvref_t<Registers&>> && std::integral<decltype(Reg::value_mask)>;
-    
+concept TMC2160Register =
+    std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
+                 std::remove_cvref_t<Registers&>> &&
+    std::integral<decltype(Reg::value_mask)>;
 
 template <typename Reg>
 concept WritableRegister = requires() {

--- a/include/motor-control/core/stepper_motor/tmc2160.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160.hpp
@@ -109,13 +109,11 @@ inline auto is_valid_address(const uint8_t add) -> bool {
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
-concept TMC2160Register = requires(Reg& r, uint64_t value) {
-    // Struct has a valid register address
-    std::same_as<decltype(Reg::address), Registers&>;
-    // Struct has an integer with the total number of bits in a register.
-    // This is used to mask the 64-bit value before writing to the IC.
-    std::integral<decltype(Reg::value_mask)>;
-};
+// Struct has a valid register address
+// Struct has an integer with the total number of bits in a register.
+// This is used to mask the 64-bit value before writing to the IC.
+concept TMC2160Register = std::same_as<std::remove_cvref_t<decltype(Reg::address)>, std::remove_cvref_t<Registers&>> && std::integral<decltype(Reg::value_mask)>;
+    
 
 template <typename Reg>
 concept WritableRegister = requires() {

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -66,13 +66,10 @@ static auto is_valid_address(const uint8_t add) -> bool {
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
-concept MMR920C04Register = requires(Reg& r, uint32_t value) {
-    // Struct has a valid register address
-    std::same_as<decltype(Reg::address), Registers&>;
-    // Struct has an integer with the total number of bits in a register.
-    // This is used to mask the value before writing it to the sensor.
-    std::integral<decltype(Reg::value_mask)>;
-};
+// Struct has a valid register address
+// Struct has an integer with the total number of bits in a register.
+// This is used to mask the value before writing it to the sensor.
+concept MMR920C04Register = std::same_as<std::remove_cvref_t<decltype(Reg::address)>, std::remove_cvref_t<Registers&>> && std::integral<decltype(Reg::value_mask)>;
 
 struct __attribute__((packed, __may_alias__)) Reset {
     static constexpr Registers address = Registers::RESET;

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -69,7 +69,10 @@ template <typename Reg>
 // Struct has a valid register address
 // Struct has an integer with the total number of bits in a register.
 // This is used to mask the value before writing it to the sensor.
-concept MMR920C04Register = std::same_as<std::remove_cvref_t<decltype(Reg::address)>, std::remove_cvref_t<Registers&>> && std::integral<decltype(Reg::value_mask)>;
+concept MMR920C04Register =
+    std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
+                 std::remove_cvref_t<Registers&>> &&
+    std::integral<decltype(Reg::value_mask)>;
 
 struct __attribute__((packed, __may_alias__)) Reset {
     static constexpr Registers address = Registers::RESET;


### PR DESCRIPTION
Several fixes to make the "cmake --build ./build-host --target build-and-test" run on the updated fedora/g++

Fedora version 36
G++ version 12.1.1