### PR TITLE
refactor(motor-control): setup automatically

### DIFF
--- a/head/core/can_task.cpp
+++ b/head/core/can_task.cpp
@@ -25,7 +25,7 @@ auto can_sender_queue = freertos_message_queue::FreeRTOSMessageQueue<
 
 using MotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::MotorHandler<head_tasks::MotorQueueClient>,
-    can::messages::ReadMotorDriverRegister, can::messages::SetupRequest,
+    can::messages::ReadMotorDriverRegister,
     can::messages::WriteMotorDriverRegister,
     can::messages::WriteMotorCurrentRequest>;
 using MoveGroupDispatchTarget = can::dispatch::DispatchParseTarget<

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -35,7 +35,6 @@ enum class MessageId {
     enable_motor_request = 0x6,
     disable_motor_request = 0x7,
     move_request = 0x10,
-    setup_request = 0x2,
     write_eeprom = 0x201,
     read_eeprom_request = 0x202,
     read_eeprom_response = 0x203,

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -37,9 +37,8 @@ class MotorHandler {
 template <brushed_motor_driver_task::TaskClient BrushedMotorDriverTaskClient>
 class BrushedMotorHandler {
   public:
-    using MessageType =
-        std::variant<std::monostate, SetupRequest, SetBrushedMotorVrefRequest,
-                     SetBrushedMotorPwmRequest>;
+    using MessageType = std::variant<std::monostate, SetBrushedMotorVrefRequest,
+                                     SetBrushedMotorPwmRequest>;
 
     BrushedMotorHandler(BrushedMotorDriverTaskClient &motor_client)
         : motor_client{motor_client} {}

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -125,8 +125,6 @@ using EnableMotorRequest = Empty<MessageId::enable_motor_request>;
 
 using DisableMotorRequest = Empty<MessageId::disable_motor_request>;
 
-using SetupRequest = Empty<MessageId::setup_request>;
-
 using ReadLimitSwitchRequest = Empty<MessageId::limit_sw_request>;
 
 struct WriteToEEPromRequest : BaseMessage<MessageId::write_eeprom> {

--- a/include/gantry/core/can_task.hpp
+++ b/include/gantry/core/can_task.hpp
@@ -18,7 +18,7 @@ namespace can_task {
 
 using MotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::MotorHandler<gantry::queues::QueueClient>,
-    can::messages::ReadMotorDriverRegister, can::messages::SetupRequest,
+    can::messages::ReadMotorDriverRegister,
     can::messages::WriteMotorDriverRegister,
     can::messages::WriteMotorCurrentRequest>;
 using MoveGroupDispatchTarget = can::dispatch::DispatchParseTarget<

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -16,7 +16,7 @@ using namespace gripper_tasks;
 
 using MotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::MotorHandler<z_tasks::QueueClient>,
-    can::messages::ReadMotorDriverRegister, can::messages::SetupRequest,
+    can::messages::ReadMotorDriverRegister,
     can::messages::WriteMotorDriverRegister,
     can::messages::WriteMotorCurrentRequest>;
 using MoveGroupDispatchTarget = can::dispatch::DispatchParseTarget<
@@ -38,7 +38,7 @@ using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::FirmwareUpdateStatusRequest, can::messages::TaskInfoRequest>;
 using BrushedMotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::BrushedMotorHandler<g_tasks::QueueClient>,
-    can::messages::SetupRequest, can::messages::SetBrushedMotorVrefRequest,
+    can::messages::SetBrushedMotorVrefRequest,
     can::messages::SetBrushedMotorPwmRequest>;
 using BrushedMotionDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motion::BrushedMotionHandler<g_tasks::QueueClient>,

--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -23,7 +23,9 @@ class MotorDriverMessageHandler {
     MotorDriverMessageHandler(
         brushed_motor_driver::BrushedMotorDriverIface& driver,
         CanClient& can_client)
-        : driver{driver}, can_client{can_client} {}
+        : driver{driver}, can_client{can_client} {
+        driver.setup();
+    }
     MotorDriverMessageHandler(const MotorDriverMessageHandler& c) = delete;
     MotorDriverMessageHandler(const MotorDriverMessageHandler&& c) = delete;
     auto operator=(const MotorDriverMessageHandler& c) = delete;
@@ -40,11 +42,6 @@ class MotorDriverMessageHandler {
 
   private:
     void handle(std::monostate m) { static_cast<void>(m); }
-
-    void handle(const can::messages::SetupRequest&) {
-        LOG("Received motor setup request");
-        driver.setup();
-    }
 
     void handle(const can::messages::SetBrushedMotorVrefRequest& m) {
         auto val = fixed_point_to_float(m.v_ref, 16);
@@ -85,9 +82,6 @@ class MotorDriverTask {
     [[noreturn]] void operator()(
         brushed_motor_driver::BrushedMotorDriverIface* driver,
         CanClient* can_client) {
-        // Set up the motor driver.
-        //        driver->setup();
-
         auto handler = MotorDriverMessageHandler{*driver, *can_client};
         TaskMessage message{};
         for (;;) {

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -14,7 +14,6 @@ using MotionControlTaskMessage = std::variant<
 
 using MotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::ReadMotorDriverRegister,
-                 can::messages::SetupRequest,
                  can::messages::WriteMotorDriverRegister,
                  can::messages::WriteMotorCurrentRequest>;
 
@@ -28,8 +27,7 @@ using MoveGroupTaskMessage =
 using MoveStatusReporterTaskMessage = motor_messages::Ack;
 
 using BrushedMotorDriverTaskMessage =
-    std::variant<std::monostate, can::messages::SetupRequest,
-                 can::messages::SetBrushedMotorVrefRequest,
+    std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,
                  can::messages::SetBrushedMotorPwmRequest>;
 
 using BrushedMotionControllerTaskMessage =

--- a/include/motor-control/core/tasks/tmc2130_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/tmc2130_motor_driver_task.hpp
@@ -27,7 +27,9 @@ class MotorDriverMessageHandler {
     MotorDriverMessageHandler(Writer& writer, CanClient& can_client,
                               TaskQueue& task_queue,
                               tmc2130::configs::TMC2130DriverConfig& configs)
-        : driver(writer, task_queue, configs), can_client(can_client) {}
+        : driver(writer, task_queue, configs), can_client(can_client) {
+        driver.write_config();
+    }
     MotorDriverMessageHandler(const MotorDriverMessageHandler& c) = delete;
     MotorDriverMessageHandler(const MotorDriverMessageHandler&& c) = delete;
     auto operator=(const MotorDriverMessageHandler& c) = delete;
@@ -62,11 +64,6 @@ class MotorDriverMessageHandler {
             };
             can_client.send_can_message(can::ids::NodeId::host, response_msg);
         }
-    }
-
-    void handle(const can::messages::SetupRequest&) {
-        LOG("Received motor setup request");
-        driver.write_config();
     }
 
     void handle(const can::messages::WriteMotorDriverRegister& m) {

--- a/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
@@ -26,7 +26,9 @@ class MotorDriverMessageHandler {
     MotorDriverMessageHandler(Writer& writer, CanClient& can_client,
                               TaskQueue& task_queue,
                               tmc2160::configs::TMC2160DriverConfig& configs)
-        : driver(writer, task_queue, configs), can_client(can_client) {}
+        : driver(writer, task_queue, configs), can_client(can_client) {
+        driver.write_config();
+    }
     MotorDriverMessageHandler(const MotorDriverMessageHandler& c) = delete;
     MotorDriverMessageHandler(const MotorDriverMessageHandler&& c) = delete;
     auto operator=(const MotorDriverMessageHandler& c) = delete;
@@ -61,11 +63,6 @@ class MotorDriverMessageHandler {
             };
             can_client.send_can_message(can::ids::NodeId::host, response_msg);
         }
-    }
-
-    void handle(const can::messages::SetupRequest&) {
-        LOG("Received motor setup request");
-        driver.write_config();
     }
 
     void handle(const can::messages::WriteMotorDriverRegister& m) {

--- a/include/motor-control/core/tasks/tmc_motor_driver_common.hpp
+++ b/include/motor-control/core/tasks/tmc_motor_driver_common.hpp
@@ -9,7 +9,6 @@ namespace tasks {
 
 using SpiResponseMessage = std::tuple<spi::messages::TransactResponse>;
 using CanMessageTuple = std::tuple<can::messages::ReadMotorDriverRegister,
-                                   can::messages::SetupRequest,
                                    can::messages::WriteMotorDriverRegister,
                                    can::messages::WriteMotorCurrentRequest>;
 using CanMessage =

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -21,20 +21,20 @@ namespace dispatch_builder {
 using TMC2130MotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::MotorHandler<
         linear_motor_tasks::tmc2130_driver::QueueClient>,
-    can::messages::ReadMotorDriverRegister, can::messages::SetupRequest,
+    can::messages::ReadMotorDriverRegister,
     can::messages::WriteMotorDriverRegister,
     can::messages::WriteMotorCurrentRequest>;
 
 using TMC2160MotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::MotorHandler<
         linear_motor_tasks::tmc2160_driver::QueueClient>,
-    can::messages::ReadMotorDriverRegister, can::messages::SetupRequest,
+    can::messages::ReadMotorDriverRegister,
     can::messages::WriteMotorDriverRegister,
     can::messages::WriteMotorCurrentRequest>;
 
 using GearMotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::MotorHandler<gear_motor_tasks::QueueClient>,
-    can::messages::ReadMotorDriverRegister, can::messages::SetupRequest,
+    can::messages::ReadMotorDriverRegister,
     can::messages::WriteMotorDriverRegister,
     can::messages::WriteMotorCurrentRequest>;
 


### PR DESCRIPTION
We have this setup request canbus message that commands all the micros
to do a bunch of motor driver configuration that they have built in
anyway. Rather than require this, and therefore run the risk of a
programmer forgetting to do it, let's just make the setuprequest happen
internally without prompting.

## Testing
- [ ] should be tested on all micros along with a followup that enables motors when they begin to move; then some basic repl commands can be run without enabling first.