### PR TITLE
feat(gripper): track brushed motor encoder speed and use it to complete brushed motor move

### DIFF
--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -87,12 +87,17 @@ extern "C" void gripper_enc_overflow_callback_glue(int32_t direction) {
     brushed_motor_hardware_iface.encoder_overflow(direction);
 }
 
+extern "C" void gripper_enc_speed_overflow_callback_glue(void) {
+    brushed_motor_interrupt.enc_speed_timer_overflows();
+}
+
 void grip_motor_iface::initialize() {
     // Initialize DAC
     initialize_dac();
     initialize_enc();
     set_brushed_motor_timer_callback(call_brushed_motor_handler,
-                                     gripper_enc_overflow_callback_glue);
+                                     gripper_enc_overflow_callback_glue,
+                                     gripper_enc_speed_overflow_callback_glue);
 }
 
 auto grip_motor_iface::get_grip_motor()

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -87,8 +87,8 @@ extern "C" void gripper_enc_overflow_callback_glue(int32_t direction) {
     brushed_motor_hardware_iface.encoder_overflow(direction);
 }
 
-extern "C" void gripper_enc_speed_overflow_callback_glue(void) {
-    brushed_motor_interrupt.enc_speed_timer_overflows();
+extern "C" void gripper_enc_idle_state_callback_glue(bool val) {
+    brushed_motor_interrupt.set_enc_idle_state(val);
 }
 
 void grip_motor_iface::initialize() {
@@ -97,7 +97,7 @@ void grip_motor_iface::initialize() {
     initialize_enc();
     set_brushed_motor_timer_callback(call_brushed_motor_handler,
                                      gripper_enc_overflow_callback_glue,
-                                     gripper_enc_speed_overflow_callback_glue);
+                                     gripper_enc_idle_state_callback_glue);
 }
 
 auto grip_motor_iface::get_grip_motor()

--- a/gripper/firmware/motor_encoder_hardware.c
+++ b/gripper/firmware/motor_encoder_hardware.c
@@ -42,12 +42,12 @@ void Encoder_GPIO_Init(void) {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    //    GPIO_InitStruct.Pin = GPIO_PIN_5;
-    //    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    //    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    //    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-    //    GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
-    //    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    GPIO_InitStruct.Pin = GPIO_PIN_5;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+    GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 }
 
 void TIM2_EncoderG_Init(void) {

--- a/gripper/firmware/motor_encoder_hardware.c
+++ b/gripper/firmware/motor_encoder_hardware.c
@@ -35,12 +35,19 @@ void Encoder_GPIO_Init(void) {
     GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
+    /*Configure GPIO pin : PA5 */
     GPIO_InitStruct.Pin = GPIO_PIN_5;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    //    GPIO_InitStruct.Pin = GPIO_PIN_5;
+    //    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    //    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    //    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+    //    GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
+    //    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 }
 
 void TIM2_EncoderG_Init(void) {
@@ -96,8 +103,8 @@ void TIM2_EncoderG_Init(void) {
  * + B.
  *
  * The timer overflows 3 ms after an edge is received. This means any encoder
- * movement below 8Hz (1 MHz / (30000 * 4 count))is rejected and that we can
- * safely assume the encoder has stopped moving.
+ * movement below 8Hz (1 MHz / (30000 * 4 count)), which is about 0.00131 mm/s,
+ * is rejected and that we can safely assume the encoder has stopped moving.
  **/
 void TIM4_EncoderGSpeed_Init(void) {
     TIM_SlaveConfigTypeDef sSlaveConfig = {0};
@@ -107,7 +114,7 @@ void TIM4_EncoderGSpeed_Init(void) {
     htim4.Init.Prescaler =
         calc_prescaler(SystemCoreClock, GRIPPER_ENCODER_SPEED_TIMER_FREQ);
     htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
-    htim4.Init.Period = 30000;  // timer overflows after 3 ms
+    htim4.Init.Period = 3000;  // timer overflows after 3 ms
     htim4.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
     htim4.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
     if (HAL_TIM_Base_Init(&htim4) != HAL_OK) {
@@ -147,7 +154,7 @@ void TIM4_EncoderGSpeed_Init(void) {
     /* The update event of the enable timer is interrupted */
     __HAL_TIM_ENABLE_IT(&htim4, TIM_IT_UPDATE);
     /* Start the input capture measurement */
-    HAL_TIM_IC_Start(&htim4, TIM_CHANNEL_1);
+    HAL_TIM_IC_Start_IT(&htim4, TIM_CHANNEL_1);
 }
 
 void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {

--- a/gripper/firmware/motor_encoder_hardware.c
+++ b/gripper/firmware/motor_encoder_hardware.c
@@ -83,6 +83,22 @@ void TIM2_EncoderG_Init(void) {
     HAL_TIM_Encoder_Start_IT(&htim2, TIM_CHANNEL_ALL);
 }
 
+/**
+ * TIM4 is used to measure the timelapse between two consecutive edges
+ * of the encoder clock. The value can then be used to estimate the speed at
+ * which the encoder is rotating, hence, the speed at which the gripper jaw is
+ * travelling.
+ *
+ * TIM4 receives the encoder clock output signal from TIM2 (tim_trgo). It counts
+ * at 1 MHz and captures the current count whenever an encoder pulse is
+ * received, then resets its counter. The velocity would thus roughly be
+ * (1 MHz / (count * 4)). Counting both rising and falling edges from channel A
+ * + B.
+ *
+ * The timer overflows 3 ms after an edge is received. This means any encoder
+ * movement below 8Hz (1 MHz / (30000 * 4 count))is rejected and that we can
+ * safely assume the encoder has stopped moving.
+ **/
 void TIM4_EncoderGSpeed_Init(void) {
     __HAL_RCC_TIM4_CLK_ENABLE();
     TIM_SlaveConfigTypeDef sSlaveConfig = {0};

--- a/gripper/firmware/motor_encoder_hardware.c
+++ b/gripper/firmware/motor_encoder_hardware.c
@@ -100,7 +100,6 @@ void TIM2_EncoderG_Init(void) {
  * safely assume the encoder has stopped moving.
  **/
 void TIM4_EncoderGSpeed_Init(void) {
-    __HAL_RCC_TIM4_CLK_ENABLE();
     TIM_SlaveConfigTypeDef sSlaveConfig = {0};
     TIM_MasterConfigTypeDef sMasterConfig = {0};
     TIM_IC_InitTypeDef sConfigIC = {0};
@@ -139,6 +138,8 @@ void TIM4_EncoderGSpeed_Init(void) {
     if (HAL_TIM_IC_ConfigChannel(&htim4, &sConfigIC, TIM_CHANNEL_1) != HAL_OK) {
         Error_Handler();
     }
+    /* The update event of the enable timer is interrupted */
+    __HAL_TIM_ENABLE_IT(&htim4, TIM_IT_UPDATE);
     /* Start the input capture measurement */
     HAL_TIM_IC_Start(&htim4, TIM_CHANNEL_1);
 }

--- a/gripper/firmware/motor_encoder_hardware.c
+++ b/gripper/firmware/motor_encoder_hardware.c
@@ -138,6 +138,12 @@ void TIM4_EncoderGSpeed_Init(void) {
     if (HAL_TIM_IC_ConfigChannel(&htim4, &sConfigIC, TIM_CHANNEL_1) != HAL_OK) {
         Error_Handler();
     }
+    /*
+     * Only counter overflow/underflow generates an update interrupt.
+     * This makes sure the input capture (when the encoder is moving) does not
+     * trigger an update event!
+     */
+    __HAL_TIM_URS_ENABLE(&htim4);
     /* The update event of the enable timer is interrupted */
     __HAL_TIM_ENABLE_IT(&htim4, TIM_IT_UPDATE);
     /* Start the input capture measurement */

--- a/gripper/firmware/motor_encoder_hardware.h
+++ b/gripper/firmware/motor_encoder_hardware.h
@@ -13,6 +13,8 @@ extern "C" {
 extern TIM_HandleTypeDef htim2;
 typedef void (*encoder_overflow_callback)(int32_t);
 
+uint32_t round_closest(uint32_t dividend, uint32_t divisor);
+uint32_t calc_prescaler(uint32_t timer_clk_freq, uint32_t counter_clk_freq);
 void initialize_enc();
 
 #ifdef __cplusplus

--- a/gripper/firmware/motor_encoder_hardware.h
+++ b/gripper/firmware/motor_encoder_hardware.h
@@ -11,6 +11,7 @@ extern "C" {
 #endif  // __cplusplus
 
 extern TIM_HandleTypeDef htim2;
+extern TIM_HandleTypeDef htim4;
 typedef void (*encoder_overflow_callback)(int32_t);
 
 uint32_t round_closest(uint32_t dividend, uint32_t divisor);

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -20,6 +20,7 @@ extern DAC_HandleTypeDef hdac1;
 typedef void (*motor_interrupt_callback)();
 typedef void (*brushed_motor_interrupt_callback)();
 typedef void (*encoder_overflow_callback)(int32_t);
+typedef void (*encoder_speed_overflow_callback)();
 
 HAL_StatusTypeDef initialize_spi();
 
@@ -31,7 +32,8 @@ void update_pwm(uint32_t duty_cycle);
 
 void set_brushed_motor_timer_callback(
     brushed_motor_interrupt_callback callback,
-    encoder_overflow_callback g_enc_f_callback);
+    encoder_overflow_callback g_enc_f_callback,
+    encoder_speed_overflow_callback g_enc_speed_callback);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "common/firmware/errors.h"
@@ -20,7 +21,7 @@ extern DAC_HandleTypeDef hdac1;
 typedef void (*motor_interrupt_callback)();
 typedef void (*brushed_motor_interrupt_callback)();
 typedef void (*encoder_overflow_callback)(int32_t);
-typedef void (*encoder_speed_overflow_callback)();
+typedef void (*encoder_idle_state_callback)(bool);
 
 HAL_StatusTypeDef initialize_spi();
 
@@ -33,7 +34,7 @@ void update_pwm(uint32_t duty_cycle);
 void set_brushed_motor_timer_callback(
     brushed_motor_interrupt_callback callback,
     encoder_overflow_callback g_enc_f_callback,
-    encoder_speed_overflow_callback g_enc_speed_callback);
+    encoder_idle_state_callback g_enc_idle_callback);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -20,6 +20,8 @@ TIM_OC_InitTypeDef htim3_sConfigOC = {0};
 static motor_interrupt_callback timer_callback = NULL;
 static brushed_motor_interrupt_callback brushed_timer_callback = NULL;
 static encoder_overflow_callback gripper_enc_overflow_callback = NULL;
+static encoder_speed_overflow_callback gripper_enc_speed_overflow_callback =
+    NULL;
 
 uint32_t clamp(uint32_t val, uint32_t min, uint32_t max) {
     if (val < min) {
@@ -240,6 +242,12 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
         /* TIM3 interrupt Init */
         HAL_NVIC_SetPriority(TIM3_IRQn, 6, 0);
         HAL_NVIC_EnableIRQ(TIM3_IRQn);
+    } else if (htim == &htim4) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM4_CLK_ENABLE();
+        /* TIM4 interrupt Init */
+        HAL_NVIC_SetPriority(TIM4_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM4_IRQn);
     }
 }
 
@@ -285,9 +293,11 @@ void update_pwm(uint32_t duty_cycle) {
 
 void set_brushed_motor_timer_callback(
     brushed_motor_interrupt_callback callback,
-    encoder_overflow_callback g_enc_f_callback) {
+    encoder_overflow_callback g_enc_f_callback,
+    encoder_speed_overflow_callback g_enc_speed_callback) {
     brushed_timer_callback = callback;
     gripper_enc_overflow_callback = g_enc_f_callback;
+    gripper_enc_speed_overflow_callback = g_enc_speed_callback;
 }
 
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
@@ -299,6 +309,9 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
     } else if (htim == &htim2 && gripper_enc_overflow_callback) {
         uint32_t direction = __HAL_TIM_IS_TIM_COUNTING_DOWN(htim);
         gripper_enc_overflow_callback(direction ? -1 : 1);
+        __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
+    } else if (htim == &htim4 && gripper_enc_speed_overflow_callback) {
+        gripper_enc_speed_overflow_callback();
         __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
     }
 }

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -52,6 +52,7 @@ extern TIM_HandleTypeDef htim7;
 extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim2;
+extern TIM_HandleTypeDef htim4;
 
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
@@ -155,8 +156,9 @@ void TIM1_CC_IRQHandler(void) { HAL_TIM_IRQHandler(&htim1); }
  */
 void TIM3_IRQHandler(void) { HAL_TIM_IRQHandler(&htim3); }
 
-void TIM2_IRQHandler(void) { HAL_TIM_IRQHandler(&htim2);}
+void TIM2_IRQHandler(void) { HAL_TIM_IRQHandler(&htim2); }
 
+void TIM4_IRQHandler(void) { HAL_TIM_IRQHandler(&htim4); }
 /**
  * @brief This function handles TIM7 global interrupt.
  */

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "common/core/logging.h"
 #include "common/core/message_queue.hpp"
 #include "motor-control/core/brushed_motor/driver_interface.hpp"
@@ -89,6 +91,7 @@ class BrushedMotorInterruptHandler {
     void homing_stopped() {
         hardware.reset_encoder_pulses();
         finish_current_move(AckMessageId::stopped_by_condition);
+        is_idle = true;
     }
 
     auto limit_switch_triggered() -> bool {
@@ -116,7 +119,7 @@ class BrushedMotorInterruptHandler {
     }
 
     bool has_active_move = false;
-    bool is_idle = true;
+    std::atomic<bool> is_idle = true;
 
   private:
     GenericQueue& queue;

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -65,10 +65,6 @@ class BrushedMotorInterruptHandler {
     }
 
     [[nodiscard]] auto should_continue() const -> bool {
-        /*
-         * TODO: Check encoder position as the condition to stop motor instead
-         * of duration.
-         */
         return tick_count < buffered_move.duration;
     }
 

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -133,9 +133,9 @@ class BrushedMotorInterruptHandler {
 
     bool has_active_move = false;
     std::atomic<bool> is_idle = true;
+    uint32_t tick = 0;
 
   private:
-    uint32_t tick = 0;
     GenericQueue& queue;
     StatusClient& status_queue_client;
     motor_hardware::BrushedMotorHardwareIface& hardware;

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "motor-control/core/brushed_motor/driver_interface.hpp"
+#include "motor-control/core/motor_hardware_interface.hpp"
+#include "motor-control/core/tasks/move_status_reporter_task.hpp"
+
+namespace test_mocks {
+
+using namespace brushed_motor_driver;
+using namespace motor_hardware;
+
+class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
+  public:
+    ~MockBrushedMotorHardware() final = default;
+    MockBrushedMotorHardware() = default;
+    MockBrushedMotorHardware(const MockBrushedMotorHardware&) = default;
+    auto operator=(const MockBrushedMotorHardware&)
+        -> MockBrushedMotorHardware& = default;
+    MockBrushedMotorHardware(MockBrushedMotorHardware&&) = default;
+    auto operator=(MockBrushedMotorHardware&&)
+        -> MockBrushedMotorHardware& = default;
+    void positive_direction() final {}
+    void negative_direction() final {}
+    void activate_motor() final {}
+    void deactivate_motor() final {}
+    auto check_limit_switch() -> bool final { return ls_val; }
+    void grip() final { is_gripping = true; }
+    void ungrip() final { is_gripping = false; }
+    void stop_pwm() final {}
+    auto check_sync_in() -> bool final { return sync_val; }
+    auto get_encoder_pulses() -> int32_t final {
+        return (motor_encoder_overflow_count << 16) + enc_val;
+    }
+    void reset_encoder_pulses() final { enc_val = 0; }
+    void start_timer_interrupt() final {}
+    void stop_timer_interrupt() final {}
+    void encoder_overflow(int32_t direction) {
+        motor_encoder_overflow_count += direction;
+    }
+    auto get_limit_switch_val() -> bool { return ls_val; }
+    auto get_is_gripping() -> bool { return is_gripping; }
+    void set_encoder_value(int32_t val) { enc_val = val; }
+    auto set_limit_switch(bool val) { ls_val = val; }
+
+  private:
+    int32_t motor_encoder_overflow_count = 0;
+    bool ls_val = false;
+    bool sync_val = false;
+    bool is_gripping = false;
+    int32_t enc_val = 0;
+};
+
+class MockBrushedMotorDriverIface : public BrushedMotorDriverIface {
+  public:
+    bool start_digital_analog_converter() final { return true; }
+    bool stop_digital_analog_converter() final { return true; }
+    bool set_reference_voltage(float) final { return true; }
+    void setup() final {}
+    void update_pwm_settings(uint32_t) final {}
+};
+
+struct MockBrushedMoveStatusReporterClient {
+    void send_brushed_move_status_reporter_queue(
+        const move_status_reporter_task::TaskMessage& m) {
+        messages.push_back(m);
+    }
+
+    std::vector<move_status_reporter_task::TaskMessage> messages{};
+};
+
+};  // namespace test_mocks

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(motor-control
         test_limit_switch.cpp
         test_move_status_handling.cpp
         test_sync_handling.cpp
+        test_brushed_motor_interrupt_handler.cpp
         )
 
 target_ot_motor_control(motor-control)

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -1,0 +1,96 @@
+#include "catch2/catch.hpp"
+#include "common/tests/mock_message_queue.hpp"
+#include "motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp"
+#include "motor-control/core/motor_messages.hpp"
+#include "motor-control/tests/mock_brushed_motor_components.hpp"
+#include "motor-control/tests/mock_move_status_reporter_client.hpp"
+
+using namespace brushed_motor_handler;
+
+struct BrushedMotorContainer {
+    test_mocks::MockBrushedMotorHardware hw{};
+    test_mocks::MockMessageQueue<motor_messages::BrushedMove> queue{};
+    test_mocks::MockBrushedMoveStatusReporterClient reporter{};
+    test_mocks::MockBrushedMotorDriverIface driver{};
+    BrushedMotorInterruptHandler<
+        test_mocks::MockMessageQueue,
+        test_mocks::MockBrushedMoveStatusReporterClient>
+        handler{queue, reporter, hw, driver};
+};
+
+SCENARIO("Brushed motor interrupt handler handle move messages") {
+    BrushedMotorContainer test_objs{};
+
+    GIVEN("A message to home") {
+        auto msg =
+            BrushedMove{.duration = 0,
+                        .duty_cycle = 50,
+                        .group_id = 0,
+                        .seq_id = 0,
+                        .stop_condition = MoveStopCondition::limit_switch};
+        test_objs.queue.try_write_isr(msg);
+
+        WHEN("A brushed move message is received and loaded") {
+            test_objs.handler.run_interrupt();
+
+            THEN("The motor hardware proceeds to home") {
+                /* handler shouldn't be idle */
+                REQUIRE(!test_objs.handler.is_idle);
+                /* motor shouldn't be gripping */
+                REQUIRE(!test_objs.hw.get_is_gripping());
+                test_objs.hw.set_encoder_value(1000);
+                test_objs.hw.set_limit_switch(true);
+
+                AND_WHEN("The limit switch is hit") {
+                    test_objs.handler.run_interrupt();
+
+                    THEN("Encoder value is reset and homed ack is sent") {
+                        REQUIRE(test_objs.hw.get_encoder_pulses() == 0);
+                        REQUIRE(test_objs.reporter.messages.size() >= 1);
+                        Ack read_ack = test_objs.reporter.messages.back();
+                        REQUIRE(read_ack.encoder_position == 0);
+                        REQUIRE(read_ack.ack_id ==
+                                AckMessageId::stopped_by_condition);
+                        REQUIRE(test_objs.handler.is_idle);
+                    }
+                }
+            }
+        }
+    }
+
+    GIVEN("A message to grip") {
+        auto msg = BrushedMove{.duration = 0,
+                               .duty_cycle = 50,
+                               .group_id = 0,
+                               .seq_id = 0,
+                               .stop_condition = MoveStopCondition::none};
+        test_objs.queue.try_write_isr(msg);
+
+        WHEN("A brushed move message is received and loaded") {
+            test_objs.handler.run_interrupt();
+
+            THEN("The motor hardware proceeds to grip") {
+                /* handler shouldn't be idle */
+                REQUIRE(!test_objs.handler.is_idle);
+                /* motor should be gripping */
+                REQUIRE(test_objs.hw.get_is_gripping());
+                test_objs.hw.set_encoder_value(30000);
+
+                AND_WHEN("The encoder speed timer overflows") {
+                    /* this happens when the enc speed is very slow */
+                    test_objs.handler.enc_speed_timer_overflows();
+                    test_objs.handler.run_interrupt();
+
+                    THEN("Gripped ack is sent") {
+                        REQUIRE(test_objs.hw.get_encoder_pulses() == 30000);
+                        REQUIRE(test_objs.reporter.messages.size() >= 1);
+                        Ack read_ack = test_objs.reporter.messages.back();
+                        REQUIRE(read_ack.encoder_position == 30000);
+                        REQUIRE(read_ack.ack_id ==
+                                AckMessageId::complete_without_condition);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -88,6 +88,7 @@ SCENARIO("Brushed motor interrupt handler handle move messages") {
                         REQUIRE(read_ack.encoder_position == 30000);
                         REQUIRE(read_ack.ack_id ==
                                 AckMessageId::complete_without_condition);
+                        REQUIRE(test_objs.handler.is_idle);
                     }
                 }
             }


### PR DESCRIPTION
Configures TIM4 to be a tracker for the encoder pulse speed. 

TIM4 counts at 1 MHz and by capturing the counter value between two consecutive encoder pulse edges (4 edges make up one full encoder pulse), we can estimate the speed of the encoder/brushed motor. When the timer overflows (timer period is set to 3 ms), we can assume that the encoder is pulsing at most 8.33 Hz (1 MHz / (30000 x 4 count)). This is slow enough that we can assume the encoder has pretty much stopped. 

We can then use this info to report back to the host that the gripper jaw has stopped moving, instead of relying on an arbitrary duration.


Here's some result I got from testing:
The compare/capture (CCR1) register reading of the TIM4 was 0x2FF, which is 767 us. 

<img width="568" alt="Screen Shot 2022-07-28 at 2 37 58 PM" src="https://user-images.githubusercontent.com/20424172/181613206-e5e5f45c-95b3-4c2c-91b2-a095780a9891.png">
