### PR TITLE
refactor(pipettes): update the G4 pin values for low throughput pipettes

### DIFF
--- a/include/pipettes/firmware/i2c_setup.h
+++ b/include/pipettes/firmware/i2c_setup.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif  // __cplusplus
 
 typedef struct HandlerStruct {
+    HAL_I2C_HANDLE i2c1;
     HAL_I2C_HANDLE i2c2;
     HAL_I2C_HANDLE i2c3;
 } I2CHandlerStruct;

--- a/include/pipettes/firmware/i2c_setup.h
+++ b/include/pipettes/firmware/i2c_setup.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif  // __cplusplus
 
 typedef struct HandlerStruct {
-    HAL_I2C_HANDLE i2c1;
+    HAL_I2C_HANDLE i2c2;
     HAL_I2C_HANDLE i2c3;
 } I2CHandlerStruct;
 void i2c_setup(I2CHandlerStruct* temp_struct);

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -72,20 +72,20 @@ static PipetteHardwarePin get_gpio_lt(PipetteHardwareDevice device) {
     PipetteHardwarePin pinout;
     switch(device) {
         case pipette_hardware_device_LED_drive:
-            pinout.port = GPIOA;
-            pinout.pin = GPIO_PIN_8;
+            pinout.port = GPIOB;
+            pinout.pin = GPIO_PIN_11;
             return pinout;
         case pipette_hardware_device_sync_in:
             pinout.port = GPIOB;
-            pinout.pin = GPIO_PIN_5;
+            pinout.pin = GPIO_PIN_7;
             return pinout;
         case pipette_hardware_device_sync_out:
             pinout.port = GPIOB;
-            pinout.pin = GPIO_PIN_4;
+            pinout.pin = GPIO_PIN_6;
             return pinout;
         case pipette_hardware_device_data_ready_front:
             pinout.port = GPIOC;
-            pinout.pin = GPIO_PIN_9;
+            pinout.pin = GPIO_PIN_3;
             return pinout;
         default:
             pinout.port = 0;
@@ -103,11 +103,10 @@ static uint16_t get_spi_pins_lt(GPIO_TypeDef* for_handle) {
      * copi -> PB15
      *
      * Chip Select
-     * PC6
+     * PB12
      */
     switch((uint32_t)for_handle) {
-        case (uint32_t)GPIOB: return GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
-        case (uint32_t)GPIOC: return GPIO_PIN_6;
+        case (uint32_t)GPIOB: return GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
         default: return 0;
     }
 }

--- a/pipettes/firmware/i2c_setup.c
+++ b/pipettes/firmware/i2c_setup.c
@@ -3,7 +3,7 @@
 #include "pipettes/firmware/i2c_setup.h"
 #include "common/firmware/errors.h"
 
-static I2C_HandleTypeDef hi2c;
+static I2C_HandleTypeDef hi2c2;
 static I2C_HandleTypeDef hi2c3;
 
 
@@ -23,10 +23,10 @@ void eeprom_write_gpio_init() {
         GPIO_InitStruct.Pin = GPIO_PIN_15;
         HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
     } else {
-        __HAL_RCC_GPIOB_CLK_ENABLE();
-        /*Configure GPIO pin : B8 */
-        GPIO_InitStruct.Pin = GPIO_PIN_8;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /*Configure GPIO pin : C5 */
+        GPIO_InitStruct.Pin = GPIO_PIN_5;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     }
 }
 
@@ -35,26 +35,31 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     __HAL_RCC_GPIOC_CLK_ENABLE();
 
-    if(hi2c->Instance==I2C1) {
+    if(hi2c->Instance==I2C2) {
         // PIN PB6 is SCL
         // PIN PB7 is SDA
-        // Primary pressure sensor
-        __HAL_RCC_I2C1_CLK_ENABLE();
-        __HAL_RCC_GPIOB_CLK_ENABLE();
-        GPIO_InitStruct.Pin = GPIO_PIN_6 | GPIO_PIN_7;
+        // Secondary sensors and eeprom
+        __HAL_RCC_I2C2_CLK_ENABLE();
+        __HAL_RCC_GPIOA_CLK_ENABLE();
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-        GPIO_InitStruct.Alternate = GPIO_AF4_I2C1;
+        GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+        GPIO_InitStruct.Pin = GPIO_PIN_8;
         HAL_GPIO_Init(
-            GPIOB,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+            GPIOA,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+            &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+
+        GPIO_InitStruct.Pin = GPIO_PIN_4;
+        HAL_GPIO_Init(
+            GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
             &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     } else if(hi2c->Instance==I2C3) {
-            // PIN PC0 is SCL
-            // PIN PC1 is SDA
-            // Secondary pressure sensor
+        // PIN PC8 is SCL
+        // PIN PC9 is SDA
+        // Primary sensors
         __HAL_RCC_I2C3_CLK_ENABLE();
-        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
+        GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
@@ -64,42 +69,42 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
             &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     }
 
-    /*Configure data ready pin : PC9 */
-    GPIO_InitStruct.Pin = GPIO_PIN_9;
+    /*Configure data ready pin : PC3 */
+    GPIO_InitStruct.Pin = GPIO_PIN_3;
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 }
 
-HAL_I2C_HANDLE MX_I2C1_Init()
+HAL_I2C_HANDLE MX_I2C2_Init()
 {
-    hi2c.Instance = I2C1;
-    hi2c.Init.Timing = 0x10C0ECFF;
-    hi2c.Init.OwnAddress1 = 0;
-    hi2c.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-    hi2c.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-    hi2c.Init.OwnAddress2 = 0;
-    hi2c.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
-    hi2c.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
-    hi2c.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
-    if (HAL_I2C_Init(&hi2c) != HAL_OK)
+    hi2c2.Instance = I2C2;
+    hi2c2.Init.Timing = 0x10C0ECFF;
+    hi2c2.Init.OwnAddress1 = 0;
+    hi2c2.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    hi2c2.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    hi2c2.Init.OwnAddress2 = 0;
+    hi2c2.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    hi2c2.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    hi2c2.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    if (HAL_I2C_Init(&hi2c2) != HAL_OK)
     {
         Error_Handler();
     }
     /** Configure Analogue filter
     */
-    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
+    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c2, I2C_ANALOGFILTER_ENABLE) != HAL_OK)
     {
         Error_Handler();
     }
     /** Configure Digital filter
     */
-    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c, 0) != HAL_OK)
+    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c2, 0) != HAL_OK)
     {
         Error_Handler();
     }
 
