### PR TITLE
fix: filter all incoming messages

### DIFF
--- a/gantry/core/can_task.cpp
+++ b/gantry/core/can_task.cpp
@@ -51,11 +51,11 @@ static auto motion_group_dispatch_target =
 static auto motion_dispatch_target =
     can_task::MotionControllerDispatchTarget{can_motion_handler};
 
+can::dispatch::StandardArbIdTest core_arb_id{.node_id = my_node_id};
 /** Dispatcher to the various handlers */
-static auto dispatcher = can_task::GantryDispatcherType(
-    [](auto) -> bool { return true; }, motor_dispatch_target,
-    motion_group_dispatch_target, motion_dispatch_target,
-    system_dispatch_target);
+static auto dispatcher = can_task::GantryDispatcherType{
+    core_arb_id, motor_dispatch_target, motion_group_dispatch_target,
+    motion_dispatch_target, system_dispatch_target};
 
 auto static reader_message_buffer =
     can::freertos_dispatch::FreeRTOSCanBufferControl<

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -36,13 +36,46 @@ static spi::hardware::Spi spi_comms(SPI_intf);
 /**
  * Motor pin configuration.
  */
-struct motion_controller::HardwareConfig motor_pins {
+struct motion_controller::HardwareConfig motor_pins_x {
     .direction =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             .port = GPIOB,
             .pin = GPIO_PIN_1,
             .active_setting = GPIO_PIN_RESET},
+    .step =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOC,
+            .pin = GPIO_PIN_8,
+            .active_setting = GPIO_PIN_SET},
+    .enable =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOA,
+            .pin = GPIO_PIN_9,
+            .active_setting = GPIO_PIN_SET},
+    .limit_switch =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOC,
+            .pin = GPIO_PIN_2,
+            .active_setting = GPIO_PIN_SET},
+    .led = {},
+    .sync_in = {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+        .port = GPIOB,
+        .pin = GPIO_PIN_7,
+        .active_setting = GPIO_PIN_RESET}
+};
+
+struct motion_controller::HardwareConfig motor_pins_y {
+    .direction =
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .port = GPIOB,
+            .pin = GPIO_PIN_1,
+            .active_setting = GPIO_PIN_SET},
     .step =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -100,8 +133,9 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_config{
 /**
  * The motor hardware interface.
  */
-static motor_hardware::MotorHardware motor_hardware_iface(motor_pins, &htim7,
-                                                          nullptr);
+static motor_hardware::MotorHardware motor_hardware_iface(
+    (get_axis_type() == gantry_x) ? motor_pins_x : motor_pins_y, &htim7,
+    nullptr);
 
 /**
  * The can bus.

--- a/gripper/core/can_tasks.cpp
+++ b/gripper/core/can_tasks.cpp
@@ -96,9 +96,10 @@ static auto dispatcher_g = can::dispatch::Dispatcher(
 
 /** Dispatcher to the various handlers */
 static auto main_dispatcher = can::dispatch::Dispatcher(
-    [](auto) -> bool { return true; }, dispatcher_z, dispatcher_g,
-    system_dispatch_target, gripper_info_dispatch_target,
-    eeprom_dispatch_target, sensor_dispatch_target);
+    can::dispatch::StandardArbIdTest{.node_id = can::ids::NodeId::gripper},
+    dispatcher_z, dispatcher_g, system_dispatch_target,
+    gripper_info_dispatch_target, eeprom_dispatch_target,
+    sensor_dispatch_target);
 
 auto static reader_message_buffer =
     freertos_message_buffer::FreeRTOSMessageBuffer<1024>{};

--- a/head/core/can_task.cpp
+++ b/head/core/can_task.cpp
@@ -129,9 +129,16 @@ static auto dispatcher_left_motor = can::dispatch::Dispatcher(
     motion_dispatch_target_left, move_group_dispatch_target_left);
 
 static auto main_dispatcher = can::dispatch::Dispatcher(
-    [](auto) -> bool { return true; }, dispatcher_right_motor,
-    dispatcher_left_motor, presence_sensing_disptach_target,
-    system_dispatch_target);
+    [](uint32_t arbitration_id) -> bool {
+        auto arb = can::arbitration_id::ArbitrationId(arbitration_id);
+        auto node_id = arb.node_id();
+        return ((node_id == can::ids::NodeId::broadcast) ||
+                (node_id == can::ids::NodeId::head) ||
+                (node_id == can::ids::NodeId::head_l) ||
+                (node_id == can::ids::NodeId::head_r));
+    },
+    dispatcher_right_motor, dispatcher_left_motor,
+    presence_sensing_disptach_target, system_dispatch_target);
 
 /**
  * The type of the message buffer populated by HAL ISR.

--- a/include/can/core/dispatch.hpp
+++ b/include/can/core/dispatch.hpp
@@ -110,6 +110,19 @@ requires(!std::movable<BufferType> &&
 };
 
 /**
+ * A useful default arbitration id matcher that works well enough
+ * if you just want a single node id plus the broadcast
+ * */
+struct StandardArbIdTest {
+    const can::ids::NodeId node_id;
+    auto operator()(uint32_t arbitration_id) const -> bool {
+        auto arb = ArbitrationId(arbitration_id);
+        auto _node_id = arb.node_id();
+        return (_node_id == NodeId::broadcast) || (_node_id == node_id);
+    }
+};
+
+/**
  * A CanMessageBufferListener that will dispatch messages to other
  * CanMessageBufferListeners
  * @tparam Listener CanMessageBufferListener objects


### PR DESCRIPTION
This avoids inadvertently entering the bootloader when the entry message
is directed at another node.

Without this fix, all nodes will enter bootloader when one is commanded
to on a shared bus.