### PR TITLE
Pressure Sensor Polling Support

### DIFF
--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -36,11 +36,6 @@ enum class SensorStatus : uint8_t {
     UNKNOWN = 0xFF
 };
 
-enum class SensorMode : uint8_t {
-    SINGLE_READ = 0x0,
-    POLLING = 0x1,
-};
-
 enum class Registers : uint8_t {
     RESET = 0x72,
     IDLE = 0x94,

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -36,6 +36,11 @@ enum class SensorStatus : uint8_t {
     UNKNOWN = 0xFF
 };
 
+enum class SensorMode : uint8_t {
+    SINGLE_READ = 0x0,
+    POLLING = 0x1,
+};
+
 enum class Registers : uint8_t {
     RESET = 0x72,
     IDLE = 0x94,

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -128,10 +128,7 @@ class MMR920C04 {
         }
     }
 
-    auto get_pressure(mmr920C04::SensorMode mode =
-                          mmr920C04::SensorMode::SINGLE_READ) -> bool {
-        //        _output_sync_bind = sync_bind;
-        _sensor_mode = mode;
+    auto get_pressure() -> bool {
         return set_measure_mode(mmr920C04::Registers::MEASURE_MODE_4);
     }
 
@@ -236,7 +233,7 @@ class MMR920C04 {
             static_cast<uint8_t>(mmr920C04::Registers::PRESSURE_READ),
             static_cast<std::size_t>(3), own_queue,
             static_cast<uint8_t>(mmr920C04::Registers::PRESSURE_READ));
-        if (_sensor_mode == mmr920C04::SensorMode::SINGLE_READ) {
+        if (stop_polling) {
             writer.write_isr(mmr920C04::ADDRESS,
                              static_cast<uint8_t>(mmr920C04::Registers::RESET),
                              data);
@@ -245,6 +242,17 @@ class MMR920C04 {
 
     auto set_sync_bind(SensorOutputBinding binding) -> void {
         _output_sync_bind = binding;
+        if (binding == SensorOutputBinding::none) {
+            // NOLINTNEXTLINE
+            stop_polling = true;
+        } else {
+            stop_polling = false;
+        }
+        hardware.reset_sync();
+    }
+
+    void set_number_of_reads(uint16_t number_of_reads) {
+        this->number_of_reads = number_of_reads;
     }
 
     auto handle_response(const i2c::messages::TransactionResponse &tm) {
@@ -290,6 +298,9 @@ class MMR920C04 {
   private:
     mmr920C04::MMR920C04RegisterMap _registers{};
     bool _initialized = false;
+    bool stop_polling = true;
+    // TODO: implement limited polling
+    uint16_t number_of_reads = 1;
     int32_t threshold_cmH20 = 0x8;
     const uint16_t DELAY = 20;
     I2CQueueWriter &writer;
@@ -298,7 +309,6 @@ class MMR920C04 {
     OwnQueue &own_queue;
     hardware::SensorHardwareBase &hardware;
     const can::ids::SensorId &sensor_id;
-    mmr920C04::SensorMode _sensor_mode = mmr920C04::SensorMode::SINGLE_READ;
     SensorOutputBinding _output_sync_bind = SensorOutputBinding::none;
 
     template <mmr920C04::MMR920C04Register Reg>

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -128,8 +128,9 @@ class MMR920C04 {
         }
     }
 
-    auto get_pressure(mmr920C04::SensorMode mode = mmr920C04::SensorMode::SINGLE_READ) -> bool {
-//        _output_sync_bind = sync_bind;
+    auto get_pressure(mmr920C04::SensorMode mode =
+                          mmr920C04::SensorMode::SINGLE_READ) -> bool {
+        //        _output_sync_bind = sync_bind;
         _sensor_mode = mode;
         return set_measure_mode(mmr920C04::Registers::MEASURE_MODE_4);
     }
@@ -257,8 +258,7 @@ class MMR920C04 {
                 if (_output_sync_bind == SensorOutputBinding::sync) {
                     if (data > threshold_cmH20) {
                         hardware.set_sync();
-                    }
-                    else {
+                    } else {
                         hardware.reset_sync();
                     }
                 }
@@ -300,7 +300,6 @@ class MMR920C04 {
     const can::ids::SensorId &sensor_id;
     mmr920C04::SensorMode _sensor_mode = mmr920C04::SensorMode::SINGLE_READ;
     SensorOutputBinding _output_sync_bind = SensorOutputBinding::none;
-
 
     template <mmr920C04::MMR920C04Register Reg>
     requires registers::WritableRegister<Reg>

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -76,7 +76,8 @@ class PressureMessageHandler {
         LOG("Received request to read from %d sensor\n", m.sensor);
         // poll a specific register, or default to a pressure read.
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.get_pressure(mmr920C04::SensorMode::POLLING);
+            driver.set_sync_bind(can::ids::SensorOutputBinding::report);
+            driver.get_pressure();
         } else {
             driver.get_temperature();
         }

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -93,8 +93,8 @@ class PressureMessageHandler {
         LOG("received bind request");
         static_cast<void>(m);
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.set_sync_bind(static_cast<can::ids::SensorOutputBinding>
-                                 (m.binding));
+            driver.set_sync_bind(
+                static_cast<can::ids::SensorOutputBinding>(m.binding));
         }
     }
 

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -76,7 +76,7 @@ class PressureMessageHandler {
         LOG("Received request to read from %d sensor\n", m.sensor);
         // poll a specific register, or default to a pressure read.
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.get_pressure();
+            driver.get_pressure(mmr920C04::SensorMode::POLLING);
         } else {
             driver.get_temperature();
         }
@@ -90,8 +90,12 @@ class PressureMessageHandler {
     }
 
     void visit(const can::messages::BindSensorOutputRequest &m) {
-        LOG("received bind request but not implemented");
+        LOG("received bind request");
         static_cast<void>(m);
+        if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
+            driver.set_sync_bind(static_cast<can::ids::SensorOutputBinding>
+                                 (m.binding));
+        }
     }
 
     void visit(const can::messages::PeripheralStatusRequest &m) {

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -65,18 +65,28 @@ SCENARIO("read pressure sensor values") {
             THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
                 REQUIRE(i2c_queue.get_size() == 1);
             }
-            AND_WHEN("the data ready interrupt is triggered") {
-                auto transact_message =
-                    get_message<i2c::messages::Transact>(i2c_queue);
-                THEN(
-                    "the i2c queue is populated with a MEASURE MODE 4 "
-                    "command") {
-                    REQUIRE(transact_message.transaction.address ==
-                            sensors::mmr920C04::ADDRESS);
-                }
-            }
+            auto transact_message =
+                get_message<i2c::messages::Transact>(i2c_queue);
+            REQUIRE(transact_message.transaction.address ==
+                    sensors::mmr920C04::ADDRESS);
         }
     }
+    GIVEN("a request to take multiple reads of the pressure sensor") {
+        auto single_read =
+            sensors::utils::TaskMessage(can::messages::BaselineSensorRequest(
+                {}, pressure_id, sensor_id_int));
+        sensor.handle_message(single_read);
+        WHEN("the handler function receives the message") {
+            THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
+                REQUIRE(i2c_queue.get_size() == 1);
+            }
+            auto transact_message =
+                get_message<i2c::messages::Transact>(i2c_queue);
+            REQUIRE(transact_message.transaction.address ==
+                    sensors::mmr920C04::ADDRESS);
+        }
+    }
+
     GIVEN("a request to take a single read of the temperature sensor") {
         auto single_read =
             sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(


### PR DESCRIPTION
This branch implements some support for polling on the firmware side:

- calls driver functions when the `pressure_sensor_task` receives a `BaselineSensorRequest` or `BindSensorOutputRequest`
- sets the sync pin active when the pressure driver receives a measurement above a threshold value
- makes sending a `RESET` command during the pressure driver's interrupt conditional on the pressure driver performing a single read, so polling doesn't get cut short after the first measurement