### PR TITLE
refactor(i2c): make GPIO frequencies low

### DIFF
--- a/gripper/firmware/i2c_setup.c
+++ b/gripper/firmware/i2c_setup.c
@@ -20,7 +20,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         GPIO_InitStruct.Pin = GPIO_PIN_8;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
         HAL_GPIO_Init(
             GPIOA,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
@@ -39,7 +39,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF8_I2C3;
         HAL_GPIO_Init(
             GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)

--- a/pipettes/firmware/i2c_setup.c
+++ b/pipettes/firmware/i2c_setup.c
@@ -42,7 +42,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         __HAL_RCC_GPIOA_CLK_ENABLE();
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
         GPIO_InitStruct.Pin = GPIO_PIN_8;
         HAL_GPIO_Init(
@@ -61,7 +61,7 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         GPIO_InitStruct.Pin = GPIO_PIN_8 | GPIO_PIN_9;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF8_I2C3;
         HAL_GPIO_Init(
             GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)


### PR DESCRIPTION
## Overview

The ultimate i2c issue on the g4 pipette boards turned out to be a cabling problem, but Joe also
recommended that we change the speed of the i2c gpios to low.