### PR TITLE
refactor(eeprom): temporarily reset eeprom simulation to handle 8 bit address

### DIFF
--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -61,9 +61,9 @@ class EEProm : public I2CDeviceBase,
 
   private:
     std::array<uint8_t, static_cast<size_t>(
-                            hardware_iface::EEpromMemorySize::ST_16_KBYTE)>
+                            hardware_iface::EEpromMemorySize::MICROCHIP_256_BYTE)>
         backing{};
-    uint16_t current_address{0};
+    uint8_t current_address{0};
     bool write_protected{true};
 };
 

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -60,8 +60,9 @@ class EEProm : public I2CDeviceBase,
     }
 
   private:
-    std::array<uint8_t, static_cast<size_t>(
-                            hardware_iface::EEpromMemorySize::MICROCHIP_256_BYTE)>
+    std::array<uint8_t,
+               static_cast<size_t>(
+                   hardware_iface::EEpromMemorySize::MICROCHIP_256_BYTE)>
         backing{};
     uint8_t current_address{0};
     bool write_protected{true};


### PR DESCRIPTION
## Overview
I was unable to figure out why the eeprom on the python side cannot handle 16 bit addresses even
though [Amit added support](https://github.com/Opentrons/opentrons/pull/10540/files) before leaving. This is a temporary fix as obviously the simulator should be able to handle 16 bit addresses. I made a [ticket](https://opentrons.atlassian.net/browse/RET-1124) to look into it.

Regardless, changing the simulator back to 8 bit addressing at least has the firmware integration tests passing. Other things were failing because the eeprom tests ended up breaking the simulator and caused it to go into the bootloader for both gripper and pipettes. This is because the addressing size didn't match the type in the backing array.