-    return &hi2c;
+    return &hi2c2;
 
 }
 
@@ -136,7 +141,7 @@ HAL_I2C_HANDLE MX_I2C3_Init()
 }
 
 int data_ready() {
-    return HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_9) == GPIO_PIN_SET;
+    return HAL_GPIO_ReadPin(GPIOC, GPIO_PIN_3) == GPIO_PIN_SET;
 }
 
 /**
@@ -146,7 +151,7 @@ void enable_eeprom_write() {
     if (get_pipette_type() == NINETY_SIX_CHANNEL) {
         HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_RESET);
     } else {
-        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(GPIOC, GPIO_PIN_5, GPIO_PIN_RESET);
     }
 }
 
@@ -157,7 +162,7 @@ void disable_eeprom_write() {
     if (get_pipette_type() == NINETY_SIX_CHANNEL) {
         HAL_GPIO_WritePin(GPIOA, GPIO_PIN_15, GPIO_PIN_SET);
     } else {
-        HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_SET);
+        HAL_GPIO_WritePin(GPIOC, GPIO_PIN_5, GPIO_PIN_SET);
     }
 }
 
@@ -165,8 +170,8 @@ void i2c_setup(I2CHandlerStruct* temp_struct) {
     HAL_I2C_HANDLE i2c3 = MX_I2C3_Init();
     temp_struct->i2c3 = i2c3;
     eeprom_write_gpio_init();
-    HAL_I2C_HANDLE i2c1 = MX_I2C1_Init();
-    temp_struct->i2c1 = i2c1;
+    HAL_I2C_HANDLE i2c2 = MX_I2C2_Init();
+    temp_struct->i2c2 = i2c2;
 
     // Write protect the eeprom
     disable_eeprom_write();

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -45,9 +45,11 @@ static auto iWatchdog = iwdg::IndependentWatchDog{};
 
 static auto can_bus_1 = can::hal::bus::HalCanBus(
     can_get_device_handle(),
+    // TODO we need to modify this based on pipette type as well since
+    // LED pin changes from board to board
     gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                    .port = GPIOA,
-                    .pin = GPIO_PIN_8,
+                    .port = GPIOB,
+                    .pin = GPIO_PIN_11,
                     .active_setting = GPIO_PIN_RESET});
 
 spi::hardware::SPI_interface SPI_intf = {.SPI_handle = &hspi2};
@@ -55,7 +57,7 @@ spi::hardware::SPI_interface SPI_intf = {.SPI_handle = &hspi2};
 static spi::hardware::Spi spi_comms(SPI_intf);
 
 static auto i2c_comms3 = i2c::hardware::I2C();
-static auto i2c_comms1 = i2c::hardware::I2C();
+static auto i2c_comms2 = i2c::hardware::I2C();
 static I2CHandlerStruct i2chandler_struct{};
 
 class EEPromHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
@@ -170,7 +172,7 @@ auto main() -> int {
 
     i2c_setup(&i2chandler_struct);
     i2c_comms3.set_handle(i2chandler_struct.i2c3);
-    i2c_comms1.set_handle(i2chandler_struct.i2c1);
+    i2c_comms2.set_handle(i2chandler_struct.i2c2);
 
     if (initialize_spi() != HAL_OK) {
         Error_Handler();
@@ -181,7 +183,7 @@ auto main() -> int {
     can_bus_1.start(can_bit_timings);
 
     central_tasks::start_tasks(can_bus_1, id);
-    peripheral_tasks::start_tasks(i2c_comms3, i2c_comms1, spi_comms);
+    peripheral_tasks::start_tasks(i2c_comms3, i2c_comms2, spi_comms);
     initialize_motor_tasks(id, motor_config.driver_configs,
                            gear_motion_control);
 

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -158,7 +158,7 @@ auto motor_configs::hardware_config_by_axis(TMC2130PipetteAxis which)
                 .direction =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
-                     .pin = GPIO_PIN_3,
+                     .pin = GPIO_PIN_6,
                      .active_setting = GPIO_PIN_SET},
                 .step =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -167,20 +167,20 @@ auto motor_configs::hardware_config_by_axis(TMC2130PipetteAxis which)
                      .active_setting = GPIO_PIN_SET},
                 .enable =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_8,
+                     .port = GPIOA,
+                     .pin = GPIO_PIN_10,
                      .active_setting = GPIO_PIN_SET},
                 .limit_switch =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_2,
+                     .port = GPIOA,
+                     .pin = GPIO_PIN_6,
                      .active_setting = GPIO_PIN_SET},
-                // LED PIN C11, active setting low
+                // LED PIN B11, active setting low
                 .led = {},
                 .tip_sense =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOA,
-                     .pin = GPIO_PIN_10,
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_2,
                      .active_setting = GPIO_PIN_SET},
             };
     }

--- a/pipettes/firmware/motor_encoder_hardware.c
+++ b/pipettes/firmware/motor_encoder_hardware.c
@@ -24,7 +24,7 @@ void Encoder_GPIO_Init(PipetteType pipette_type){
     GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
     /*Encoder P Axis Index Pin Configuration
-    PC3    ------> CHANNEL I -----> SINGLE_CHANNEL/EIGHT_CHANNEL
+    PA5    ------> CHANNEL I -----> SINGLE_CHANNEL/EIGHT_CHANNEL
     PA7    ------> CHANNEL I -----> NINETY_SIX_CHANNEL/THREE_EIGHTY_FOUR_CHANNEL
     * The Encoder Index Pin is routed to different GPIO pins
     * depending on the pipette type.
@@ -38,7 +38,7 @@ void Encoder_GPIO_Init(PipetteType pipette_type){
             HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
         }
     else{
-            GPIO_InitStruct.Pin = GPIO_PIN_7;
+            GPIO_InitStruct.Pin = GPIO_PIN_5;
             GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
             GPIO_InitStruct.Pull = GPIO_NOPULL;
             GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;

--- a/pipettes/firmware/mount_detect_hardware.c
+++ b/pipettes/firmware/mount_detect_hardware.c
@@ -48,7 +48,7 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc) {
 
         __HAL_RCC_GPIOB_CLK_ENABLE();
 
-        GPIO_InitStruct.Pin = GPIO_PIN_1;
+        GPIO_InitStruct.Pin = GPIO_PIN_0;
         GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -29,10 +29,10 @@ void tip_sense_gpio_init() {
 
     } else {
         /* GPIO Ports Clock Enable */
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        /*Configure GPIO pin : A10 */
-        GPIO_InitStruct.Pin = GPIO_PIN_10;
-        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+        __HAL_RCC_GPIOC_CLK_ENABLE();
+        /*Configure GPIO pin : C2 */
+        GPIO_InitStruct.Pin = GPIO_PIN_2;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     }
 }
 


### PR DESCRIPTION
## Overview

Related to #RET-848. For now, we only have the pin configurations available for single/eight channel pipettes. This PR only addresses pin changes, and no functionality change around timers or EXTI callbacks that may need to change.