### PR TITLE
Fix broken compilation on Fedora 36 and G++ 12.1.1

### DIFF
--- a/i2c/simulation/i2c_sim.cpp
+++ b/i2c/simulation/i2c_sim.cpp
@@ -1,5 +1,6 @@
 #include "i2c/simulation/i2c_sim.hpp"
 
+#include <algorithm>
 #include <map>
 #include <vector>
 

--- a/include/can/tests/mock_message_buffer.hpp
+++ b/include/can/tests/mock_message_buffer.hpp
@@ -44,9 +44,10 @@ struct MockMessageBuffer {
 
     template <typename Iter, typename Limit>
     auto receive(Iter iter, Limit limit, uint32_t timeout) -> std::size_t {
-        auto buffer_length = limit - iter;
+        auto buffer_length =
+            std::min((size_t)(limit - iter), size_t(buff.size()));
         auto read_iter = buff.begin();
-        for (int i = 0; i < buffer_length; i++) {
+        for (size_t i = 0; i < buffer_length; i++) {
             *(iter++) = *(read_iter++);
         }
         this->timeout = timeout;

--- a/include/motor-control/core/stepper_motor/tmc2130.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130.hpp
@@ -95,13 +95,13 @@ inline auto is_valid_address(const uint8_t add) -> bool {
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
-concept TMC2130Register = requires(Reg& r, uint64_t value) {
-    // Struct has a valid register address
-    std::same_as<decltype(Reg::address), Registers&>;
-    // Struct has an integer with the total number of bits in a register.
-    // This is used to mask the 64-bit value before writing to the IC.
+// Struct has a valid register address
+// Struct has an integer with the total number of bits in a register.
+// This is used to mask the 64-bit value before writing to the IC.
+concept TMC2130Register =
+    std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
+                 std::remove_cvref_t<Registers&>> &&
     std::integral<decltype(Reg::value_mask)>;
-};
 
 template <typename Reg>
 concept WritableRegister = requires() {

--- a/include/motor-control/core/stepper_motor/tmc2160.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2160.hpp
@@ -109,13 +109,13 @@ inline auto is_valid_address(const uint8_t add) -> bool {
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
-concept TMC2160Register = requires(Reg& r, uint64_t value) {
-    // Struct has a valid register address
-    std::same_as<decltype(Reg::address), Registers&>;
-    // Struct has an integer with the total number of bits in a register.
-    // This is used to mask the 64-bit value before writing to the IC.
+// Struct has a valid register address
+// Struct has an integer with the total number of bits in a register.
+// This is used to mask the 64-bit value before writing to the IC.
+concept TMC2160Register =
+    std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
+                 std::remove_cvref_t<Registers&>> &&
     std::integral<decltype(Reg::value_mask)>;
-};
 
 template <typename Reg>
 concept WritableRegister = requires() {

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -66,13 +66,13 @@ static auto is_valid_address(const uint8_t add) -> bool {
 
 /** Template concept to constrain what structures encapsulate registers.*/
 template <typename Reg>
-concept MMR920C04Register = requires(Reg& r, uint32_t value) {
-    // Struct has a valid register address
-    std::same_as<decltype(Reg::address), Registers&>;
-    // Struct has an integer with the total number of bits in a register.
-    // This is used to mask the value before writing it to the sensor.
+// Struct has a valid register address
+// Struct has an integer with the total number of bits in a register.
+// This is used to mask the value before writing it to the sensor.
+concept MMR920C04Register =
+    std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
+                 std::remove_cvref_t<Registers&>> &&
     std::integral<decltype(Reg::value_mask)>;
-};
 
 struct __attribute__((packed, __may_alias__)) Reset {
     static constexpr Registers address = Registers::RESET;


### PR DESCRIPTION
While Onboarding there were several errors on my new system that required some minor tweaks to get the "cmake --build ./build-host --target build-and-test" to run on my system.