### PR TITLE
refactor(motor-control): Enable automatically

### DIFF
--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -32,6 +32,7 @@ class MotionController {
                         .group_id = can_msg.group_id,
                         .seq_id = can_msg.seq_id,
                         .stop_condition = MoveStopCondition::none};
+        enable_motor();
         queue.try_write(msg);
     }
 
@@ -42,17 +43,22 @@ class MotionController {
                         .group_id = can_msg.group_id,
                         .seq_id = can_msg.seq_id,
                         .stop_condition = MoveStopCondition::limit_switch};
+        if (!enabled) {
+            enable_motor();
+        }
         queue.try_write(msg);
     }
 
     void enable_motor() {
         hardware.activate_motor();
         hardware.start_timer_interrupt();
+        enabled = true;
     }
 
     void disable_motor() {
         hardware.deactivate_motor();
         hardware.stop_timer_interrupt();
+        enabled = false;
     }
 
     void stop() { hardware.stop_pwm(); }
@@ -62,6 +68,7 @@ class MotionController {
   private:
     BrushedMotorHardwareIface& hardware;
     GenericQueue& queue;
+    bool enabled = false;
 };
 
 }  // namespace brushed_motion_controller

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -168,6 +168,9 @@ class PipetteMotionController {
             can_msg.seq_id,
             static_cast<MoveStopCondition>(can_msg.request_stop_condition),
             can_msg.action};
+        if (!enabled) {
+            enable_motor();
+        }
         queue.try_write(msg);
     }
 

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -114,8 +114,8 @@ class MotionController {
     StepperMotorHardwareIface& hardware;
     MotionConstraints motion_constraints;
     GenericQueue& queue;
-        sq31_31 steps_per_mm{0};
-        bool enabled = false;
+    sq31_31 steps_per_mm{0};
+    bool enabled = false;
 };
 
 }  // namespace motion_controller
@@ -141,7 +141,7 @@ class PipetteMotionController {
           motion_constraints(constraints),
           queue(queue),
           steps_per_mm(convert_to_fixed_point_64_bit(
-                           linear_motion_sys_config.get_steps_per_mm(), 31)){}
+              linear_motion_sys_config.get_steps_per_mm(), 31)) {}
 
     auto operator=(const PipetteMotionController&)
         -> PipetteMotionController& = delete;


### PR DESCRIPTION
When the motors are about to move, they should get enabled without
requiring a previous enable request. This moves the enable motors
message into something used only for turning on motors and holding, as
in the OT-2, rather than a necessary step before turning motors -
removes the possibility for programmer error.