### PR TITLE
fix(pipettes): use correct CS pin for SPI on the G4s

### DIFF
--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -78,9 +78,9 @@ auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
         case TMC2130PipetteAxis::linear_motor:
         default:
             tmc2130_conf.chip_select = {
-                .cs_pin = GPIO_PIN_6,
+                .cs_pin = GPIO_PIN_12,
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                .GPIO_handle = GPIOC,
+                .GPIO_handle = GPIOB,
             };
             return tmc2130_conf;
     }


### PR DESCRIPTION
I forgot to specify the new/correct chip select pin for the motor on the G4.