### PR TITLE
refactor(gripper): remove pwm freq via can

### DIFF
--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -25,7 +25,7 @@ void initialize_timer(motor_interrupt_callback callback);
 
 void initialize_dac();
 
-void update_pwm(uint32_t freq, uint32_t duty_cycle);
+void update_pwm(uint32_t duty_cycle);
 
 void set_brushed_motor_timer_callback(
     brushed_motor_interrupt_callback callback);

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -1,4 +1,13 @@
 #include "motor_hardware.h"
+#include "system_stm32g4xx.h"
+
+// The frequency of one full PWM cycle
+#define GRIPPER_JAW_PWM_FREQ_HZ (32000UL)
+// the number of selectable points in the PWM
+#define GRIPPER_JAW_PWM_WIDTH (100UL)
+// the frequency at which the timer should count so that it
+// does a full PWM cycle in the time specified by GRIPPER_JAW_PWM_FREQ_HZ
+#define GRIPPER_JAW_TIMER_FREQ (GRIPPER_JAW_PWM_FREQ_HZ * GRIPPER_JAW_PWM_WIDTH)
 
 TIM_HandleTypeDef htim1;
 TIM_HandleTypeDef htim3;
@@ -63,9 +72,9 @@ static void MX_TIM1_Init(void) {
      * Note that brushed timer tick at a different frequency from the stepper
      * motor timer.
      */
-    htim1.Init.Prescaler = calc_prescaler(1700000, 32000);
+    htim1.Init.Prescaler = calc_prescaler(SystemCoreClock, GRIPPER_JAW_TIMER_FREQ);
     htim1.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim1.Init.Period = 100 - 1;
+    htim1.Init.Period = GRIPPER_JAW_PWM_WIDTH-1;
     htim1.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     htim1.Init.RepetitionCounter = 0;
     htim1.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
@@ -88,7 +97,7 @@ static void MX_TIM1_Init(void) {
     }
     htim1_sConfigOC.OCMode = TIM_OCMODE_PWM1;
     /* Set duty cycle at 65% */
-    htim1_sConfigOC.Pulse = 65;
+    htim1_sConfigOC.Pulse = GRIPPER_JAW_PWM_WIDTH * 2 / 3;
     htim1_sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     htim1_sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
     htim1_sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
@@ -133,9 +142,9 @@ static void MX_TIM3_Init(void) {
      * Note that brushed timer tick at a different frequency from the stepper
      * motor timer.
      */
-    htim3.Init.Prescaler = calc_prescaler(1700000, 32000);
+    htim3.Init.Prescaler = calc_prescaler(SystemCoreClock, GRIPPER_JAW_TIMER_FREQ);
     htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim3.Init.Period = 100 - 1;
+    htim3.Init.Period = GRIPPER_JAW_PWM_WIDTH - 1;
     htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
     if (HAL_TIM_Base_Init(&htim3) != HAL_OK) {
@@ -156,7 +165,7 @@ static void MX_TIM3_Init(void) {
     }
     htim3_sConfigOC.OCMode = TIM_OCMODE_PWM1;
     /* Set duty cycle at 65% */
-    htim3_sConfigOC.Pulse = 65;  // round_closest(htim3.Init.Period, 2);
+    htim3_sConfigOC.Pulse = GRIPPER_JAW_PWM_WIDTH * 2 / 3;
     htim3_sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     htim3_sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
     if (HAL_TIM_PWM_ConfigChannel(&htim3, &htim3_sConfigOC, TIM_CHANNEL_1) !=
@@ -256,14 +265,12 @@ void initialize_timer(motor_interrupt_callback callback) {
     MX_TIM7_Init();
 }
 
-void update_pwm(uint32_t freq, uint32_t duty_cycle) {
-    htim1.Instance->PSC = calc_prescaler(1700000, freq);
+void update_pwm(uint32_t duty_cycle) {
     if (duty_cycle < htim1.Init.Period) {
         htim1.Instance->CCR1 = duty_cycle;
     }
     htim1.Instance->EGR = TIM_EGR_UG;
 
-    htim3.Instance->PSC = calc_prescaler(1700000, freq);
     if (duty_cycle < htim3.Init.Period) {
         htim3.Instance->CCR1 = duty_cycle;
     }
@@ -279,7 +286,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
     // Check which version of the timer triggered this callback
     if (htim == &htim7 && timer_callback) {
         timer_callback();
-    } else if (htim == &htim1) {
+    } else if (htim == &htim1 && brushed_timer_callback) {
         brushed_timer_callback();
     }
 }

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -106,7 +106,7 @@ static void MX_TIM1_Init(void) {
         Error_Handler();
     }
     htim1_sConfigOC.OCMode = TIM_OCMODE_PWM1;
-    /* Set duty cycle at 65% */
+    /* Set duty cycle at 66% */
     htim1_sConfigOC.Pulse = GRIPPER_JAW_PWM_WIDTH * 2 / 3;
     htim1_sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     htim1_sConfigOC.OCNPolarity = TIM_OCNPOLARITY_HIGH;
@@ -174,7 +174,7 @@ static void MX_TIM3_Init(void) {
         Error_Handler();
     }
     htim3_sConfigOC.OCMode = TIM_OCMODE_PWM1;
-    /* Set duty cycle at 65% */
+    /* Set duty cycle at 66% */
     htim3_sConfigOC.Pulse = GRIPPER_JAW_PWM_WIDTH * 2 / 3;
     htim3_sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
     htim3_sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -691,17 +691,13 @@ struct SetBrushedMotorVrefRequest
 
 struct SetBrushedMotorPwmRequest
     : BaseMessage<MessageId::set_brushed_motor_pwm_request> {
-    uint32_t freq;
     uint32_t duty_cycle;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SetBrushedMotorPwmRequest {
-        uint32_t freq = 0;
         uint32_t duty_cycle = 0;
-        body = bit_utils::bytes_to_int(body, limit, freq);
         body = bit_utils::bytes_to_int(body, limit, duty_cycle);
-        return SetBrushedMotorPwmRequest{.freq = freq,
-                                         .duty_cycle = duty_cycle};
+        return SetBrushedMotorPwmRequest{.duty_cycle = duty_cycle};
     }
 
     auto operator==(const SetBrushedMotorPwmRequest& other) const
@@ -712,7 +708,6 @@ struct GripperGripRequest : BaseMessage<MessageId::gripper_grip_request> {
     uint8_t group_id;
     uint8_t seq_id;
     brushed_timer_ticks duration;
-    uint32_t freq;
     uint32_t duty_cycle;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -720,18 +715,15 @@ struct GripperGripRequest : BaseMessage<MessageId::gripper_grip_request> {
         uint8_t group_id = 0;
         uint8_t seq_id = 0;
         brushed_timer_ticks duration = 0;
-        uint32_t freq = 0;
         uint32_t duty_cycle = 0;
         body = bit_utils::bytes_to_int(body, limit, group_id);
         body = bit_utils::bytes_to_int(body, limit, seq_id);
         body = bit_utils::bytes_to_int(body, limit, duration);
-        body = bit_utils::bytes_to_int(body, limit, freq);
         body = bit_utils::bytes_to_int(body, limit, duty_cycle);
 
         return GripperGripRequest{.group_id = group_id,
                                   .seq_id = seq_id,
                                   .duration = duration,
-                                  .freq = freq,
                                   .duty_cycle = duty_cycle};
     }
 
@@ -742,7 +734,6 @@ struct GripperHomeRequest : BaseMessage<MessageId::gripper_home_request> {
     uint8_t group_id;
     uint8_t seq_id;
     brushed_timer_ticks duration;
-    uint32_t freq;
     uint32_t duty_cycle;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -750,18 +741,15 @@ struct GripperHomeRequest : BaseMessage<MessageId::gripper_home_request> {
         uint8_t group_id = 0;
         uint8_t seq_id = 0;
         brushed_timer_ticks duration = 0;
-        uint32_t freq = 0;
         uint32_t duty_cycle = 0;
         body = bit_utils::bytes_to_int(body, limit, group_id);
         body = bit_utils::bytes_to_int(body, limit, seq_id);
         body = bit_utils::bytes_to_int(body, limit, duration);
-        body = bit_utils::bytes_to_int(body, limit, freq);
         body = bit_utils::bytes_to_int(body, limit, duty_cycle);
 
         return GripperHomeRequest{.group_id = group_id,
                                   .seq_id = seq_id,
                                   .duration = duration,
-                                  .freq = freq,
                                   .duty_cycle = duty_cycle};
     }
 

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -27,7 +27,6 @@ class MotionController {
 
     void move(const can::messages::GripperGripRequest& can_msg) {
         BrushedMove msg{.duration = can_msg.duration,
-                        .freq = can_msg.freq,
                         .duty_cycle = can_msg.duty_cycle,
                         .group_id = can_msg.group_id,
                         .seq_id = can_msg.seq_id,
@@ -38,7 +37,6 @@ class MotionController {
 
     void move(const can::messages::GripperHomeRequest& can_msg) {
         BrushedMove msg{.duration = can_msg.duration,
-                        .freq = can_msg.freq,
                         .duty_cycle = can_msg.duty_cycle,
                         .group_id = can_msg.group_id,
                         .seq_id = can_msg.seq_id,

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -77,8 +77,7 @@ class BrushedMotorInterruptHandler {
     void update_and_start_move() {
         has_active_move = queue.try_read_isr(&buffered_move);
         if (buffered_move.freq != 0U && buffered_move.duty_cycle != 0U) {
-            driver_hardware.update_pwm_settings(buffered_move.freq,
-                                                buffered_move.duty_cycle);
+            driver_hardware.update_pwm_settings(buffered_move.duty_cycle);
         }
         if (buffered_move.stop_condition == MoveStopCondition::limit_switch) {
             hardware.ungrip();

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -76,7 +76,7 @@ class BrushedMotorInterruptHandler {
 
     void update_and_start_move() {
         has_active_move = queue.try_read_isr(&buffered_move);
-        if (buffered_move.freq != 0U && buffered_move.duty_cycle != 0U) {
+        if (buffered_move.duty_cycle != 0U) {
             driver_hardware.update_pwm_settings(buffered_move.duty_cycle);
         }
         if (buffered_move.stop_condition == MoveStopCondition::limit_switch) {

--- a/include/motor-control/core/brushed_motor/driver_interface.hpp
+++ b/include/motor-control/core/brushed_motor/driver_interface.hpp
@@ -23,7 +23,7 @@ class BrushedMotorDriverIface {
     virtual auto stop_digital_analog_converter() -> bool = 0;
     virtual auto set_reference_voltage(float val) -> bool = 0;
     virtual void setup() = 0;
-    virtual void update_pwm_settings(uint32_t freq, uint32_t duty_cycle) = 0;
+    virtual void update_pwm_settings(uint32_t duty_cycle) = 0;
 };
 
 }  // namespace brushed_motor_driver

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -78,7 +78,6 @@ struct BrushedMove {  // NOLINT(cppcoreguidelines-pro-type-member-init)
      * motor timer.
      */
     brushed_timer_ticks duration;  // in brushed timer ticks
-    uint32_t freq;
     uint32_t duty_cycle;
     uint8_t group_id;
     uint8_t seq_id;

--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -52,7 +52,7 @@ class MotorDriverMessageHandler {
     void handle(const can::messages::SetBrushedMotorPwmRequest& m) {
         LOG("Received set motor PWM request, freq=%d, duty_cycle=%d", m.freq,
             m.duty_cycle);
-        driver.update_pwm_settings(m.freq, m.duty_cycle);
+        driver.update_pwm_settings(m.duty_cycle);
     }
 
     brushed_motor_driver::BrushedMotorDriverIface& driver;

--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -45,13 +45,12 @@ class MotorDriverMessageHandler {
 
     void handle(const can::messages::SetBrushedMotorVrefRequest& m) {
         auto val = fixed_point_to_float(m.v_ref, 16);
-        LOG("Received set motor reference voltage request,  vref=%f", val);
+        LOG("Received set motor reference voltage request, vref=%f", val);
         driver.set_reference_voltage(val);
     }
 
     void handle(const can::messages::SetBrushedMotorPwmRequest& m) {
-        LOG("Received set motor PWM request, freq=%d, duty_cycle=%d", m.freq,
-            m.duty_cycle);
+        LOG("Received set motor PWM request, duty_cycle=%d", m.duty_cycle);
         driver.update_pwm_settings(m.duty_cycle);
     }
 

--- a/include/motor-control/firmware/brushed_motor/driver_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor/driver_hardware.hpp
@@ -19,7 +19,7 @@ struct DriverConfig {
 
 class BrushedMotorDriver : public BrushedMotorDriverIface {
   public:
-    using Callback = std::function<void(uint32_t freq, uint32_t duty_cycle)>;
+    using Callback = std::function<void(uint32_t duty_cycle)>;
     ~BrushedMotorDriver() final = default;
     BrushedMotorDriver() = delete;
     BrushedMotorDriver(const DacConfig& dac_config,
@@ -34,8 +34,8 @@ class BrushedMotorDriver : public BrushedMotorDriverIface {
     auto stop_digital_analog_converter() -> bool final;
     auto set_reference_voltage(float val) -> bool final;
     void setup() final;
-    void update_pwm_settings(uint32_t freq, uint32_t duty_cycle) final {
-        callback(freq, duty_cycle);
+    void update_pwm_settings(uint32_t duty_cycle) final {
+        callback(duty_cycle);
     }
 
   private:

--- a/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
@@ -12,7 +12,7 @@ class SimBrushedMotorDriverIface : public BrushedMotorDriverIface {
     bool stop_digital_analog_converter() final { return true; }
     bool set_reference_voltage(float) final { return true; }
     void setup() final {}
-    void update_pwm_settings(uint32_t, uint32_t) final {}
+    void update_pwm_settings(uint32_t) final {}
 };
 
 }  // namespace sim_brushed_motor_hardware_iface


### PR DESCRIPTION
This isn't necessary for gripper workflows.

In addition, we can derive the clock dividers for the pwm driver using
the global from the system file that contains the system clock frequency.

Needs https://github.com/Opentrons/opentrons/pull/10987