### PR TITLE
fix(sensors): add a missing include to sensor_hardware_interface.hpp

### DIFF
--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "common/firmware/gpio.hpp"
 
 namespace sensors {


### PR DESCRIPTION
This fixes an issue where it won't compile for the simulation