### PR TITLE
fix(pipettes): spi chip select gpio mode should be push-pull

### DIFF
--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -106,7 +106,7 @@ static uint16_t get_spi_pins_lt(GPIO_TypeDef* for_handle) {
      * PB12
      */
     switch((uint32_t)for_handle) {
-        case (uint32_t)GPIOB: return GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
+        case (uint32_t)GPIOB: return GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
         default: return 0;
     }
 }

--- a/pipettes/firmware/motor_hardware.c
+++ b/pipettes/firmware/motor_hardware.c
@@ -9,7 +9,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     if (hspi->Instance == SPI2) {
         /**SPI2 GPIO Configuration
-        PC6     ------> SPI2_CS
+        PB12     ------> SPI2_CS
         PB13     ------> SPI2_SCK
         PB14     ------> SPI2_CIPO
         PB15     ------> SPI2_COPI
@@ -24,13 +24,13 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
         // Chip Select
-        GPIO_InitStruct.Pin = pipette_hardware_spi_pins(pipette_type, GPIOC);
+        GPIO_InitStruct.Pin = GPIO_PIN_12;
         GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-        HAL_GPIO_WritePin(GPIOC, GPIO_InitStruct.Pin, GPIO_PIN_SET);
+        HAL_GPIO_WritePin(GPIOB, GPIO_InitStruct.Pin, GPIO_PIN_SET);
     }
 }
 


### PR DESCRIPTION
The motor was not engaging on the G4 boards because the chip select pin was using the wrong gpio
mode.