### PR TITLE
feat(motor-control): add stealth chop config for TMC2130

### DIFF
--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -80,7 +80,7 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
                                .tbl = 0x2,
                                .mres = 0x4},
                   .coolconf = {.sgt = 0x6},
-                  .pwmconf = {.freewheel0 = 0x0, .freewheel1 = 0x1}},
+                  .pwmconf = {.freewheel = 0x2}},
     .current_config =
         {
             .r_sense = 0.1,

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -67,22 +67,20 @@ static motor_hardware::MotorHardware motor_hardware_iface(motor_pins, &htim7,
  * Motor driver configuration.
  */
 static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
-    .registers =
-        {
-            .gconfig = {.en_pwm_mode = 1},
-            .ihold_irun = {.hold_current = 0x2,
-                           .run_current = 0x19,
-                           .hold_current_delay = 0x7},
-            .tpowerdown = {},
-            .tcoolthrs = {.threshold = 0},
-            .thigh = {.threshold = 0xFFFFF},
-            .chopconf = {.toff = 0x5,
-                         .hstrt = 0x5,
-                         .hend = 0x3,
-                         .tbl = 0x2,
-                         .mres = 0x4},
-            .coolconf = {.sgt = 0x6},
-        },
+    .registers = {.gconfig = {.en_pwm_mode = 0x1},
+                  .ihold_irun = {.hold_current = 0x0,
+                                 .run_current = 0x19,
+                                 .hold_current_delay = 0x7},
+                  .tpowerdown = {},
+                  .tcoolthrs = {.threshold = 0},
+                  .thigh = {.threshold = 0xFFFFF},
+                  .chopconf = {.toff = 0x5,
+                               .hstrt = 0x5,
+                               .hend = 0x3,
+                               .tbl = 0x2,
+                               .mres = 0x4},
+                  .coolconf = {.sgt = 0x6},
+                  .pwmconf = {.freewheel0 = 0x0, .freewheel1 = 0x1}},
     .current_config =
         {
             .r_sense = 0.1,

--- a/include/motor-control/core/stepper_motor/tmc2130.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130.hpp
@@ -456,8 +456,7 @@ struct __attribute__((packed, __may_alias__)) StealthChop {
 
     uint32_t pwm_ampl : 8 = 0;
     uint32_t pwm_grad : 8 = 0;
-    uint32_t pwm_freq0 : 1 = 0;
-    uint32_t pwm_freq1 : 1 = 0;
+    uint32_t pwm_freq : 2 = 0;
     uint32_t pwm_autoscale : 1 = 0;
     uint32_t pwm_symmetric : 1 = 0;
     /**
@@ -467,8 +466,7 @@ struct __attribute__((packed, __may_alias__)) StealthChop {
      * %10: Coil shorted using LS drivers
      * %11: Coil shorted using HS drivers
      */
-    uint32_t freewheel0 : 1 = 0;
-    uint32_t freewheel1 : 1 = 0;
+    uint32_t freewheel : 2 = 0;
 };
 
 // Encapsulates all of the registers that should be configured by software

--- a/include/motor-control/core/stepper_motor/tmc2130.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130.hpp
@@ -446,6 +446,31 @@ struct __attribute__((packed, __may_alias__)) DriveStatus {
     uint32_t stst : 1 = 0;
 };
 
+/**
+ * This register sets the control current for voltage PWM mode stealth chop.
+ */
+struct __attribute__((packed, __may_alias__)) StealthChop {
+    static constexpr Registers address = Registers::PWMCONF;
+    static constexpr bool writable = true;
+    static constexpr uint32_t value_mask = (1 << 22) - 1;
+
+    uint32_t pwm_ampl : 8 = 0;
+    uint32_t pwm_grad : 8 = 0;
+    uint32_t pwm_freq0 : 1 = 0;
+    uint32_t pwm_freq1 : 1 = 0;
+    uint32_t pwm_autoscale : 1 = 0;
+    uint32_t pwm_symmetric : 1 = 0;
+    /**
+     * Stand still option when motor current setting is zero (I_HOLD=0).
+     * %00: Normal operation
+     * %01: Freewheeling
+     * %10: Coil shorted using LS drivers
+     * %11: Coil shorted using HS drivers
+     */
+    uint32_t freewheel0 : 1 = 0;
+    uint32_t freewheel1 : 1 = 0;
+};
+
 // Encapsulates all of the registers that should be configured by software
 struct TMC2130RegisterMap {
     GConfig gconfig = {};
@@ -457,6 +482,7 @@ struct TMC2130RegisterMap {
     CoolConfig coolconf = {};
     DriveStatus drvstatus = {};
     GStatus gstat = {};
+    StealthChop pwmconf = {};
 };
 
 // Registers are all 32 bits

--- a/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
+++ b/include/motor-control/core/stepper_motor/tmc2130_driver.hpp
@@ -101,6 +101,9 @@ class TMC2130 {
         if (!set_cool_config(_registers.coolconf)) {
             return false;
         }
+        if (!set_stealth_chop(_registers.pwmconf)) {
+            return false;
+        }
         _initialized = true;
         return true;
     }
@@ -352,6 +355,19 @@ class TMC2130 {
         if (ret.has_value()) {
             _registers.drvstatus = ret.value();
         }
+    }
+
+    /**
+     * @brief Update PWMCONF register
+     * @param reg New configuration register to set
+     * @return True if new register was set succesfully, false otherwise
+     */
+    auto set_stealth_chop(StealthChop reg) -> bool {
+        if (set_register(reg)) {
+            _registers.pwmconf = reg;
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Enables passive motor braking using StealthChop. 

Passive braking is enabled by setting the standstill current IHOLD to zero and choosing the desired option using the FREEWHEEL setting (%10 - Coil shorted using LS drivers).