### PR TITLE
fix(gripper): do not stop motor when moves "end"

### DIFF
--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -53,12 +53,10 @@ class BrushedMotorInterruptHandler {
             if (buffered_move.stop_condition ==
                     MoveStopCondition::limit_switch &&
                 limit_switch_triggered()) {
-                hardware.stop_pwm();
                 homing_stopped();
             } else {
                 tick_count++;
                 if (!should_continue()) {
-                    hardware.stop_pwm();
                     finish_current_move(
                         AckMessageId::complete_without_condition);
                 }


### PR DESCRIPTION
Because moves don't really end in the same way as a stepper - we want to
continue applying the force, we just need to send an ack to indicate
we're in more or less the correct location.