### PR TITLE
Refactor(eeprom): refactor the hardware interface and task to support 16bit and 8bit memory addresses

### DIFF
--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -8,7 +8,8 @@
 #include "i2c/tests/mock_response_queue.hpp"
 
 class MockHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
-  using eeprom::hardware_iface::EEPromHardwareIface::EEPromHardwareIface;
+    using eeprom::hardware_iface::EEPromHardwareIface::EEPromHardwareIface;
+
   public:
     void set_write_protect(bool enabled) { set_calls.push_back(enabled); }
     std::vector<bool> set_calls{};
@@ -24,6 +25,11 @@ SCENARIO("Sending messages to Eeprom task") {
     auto eeprom = eeprom::task::EEPromMessageHandler{writer, response_queue,
                                                      hardware_iface};
 
+    auto hardware_iface_16 =
+        MockHardwareIface(eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
+
+    auto eeprom_16 = eeprom::task::EEPromMessageHandler{writer, response_queue,
+                                                       hardware_iface_16};
     GIVEN("A write message") {
         auto data = eeprom::types::EepromData{1, 2, 3, 4};
         eeprom::types::address address = 12;
@@ -44,8 +50,10 @@ SCENARIO("Sending messages to Eeprom task") {
                     std::get<i2c::messages::Transact>(i2c_message);
                 REQUIRE(transact_message.transaction.address == 0xA0);
                 REQUIRE(transact_message.transaction.bytes_to_read == 0);
-                REQUIRE(transact_message.transaction.bytes_to_write ==
-                        static_cast<std::size_t>(data_length + 1));
+                REQUIRE(
+                    transact_message.transaction.bytes_to_write ==
+                    static_cast<std::size_t>(
+                        data_length + hardware_iface.get_eeprom_addr_bytes()));
                 REQUIRE(transact_message.transaction.write_buffer[0] ==
                         address);
                 REQUIRE(transact_message.transaction.write_buffer[1] ==
@@ -55,6 +63,46 @@ SCENARIO("Sending messages to Eeprom task") {
                 REQUIRE(transact_message.transaction.write_buffer[3] ==
                         data[2]);
                 REQUIRE(transact_message.transaction.write_buffer[4] ==
+                        data[3]);
+                REQUIRE(transact_message.id.token == eeprom.WRITE_TOKEN);
+            }
+        }
+    }
+    GIVEN("A 16 bit write message") {
+        auto data = eeprom::types::EepromData{1, 2, 3, 4};
+        eeprom::types::address address = 0xabcd;
+        eeprom::types::data_length data_length = 4;
+        auto write_msg = eeprom::task::TaskMessage(
+            eeprom::message::WriteEepromMessage{.memory_address = address,
+                                                .length = data_length,
+                                                .data = data});
+        WHEN("the message is sent") {
+            eeprom_16.handle_message(write_msg);
+            THEN("the i2c queue is populated with a transact command") {
+                REQUIRE(i2c_queue.get_size() == 1);
+
+                auto i2c_message = i2c::writer::TaskMessage{};
+                i2c_queue.try_read(&i2c_message);
+
+                auto transact_message =
+                    std::get<i2c::messages::Transact>(i2c_message);
+                REQUIRE(transact_message.transaction.address == 0xA0);
+                REQUIRE(transact_message.transaction.bytes_to_read == 0);
+                REQUIRE(transact_message.transaction.bytes_to_write ==
+                        static_cast<std::size_t>(
+                            data_length +
+                            hardware_iface_16.get_eeprom_addr_bytes()));
+                REQUIRE(transact_message.transaction.write_buffer[0] ==
+                        ((address >> 8) & 0xff));
+				REQUIRE(transact_message.transaction.write_buffer[1] ==
+                        (address & 0xff));
+                REQUIRE(transact_message.transaction.write_buffer[2] ==
+                        data[0]);
+                REQUIRE(transact_message.transaction.write_buffer[3] ==
+                        data[1]);
+                REQUIRE(transact_message.transaction.write_buffer[4] ==
+                        data[2]);
+                REQUIRE(transact_message.transaction.write_buffer[5] ==
                         data[3]);
                 REQUIRE(transact_message.id.token == eeprom.WRITE_TOKEN);
             }
@@ -94,7 +142,8 @@ SCENARIO("Sending messages to Eeprom task") {
                 REQUIRE(transact_message.transaction.address == 0xA0);
                 REQUIRE(transact_message.transaction.bytes_to_read ==
                         data_length);
-                REQUIRE(transact_message.transaction.bytes_to_write == 1);
+                REQUIRE(transact_message.transaction.bytes_to_write ==
+                        hardware_iface.get_eeprom_addr_bytes());
                 REQUIRE(transact_message.transaction.write_buffer[0] ==
                         address);
                 REQUIRE(transact_message.id.token == 0);

--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -7,7 +7,8 @@
 #include "i2c/core/writer.hpp"
 #include "i2c/tests/mock_response_queue.hpp"
 
-struct MockHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
+class MockHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
+  public:
     void set_write_protect(bool enabled) { set_calls.push_back(enabled); }
     std::vector<bool> set_calls{};
 };

--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -29,7 +29,7 @@ SCENARIO("Sending messages to Eeprom task") {
         MockHardwareIface(eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
 
     auto eeprom_16 = eeprom::task::EEPromMessageHandler{writer, response_queue,
-                                                       hardware_iface_16};
+                                                        hardware_iface_16};
     GIVEN("A write message") {
         auto data = eeprom::types::EepromData{1, 2, 3, 4};
         eeprom::types::address address = 12;
@@ -94,7 +94,7 @@ SCENARIO("Sending messages to Eeprom task") {
                             hardware_iface_16.get_eeprom_addr_bytes()));
                 REQUIRE(transact_message.transaction.write_buffer[0] ==
                         ((address >> 8) & 0xff));
-				REQUIRE(transact_message.transaction.write_buffer[1] ==
+                REQUIRE(transact_message.transaction.write_buffer[1] ==
                         (address & 0xff));
                 REQUIRE(transact_message.transaction.write_buffer[2] ==
                         data[0]);
@@ -150,7 +150,7 @@ SCENARIO("Sending messages to Eeprom task") {
             }
         }
     }
-     GIVEN("A 16 bit read message") {
+    GIVEN("A 16 bit read message") {
         eeprom::types::address address = 0xabcd;
         eeprom::types::data_length data_length = 5;
         auto read_msg =
@@ -173,7 +173,7 @@ SCENARIO("Sending messages to Eeprom task") {
                         hardware_iface_16.get_eeprom_addr_bytes());
                 REQUIRE(transact_message.transaction.write_buffer[0] ==
                         ((address >> 8) & 0xff));
-				REQUIRE(transact_message.transaction.write_buffer[1] ==
+                REQUIRE(transact_message.transaction.write_buffer[1] ==
                         (address & 0xff));
                 REQUIRE(transact_message.id.token == 0);
             }

--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -24,12 +24,6 @@ SCENARIO("Sending messages to Eeprom task") {
 
     auto eeprom = eeprom::task::EEPromMessageHandler{writer, response_queue,
                                                      hardware_iface};
-
-    auto hardware_iface_16 =
-        MockHardwareIface(eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
-
-    auto eeprom_16 = eeprom::task::EEPromMessageHandler{writer, response_queue,
-                                                        hardware_iface_16};
     GIVEN("A write message") {
         auto data = eeprom::types::EepromData{1, 2, 3, 4};
         eeprom::types::address address = 12;
@@ -63,46 +57,6 @@ SCENARIO("Sending messages to Eeprom task") {
                 REQUIRE(transact_message.transaction.write_buffer[3] ==
                         data[2]);
                 REQUIRE(transact_message.transaction.write_buffer[4] ==
-                        data[3]);
-                REQUIRE(transact_message.id.token == eeprom.WRITE_TOKEN);
-            }
-        }
-    }
-    GIVEN("A 16 bit write message") {
-        auto data = eeprom::types::EepromData{1, 2, 3, 4};
-        eeprom::types::address address = 0xabcd;
-        eeprom::types::data_length data_length = 4;
-        auto write_msg = eeprom::task::TaskMessage(
-            eeprom::message::WriteEepromMessage{.memory_address = address,
-                                                .length = data_length,
-                                                .data = data});
-        WHEN("the message is sent") {
-            eeprom_16.handle_message(write_msg);
-            THEN("the i2c queue is populated with a transact command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-
-                auto i2c_message = i2c::writer::TaskMessage{};
-                i2c_queue.try_read(&i2c_message);
-
-                auto transact_message =
-                    std::get<i2c::messages::Transact>(i2c_message);
-                REQUIRE(transact_message.transaction.address == 0xA0);
-                REQUIRE(transact_message.transaction.bytes_to_read == 0);
-                REQUIRE(transact_message.transaction.bytes_to_write ==
-                        static_cast<std::size_t>(
-                            data_length +
-                            hardware_iface_16.get_eeprom_addr_bytes()));
-                REQUIRE(transact_message.transaction.write_buffer[0] ==
-                        ((address >> 8) & 0xff));
-                REQUIRE(transact_message.transaction.write_buffer[1] ==
-                        (address & 0xff));
-                REQUIRE(transact_message.transaction.write_buffer[2] ==
-                        data[0]);
-                REQUIRE(transact_message.transaction.write_buffer[3] ==
-                        data[1]);
-                REQUIRE(transact_message.transaction.write_buffer[4] ==
-                        data[2]);
-                REQUIRE(transact_message.transaction.write_buffer[5] ==
                         data[3]);
                 REQUIRE(transact_message.id.token == eeprom.WRITE_TOKEN);
             }
@@ -150,6 +104,71 @@ SCENARIO("Sending messages to Eeprom task") {
             }
         }
     }
+    GIVEN("A read message with zero length") {
+        eeprom::types::address address = 14;
+        eeprom::types::data_length data_length = 0;
+        auto read_msg =
+            eeprom::task::TaskMessage(eeprom::message::ReadEepromMessage{
+                .memory_address = address, .length = data_length});
+        eeprom.handle_message(read_msg);
+        WHEN("the message is sent") {
+            THEN("the i2c queue is not populated with a transact command") {
+                REQUIRE(i2c_queue.get_size() == 0);
+            }
+        }
+    }
+}
+SCENARIO("Sending messages to 16 bit address Eeprom task") {
+    test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
+    test_mocks::MockI2CResponseQueue response_queue{};
+    auto writer = i2c::writer::Writer<test_mocks::MockMessageQueue>{};
+    writer.set_queue(&i2c_queue);
+
+    auto hardware_iface_16 =
+        MockHardwareIface(eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
+
+    auto eeprom_16 = eeprom::task::EEPromMessageHandler{writer, response_queue,
+                                                        hardware_iface_16};
+    GIVEN("A 16 bit write message") {
+        auto data = eeprom::types::EepromData{1, 2, 3, 4};
+        eeprom::types::address address = 0xabcd;
+        eeprom::types::data_length data_length = 4;
+        auto write_msg = eeprom::task::TaskMessage(
+            eeprom::message::WriteEepromMessage{.memory_address = address,
+                                                .length = data_length,
+                                                .data = data});
+        WHEN("the message is sent") {
+            eeprom_16.handle_message(write_msg);
+            THEN("the i2c queue is populated with a transact command") {
+                REQUIRE(i2c_queue.get_size() == 1);
+
+                auto i2c_message = i2c::writer::TaskMessage{};
+                i2c_queue.try_read(&i2c_message);
+
+                auto transact_message =
+                    std::get<i2c::messages::Transact>(i2c_message);
+                REQUIRE(transact_message.transaction.address == 0xA0);
+                REQUIRE(transact_message.transaction.bytes_to_read == 0);
+                REQUIRE(transact_message.transaction.bytes_to_write ==
+                        static_cast<std::size_t>(
+                            data_length +
+                            hardware_iface_16.get_eeprom_addr_bytes()));
+                REQUIRE(transact_message.transaction.write_buffer[0] ==
+                        ((address >> 8) & 0xff));
+                REQUIRE(transact_message.transaction.write_buffer[1] ==
+                        (address & 0xff));
+                REQUIRE(transact_message.transaction.write_buffer[2] ==
+                        data[0]);
+                REQUIRE(transact_message.transaction.write_buffer[3] ==
+                        data[1]);
+                REQUIRE(transact_message.transaction.write_buffer[4] ==
+                        data[2]);
+                REQUIRE(transact_message.transaction.write_buffer[5] ==
+                        data[3]);
+                REQUIRE(transact_message.id.token == eeprom_16.WRITE_TOKEN);
+            }
+        }
+    }
     GIVEN("A 16 bit read message") {
         eeprom::types::address address = 0xabcd;
         eeprom::types::data_length data_length = 5;
@@ -176,19 +195,6 @@ SCENARIO("Sending messages to Eeprom task") {
                 REQUIRE(transact_message.transaction.write_buffer[1] ==
                         (address & 0xff));
                 REQUIRE(transact_message.id.token == 0);
-            }
-        }
-    }
-    GIVEN("A read message with zero length") {
-        eeprom::types::address address = 14;
-        eeprom::types::data_length data_length = 0;
-        auto read_msg =
-            eeprom::task::TaskMessage(eeprom::message::ReadEepromMessage{
-                .memory_address = address, .length = data_length});
-        eeprom.handle_message(read_msg);
-        WHEN("the message is sent") {
-            THEN("the i2c queue is not populated with a transact command") {
-                REQUIRE(i2c_queue.get_size() == 0);
             }
         }
     }

--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -125,7 +125,7 @@ SCENARIO("Sending messages to 16 bit address Eeprom task") {
     writer.set_queue(&i2c_queue);
 
     auto hardware_iface_16 =
-        MockHardwareIface(eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
+        MockHardwareIface(eeprom::hardware_iface::EEPromChipType::ST_M24128);
 
     auto eeprom_16 = eeprom::task::EEPromMessageHandler{writer, response_queue,
                                                         hardware_iface_16};

--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -6,9 +6,10 @@
 #include "eeprom/core/types.hpp"
 #include "i2c/core/writer.hpp"
 #include "i2c/tests/mock_response_queue.hpp"
+namespace eeprom {
 
-class MockHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
-    using eeprom::hardware_iface::EEPromHardwareIface::EEPromHardwareIface;
+class MockHardwareIface : public hardware_iface::EEPromHardwareIface {
+    using hardware_iface::EEPromHardwareIface::EEPromHardwareIface;
 
   public:
     void set_write_protect(bool enabled) { set_calls.push_back(enabled); }
@@ -22,16 +23,14 @@ SCENARIO("Sending messages to Eeprom task") {
     writer.set_queue(&i2c_queue);
     auto hardware_iface = MockHardwareIface{};
 
-    auto eeprom = eeprom::task::EEPromMessageHandler{writer, response_queue,
-                                                     hardware_iface};
+    auto eeprom =
+        task::EEPromMessageHandler{writer, response_queue, hardware_iface};
     GIVEN("A write message") {
-        auto data = eeprom::types::EepromData{1, 2, 3, 4};
-        eeprom::types::address address = 12;
-        eeprom::types::data_length data_length = 4;
-        auto write_msg = eeprom::task::TaskMessage(
-            eeprom::message::WriteEepromMessage{.memory_address = address,
-                                                .length = data_length,
-                                                .data = data});
+        auto data = types::EepromData{1, 2, 3, 4};
+        types::address address = 12;
+        types::data_length data_length = 4;
+        auto write_msg = task::TaskMessage(message::WriteEepromMessage{
+            .memory_address = address, .length = data_length, .data = data});
         WHEN("the message is sent") {
             eeprom.handle_message(write_msg);
             THEN("the i2c queue is populated with a transact command") {
@@ -63,13 +62,11 @@ SCENARIO("Sending messages to Eeprom task") {
         }
     }
     GIVEN("A write message with zero length") {
-        auto data = eeprom::types::EepromData{};
-        eeprom::types::address address = 14;
-        eeprom::types::data_length data_length = 0;
-        auto write_msg = eeprom::task::TaskMessage(
-            eeprom::message::WriteEepromMessage{.memory_address = address,
-                                                .length = data_length,
-                                                .data = data});
+        auto data = types::EepromData{};
+        types::address address = 14;
+        types::data_length data_length = 0;
+        auto write_msg = task::TaskMessage(message::WriteEepromMessage{
+            .memory_address = address, .length = data_length, .data = data});
         WHEN("the message is sent") {
             eeprom.handle_message(write_msg);
             THEN("the i2c queue is not populated with a transact command") {
@@ -78,11 +75,10 @@ SCENARIO("Sending messages to Eeprom task") {
         }
     }
     GIVEN("A read message") {
-        eeprom::types::address address = 14;
-        eeprom::types::data_length data_length = 5;
-        auto read_msg =
-            eeprom::task::TaskMessage(eeprom::message::ReadEepromMessage{
-                .memory_address = address, .length = data_length});
+        types::address address = 14;
+        types::data_length data_length = 5;
+        auto read_msg = task::TaskMessage(message::ReadEepromMessage{
+            .memory_address = address, .length = data_length});
         eeprom.handle_message(read_msg);
         WHEN("the message is sent") {
             THEN("the i2c queue is populated with a transact command") {
@@ -105,11 +101,10 @@ SCENARIO("Sending messages to Eeprom task") {
         }
     }
     GIVEN("A read message with zero length") {
-        eeprom::types::address address = 14;
-        eeprom::types::data_length data_length = 0;
-        auto read_msg =
-            eeprom::task::TaskMessage(eeprom::message::ReadEepromMessage{
-                .memory_address = address, .length = data_length});
+        types::address address = 14;
+        types::data_length data_length = 0;
+        auto read_msg = task::TaskMessage(message::ReadEepromMessage{
+            .memory_address = address, .length = data_length});
         eeprom.handle_message(read_msg);
         WHEN("the message is sent") {
             THEN("the i2c queue is not populated with a transact command") {
@@ -125,18 +120,16 @@ SCENARIO("Sending messages to 16 bit address Eeprom task") {
     writer.set_queue(&i2c_queue);
 
     auto hardware_iface_16 =
-        MockHardwareIface(eeprom::hardware_iface::EEPromChipType::ST_M24128);
+        MockHardwareIface(hardware_iface::EEPromChipType::ST_M24128);
 
-    auto eeprom_16 = eeprom::task::EEPromMessageHandler{writer, response_queue,
-                                                        hardware_iface_16};
+    auto eeprom_16 =
+        task::EEPromMessageHandler{writer, response_queue, hardware_iface_16};
     GIVEN("A 16 bit write message") {
-        auto data = eeprom::types::EepromData{1, 2, 3, 4};
-        eeprom::types::address address = 0xabcd;
-        eeprom::types::data_length data_length = 4;
-        auto write_msg = eeprom::task::TaskMessage(
-            eeprom::message::WriteEepromMessage{.memory_address = address,
-                                                .length = data_length,
-                                                .data = data});
+        auto data = types::EepromData{1, 2, 3, 4};
+        types::address address = 0xabcd;
+        types::data_length data_length = 4;
+        auto write_msg = task::TaskMessage(message::WriteEepromMessage{
+            .memory_address = address, .length = data_length, .data = data});
         WHEN("the message is sent") {
             eeprom_16.handle_message(write_msg);
             THEN("the i2c queue is populated with a transact command") {
@@ -170,11 +163,10 @@ SCENARIO("Sending messages to 16 bit address Eeprom task") {
         }
     }
     GIVEN("A 16 bit read message") {
-        eeprom::types::address address = 0xabcd;
-        eeprom::types::data_length data_length = 5;
-        auto read_msg =
-            eeprom::task::TaskMessage(eeprom::message::ReadEepromMessage{
-                .memory_address = address, .length = data_length});
+        types::address address = 0xabcd;
+        types::data_length data_length = 5;
+        auto read_msg = task::TaskMessage(message::ReadEepromMessage{
+            .memory_address = address, .length = data_length});
         eeprom_16.handle_message(read_msg);
         WHEN("the message is sent") {
             THEN("the i2c queue is populated with a transact command") {
@@ -201,12 +193,11 @@ SCENARIO("Sending messages to 16 bit address Eeprom task") {
 }
 
 struct ReadResponseHandler {
-    static void callback(const eeprom::message::EepromMessage& msg,
-                         void* param) {
+    static void callback(const message::EepromMessage& msg, void* param) {
         reinterpret_cast<ReadResponseHandler*>(param)->_callback(msg);
     }
-    void _callback(const eeprom::message::EepromMessage& msg) { message = msg; }
-    eeprom::message::EepromMessage message;
+    void _callback(const message::EepromMessage& msg) { message = msg; }
+    message::EepromMessage message;
 };
 
 SCENARIO("Transaction response handling.") {
@@ -216,24 +207,23 @@ SCENARIO("Transaction response handling.") {
     writer.set_queue(&i2c_queue);
     auto hardware_iface = MockHardwareIface{};
 
-    auto eeprom = eeprom::task::EEPromMessageHandler{writer, response_queue,
-                                                     hardware_iface};
+    auto eeprom =
+        task::EEPromMessageHandler{writer, response_queue, hardware_iface};
 
     GIVEN("A read request") {
-        eeprom::types::address address = 14;
-        eeprom::types::data_length data_length = 5;
+        types::address address = 14;
+        types::data_length data_length = 5;
         auto read_response_handler = ReadResponseHandler{};
-        auto read_msg =
-            eeprom::task::TaskMessage(eeprom::message::ReadEepromMessage{
-                .memory_address = address,
-                .length = data_length,
-                .callback = ReadResponseHandler::callback,
-                .callback_param = &read_response_handler});
+        auto read_msg = task::TaskMessage(message::ReadEepromMessage{
+            .memory_address = address,
+            .length = data_length,
+            .callback = ReadResponseHandler::callback,
+            .callback_param = &read_response_handler});
         eeprom.handle_message(read_msg);
 
         WHEN("a transaction response is sent") {
             auto transaction_response =
-                eeprom::task::TaskMessage(i2c::messages::TransactionResponse{
+                task::TaskMessage(i2c::messages::TransactionResponse{
                     .id = i2c::messages::TransactionIdentifier{.token = 0},
                     .bytes_read = data_length,
                     .read_buffer =
@@ -242,27 +232,25 @@ SCENARIO("Transaction response handling.") {
             eeprom.handle_message(transaction_response);
             THEN("the callback is called") {
                 REQUIRE(read_response_handler.message ==
-                        eeprom::message::EepromMessage{
+                        message::EepromMessage{
                             .memory_address = address,
                             .length = data_length,
-                            .data = eeprom::types::EepromData{1, 2, 3, 4, 5}});
+                            .data = types::EepromData{1, 2, 3, 4, 5}});
             }
         }
     }
 
     GIVEN("A write request") {
-        auto data = eeprom::types::EepromData{1, 2, 3};
-        eeprom::types::address address = 14;
-        eeprom::types::data_length data_length = 3;
-        auto write_msg = eeprom::task::TaskMessage(
-            eeprom::message::WriteEepromMessage{.memory_address = address,
-                                                .length = data_length,
-                                                .data = data});
+        auto data = types::EepromData{1, 2, 3};
+        types::address address = 14;
+        types::data_length data_length = 3;
+        auto write_msg = task::TaskMessage(message::WriteEepromMessage{
+            .memory_address = address, .length = data_length, .data = data});
         eeprom.handle_message(write_msg);
 
         WHEN("a transaction response is sent") {
             auto transaction_response =
-                eeprom::task::TaskMessage(i2c::messages::TransactionResponse{
+                task::TaskMessage(i2c::messages::TransactionResponse{
                     .id =
                         i2c::messages::TransactionIdentifier{
                             .token = static_cast<uint32_t>(-1)},
@@ -277,3 +265,4 @@ SCENARIO("Transaction response handling.") {
         }
     }
 }
+}  // namespace eeprom

--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -8,6 +8,7 @@
 #include "i2c/tests/mock_response_queue.hpp"
 
 class MockHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
+  using eeprom::hardware_iface::EEPromHardwareIface::EEPromHardwareIface;
   public:
     void set_write_protect(bool enabled) { set_calls.push_back(enabled); }
     std::vector<bool> set_calls{};

--- a/eeprom/tests/test_hardware_iface.cpp
+++ b/eeprom/tests/test_hardware_iface.cpp
@@ -18,23 +18,29 @@ SCENARIO("Configuring EEProm Address Length") {
             auto hw_default = MockEepromHardwareIface{};
             THEN("address setting is 8 bit") {
                 REQUIRE(hw_default.get_eeprom_addr_bytes() ==
-                        eeprom::hardware_iface::EEPROM_ADDR_8_BIT);
+                        static_cast<size_t>(
+                            eeprom::hardware_iface::EEPromAddressType::
+                                EEPROM_ADDR_8_BIT));
             }
         }
         WHEN("Explicit 8 bit contructor used") {
             auto hw_8_bit_explicit = MockEepromHardwareIface(
-                eeprom::hardware_iface::EEPROM_ADDR_8_BIT);
+                eeprom::hardware_iface::EEPromChipType::MICROCHIP_24AA02T);
             THEN("address setting is 8 bit") {
                 REQUIRE(hw_8_bit_explicit.get_eeprom_addr_bytes() ==
-                        eeprom::hardware_iface::EEPROM_ADDR_8_BIT);
+                        static_cast<size_t>(
+                            eeprom::hardware_iface::EEPromAddressType::
+                                EEPROM_ADDR_8_BIT));
             }
         }
         WHEN("Explicit 16 bit contructor used") {
             auto hw_16_bit_explicit = MockEepromHardwareIface(
-                eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
+                eeprom::hardware_iface::EEPromChipType::ST_M24128);
             THEN("address setting is 16 bit") {
                 REQUIRE(hw_16_bit_explicit.get_eeprom_addr_bytes() ==
-                        eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
+                        static_cast<size_t>(
+                            eeprom::hardware_iface::EEPromAddressType::
+                                EEPROM_ADDR_16_BIT));
             }
         }
     }

--- a/eeprom/tests/test_hardware_iface.cpp
+++ b/eeprom/tests/test_hardware_iface.cpp
@@ -5,10 +5,40 @@
 
 class MockEepromHardwareIface
     : public eeprom::hardware_iface::EEPromHardwareIface {
+    using eeprom::hardware_iface::EEPromHardwareIface::EEPromHardwareIface;
+
   public:
     void set_write_protect(bool enabled) { set_calls.push_back(enabled); }
     std::vector<bool> set_calls{};
 };
+
+SCENARIO("Configuring EEProm Address Length") {
+    GIVEN("EEProm hw interface constructor") {
+        WHEN("Default constructor used") {
+            auto hw_default = MockEepromHardwareIface{};
+            THEN("address setting is 8 bit") {
+                REQUIRE(hw_default.get_eeprom_addr_bytes() ==
+                        eeprom::hardware_iface::EEPROM_ADDR_8_BIT);
+            }
+        }
+        WHEN("Explicit 8 bit contructor used") {
+            auto hw_8_bit_explicit = MockEepromHardwareIface(
+                eeprom::hardware_iface::EEPROM_ADDR_8_BIT);
+            THEN("address setting is 8 bit") {
+                REQUIRE(hw_8_bit_explicit.get_eeprom_addr_bytes() ==
+                        eeprom::hardware_iface::EEPROM_ADDR_8_BIT);
+            }
+        }
+        WHEN("Explicit 16 bit contructor used") {
+            auto hw_16_bit_explicit = MockEepromHardwareIface(
+                eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
+            THEN("address setting is 16 bit") {
+                REQUIRE(hw_16_bit_explicit.get_eeprom_addr_bytes() ==
+                        eeprom::hardware_iface::EEPROM_ADDR_16_BIT);
+            }
+        }
+    }
+}
 
 SCENARIO("WriteProtector class") {
     GIVEN("A write protector") {

--- a/eeprom/tests/test_hardware_iface.cpp
+++ b/eeprom/tests/test_hardware_iface.cpp
@@ -3,9 +3,11 @@
 #include "catch2/catch.hpp"
 #include "eeprom/core/hardware_iface.hpp"
 
-class MockEepromHardwareIface
-    : public eeprom::hardware_iface::EEPromHardwareIface {
-    using eeprom::hardware_iface::EEPromHardwareIface::EEPromHardwareIface;
+namespace eeprom {
+namespace hardware_iface {
+
+class MockEepromHardwareIface : public EEPromHardwareIface {
+    using EEPromHardwareIface::EEPromHardwareIface;
 
   public:
     void set_write_protect(bool enabled) { set_calls.push_back(enabled); }
@@ -17,30 +19,27 @@ SCENARIO("Configuring EEProm Address Length") {
         WHEN("Default constructor used") {
             auto hw_default = MockEepromHardwareIface{};
             THEN("address setting is 8 bit") {
-                REQUIRE(hw_default.get_eeprom_addr_bytes() ==
-                        static_cast<size_t>(
-                            eeprom::hardware_iface::EEPromAddressType::
-                                EEPROM_ADDR_8_BIT));
+                REQUIRE(
+                    hw_default.get_eeprom_addr_bytes() ==
+                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_8_BIT));
             }
         }
         WHEN("Explicit 8 bit contructor used") {
-            auto hw_8_bit_explicit = MockEepromHardwareIface(
-                eeprom::hardware_iface::EEPromChipType::MICROCHIP_24AA02T);
+            auto hw_8_bit_explicit =
+                MockEepromHardwareIface(EEPromChipType::MICROCHIP_24AA02T);
             THEN("address setting is 8 bit") {
-                REQUIRE(hw_8_bit_explicit.get_eeprom_addr_bytes() ==
-                        static_cast<size_t>(
-                            eeprom::hardware_iface::EEPromAddressType::
-                                EEPROM_ADDR_8_BIT));
+                REQUIRE(
+                    hw_8_bit_explicit.get_eeprom_addr_bytes() ==
+                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_8_BIT));
             }
         }
         WHEN("Explicit 16 bit contructor used") {
-            auto hw_16_bit_explicit = MockEepromHardwareIface(
-                eeprom::hardware_iface::EEPromChipType::ST_M24128);
+            auto hw_16_bit_explicit =
+                MockEepromHardwareIface(EEPromChipType::ST_M24128);
             THEN("address setting is 16 bit") {
-                REQUIRE(hw_16_bit_explicit.get_eeprom_addr_bytes() ==
-                        static_cast<size_t>(
-                            eeprom::hardware_iface::EEPromAddressType::
-                                EEPROM_ADDR_16_BIT));
+                REQUIRE(
+                    hw_16_bit_explicit.get_eeprom_addr_bytes() ==
+                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_16_BIT));
             }
         }
     }
@@ -100,3 +99,6 @@ SCENARIO("WriteProtector class") {
         }
     }
 }
+
+}  // namespace hardware_iface
+}  // namespace eeprom

--- a/eeprom/tests/test_hardware_iface.cpp
+++ b/eeprom/tests/test_hardware_iface.cpp
@@ -3,8 +3,9 @@
 #include "catch2/catch.hpp"
 #include "eeprom/core/hardware_iface.hpp"
 
-struct MockEepromHardwareIface
+class MockEepromHardwareIface
     : public eeprom::hardware_iface::EEPromHardwareIface {
+  public:
     void set_write_protect(bool enabled) { set_calls.push_back(enabled); }
     std::vector<bool> set_calls{};
 };
@@ -12,52 +13,51 @@ struct MockEepromHardwareIface
 SCENARIO("WriteProtector class") {
     GIVEN("A write protector") {
         auto hw = MockEepromHardwareIface{};
-        auto subject = eeprom::hardware_iface::WriteProtector(hw);
         WHEN("disable is called") {
-            subject.disable();
+            hw.disable();
             THEN("write protect is disabled") {
                 REQUIRE(hw.set_calls == std::vector<bool>{false});
             }
         }
         WHEN("disable then enable is called") {
-            subject.disable();
-            subject.enable();
+            hw.disable();
+            hw.enable();
             THEN("write protect is disabled then enabled") {
                 REQUIRE(hw.set_calls == std::vector<bool>{false, true});
             }
         }
 
         WHEN("disable is called twice then enable is called once") {
-            subject.disable();
-            subject.disable();
-            subject.enable();
+            hw.disable();
+            hw.disable();
+            hw.enable();
             THEN("write protect is disabled and not reenabled") {
                 REQUIRE(hw.set_calls == std::vector<bool>{false});
             }
         }
 
         WHEN("enable is called after a series of disable and enable calls") {
-            subject.disable();
-            subject.disable();
-            subject.enable();
-            subject.disable();
-            subject.enable();
-            subject.enable();
+            hw.disable();
+            hw.disable();
+            hw.enable();
+            hw.disable();
+            hw.enable();
+            hw.enable();
             THEN("write protect is disabled and re enabled") {
                 REQUIRE(hw.set_calls == std::vector<bool>{false, true});
             }
         }
 
         WHEN("enable is only  call") {
-            subject.enable();
+            hw.enable();
             THEN("write protect is enabled") {
                 REQUIRE(hw.set_calls == std::vector<bool>{true});
             }
         }
 
         WHEN("enable first call") {
-            subject.enable();
-            subject.disable();
+            hw.enable();
+            hw.disable();
             THEN("write protect is enabled then disabled") {
                 REQUIRE(hw.set_calls == std::vector<bool>{true, false});
             }

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -7,6 +7,8 @@ enum EEPromAddressType {
     EEPROM_ADDR_8_BIT = sizeof(uint8_t),
     EEPROM_ADDR_16_BIT = sizeof(uint16_t)
 };
+
+enum EEpromMemorySize { MICROCHIP_256Byte = 256, ST_16KByte = 16384 };
 /**
  * Interface to eeprom. Must be implemented in FW and Simulation
  *

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -3,8 +3,10 @@
 namespace eeprom {
 namespace hardware_iface {
 
-static const size_t EEPROM_ADDR_8_BIT = sizeof(uint8_t);
-static const size_t EEPROM_ADDR_16_BIT = sizeof(uint16_t);
+enum EEPromAddressType {
+	EEPROM_ADDR_8_BIT = sizeof(uint8_t),
+	EEPROM_ADDR_16_BIT = sizeof(uint16_t)
+};
 /**
  * Interface to eeprom. Must be implemented in FW and Simulation
  *

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -3,6 +3,8 @@
 namespace eeprom {
 namespace hardware_iface {
 
+static const size_t EEPROM_ADDR_8_BIT = sizeof(uint8_t);
+static const size_t EEPROM_ADDR_16_BIT = sizeof(uint16_t);
 /**
  * Interface to eeprom. Must be implemented in FW and Simulation
  *
@@ -55,7 +57,7 @@ class EEPromHardwareIface {
     uint32_t count{0};
     // How many bytes the EEProm memory address is. default to old boards 1 byte
     // address
-    size_t eeprom_addr_bytes = sizeof(uint8_t);
+    size_t eeprom_addr_bytes = EEPROM_ADDR_8_BIT;
 };
 
 }  // namespace hardware_iface

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -15,7 +15,8 @@ static const size_t EEPROM_ADDR_16_BIT = sizeof(uint16_t);
 class EEPromHardwareIface {
   public:
     EEPromHardwareIface() = default;
-    EEPromHardwareIface(size_t addr_bytes) : eeprom_addr_bytes(addr_bytes) {}
+    EEPromHardwareIface(const size_t addr_bytes)
+        : eeprom_addr_bytes(addr_bytes) {}
     EEPromHardwareIface(const EEPromHardwareIface&) = default;
     EEPromHardwareIface(EEPromHardwareIface&&) = default;
     auto operator=(EEPromHardwareIface&&) -> EEPromHardwareIface& = default;

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -20,7 +20,11 @@ class EEPromHardwareIface {
   public:
     EEPromHardwareIface() = default;
     EEPromHardwareIface(const size_t addr_bytes)
-        : eeprom_addr_bytes(addr_bytes) {}
+        : eeprom_addr_bytes(addr_bytes) {
+        if (addr_bytes == EEPROM_ADDR_16_BIT) {
+            eeprom_mem_size = ST_16KByte;
+        }
+    }
     EEPromHardwareIface(const EEPromHardwareIface&) = default;
     EEPromHardwareIface(EEPromHardwareIface&&) = default;
     auto operator=(EEPromHardwareIface&&) -> EEPromHardwareIface& = default;
@@ -65,6 +69,7 @@ class EEPromHardwareIface {
     // How many bytes the EEProm memory address is. default to old boards 1 byte
     // address
     size_t eeprom_addr_bytes = EEPROM_ADDR_8_BIT;
+    size_t eeprom_mem_size = MICROCHIP_256Byte;
 };
 
 }  // namespace hardware_iface

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -4,8 +4,8 @@ namespace eeprom {
 namespace hardware_iface {
 
 enum EEPromAddressType {
-	EEPROM_ADDR_8_BIT = sizeof(uint8_t),
-	EEPROM_ADDR_16_BIT = sizeof(uint16_t)
+    EEPROM_ADDR_8_BIT = sizeof(uint8_t),
+    EEPROM_ADDR_16_BIT = sizeof(uint16_t)
 };
 /**
  * Interface to eeprom. Must be implemented in FW and Simulation

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -3,12 +3,14 @@
 namespace eeprom {
 namespace hardware_iface {
 
-enum EEPromAddressType {
+enum class EEPromChipType { MICROCHIP_24AA02T, ST_M24128 };
+
+enum class EEPromAddressType {
     EEPROM_ADDR_8_BIT = sizeof(uint8_t),
     EEPROM_ADDR_16_BIT = sizeof(uint16_t)
 };
 
-enum EEpromMemorySize { MICROCHIP_256Byte = 256, ST_16KByte = 16384 };
+enum class EEpromMemorySize { MICROCHIP_256_BYTE = 256, ST_16_KBYTE = 16384 };
 /**
  * Interface to eeprom. Must be implemented in FW and Simulation
  *
@@ -19,11 +21,22 @@ enum EEpromMemorySize { MICROCHIP_256Byte = 256, ST_16KByte = 16384 };
 class EEPromHardwareIface {
   public:
     EEPromHardwareIface() = default;
-    EEPromHardwareIface(const size_t addr_bytes)
-        : eeprom_addr_bytes(addr_bytes) {
-        if (addr_bytes == EEPROM_ADDR_16_BIT) {
-            eeprom_mem_size = ST_16KByte;
+    EEPromHardwareIface(EEPromChipType chip) {
+        switch (chip) {
+            case EEPromChipType::MICROCHIP_24AA02T:
+                eeprom_addr_bytes =
+                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_8_BIT);
+                eeprom_mem_size =
+                    static_cast<size_t>(EEpromMemorySize::MICROCHIP_256_BYTE);
+                break;
+            case EEPromChipType::ST_M24128:
+                eeprom_addr_bytes =
+                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_16_BIT);
+                eeprom_mem_size =
+                    static_cast<size_t>(EEpromMemorySize::ST_16_KBYTE);
+                break;
         }
+        eeprom_chip_type = chip;
     }
     EEPromHardwareIface(const EEPromHardwareIface&) = default;
     EEPromHardwareIface(EEPromHardwareIface&&) = default;
@@ -62,14 +75,20 @@ class EEPromHardwareIface {
     [[nodiscard]] auto get_eeprom_addr_bytes() const -> size_t {
         return eeprom_addr_bytes;
     }
+    [[nodiscard]] auto get_eeprom_chip_type() const -> EEPromChipType {
+        return eeprom_chip_type;
+    }
 
   private:
     // The number of times that disable has been called.
     uint32_t count{0};
     // How many bytes the EEProm memory address is. default to old boards 1 byte
     // address
-    size_t eeprom_addr_bytes = EEPROM_ADDR_8_BIT;
-    size_t eeprom_mem_size = MICROCHIP_256Byte;
+    size_t eeprom_addr_bytes =
+        static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_8_BIT);
+    size_t eeprom_mem_size =
+        static_cast<size_t>(EEpromMemorySize::MICROCHIP_256_BYTE);
+    EEPromChipType eeprom_chip_type = EEPromChipType::MICROCHIP_24AA02T;
 };
 
 }  // namespace hardware_iface

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -51,7 +51,9 @@ class EEPromHardwareIface {
             set_write_protect(true);
         }
     }
-    size_t get_eeprom_addr_bytes() { return eeprom_addr_bytes; }
+    [[nodiscard]] auto get_eeprom_addr_bytes() const -> size_t {
+        return eeprom_addr_bytes;
+    }
 
   private:
     // The number of times that disable has been called.

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -161,13 +161,13 @@ class EEPromMessageHandler {
         // Older boards use 1 byte addresses, if we're on an older board we
         // need to drop the higher byte of the memory address when sending the
         // the message over i2c
-         if (hw_iface.get_eeprom_addr_bytes() ==
+        if (hw_iface.get_eeprom_addr_bytes() ==
             eeprom::hardware_iface::EEPROM_ADDR_8_BIT) {
             m.memory_address = m.memory_address << 8;
         }
         iter = bit_utils::int_to_bytes(
             m.memory_address, iter, (iter + hw_iface.get_eeprom_addr_bytes()));
-            
+
         auto transaction = i2c::messages::Transaction{
             .address = types::DEVICE_ADDRESS,
             .bytes_to_read = m.length,

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -90,7 +90,8 @@ class EEPromMessageHandler {
         // that crosses the page boundry (8 Bytes) it will wrap and overwrite
         // the begining of the current page instead of moving to the next page
 
-        if (hw_iface.get_eeprom_addr_bytes() == eeprom::hardware_iface::EEPROM_ADDR_8_BIT &&
+        if (hw_iface.get_eeprom_addr_bytes() ==
+                eeprom::hardware_iface::EEPROM_ADDR_8_BIT &&
             ((m.memory_address % 8) + m.length) > 8) {
             LOG("Warning: write request will overrun page");
         }
@@ -112,6 +113,7 @@ class EEPromMessageHandler {
             m.memory_address = m.memory_address << 8;
         }
         iter = bit_utils::int_to_bytes(
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             m.memory_address, iter, (iter + hw_iface.get_eeprom_addr_bytes()));
         // Remainder is data
         iter = std::copy_n(
@@ -165,7 +167,9 @@ class EEPromMessageHandler {
             eeprom::hardware_iface::EEPROM_ADDR_8_BIT) {
             m.memory_address = m.memory_address << 8;
         }
+
         iter = bit_utils::int_to_bytes(
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             m.memory_address, iter, (iter + hw_iface.get_eeprom_addr_bytes()));
 
         auto transaction = i2c::messages::Transaction{

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -90,7 +90,8 @@ class EEPromMessageHandler {
         // that crosses the page boundry (8 Bytes) it will wrap and overwrite
         // the begining of the current page instead of moving to the next page
 
-        if (hw_iface.get_eeprom_addr_bytes() && ((m.memory_address % 8) + m.length)) {
+        if (hw_iface.get_eeprom_addr_bytes() &&
+            ((m.memory_address % 8) + m.length)) {
             LOG("Warning: write request will overrun page");
         }
 

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -161,9 +161,13 @@ class EEPromMessageHandler {
         // Older boards use 1 byte addresses, if we're on an older board we
         // need to drop the higher byte of the memory address when sending the
         // the message over i2c
-        iter = std::copy_n((&m.memory_address),
-                           hw_iface.get_eeprom_addr_bytes(), iter);
-
+         if (hw_iface.get_eeprom_addr_bytes() ==
+            eeprom::hardware_iface::EEPROM_ADDR_8_BIT) {
+            m.memory_address = m.memory_address << 8;
+        }
+        iter = bit_utils::int_to_bytes(
+            m.memory_address, iter, (iter + hw_iface.get_eeprom_addr_bytes()));
+            
         auto transaction = i2c::messages::Transaction{
             .address = types::DEVICE_ADDRESS,
             .bytes_to_read = m.length,

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -85,11 +85,15 @@ class EEPromMessageHandler {
         if (m.length <= 0) {
             return;
         }
+        // TODO (Ryan, 2022-07-08): Current board revisions' eeprom has 8-bit
+        // addressing.
+        //  To use the newer 16-bit addressing, remove this static_cast.
+        auto address = static_cast<uint8_t>(m.memory_address);
 
         auto buffer = i2c::messages::MaxMessageBuffer{};
         auto *iter = buffer.begin();
-        // First byte is address
-        iter = std::copy_n(&m.memory_address, 1, iter);
+        // First byte(s) is address
+        iter = std::copy_n(&address, sizeof(address), iter);
         // Remainder is data
         iter = std::copy_n(
             m.data.cbegin(),
@@ -135,7 +139,7 @@ class EEPromMessageHandler {
         // The transaction will write the memory address, then read the
         // data.
         auto write_buffer = i2c::messages::MaxMessageBuffer{};
-        // TODO (amit, 2022-05-31): Current board revisions' eeprom has 8-bit
+        // TODO (Ryan, 2022-07-08): Current board revisions' eeprom has 8-bit
         // addressing.
         //  To use the newer 16-bit addressing, remove this static_cast.
         auto address = static_cast<uint8_t>(m.memory_address);

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -90,8 +90,8 @@ class EEPromMessageHandler {
         // that crosses the page boundry (8 Bytes) it will wrap and overwrite
         // the begining of the current page instead of moving to the next page
 
-        if (hw_iface.get_eeprom_addr_bytes() &&
-            ((m.memory_address % 8) + m.length)) {
+        if (hw_iface.get_eeprom_addr_bytes() == eeprom::hardware_iface::EEPROM_ADDR_8_BIT &&
+            ((m.memory_address % 8) + m.length) > 8) {
             LOG("Warning: write request will overrun page");
         }
 

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -107,9 +107,9 @@ class EEPromMessageHandler {
         // Older boards use 1 byte addresses, if we're on an older board we
         // need to drop the higher byte of the memory address when sending the
         // the message over i2c
-        iter = std::copy_n((&m.memory_address),
-                           hw_iface.get_eeprom_addr_bytes(), iter);
 
+        iter = bit_utils::int_to_bytes(m.memory_address, iter,
+                                           (iter + hw_iface.get_eeprom_addr_bytes()));
         // Remainder is data
         iter = std::copy_n(
             m.data.cbegin(),

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -90,8 +90,8 @@ class EEPromMessageHandler {
         // that crosses the page boundry (8 Bytes) it will wrap and overwrite
         // the begining of the current page instead of moving to the next page
 
-        if (hw_iface.get_eeprom_addr_bytes() ==
-                eeprom::hardware_iface::EEPROM_ADDR_8_BIT &&
+        if (hw_iface.get_eeprom_chip_type() ==
+                hardware_iface::EEPromChipType::MICROCHIP_24AA02T &&
             ((m.memory_address % 8) + m.length) > 8) {
             LOG("Warning: write request will overrun page");
         }
@@ -109,7 +109,8 @@ class EEPromMessageHandler {
         // need to drop the higher byte of the memory address when sending the
         // the message over i2c
         if (hw_iface.get_eeprom_addr_bytes() ==
-            eeprom::hardware_iface::EEPROM_ADDR_8_BIT) {
+            static_cast<size_t>(
+                hardware_iface::EEPromAddressType::EEPROM_ADDR_8_BIT)) {
             m.memory_address = m.memory_address << 8;
         }
         iter = bit_utils::int_to_bytes(
@@ -164,7 +165,8 @@ class EEPromMessageHandler {
         // need to drop the higher byte of the memory address when sending the
         // the message over i2c
         if (hw_iface.get_eeprom_addr_bytes() ==
-            eeprom::hardware_iface::EEPROM_ADDR_8_BIT) {
+            static_cast<size_t>(
+                hardware_iface::EEPromAddressType::EEPROM_ADDR_8_BIT)) {
             m.memory_address = m.memory_address << 8;
         }
 

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -17,6 +17,11 @@ class EEProm : public I2CDeviceBase,
                public hardware_iface::EEPromHardwareIface {
   public:
     EEProm() : I2CDeviceBase(types::DEVICE_ADDRESS) { backing.fill(0xFF); }
+    EEProm(const size_t address_size)
+        : I2CDeviceBase(types::DEVICE_ADDRESS),
+          hardware_iface::EEPromHardwareIface(address_size) {
+        backing.fill(0xFF);
+    }
 
     auto handle_write(const uint8_t *data, uint16_t size) -> bool {
         auto *iter = data;
@@ -55,8 +60,8 @@ class EEProm : public I2CDeviceBase,
     }
 
   private:
-    std::array<uint8_t, 256> backing{};
-    uint8_t current_address{0};
+    std::array<uint8_t, hardware_iface::EEpromMemorySize::ST_16KByte> backing{};
+    uint16_t current_address{0};
     bool write_protected{true};
 };
 

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -17,9 +17,9 @@ class EEProm : public I2CDeviceBase,
                public hardware_iface::EEPromHardwareIface {
   public:
     EEProm() : I2CDeviceBase(types::DEVICE_ADDRESS) { backing.fill(0xFF); }
-    EEProm(const size_t address_size)
+    EEProm(hardware_iface::EEPromChipType chip)
         : I2CDeviceBase(types::DEVICE_ADDRESS),
-          hardware_iface::EEPromHardwareIface(address_size) {
+          hardware_iface::EEPromHardwareIface(chip) {
         backing.fill(0xFF);
     }
 
@@ -60,7 +60,9 @@ class EEProm : public I2CDeviceBase,
     }
 
   private:
-    std::array<uint8_t, hardware_iface::EEpromMemorySize::ST_16KByte> backing{};
+    std::array<uint8_t, static_cast<size_t>(
+                            hardware_iface::EEpromMemorySize::ST_16_KBYTE)>
+        backing{};
     uint16_t current_address{0};
     bool write_protected{true};
 };


### PR DESCRIPTION
refactor the eeprom hardware interface so that it can be configured to use 16 bit memory addresses. still defaults to the old 8 bit addresses so it doesn't require changes in any of the current code outside of the eeprom library