### PR TITLE
polling for pressure sensor

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -605,13 +605,13 @@ struct WriteToSensorRequest : BaseMessage<MessageId::write_sensor_request> {
 struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
     uint8_t sensor = 0;
     uint8_t sensor_id = 0;
-    uint8_t sample_rate = 1;
+    uint16_t sample_rate = 1;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> BaselineSensorRequest {
         uint8_t sensor = 0;
         uint8_t sensor_id = 0;
-        uint8_t sample_rate = 0;
+        uint16_t sample_rate = 0;
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, sensor_id);
         body = bit_utils::bytes_to_int(body, limit, sample_rate);

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -179,6 +179,7 @@ class CapacitiveMessageHandler {
   public:
     // Kept public for testability
     ReadCapacitanceCallback<CanClient, I2CQueueWriter> capacitance_handler;
+    bool is_initialized = false;
 };
 
 /**

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -179,7 +179,6 @@ class CapacitiveMessageHandler {
   public:
     // Kept public for testability
     ReadCapacitanceCallback<CanClient, I2CQueueWriter> capacitance_handler;
-    bool is_initialized = false;
 };
 
 /**

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -247,7 +247,7 @@ class MMR920C04 {
     }
 
     auto set_sync_bind(SensorOutputBinding binding) -> void {
-//        _output_sync_bind = binding;
+        //        _output_sync_bind = binding;
         hardware.reset_sync();
         stop_polling = ((static_cast<uint8_t>(binding) & 0x3) == 0x0);
         report = ((static_cast<uint8_t>(binding) & 0x2) == 0x2);
@@ -258,9 +258,7 @@ class MMR920C04 {
         this->number_of_reads = number_of_reads;
     }
 
-    void set_limited_poll(bool _limited) {
-        limited_poll = _limited;
-    }
+    void set_limited_poll(bool _limited) { limited_poll = _limited; }
 
     auto handle_response(const i2c::messages::TransactionResponse &tm) {
         int32_t data = 0x0;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -308,7 +308,7 @@ class MMR920C04 {
     bool _initialized = false;
     bool stop_polling = true;
     bool sync = false;
-    bool report = false;
+    bool report = true;
     bool limited_poll = true;
     uint16_t number_of_reads = 0x1;
     int32_t threshold_cmH20 = 0x8;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -277,7 +277,6 @@ class MMR920C04 {
                     }
                 }
                 if (report) {
-                    LOG("report is true");
                     send_pressure();
                 }
                 break;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -233,6 +233,12 @@ class MMR920C04 {
             static_cast<uint8_t>(mmr920C04::Registers::PRESSURE_READ),
             static_cast<std::size_t>(3), own_queue,
             static_cast<uint8_t>(mmr920C04::Registers::PRESSURE_READ));
+        if (limited_poll) {
+            number_of_reads--;
+            if (number_of_reads < 1) {
+                stop_polling = true;
+            }
+        }
         if (stop_polling) {
             writer.write_isr(mmr920C04::ADDRESS,
                              static_cast<uint8_t>(mmr920C04::Registers::RESET),
@@ -241,18 +247,19 @@ class MMR920C04 {
     }
 
     auto set_sync_bind(SensorOutputBinding binding) -> void {
-        _output_sync_bind = binding;
-        if (binding == SensorOutputBinding::none) {
-            // NOLINTNEXTLINE
-            stop_polling = true;
-        } else {
-            stop_polling = false;
-        }
+//        _output_sync_bind = binding;
         hardware.reset_sync();
+        stop_polling = ((static_cast<uint8_t>(binding) & 0x3) == 0x0);
+        report = ((static_cast<uint8_t>(binding) & 0x2) == 0x2);
+        sync = ((static_cast<uint8_t>(binding) & 0x1) == 0x1);
     }
 
     void set_number_of_reads(uint16_t number_of_reads) {
         this->number_of_reads = number_of_reads;
+    }
+
+    void set_limited_poll(bool _limited) {
+        limited_poll = _limited;
     }
 
     auto handle_response(const i2c::messages::TransactionResponse &tm) {
@@ -263,14 +270,17 @@ class MMR920C04 {
         switch (static_cast<mmr920C04::Registers>(tm.id.token)) {
             case mmr920C04::Registers::PRESSURE_READ:
                 read_pressure(data);
-                if (_output_sync_bind == SensorOutputBinding::sync) {
+                if (sync) {
                     if (data > threshold_cmH20) {
                         hardware.set_sync();
+                        stop_polling = true;
                     } else {
                         hardware.reset_sync();
                     }
                 }
-                send_pressure();
+                if (report) {
+                    send_pressure();
+                }
                 break;
             case mmr920C04::Registers::LOW_PASS_PRESSURE_READ:
                 read_pressure_low_pass(data);
@@ -299,8 +309,10 @@ class MMR920C04 {
     mmr920C04::MMR920C04RegisterMap _registers{};
     bool _initialized = false;
     bool stop_polling = true;
-    // TODO: implement limited polling
-    uint16_t number_of_reads = 1;
+    bool sync = false;
+    bool report = false;
+    bool limited_poll = true;
+    uint16_t number_of_reads = 0x1;
     int32_t threshold_cmH20 = 0x8;
     const uint16_t DELAY = 20;
     I2CQueueWriter &writer;
@@ -309,7 +321,6 @@ class MMR920C04 {
     OwnQueue &own_queue;
     hardware::SensorHardwareBase &hardware;
     const can::ids::SensorId &sensor_id;
-    SensorOutputBinding _output_sync_bind = SensorOutputBinding::none;
 
     template <mmr920C04::MMR920C04Register Reg>
     requires registers::WritableRegister<Reg>

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -247,7 +247,6 @@ class MMR920C04 {
     }
 
     auto set_sync_bind(SensorOutputBinding binding) -> void {
-        //        _output_sync_bind = binding;
         hardware.reset_sync();
         stop_polling = ((static_cast<uint8_t>(binding) & 0x3) == 0x0);
         report = ((static_cast<uint8_t>(binding) & 0x2) == 0x2);

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -60,9 +60,12 @@ class PressureMessageHandler {
                 LOG("Could not send read pressure command");
             }
         } else {
-            if (!driver.get_temperature()) {
-                LOG("Could not send read temperature command");
-            }
+            if (can::ids::SensorType(m.sensor) == can::ids::SensorType::temperature) {
+                driver.set_sync_bind(can::ids::SensorOutputBinding::report);
+                driver.set_limited_poll(true);
+                if (!driver.get_temperature()) {
+                    LOG("Could not send read pressure command");
+                }
         }
     }
 

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -77,6 +77,9 @@ class PressureMessageHandler {
         // poll a specific register, or default to a pressure read.
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
+            driver.set_limited_poll(true);
+//            driver.set_number_of_reads(static_cast<uint8_t>(5));
+            driver.set_number_of_reads(m.sample_rate);
             driver.get_pressure();
         } else {
             driver.get_temperature();
@@ -96,6 +99,8 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(
                 static_cast<can::ids::SensorOutputBinding>(m.binding));
+            driver.set_limited_poll(false);
+            driver.get_pressure();
         }
     }
 

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -60,12 +60,14 @@ class PressureMessageHandler {
                 LOG("Could not send read pressure command");
             }
         } else {
-            if (can::ids::SensorType(m.sensor) == can::ids::SensorType::temperature) {
+            if (can::ids::SensorType(m.sensor) ==
+                can::ids::SensorType::pressure_temperature) {
                 driver.set_sync_bind(can::ids::SensorOutputBinding::report);
                 driver.set_limited_poll(true);
                 if (!driver.get_temperature()) {
-                    LOG("Could not send read pressure command");
+                    LOG("Could not send read temperature command");
                 }
+            }
         }
     }
 
@@ -159,5 +161,5 @@ class PressureSensorTask {
     QueueType &queue;
     can::ids::SensorId sensor_id;
 };
-}  // namespace tasks
-}  // namespace sensors
+};  // namespace tasks
+};  // namespace sensors

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -78,7 +78,7 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
             driver.set_limited_poll(true);
-//            driver.set_number_of_reads(static_cast<uint8_t>(5));
+            //            driver.set_number_of_reads(static_cast<uint8_t>(5));
             driver.set_number_of_reads(m.sample_rate);
             driver.get_pressure();
         } else {

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -54,6 +54,8 @@ class PressureMessageHandler {
     void visit(const can::messages::ReadFromSensorRequest &m) {
         LOG("Received request to read from %d sensor\n", m.sensor);
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
+            driver.set_sync_bind(can::ids::SensorOutputBinding::report);
+            driver.set_limited_poll(true);
             if (!driver.get_pressure()) {
                 LOG("Could not send read pressure command");
             }
@@ -78,7 +80,6 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
             driver.set_limited_poll(true);
-            //            driver.set_number_of_reads(static_cast<uint8_t>(5));
             driver.set_number_of_reads(m.sample_rate);
             driver.get_pressure();
         } else {

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -56,6 +56,7 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
             driver.set_limited_poll(true);
+            driver.set_number_of_reads(1);
             if (!driver.get_pressure()) {
                 LOG("Could not send read pressure command");
             }

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -103,10 +103,9 @@ SCENARIO("read pressure sensor values") {
                 THEN("The command addresses are correct") {
                     REQUIRE(transact_message.transaction.address ==
                             sensors::mmr920C04::ADDRESS);
-                    REQUIRE(
-                        transact_message.transaction.write_buffer[0] ==
-                        static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::TEMPERATURE_READ));
+                    REQUIRE(transact_message.transaction.write_buffer[0] ==
+                            static_cast<uint8_t>(
+                                sensors::mmr920C04::Registers::MEASURE_MODE_4));
                 }
             }
         }


### PR DESCRIPTION
Implemented polling and limited polling for the pressure sensor:

- Sending a `BindSensorOutputRequest` with any value that isn't `none` will tell the sensor to poll continuously and indefinitely 
- the `report` binding will determine whether or not the sensor sends its readings back to the CAN bus
- the `sync` binding determines whether or not it will set the sync pin to active and subsequently stop the pipette motors upon detecting a liquid threshold.
- sending a binding value of 0, or `none`, will stop the polling.



- Sending a `BaselineSensorRequest` will start a limited poll, which will prompt sensor responses to the CAN bus with no delay, reading as many times as specified in the `sample_rate` field

Updated the tests to reflect this stuff, and also changed the data type of the `sample_rate` variable to match with the Python code.