### PR TITLE
feat: OT-3 state manager communication (RET-1104)

### DIFF
--- a/ot3_state_manager/ot3_state_manager/hardware.py
+++ b/ot3_state_manager/ot3_state_manager/hardware.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from opentrons.hardware_control.types import OT3Axis
 
 from ot3_state_manager.measurable_states import Force, Position
@@ -12,13 +10,17 @@ from ot3_state_manager.pipette_model import PipetteModel
 
 class GantryX:
     """Gantry X Hardware."""
+
     def __init__(self) -> None:
+        """Creates GantryX object."""
         self.position = Position(axis=OT3Axis.X)
 
 
 class GantryY:
     """Gantry Y Hardware."""
+
     def __init__(self) -> None:
+        """Creates GantryY object."""
         self.position = Position(axis=OT3Axis.Y)
 
 
@@ -27,42 +29,52 @@ class Gripper:
 
     # Gripper z is controlled by gripper board so it is being filed under gripper
     def __init__(self) -> None:
+        """Creates Gripper object."""
         self.gripper_z_position = Position(axis=OT3Axis.Z_G)
         self.position = Position(axis=OT3Axis.G)
         self.jaw_force = Force(axis=OT3Axis.G)
 
 
 class LeftPipette:
-    """Left Pipette Hardware"""
+    """Left Pipette Hardware."""
 
     def __init__(self, model: PipetteModel) -> None:
+        """Creates LeftPipette object."""
         self.model = model
         self.position = Position(axis=OT3Axis.P_L)
 
 
 class RightPipette:
-    """Right Pipette Hardware"""
+    """Right Pipette Hardware."""
 
     def __init__(self, model: PipetteModel) -> None:
+        """Creates RightPipette object."""
         self.model = model
         self.position = Position(axis=OT3Axis.P_R)
 
 
 class Head:
     """OT3 Head Hardware."""
+
     def __init__(self) -> None:
+        """Creates Head object."""
         # Putting z control for pipettes under head because that is the board that
         # actually controls it.
         self.left_pipette_z_position = Position(axis=OT3Axis.Z_L)
         self.right_pipette_z_position = Position(axis=OT3Axis.Z_R)
 
 
-@dataclass
 class SyncPin:
-    sync_pin: bool = False
+    """OT3 Sync Pin."""
 
-    def set_sync_pin_high(self):
+    def __init__(self) -> None:
+        """Creates SyncPin object."""
+        self.sync_pin = False
+
+    def set_sync_pin_high(self) -> None:
+        """Sets sync pin high."""
         self.sync_pin = True
 
-    def set_sync_pin_low(self):
+    def set_sync_pin_low(self) -> None:
+        """Sets sync pin low."""
         self.sync_pin = False

--- a/ot3_state_manager/ot3_state_manager/hardware.py
+++ b/ot3_state_manager/ot3_state_manager/hardware.py
@@ -10,51 +10,59 @@ from ot3_state_manager.measurable_states import Force, Position
 from ot3_state_manager.pipette_model import PipetteModel
 
 
-@dataclass
 class GantryX:
     """Gantry X Hardware."""
+    def __init__(self) -> None:
+        self.position = Position(axis=OT3Axis.X)
 
-    position = Position(axis=OT3Axis.X)
 
-
-@dataclass
 class GantryY:
     """Gantry Y Hardware."""
+    def __init__(self) -> None:
+        self.position = Position(axis=OT3Axis.Y)
 
-    position = Position(axis=OT3Axis.Y)
 
-
-@dataclass
 class Gripper:
     """Gripper Hardware."""
 
     # Gripper z is controlled by gripper board so it is being filed under gripper
-    gripper_z_position = Position(axis=OT3Axis.Z_G)
-    position = Position(axis=OT3Axis.G)
-    jaw_force = Force(axis=OT3Axis.G)
+    def __init__(self) -> None:
+        self.gripper_z_position = Position(axis=OT3Axis.Z_G)
+        self.position = Position(axis=OT3Axis.G)
+        self.jaw_force = Force(axis=OT3Axis.G)
 
 
-@dataclass
 class LeftPipette:
     """Left Pipette Hardware"""
 
-    model: PipetteModel
-    position = Position(axis=OT3Axis.P_L)
+    def __init__(self, model: PipetteModel) -> None:
+        self.model = model
+        self.position = Position(axis=OT3Axis.P_L)
 
 
-@dataclass
 class RightPipette:
     """Right Pipette Hardware"""
 
-    model: PipetteModel
-    position = Position(axis=OT3Axis.P_R)
+    def __init__(self, model: PipetteModel) -> None:
+        self.model = model
+        self.position = Position(axis=OT3Axis.P_R)
+
+
+class Head:
+    """OT3 Head Hardware."""
+    def __init__(self) -> None:
+        # Putting z control for pipettes under head because that is the board that
+        # actually controls it.
+        self.left_pipette_z_position = Position(axis=OT3Axis.Z_L)
+        self.right_pipette_z_position = Position(axis=OT3Axis.Z_R)
 
 
 @dataclass
-class Head:
-    """OT3 Head Hardware."""
+class SyncPin:
+    sync_pin: bool = False
 
-    # Putting z control for pipettes under head because that is the board that
-    # actually controls it.
-    left_pipette_z_position = Position(axis=OT3Axis.Z_L)
-    right_pipette_z_position = Position(axis=OT3Axis.Z_R)
+    def set_sync_pin_high(self):
+        self.sync_pin = True
+
+    def set_sync_pin_low(self):
+        self.sync_pin = False

--- a/ot3_state_manager/ot3_state_manager/hardware.py
+++ b/ot3_state_manager/ot3_state_manager/hardware.py
@@ -2,74 +2,73 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 from opentrons.hardware_control.types import OT3Axis
 
 from ot3_state_manager.measurable_states import Force, Position
 from ot3_state_manager.pipette_model import PipetteModel
 
 
+@dataclass
 class GantryX:
     """Gantry X Hardware."""
 
-    def __init__(self) -> None:
-        """Creates GantryX object."""
-        self.position = Position(axis=OT3Axis.X)
+    position: Position = field(default_factory=lambda: Position(axis=OT3Axis.X))
 
 
+@dataclass
 class GantryY:
     """Gantry Y Hardware."""
 
-    def __init__(self) -> None:
-        """Creates GantryY object."""
-        self.position = Position(axis=OT3Axis.Y)
+    position: Position = field(default_factory=lambda: Position(axis=OT3Axis.Y))
 
 
+@dataclass
 class Gripper:
     """Gripper Hardware."""
 
     # Gripper z is controlled by gripper board so it is being filed under gripper
-    def __init__(self) -> None:
-        """Creates Gripper object."""
-        self.gripper_z_position = Position(axis=OT3Axis.Z_G)
-        self.position = Position(axis=OT3Axis.G)
-        self.jaw_force = Force(axis=OT3Axis.G)
+    gripper_z_position: Position = field(
+        default_factory=lambda: Position(axis=OT3Axis.Z_G)
+    )
+    position: Position = field(default_factory=lambda: Position(axis=OT3Axis.G))
+    jaw_force: Force = field(default_factory=lambda: Force(axis=OT3Axis.G))
 
 
+@dataclass
 class LeftPipette:
     """Left Pipette Hardware."""
 
-    def __init__(self, model: PipetteModel) -> None:
-        """Creates LeftPipette object."""
-        self.model = model
-        self.position = Position(axis=OT3Axis.P_L)
+    model: PipetteModel
+    position: Position = field(default_factory=lambda: Position(axis=OT3Axis.P_L))
 
 
+@dataclass
 class RightPipette:
     """Right Pipette Hardware."""
 
-    def __init__(self, model: PipetteModel) -> None:
-        """Creates RightPipette object."""
-        self.model = model
-        self.position = Position(axis=OT3Axis.P_R)
+    model: PipetteModel
+    position: Position = field(default_factory=lambda: Position(axis=OT3Axis.P_R))
 
 
+@dataclass
 class Head:
     """OT3 Head Hardware."""
 
-    def __init__(self) -> None:
-        """Creates Head object."""
-        # Putting z control for pipettes under head because that is the board that
-        # actually controls it.
-        self.left_pipette_z_position = Position(axis=OT3Axis.Z_L)
-        self.right_pipette_z_position = Position(axis=OT3Axis.Z_R)
+    left_pipette_z_position: Position = field(
+        default_factory=lambda: Position(axis=OT3Axis.Z_L)
+    )
+    right_pipette_z_position: Position = field(
+        default_factory=lambda: Position(axis=OT3Axis.Z_R)
+    )
 
 
+@dataclass
 class SyncPin:
     """OT3 Sync Pin."""
 
-    def __init__(self) -> None:
-        """Creates SyncPin object."""
-        self.sync_pin = False
+    sync_pin: bool = field(default_factory=lambda: False)
 
     def set_sync_pin_high(self) -> None:
         """Sets sync pin high."""

--- a/ot3_state_manager/ot3_state_manager/measurable_states.py
+++ b/ot3_state_manager/ot3_state_manager/measurable_states.py
@@ -9,9 +9,9 @@ class Position:
     """Represents position state."""
 
     axis: OT3Axis
-    current_position: float = 0.0
-    commanded_position: float = 0.0
-    encoder_position: float = 0.0
+    current_position: int = 0
+    commanded_position: int = 0
+    encoder_position: int = 0
 
 
 @dataclass
@@ -19,6 +19,6 @@ class Force:
     """Represents force state."""
 
     axis: OT3Axis
-    current_force: float = 0.0
-    commanded_force: float = 0.0
-    encoder_force: float = 0.0
+    current_force: int = 0
+    commanded_force: int = 0
+    encoder_force: int = 0

--- a/ot3_state_manager/ot3_state_manager/messages.py
+++ b/ot3_state_manager/ot3_state_manager/messages.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import (
+    Literal,
+    Optional,
+    Union,
+)
+
+from opentrons.hardware_control.types import OT3Axis
+
+from ot3_state_manager.ot3_state import OT3State
+from ot3_state_manager.util import (
+    Direction,
+    get_md5_hash,
+)
+
+
+@dataclass
+class Message:
+    """Generic Message Type."""
+
+    @classmethod
+    def to_message(cls, string: str) -> Optional[Message]:
+        """Parse string into message."""
+        raise NotImplementedError
+
+
+@dataclass
+class SyncPinMessage(Message):
+    """Message for setting sync pin high or low."""
+
+    state: Literal["HIGH", "LOW"]
+
+    @classmethod
+    def to_message(cls, string: str) -> Optional[SyncPinMessage]:
+        """Parse string into SyncPinMessage or None."""
+        if string.startswith("SYNC_PIN"):
+            split_string = string.split(" ")
+            if len(split_string) == 2:
+                sync_pin_state = split_string[1]
+                if sync_pin_state == "HIGH":
+                    return cls(state="HIGH")
+                elif sync_pin_state == "LOW":
+                    return cls(state="LOW")
+
+        return None
+
+
+@dataclass
+class MoveMessage(Message):
+    """Message to be sent between hardware simulators and OT3StateManager"""
+
+    axis: OT3Axis
+    direction: Direction
+
+    @classmethod
+    def to_message(cls, string: str) -> Optional[MoveMessage]:
+        """Parse string to Message or None."""
+        split_string = string.split(" ")
+
+        if len(split_string) == 2:
+            try:
+                axis = OT3Axis[split_string[1]]
+            except KeyError:
+                axis = None
+
+            try:
+                direction = Direction.from_symbol(split_string[0])
+            except ValueError:
+                direction = None
+
+            if axis is not None and direction is not None:
+                return cls(axis=axis, direction=direction)
+
+        return None
+
+def parse_message(string: str) -> Union[SyncPinMessage, MoveMessage]:
+    """Parse string into a Message Type"""
+    sync_pin_message = SyncPinMessage.to_message(string)
+    move_message = MoveMessage.to_message(string)
+
+    if sync_pin_message is not None:
+        return sync_pin_message
+
+    if move_message is not None:
+        return move_message
+
+    raise ValueError(f'Not able to parse message: "{string}"')
+
+
+def handle_message(data: bytes, ot3_state: OT3State) -> bytes:
+    error_response: Optional[str] = None
+    try:
+        message = parse_message(data.decode())
+    except ValueError as err:
+        error_response = f"{err.args[0]}"
+    except:  # noqa: E722
+        error_response = "Unhandled Exception"
+    else:
+        if isinstance(message, MoveMessage):
+            ot3_state.pulse(message.axis, message.direction)
+            print(ot3_state.current_position)
+        elif isinstance(message, SyncPinMessage):
+            ot3_state.set_sync_pin(message.state)
+        else:
+            error_response = "Parsed to an unhandled message."
+
+    if error_response is not None:
+        response = f"ERROR: {error_response}".encode()
+    else:
+        response = get_md5_hash(data)
+
+    return response

--- a/ot3_state_manager/ot3_state_manager/messages.py
+++ b/ot3_state_manager/ot3_state_manager/messages.py
@@ -1,18 +1,17 @@
+"""Class for all messages exchanged between client and server.
+
+Also, location for all message handling functions.
+"""
+
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import (
-    Literal,
-    Optional,
-    Union,
-)
+from typing import Literal, Optional, Union
 
 from opentrons.hardware_control.types import OT3Axis
 
 from ot3_state_manager.ot3_state import OT3State
-from ot3_state_manager.util import (
-    Direction,
-    get_md5_hash,
-)
+from ot3_state_manager.util import Direction, get_md5_hash
 
 
 @dataclass
@@ -74,6 +73,7 @@ class MoveMessage(Message):
 
         return None
 
+
 def parse_message(string: str) -> Union[SyncPinMessage, MoveMessage]:
     """Parse string into a Message Type"""
     sync_pin_message = SyncPinMessage.to_message(string)
@@ -89,6 +89,7 @@ def parse_message(string: str) -> Union[SyncPinMessage, MoveMessage]:
 
 
 def handle_message(data: bytes, ot3_state: OT3State) -> bytes:
+    """Parse incoming message, react to it accordingly, and respond."""
     error_response: Optional[str] = None
     try:
         message = parse_message(data.decode())

--- a/ot3_state_manager/ot3_state_manager/ot3_state.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state.py
@@ -34,8 +34,8 @@ class OT3State:
     @classmethod
     def build(
         cls,
-        left_pipette_model: Optional[PipetteModel],
-        right_pipette_model: Optional[PipetteModel],
+        left_pipette_model_name: Optional[str],
+        right_pipette_model_name: Optional[str],
         use_gripper: bool,
     ) -> OT3State:
         """Helper function to build an OT3State object.
@@ -51,13 +51,13 @@ class OT3State:
         slot.
         """
         left_pipette = (
-            LeftPipette(model=left_pipette_model)
-            if left_pipette_model is not None
+            LeftPipette(PipetteModel.model_name_to_enum(left_pipette_model_name))
+            if left_pipette_model_name is not None
             else None
         )
         right_pipette = (
-            RightPipette(model=right_pipette_model)
-            if right_pipette_model is not None
+            RightPipette(PipetteModel.model_name_to_enum(right_pipette_model_name))
+            if right_pipette_model_name is not None
             else None
         )
         gripper = Gripper() if use_gripper else None

--- a/ot3_state_manager/ot3_state_manager/ot3_state.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state.py
@@ -1,0 +1,220 @@
+"""Class to maintain state of the OT3."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+from ot3_state_manager.util import Direction, Message
+from opentrons.hardware_control.types import OT3Axis
+
+from ot3_state_manager.hardware import (
+    GantryX,
+    GantryY,
+    Gripper,
+    Head,
+    LeftPipette,
+    RightPipette,
+    SyncPin,
+)
+from ot3_state_manager.measurable_states import Position
+from ot3_state_manager.pipette_model import PipetteModel
+
+
+log = logging.getLogger(__name__)
+
+class OT3State:
+    """Class to maintain state of OT3.
+
+    Provides properties to get current_position, commanded_position, and
+    encoder_position. Also provides update_position function to update the previously
+    state values.
+    """
+
+    @classmethod
+    def build(
+        cls,
+        left_pipette_model: Optional[PipetteModel],
+        right_pipette_model: Optional[PipetteModel],
+        use_gripper: bool,
+    ) -> OT3State:
+        """Helper function to build an OT3State object.
+
+        Takes optional left pipette and right pipette model names. Passing None for the
+        pipette models names tells the system that there is no pipette attached that
+        slot.
+
+        Pass True for use_gripper parameter to tell the model there is a gripper
+        attached. Pass False if no gripper is attached.
+
+        If you are attaching a high-throughput pipette it must go in the right-side
+        slot.
+        """
+        left_pipette = (
+            LeftPipette(model=left_pipette_model)
+            if left_pipette_model is not None
+            else None
+        )
+        right_pipette = (
+            RightPipette(model=right_pipette_model)
+            if right_pipette_model is not None
+            else None
+        )
+        gripper = Gripper() if use_gripper else None
+
+        return cls(
+            left_pipette=left_pipette,
+            right_pipette=right_pipette,
+            gripper=gripper
+        )
+
+    def __init__(
+        self,
+        left_pipette: Optional[LeftPipette],
+        right_pipette: Optional[RightPipette],
+        gripper: Optional[Gripper],
+    ) -> None:
+        """Creates OT3State object.
+
+        Args:
+            left_pipette: PipetteModel to attach, or None.
+            right_pipette: PipetteModel to attach, or None.
+            gripper: Whether or not to attach a gripper.
+        """
+        if (
+            left_pipette is not None
+            and left_pipette.model == PipetteModel.MULTI_96_1000
+        ):
+            raise ValueError(
+                "High-throughput pipette must be connected to right pipette mount"
+            )
+
+        if (
+            left_pipette is not None
+            and right_pipette is not None
+            and right_pipette.model == PipetteModel.MULTI_96_1000
+        ):
+            raise ValueError(
+                "When using high-throughput pipette you cannot have a pipette in the "
+                "left mount"
+            )
+
+        self.head = Head()
+        self.gantry_x = GantryX()
+        self.gantry_y = GantryY()
+        self.left_pipette = left_pipette
+        self.right_pipette = right_pipette
+        self.gripper = gripper
+        self.sync_pin = SyncPin()
+
+    def _pos_dict(self) -> Dict[OT3Axis, Optional[Position]]:
+        """Generates lookup dict for class's position properties."""
+        left_pipette_pos = (
+            self.left_pipette.position if self.left_pipette is not None else None
+        )
+        right_pipette_pos = (
+            self.right_pipette.position if self.right_pipette is not None else None
+        )
+        gripper_pos = self.gripper.position if self.gripper is not None else None
+        gripper_mount_pos = (
+            self.gripper.gripper_z_position if self.gripper is not None else None
+        )
+
+        return {
+            OT3Axis.Z_L: self.head.left_pipette_z_position,
+            OT3Axis.Z_R: self.head.right_pipette_z_position,
+            OT3Axis.X: self.gantry_x.position,
+            OT3Axis.Y: self.gantry_y.position,
+            OT3Axis.P_L: left_pipette_pos,
+            OT3Axis.P_R: right_pipette_pos,
+            OT3Axis.G: gripper_pos,
+            OT3Axis.Z_G: gripper_mount_pos,
+        }
+
+    @property
+    def current_position(self) -> Dict[OT3Axis, Optional[int]]:
+        """Returns dictionary with axis mapped to current position of said axis.
+
+        If hardware is not attached for axis, then position value will be None.
+        """
+        pos_dict = self._pos_dict()
+
+        # Ignoring the mypy error because we are checking that the value is None
+        return {
+            key: (pos_dict[key].current_position if value is not None else None)  # type: ignore[union-attr]
+            for key, value in pos_dict.items()
+        }
+
+    @property
+    def encoder_position(self) -> Dict[OT3Axis, Optional[int]]:
+        """Returns dictionary with axis mapped to encoder position of said axis.
+
+        If hardware is not attached for axis, then position value will be None.
+        """
+        pos_dict = self._pos_dict()
+
+        # Ignoring the mypy error because we are checking that the value is None
+        return {
+            key: (pos_dict[key].encoder_position if value is not None else None)  # type: ignore[union-attr]
+            for key, value in pos_dict.items()
+        }
+
+    @property
+    def updatable_axes(self) -> List[OT3Axis]:
+        """Returns a list of positions that are available to be updated."""
+        return [key for key, value in self._pos_dict().items() if value is not None]
+
+    @property
+    def is_gripper_attached(self) -> bool:
+        """Returns True if gripper is attached, False if not."""
+        return self.gripper is not None
+
+    @property
+    def is_left_pipette_attached(self) -> bool:
+        """Returns True if left pipette is attached, False if not."""
+        return self.left_pipette is not None
+
+    @property
+    def is_right_pipette_attached(self) -> bool:
+        """Returns True if right pipette is attached, False if not."""
+        return self.right_pipette is not None
+
+    @property
+    def is_high_throughput_pipette_attached(self) -> bool:
+        """Returns True if high throughput pipette is attached, False if not."""
+        return (
+            self.right_pipette is not None
+            and self.right_pipette.model == PipetteModel.MULTI_96_1000
+        )
+
+    def axis_current_position(self, axis: OT3Axis) -> int:
+        return self.current_position[axis]
+
+    def axis_encoder_position(self, axis: OT3Axis) -> int:
+        return self.encoder_position[axis]
+
+    def update_position(
+        self,
+        axis_to_update: OT3Axis,
+        current_position: float,
+        encoder_position: float,
+    ) -> None:
+        """Method to update the position of a piece of OT3 hardware."""
+        pos_to_update = self._pos_dict()[axis_to_update]
+
+        if pos_to_update is None:
+            raise ValueError(
+                f'Axis "{axis_to_update.name}" is not available. '
+                f"Cannot update it's position."
+            )
+        pos_to_update.current_position = current_position
+        pos_to_update.encoder_position = encoder_position
+
+    def pulse(self, message: Message) -> None:
+        log.info(f"SERVER: Pulsing {message.axis}")
+        mod = 1 if message.direction == Direction.POSITIVE else -1
+        self.update_position(
+            axis_to_update=message.axis,
+            current_position=self.axis_current_position(message.axis) + mod,
+            encoder_position=self.axis_encoder_position(message.axis) + mod
+        )

--- a/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
@@ -12,17 +12,25 @@ log = logging.getLogger(__name__)
 
 
 class OT3StateManager:
-    def __init__(self, host: str, port: int, ot3_state:OT3State) -> None:
+    """Async socket server that accepts pulse messages."""
+    def __init__(self, host: str, port: int, ot3_state: OT3State) -> None:
         self._host = host
         self._port = port
         self._ot3_state = ot3_state
 
     async def _handle_message(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
         data = await reader.read(100)
-        self._ot3_state.pulse(Message.to_message(data.decode()))
-        writer.write(get_md5_hash(data))
-        await writer.drain()
-        writer.close()
+        try:
+            message = Message.to_message(data.decode())
+        except ValueError as err:
+            writer.write(f"ERROR: {err.args[0]}".encode())
+        except:
+            writer.write(f"ERROR: Unhandled Exception".encode())
+        else:
+            self._ot3_state.pulse(message)
+            writer.write(get_md5_hash(data))
+            await writer.drain()
+            writer.close()
 
     async def start_message_handler(self):
         server = await asyncio.start_server(self._handle_message, self._host, self._port)

--- a/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
@@ -5,18 +5,17 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-from typing import Optional
+from asyncio import BaseProtocol
+from typing import Tuple, cast
 
-from opentrons.hardware_control.types import OT3Axis
-
+from ot3_state_manager.messages import handle_message
 from ot3_state_manager.ot3_state import OT3State
 from ot3_state_manager.pipette_model import PipetteModel
-from ot3_state_manager.messages import handle_message
 
 log = logging.getLogger(__name__)
 
 
-class OT3StateManager:
+class OT3StateManager(BaseProtocol):
     """Async socket server that accepts pulse messages."""
 
     def __init__(self, ot3_state: OT3State) -> None:
@@ -29,22 +28,40 @@ class OT3StateManager:
         """
         self._ot3_state = ot3_state
         self.transport = None
+        self._connected = False
 
-    def connection_made(self, transport):
-        print("Server: Connection Made")
+    def connection_made(self, transport) -> None:  # noqa: ANN001
+        """Called when connection is made from client."""
+        self._connected = True
         self.transport = transport
 
-    def datagram_received(self, data, addr):
-        print("Received from client: ", data)
-        self.transport.sendto(handle_message(data, self._ot3_state), addr)
-        self.transport = None
+    def datagram_received(self, data: bytes, addr: Tuple[str, str]) -> None:
+        """Called when a datagram is received from client."""
+        if self.transport is not None:
+            self.transport.sendto(handle_message(data, self._ot3_state), addr)
 
-    async def start_server(self, host, port) -> None:
+    async def start_server(self, host: str, port: int) -> OT3StateManager:
+        """Starts OT3StateManager UDP Datagram server"""
         loop = asyncio.get_running_loop()
-        await loop.create_datagram_endpoint(lambda: self, local_addr=(host, port))
+        transport, protocol = await loop.create_datagram_endpoint(
+            lambda: self,
+            local_addr=(host, port),
+        )
+        return cast(OT3StateManager, protocol)  # Casting for mypy
+
+    async def is_connected(self) -> bool:
+        """Flag for when a client is connected."""
+        return self._connected
+
+    async def close(self) -> None:
+        """Close existing socket connection."""
+        if self.transport is not None:
+            self.transport.close()
+        self._connected = False
 
 
-async def main():
+async def main() -> None:
+    """CLI interface."""
     LEFT_PIPETTE_DEST = "left_pipette_model_name"
     RIGHT_PIPETTE_DEST = "right_pipette_model_name"
     GRIPPER_DEST = "use_gripper"

--- a/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
@@ -1,213 +1,34 @@
-"""Class to maintain state of the OT3."""
-
 from __future__ import annotations
-
-from typing import Dict, List, Optional
-
-from opentrons.hardware_control.types import OT3Axis
-
-from ot3_state_manager.hardware import (
-    GantryX,
-    GantryY,
-    Gripper,
-    Head,
-    LeftPipette,
-    RightPipette,
+import asyncio
+import hashlib
+import logging
+from ot3_state_manager.ot3_state import OT3State
+from ot3_state_manager.util import (
+    Message,
+    get_md5_hash,
 )
-from ot3_state_manager.measurable_states import Position
-from ot3_state_manager.pipette_model import PipetteModel
+
+log = logging.getLogger(__name__)
 
 
 class OT3StateManager:
-    """Class to maintain state of OT3.
+    def __init__(self, host: str, port: int, ot3_state:OT3State) -> None:
+        self._host = host
+        self._port = port
+        self._ot3_state = ot3_state
 
-    Provides properties to get current_position, commanded_position, and
-    encoder_position. Also provides update_position function to update the previously
-    state values.
-    """
+    async def _handle_message(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        data = await reader.read(100)
+        self._ot3_state.pulse(Message.to_message(data.decode()))
+        writer.write(get_md5_hash(data))
+        await writer.drain()
+        writer.close()
 
-    @classmethod
-    def build(
-        cls,
-        left_pipette_model: Optional[PipetteModel],
-        right_pipette_model: Optional[PipetteModel],
-        use_gripper: bool,
-    ) -> OT3StateManager:
-        """Helper function to build an OT3StateManager object.
+    async def start_message_handler(self):
+        server = await asyncio.start_server(self._handle_message, self._host, self._port)
 
-        Takes optional left pipette and right pipette model names. Passing None for the
-        pipette models names tells the system that there is no pipette attached that
-        slot.
+        addr = server.sockets[0].getsockname()
+        log.info(f'SERVER: Serving on {addr[0:2]}')
 
-        Pass True for use_gripper parameter to tell the model there is a gripper
-        attached. Pass False if no gripper is attached.
-
-        If you are attaching a high-throughput pipette it must go in the right-side
-        slot.
-        """
-        left_pipette = (
-            LeftPipette(model=left_pipette_model)
-            if left_pipette_model is not None
-            else None
-        )
-        right_pipette = (
-            RightPipette(model=right_pipette_model)
-            if right_pipette_model is not None
-            else None
-        )
-        gripper = Gripper() if use_gripper else None
-
-        return cls(
-            left_pipette=left_pipette, right_pipette=right_pipette, gripper=gripper
-        )
-
-    def __init__(
-        self,
-        left_pipette: Optional[LeftPipette],
-        right_pipette: Optional[RightPipette],
-        gripper: Optional[Gripper],
-    ) -> None:
-        """Creates OT3StateManager object.
-
-        Args:
-            left_pipette: PipetteModel to attach, or None.
-            right_pipette: PipetteModel to attach, or None.
-            gripper: Whether or not to attach a gripper.
-        """
-        if (
-            left_pipette is not None
-            and left_pipette.model == PipetteModel.MULTI_96_1000
-        ):
-            raise ValueError(
-                "High-throughput pipette must be connected to right pipette mount"
-            )
-
-        if (
-            left_pipette is not None
-            and right_pipette is not None
-            and right_pipette.model == PipetteModel.MULTI_96_1000
-        ):
-            raise ValueError(
-                "When using high-throughput pipette you cannot have a pipette in the "
-                "left mount"
-            )
-
-        self.head = Head()
-        self.gantry_x = GantryX()
-        self.gantry_y = GantryY()
-        self.left_pipette = left_pipette
-        self.right_pipette = right_pipette
-        self.gripper = gripper
-
-    def _pos_dict(self) -> Dict[OT3Axis, Optional[Position]]:
-        """Generates lookup dict for class's position properties."""
-        left_pipette_pos = (
-            self.left_pipette.position if self.left_pipette is not None else None
-        )
-        right_pipette_pos = (
-            self.right_pipette.position if self.right_pipette is not None else None
-        )
-        gripper_pos = self.gripper.position if self.gripper is not None else None
-        gripper_mount_pos = (
-            self.gripper.gripper_z_position if self.gripper is not None else None
-        )
-
-        return {
-            Head.left_pipette_z_position.axis: self.head.left_pipette_z_position,
-            Head.right_pipette_z_position.axis: self.head.right_pipette_z_position,
-            GantryX.position.axis: self.gantry_x.position,
-            GantryY.position.axis: self.gantry_y.position,
-            LeftPipette.position.axis: left_pipette_pos,
-            RightPipette.position.axis: right_pipette_pos,
-            Gripper.position.axis: gripper_pos,
-            Gripper.gripper_z_position.axis: gripper_mount_pos,
-        }
-
-    @property
-    def current_position(self) -> Dict[OT3Axis, Optional[float]]:
-        """Returns dictionary with axis mapped to current position of said axis.
-
-        If hardware is not attached for axis, then position value will be None.
-        """
-        pos_dict = self._pos_dict()
-
-        # Ignoring the mypy error because we are checking that the value is None
-        return {
-            key: (pos_dict[key].current_position if value is not None else None)  # type: ignore[union-attr]
-            for key, value in pos_dict.items()
-        }
-
-    @property
-    def commanded_position(self) -> Dict[OT3Axis, Optional[float]]:
-        """Returns dictionary with axis mapped to commanded position of said axis.
-
-        If hardware is not attached for axis, then position value will be None.
-        """
-        pos_dict = self._pos_dict()
-
-        # Ignoring the mypy error because we are checking that the value is None
-        return {
-            key: (pos_dict[key].commanded_position if value is not None else None)  # type: ignore[union-attr]
-            for key, value in pos_dict.items()
-        }
-
-    @property
-    def encoder_position(self) -> Dict[OT3Axis, Optional[float]]:
-        """Returns dictionary with axis mapped to encoder position of said axis.
-
-        If hardware is not attached for axis, then position value will be None.
-        """
-        pos_dict = self._pos_dict()
-
-        # Ignoring the mypy error because we are checking that the value is None
-        return {
-            key: (pos_dict[key].encoder_position if value is not None else None)  # type: ignore[union-attr]
-            for key, value in pos_dict.items()
-        }
-
-    @property
-    def updatable_axes(self) -> List[OT3Axis]:
-        """Returns a list of positions that are available to be updated."""
-        return [key for key, value in self._pos_dict().items() if value is not None]
-
-    @property
-    def is_gripper_attached(self) -> bool:
-        """Returns True if gripper is attached, False if not."""
-        return self.gripper is not None
-
-    @property
-    def is_left_pipette_attached(self) -> bool:
-        """Returns True if left pipette is attached, False if not."""
-        return self.left_pipette is not None
-
-    @property
-    def is_right_pipette_attached(self) -> bool:
-        """Returns True if right pipette is attached, False if not."""
-        return self.right_pipette is not None
-
-    @property
-    def is_high_throughput_pipette_attached(self) -> bool:
-        """Returns True if high throughput pipette is attached, False if not."""
-        return (
-            self.right_pipette is not None
-            and self.right_pipette.model == PipetteModel.MULTI_96_1000
-        )
-
-    def update_position(
-        self,
-        axis_to_update: OT3Axis,
-        current_position: float,
-        commanded_position: float,
-        encoder_position: float,
-    ) -> None:
-        """Method to update the position of a piece of OT3 hardware."""
-        pos_to_update = self._pos_dict()[axis_to_update]
-
-        if pos_to_update is None:
-            raise ValueError(
-                f'Axis "{axis_to_update.name}" is not available. '
-                f"Cannot update it's position."
-            )
-        pos_to_update.current_position = current_position
-        pos_to_update.commanded_position = commanded_position
-        pos_to_update.encoder_position = encoder_position
+        async with server:
+            await server.serve_forever()

--- a/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
@@ -1,11 +1,17 @@
+"""Class that communicates with hardware simulators and updates OT3State."""
+
 from __future__ import annotations
+
 import asyncio
-import hashlib
 import logging
+from typing import Optional
+
 from ot3_state_manager.ot3_state import OT3State
 from ot3_state_manager.util import (
-    Message,
+    MoveMessage,
+    SyncPinMessage,
     get_md5_hash,
+    parse_message,
 )
 
 log = logging.getLogger(__name__)
@@ -13,30 +19,53 @@ log = logging.getLogger(__name__)
 
 class OT3StateManager:
     """Async socket server that accepts pulse messages."""
+
     def __init__(self, host: str, port: int, ot3_state: OT3State) -> None:
+        """Creates an OT3StateManager Object.
+
+        Args:
+            host: hostname to connect to
+            port: port to connect to
+            ot3_state: OT3State object to modify
+        """
         self._host = host
         self._port = port
         self._ot3_state = ot3_state
 
-    async def _handle_message(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+    async def _handle_message(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
         data = await reader.read(100)
+        error_response: Optional[str] = None
         try:
-            message = Message.to_message(data.decode())
+            message = parse_message(data.decode())
         except ValueError as err:
-            writer.write(f"ERROR: {err.args[0]}".encode())
-        except:
-            writer.write(f"ERROR: Unhandled Exception".encode())
+            error_response = f"{err.args[0]}"
+        except:  # noqa: E722
+            error_response = "Unhandled Exception"
         else:
-            self._ot3_state.pulse(message)
-            writer.write(get_md5_hash(data))
-            await writer.drain()
-            writer.close()
+            if isinstance(message, MoveMessage):
+                self._ot3_state.pulse(message.axis, message.direction)
+            elif isinstance(message, SyncPinMessage):
+                self._ot3_state.set_sync_pin(message.state)
+            else:
+                error_response = "Parsed to an unhandled message."
 
-    async def start_message_handler(self):
-        server = await asyncio.start_server(self._handle_message, self._host, self._port)
+        if error_response is not None:
+            writer.write(f"ERROR: {error_response}".encode())
+        else:
+            writer.write(get_md5_hash(data))
+        await writer.drain()
+        writer.close()
+
+    async def start_server(self) -> None:
+        """Starts asyncio server"""
+        server = await asyncio.start_server(
+            self._handle_message, self._host, self._port
+        )
 
         addr = server.sockets[0].getsockname()
-        log.info(f'SERVER: Serving on {addr[0:2]}')
+        log.info(f"SERVER: Serving on {addr[0:2]}")
 
         async with server:
             await server.serve_forever()

--- a/ot3_state_manager/ot3_state_manager/pipette_model.py
+++ b/ot3_state_manager/ot3_state_manager/pipette_model.py
@@ -1,4 +1,6 @@
 """Enum containing valid pipette models."""
+from __future__ import annotations
+
 from enum import Enum
 
 
@@ -13,3 +15,15 @@ class PipetteModel(Enum):
     MULTI_8_20 = "P20-multi-8"
     MULTI_8_300 = "P300-multi-8"
     MULTI_96_1000 = "P1000-multi-96"
+
+    @staticmethod
+    def model_name_to_enum(name: str) -> PipetteModel:
+        """Get PipetteModel by name of pipette."""
+        lookup_dict = {
+            PipetteModel.SINGLE_20.value: PipetteModel.SINGLE_20,
+            PipetteModel.SINGLE_300.value: PipetteModel.SINGLE_300,
+            PipetteModel.MULTI_8_20.value: PipetteModel.MULTI_8_20,
+            PipetteModel.MULTI_8_300.value: PipetteModel.MULTI_8_300,
+            PipetteModel.MULTI_96_1000.value: PipetteModel.MULTI_96_1000,
+        }
+        return lookup_dict[name]

--- a/ot3_state_manager/ot3_state_manager/util.py
+++ b/ot3_state_manager/ot3_state_manager/util.py
@@ -4,10 +4,6 @@ from __future__ import annotations
 
 import enum
 import hashlib
-from dataclasses import dataclass
-from typing import Literal, Optional, Union
-
-from opentrons.hardware_control.types import OT3Axis
 
 
 class Direction(enum.Enum):
@@ -29,80 +25,6 @@ class Direction(enum.Enum):
             )
 
 
-@dataclass
-class Message:
-    """Generic Message Type."""
-
-    @classmethod
-    def to_message(cls, string: str) -> Optional[Message]:
-        """Parse string into message."""
-        raise NotImplementedError
-
-
-@dataclass
-class SyncPinMessage(Message):
-    """Message for setting sync pin high or low."""
-
-    state: Literal["HIGH", "LOW"]
-
-    @classmethod
-    def to_message(cls, string: str) -> Optional[SyncPinMessage]:
-        """Parse string into SyncPinMessage or None."""
-        if string.startswith("SYNC_PIN"):
-            split_string = string.split(" ")
-            if len(split_string) == 2:
-                sync_pin_state = split_string[1]
-                if sync_pin_state == "HIGH":
-                    return cls(state="HIGH")
-                elif sync_pin_state == "LOW":
-                    return cls(state="LOW")
-
-        return None
-
-
-@dataclass
-class MoveMessage(Message):
-    """Message to be sent between hardware simulators and OT3StateManager"""
-
-    axis: OT3Axis
-    direction: Direction
-
-    @classmethod
-    def to_message(cls, string: str) -> Optional[MoveMessage]:
-        """Parse string to Message or None."""
-        split_string = string.split(" ")
-
-        if len(split_string) == 2:
-            try:
-                axis = OT3Axis[split_string[1]]
-            except KeyError:
-                axis = None
-
-            try:
-                direction = Direction.from_symbol(split_string[0])
-            except ValueError:
-                direction = None
-
-            if axis is not None and direction is not None:
-                return cls(axis=axis, direction=direction)
-
-        return None
-
-
 def get_md5_hash(data: bytes) -> bytes:
     """Convert bytes into a md5 hash."""
     return hashlib.md5(data).hexdigest().encode()
-
-
-def parse_message(string: str) -> Union[SyncPinMessage, MoveMessage]:
-    """Parse string into a Message Type"""
-    sync_pin_message = SyncPinMessage.to_message(string)
-    move_message = MoveMessage.to_message(string)
-
-    if sync_pin_message is not None:
-        return sync_pin_message
-
-    if move_message is not None:
-        return move_message
-
-    raise ValueError(f'Not able to parse message: "{string}"')

--- a/ot3_state_manager/ot3_state_manager/util.py
+++ b/ot3_state_manager/ot3_state_manager/util.py
@@ -38,11 +38,29 @@ class Message:
     def to_message(string: str) -> Message:
         """Parse string to Message."""
         split_string = string.split(" ")
-        assert len(split_string) == 2
-        direction, axis = split_string
+        if not len(split_string) == 2:
+            raise ValueError(
+                "Bad Message Format. Expects \"<axis> <direction>\". "
+                f"You passed \"{string}\""
+            )
+
+        axis_string = split_string[1]
+
+        try:
+            axis = OT3Axis[axis_string]
+        except KeyError:
+            raise ValueError(
+                f"Invalid Axis Passed. You passed \"{axis_string}\""
+            )
+
+        try:
+            direction = Direction.from_symbol(split_string[0])
+        except ValueError:
+            raise
+
         return Message(
-            axis=OT3Axis[axis],
-            direction=Direction.from_symbol(direction)
+            axis=axis,
+            direction=direction
         )
 
 

--- a/ot3_state_manager/ot3_state_manager/util.py
+++ b/ot3_state_manager/ot3_state_manager/util.py
@@ -1,18 +1,20 @@
+"""Functions and classes that are shared across the package."""
+
 from __future__ import annotations
+
 import enum
 import hashlib
 from dataclasses import dataclass
+from typing import Literal, Optional, Union
 
 from opentrons.hardware_control.types import OT3Axis
 
 
 class Direction(enum.Enum):
     """Class representing direction to move axis in."""
+
     POSITIVE = "+"
     NEGATIVE = "-"
-
-    def __str__(self) -> str:
-        return self.name
 
     @classmethod
     def from_symbol(cls, symbol: str) -> "Direction":
@@ -23,46 +25,84 @@ class Direction(enum.Enum):
             return cls.NEGATIVE
         else:
             raise ValueError(
-                f"Symbol \"{symbol}\" is not valid."
-                f" Valid symbols are \"+\" and \"-\""
+                f'Symbol "{symbol}" is not valid.' f' Valid symbols are "+" and "-"'
             )
 
 
 @dataclass
 class Message:
+    """Generic Message Type."""
+
+    @classmethod
+    def to_message(cls, string: str) -> Optional[Message]:
+        """Parse string into message."""
+        raise NotImplementedError
+
+
+@dataclass
+class SyncPinMessage(Message):
+    """Message for setting sync pin high or low."""
+
+    state: Literal["HIGH", "LOW"]
+
+    @classmethod
+    def to_message(cls, string: str) -> Optional[SyncPinMessage]:
+        """Parse string into SyncPinMessage or None."""
+        if string.startswith("SYNC_PIN"):
+            split_string = string.split(" ")
+            if len(split_string) == 2:
+                sync_pin_state = split_string[1]
+                if sync_pin_state == "HIGH":
+                    return cls(state="HIGH")
+                elif sync_pin_state == "LOW":
+                    return cls(state="LOW")
+
+        return None
+
+
+@dataclass
+class MoveMessage(Message):
     """Message to be sent between hardware simulators and OT3StateManager"""
+
     axis: OT3Axis
     direction: Direction
 
-    @staticmethod
-    def to_message(string: str) -> Message:
-        """Parse string to Message."""
+    @classmethod
+    def to_message(cls, string: str) -> Optional[MoveMessage]:
+        """Parse string to Message or None."""
         split_string = string.split(" ")
-        if not len(split_string) == 2:
-            raise ValueError(
-                "Bad Message Format. Expects \"<axis> <direction>\". "
-                f"You passed \"{string}\""
-            )
 
-        axis_string = split_string[1]
+        if len(split_string) == 2:
+            try:
+                axis = OT3Axis[split_string[1]]
+            except KeyError:
+                axis = None
 
-        try:
-            axis = OT3Axis[axis_string]
-        except KeyError:
-            raise ValueError(
-                f"Invalid Axis Passed. You passed \"{axis_string}\""
-            )
+            try:
+                direction = Direction.from_symbol(split_string[0])
+            except ValueError:
+                direction = None
 
-        try:
-            direction = Direction.from_symbol(split_string[0])
-        except ValueError:
-            raise
+            if axis is not None and direction is not None:
+                return cls(axis=axis, direction=direction)
 
-        return Message(
-            axis=axis,
-            direction=direction
-        )
+        return None
 
 
 def get_md5_hash(data: bytes) -> bytes:
+    """Convert bytes into a md5 hash."""
     return hashlib.md5(data).hexdigest().encode()
+
+
+def parse_message(string: str) -> Union[SyncPinMessage, MoveMessage]:
+    """Parse string into a Message Type"""
+    sync_pin_message = SyncPinMessage.to_message(string)
+    move_message = MoveMessage.to_message(string)
+
+    if sync_pin_message is not None:
+        return sync_pin_message
+
+    if move_message is not None:
+        return move_message
+
+    raise ValueError(f'Not able to parse message: "{string}"')

--- a/ot3_state_manager/ot3_state_manager/util.py
+++ b/ot3_state_manager/ot3_state_manager/util.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import enum
+import hashlib
+from dataclasses import dataclass
+
+from opentrons.hardware_control.types import OT3Axis
+
+
+class Direction(enum.Enum):
+    """Class representing direction to move axis in."""
+    POSITIVE = "+"
+    NEGATIVE = "-"
+
+    def __str__(self) -> str:
+        return self.name
+
+    @classmethod
+    def from_symbol(cls, symbol: str) -> "Direction":
+        """Parse plus or minus symbol into direction."""
+        if symbol == "+":
+            return cls.POSITIVE
+        elif symbol == "-":
+            return cls.NEGATIVE
+        else:
+            raise ValueError(
+                f"Symbol \"{symbol}\" is not valid."
+                f" Valid symbols are \"+\" and \"-\""
+            )
+
+
+@dataclass
+class Message:
+    """Message to be sent between hardware simulators and OT3StateManager"""
+    axis: OT3Axis
+    direction: Direction
+
+    @staticmethod
+    def to_message(string: str) -> Message:
+        """Parse string to Message."""
+        split_string = string.split(" ")
+        assert len(split_string) == 2
+        direction, axis = split_string
+        return Message(
+            axis=OT3Axis[axis],
+            direction=Direction.from_symbol(direction)
+        )
+
+
+def get_md5_hash(data: bytes) -> bytes:
+    return hashlib.md5(data).hexdigest().encode()

--- a/ot3_state_manager/poetry.lock
+++ b/ot3_state_manager/poetry.lock
@@ -610,6 +610,20 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.19.0"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=6.1.0"
+
+[package.extras]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "pytest-cov"
 version = "2.10.1"
 description = "Pytest plugin for measuring coverage."
@@ -776,7 +790,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "194b24d9a1a18d0a2427b2101634ab11cd4df04134cfc48471da5cbec2257fcb"
+content-hash = "bcaf4f86f4dd23f2768b872f4dfafb928a073595d742acf1f320f1eb04838c71"
 
 [metadata.files]
 aenum = [
@@ -1100,6 +1114,10 @@ pyserial = [
 pytest = [
     {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
     {file = "pytest-7.0.1.tar.gz", hash = "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.19.0.tar.gz", hash = "sha256:ac4ebf3b6207259750bc32f4c1d8fcd7e79739edbc67ad0c58dd150b1d072fed"},
+    {file = "pytest_asyncio-0.19.0-py3-none-any.whl", hash = "sha256:7a97e37cfe1ed296e2e84941384bdd37c376453912d397ed39293e0916f521fa"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},

--- a/ot3_state_manager/poetry.lock
+++ b/ot3_state_manager/poetry.lock
@@ -154,18 +154,18 @@ pydocstyle = ">=2.1"
 
 [[package]]
 name = "flake8-noqa"
-version = "1.2.7"
+version = "1.2.8"
 description = "Flake8 noqa comment validation"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-flake8 = ">=3.8.0,<5.0"
+flake8 = ">=3.8.0,<6.0"
 typing-extensions = ">=3.7.4.2"
 
 [package.extras]
-dev = ["mypy", "flake8", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake8-commas", "flake8-comprehensions", "flake8-continuation", "flake8-datetimez", "flake8-docstrings", "flake8-import-order", "flake8-literal", "flake8-noqa", "flake8-polyfill", "flake8-postponed-annotations", "flake8-requirements", "flake8-tabs", "flake8-typechecking-import", "flake8-use-fstring", "pep8-naming"]
+dev = ["mypy", "flake8 (>=3.8.0,<5.0)", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake8-commas", "flake8-comprehensions", "flake8-continuation", "flake8-datetimez", "flake8-docstrings", "flake8-import-order", "flake8-literal", "flake8-noqa", "flake8-polyfill", "flake8-postponed-annotations", "flake8-requirements", "flake8-tabs", "flake8-typechecking-import", "flake8-use-fstring", "pep8-naming"]
 test = ["flake8-docstrings"]
 
 [[package]]
@@ -790,7 +790,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "bcaf4f86f4dd23f2768b872f4dfafb928a073595d742acf1f320f1eb04838c71"
+content-hash = "84c89ef7488f1488c4e2bc67c3c18088be9c2089895a7235a5e0930decc8f8d1"
 
 [metadata.files]
 aenum = [
@@ -906,8 +906,8 @@ flake8-docstrings = [
     {file = "flake8_docstrings-1.6.0-py2.py3-none-any.whl", hash = "sha256:99cac583d6c7e32dd28bbfbef120a7c0d1b6dde4adb5a9fd441c4227a6534bde"},
 ]
 flake8-noqa = [
-    {file = "flake8-noqa-1.2.7.tar.gz", hash = "sha256:056a534871f17cb68f95653c4ab98b9fce2494b3d1ccde568ee5ae0b07845226"},
-    {file = "flake8_noqa-1.2.7-py3-none-any.whl", hash = "sha256:1a19722e3ea572a9931f091c48f546e61b5997dc354627872b0de7d444b68db0"},
+    {file = "flake8-noqa-1.2.8.tar.gz", hash = "sha256:bf09d7305806b83097331fd592344073e65fcb48524a9da5883b294d36ae7a07"},
+    {file = "flake8_noqa-1.2.8-py3-none-any.whl", hash = "sha256:14231bd202064bb1da5cf5d2bdbfff82be6438fdaabb421009a86739867231b1"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/ot3_state_manager/pyproject.toml
+++ b/ot3_state_manager/pyproject.toml
@@ -24,7 +24,6 @@ isort = "5.10.1"
 mdformat-gfm = "^0.3.5"
 mdformat_frontmatter = "^0.4.1"
 mdformat_footnote = "^0.1.1"
-pydantic = "1.8.2"
 
 # Expects the monorepo (opentrons) to be a sibling of this repo
 opentrons-hardware = { path = "../../opentrons/hardware" }

--- a/ot3_state_manager/pyproject.toml
+++ b/ot3_state_manager/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.8"
 pytest = "7.0.1"
 pytest-cov = "2.10.1"
 pytest-xdist = "~2.2.1"
+pytest-asyncio = "~=0.18"
 mypy = "0.931"
 flake8 = "~4.0.1"
 flake8-annotations = "~2.7.0"
@@ -23,6 +24,7 @@ isort = "5.10.1"
 mdformat-gfm = "^0.3.5"
 mdformat_frontmatter = "^0.4.1"
 mdformat_footnote = "^0.1.1"
+pydantic = "1.8.2"
 
 # Expects the monorepo (opentrons) to be a sibling of this repo
 opentrons-hardware = { path = "../../opentrons/hardware" }
@@ -30,6 +32,7 @@ opentrons = { path = "../../opentrons/api" }
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"
+asyncio_mode = "auto"
 
 [tool.mypy]
 ignore_missing_imports = false

--- a/ot3_state_manager/tests/conftest.py
+++ b/ot3_state_manager/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Global fixtures available to all test files at the same level or below this file."""
+
 import pytest
 
 from ot3_state_manager.ot3_state import OT3State

--- a/ot3_state_manager/tests/conftest.py
+++ b/ot3_state_manager/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ot3_state_manager.ot3_state import OT3State
+from ot3_state_manager.pipette_model import PipetteModel
+
+
+@pytest.fixture
+def ot3_state() -> OT3State:
+    """Returns OT3State with left/right pipette and a gripper."""
+    return OT3State.build(
+        left_pipette_model_name=PipetteModel.SINGLE_20.value,
+        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
+        use_gripper=True,
+    )

--- a/ot3_state_manager/tests/test_messages.py
+++ b/ot3_state_manager/tests/test_messages.py
@@ -1,0 +1,111 @@
+from typing import Type
+
+import pytest
+from opentrons.hardware_control.types import OT3Axis
+
+from ot3_state_manager.messages import (
+    MoveMessage,
+    SyncPinMessage,
+    parse_message,
+)
+from ot3_state_manager.util import Direction
+
+
+@pytest.mark.parametrize(
+    "message,expected_state",
+    [
+        ["SYNC_PIN HIGH", "HIGH"],
+        ["SYNC_PIN LOW", "LOW"],
+    ]
+)
+def test_sync_pin_message_to_message(message: str, expected_state: str) -> None:
+    assert SyncPinMessage.to_message(message).state == expected_state
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "SYNC_PIN_HIGH",
+        "SYNC PIN HIGH",
+        "SYNC PIN_HIGH",
+        "SYNCPINHIGH",
+        "SYNCPIN_HIGH",
+        "SYNC_PINHIGH",
+        "BLARGH",
+        "SYNC_PIN TOGGLE"
+    ]
+)
+def test_invalid_sync_pin_message_to_message(message: str) -> None:
+    assert SyncPinMessage.to_message(message) is None
+
+@pytest.mark.parametrize(
+    "message,expected_axis,expected_direction",
+    [
+        ["+ X", OT3Axis.X, Direction.POSITIVE],
+        ["- X", OT3Axis.X, Direction.NEGATIVE],
+        ["+ Y", OT3Axis.Y, Direction.POSITIVE],
+        ["- Y", OT3Axis.Y, Direction.NEGATIVE],
+        ["+ Z_L", OT3Axis.Z_L, Direction.POSITIVE],
+        ["- Z_L", OT3Axis.Z_L, Direction.NEGATIVE],
+        ["+ Z_R", OT3Axis.Z_R, Direction.POSITIVE],
+        ["- Z_R", OT3Axis.Z_R, Direction.NEGATIVE],
+        ["+ Z_G", OT3Axis.Z_G, Direction.POSITIVE],
+        ["- Z_G", OT3Axis.Z_G, Direction.NEGATIVE],
+        ["+ P_L", OT3Axis.P_L, Direction.POSITIVE],
+        ["- P_L", OT3Axis.P_L, Direction.NEGATIVE],
+        ["+ P_R", OT3Axis.P_R, Direction.POSITIVE],
+        ["- P_R", OT3Axis.P_R, Direction.NEGATIVE],
+        ["+ Q", OT3Axis.Q, Direction.POSITIVE],
+        ["- Q", OT3Axis.Q, Direction.NEGATIVE],
+        ["+ G", OT3Axis.G, Direction.POSITIVE],
+        ["- G", OT3Axis.G, Direction.NEGATIVE],
+    ]
+)
+def test_move_message_to_message(
+    message: str, expected_axis: OT3Axis, expected_direction: Direction
+) -> None:
+    assert MoveMessage.to_message(message).axis == expected_axis
+    assert MoveMessage.to_message(message).direction == expected_direction
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "X",
+        "X +",
+        "= X",
+        "+ F",
+        "F",
+    ]
+)
+def test_invalid_move_message_to_message(message: str) -> None:
+    assert MoveMessage.to_message(message) is None
+
+
+@pytest.mark.parametrize(
+    "message,expected_type",
+    [
+        ["+ X", MoveMessage],
+        ["SYNC_PIN HIGH", SyncPinMessage],
+    ]
+)
+def test_parse_message(
+    message: str, expected_type: Type
+) -> None:
+    assert isinstance(parse_message(message), expected_type)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "X",
+        "X +",
+        "= X",
+        "+ F",
+        "F",
+    ]
+)
+def test_invalid_parse_message(message: str) -> None:
+    with pytest.raises(ValueError) as err:
+        parse_message(message)
+        assert err.value == f'Not able to parse message: "{message}"'

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -8,9 +8,6 @@ from ot3_state_manager.pipette_model import PipetteModel
 from ot3_state_manager.util import Direction
 
 
-
-
-
 @pytest.fixture
 def ot3_state_no_pipettes_or_gripper() -> OT3State:
     """Returns OT3State without left/right pipette and a gripper."""
@@ -19,7 +16,7 @@ def ot3_state_no_pipettes_or_gripper() -> OT3State:
     )
 
 
-def test_build(ot3_state) -> None:
+def test_build(ot3_state: OT3State) -> None:
     """Confirms that when building OT3State with pipettes and gripper that it is configured correctly."""
     assert ot3_state.left_pipette is not None
     assert ot3_state.right_pipette is not None
@@ -133,7 +130,7 @@ def test_high_throughput() -> None:
     assert not manager.is_gripper_attached
 
 
-def test_current_position(ot3_state) -> None:
+def test_current_position(ot3_state: OT3State) -> None:
     """Confirms that .current_position returns correctly."""
     current_position_dict = ot3_state.current_position
     assert set(current_position_dict.keys()) == {
@@ -150,7 +147,7 @@ def test_current_position(ot3_state) -> None:
 
 
 def test_current_position_no_gripper_or_pipettes(
-    ot3_state_no_pipettes_or_gripper,
+    ot3_state_no_pipettes_or_gripper: OT3State,
 ) -> None:
     """Confirms that .current_position returns correctly when no pipettes or gripper is attached."""
     current_position_dict = ot3_state_no_pipettes_or_gripper.current_position
@@ -172,7 +169,7 @@ def test_current_position_no_gripper_or_pipettes(
     )
 
 
-def test_update_current_position(ot3_state) -> None:
+def test_update_current_position(ot3_state: OT3State) -> None:
     """Confirms that updating the current position works."""
     ot3_state.update_position(
         axis_to_update=OT3Axis.X,
@@ -182,7 +179,7 @@ def test_update_current_position(ot3_state) -> None:
     assert ot3_state.current_position[OT3Axis.X] == 5
 
 
-def test_update_encoder_position(ot3_state) -> None:
+def test_update_encoder_position(ot3_state: OT3State) -> None:
     """Confirms that updating the encoder position works."""
     ot3_state.update_position(
         axis_to_update=OT3Axis.X,
@@ -192,7 +189,7 @@ def test_update_encoder_position(ot3_state) -> None:
     assert ot3_state.encoder_position[OT3Axis.X] == 7
 
 
-def test_update_multiple_positions(ot3_state) -> None:
+def test_update_multiple_positions(ot3_state: OT3State) -> None:
     """Confirms that updating the multiple positions at the same time works."""
     ot3_state.update_position(
         axis_to_update=OT3Axis.X,
@@ -204,7 +201,7 @@ def test_update_multiple_positions(ot3_state) -> None:
 
 
 def test_update_position_hardware_not_attached(
-    ot3_state_no_pipettes_or_gripper,
+    ot3_state_no_pipettes_or_gripper: OT3State,
 ) -> None:
     """Confirms that updating a position of a piece of equipment, that is not attached, throws an exception."""
     with pytest.raises(ValueError) as err:

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -9,7 +9,7 @@ from ot3_state_manager.util import Direction
 
 
 @pytest.fixture
-def ot3_state_manager() -> OT3State:
+def ot3_state() -> OT3State:
     """Returns OT3State with left/right pipette and a gripper."""
     return OT3State.build(
         left_pipette_model_name=PipetteModel.SINGLE_20.value,
@@ -19,26 +19,26 @@ def ot3_state_manager() -> OT3State:
 
 
 @pytest.fixture
-def ot3_state_manager_no_pipettes_or_gripper() -> OT3State:
+def ot3_state_no_pipettes_or_gripper() -> OT3State:
     """Returns OT3State without left/right pipette and a gripper."""
     return OT3State.build(
         left_pipette_model_name=None, right_pipette_model_name=None, use_gripper=False
     )
 
 
-def test_build(ot3_state_manager: OT3State) -> None:
+def test_build(ot3_state) -> None:
     """Confirms that when building OT3State with pipettes and gripper that it is configured correctly."""
-    assert ot3_state_manager.left_pipette is not None
-    assert ot3_state_manager.right_pipette is not None
-    assert ot3_state_manager.gripper is not None
+    assert ot3_state.left_pipette is not None
+    assert ot3_state.right_pipette is not None
+    assert ot3_state.gripper is not None
 
-    assert isinstance(ot3_state_manager.left_pipette, LeftPipette)
-    assert isinstance(ot3_state_manager.right_pipette, RightPipette)
-    assert isinstance(ot3_state_manager.gripper, Gripper)
+    assert isinstance(ot3_state.left_pipette, LeftPipette)
+    assert isinstance(ot3_state.right_pipette, RightPipette)
+    assert isinstance(ot3_state.gripper, Gripper)
 
-    assert ot3_state_manager.is_left_pipette_attached
-    assert ot3_state_manager.is_right_pipette_attached
-    assert ot3_state_manager.is_gripper_attached
+    assert ot3_state.is_left_pipette_attached
+    assert ot3_state.is_right_pipette_attached
+    assert ot3_state.is_gripper_attached
 
 
 def test_build_no_gripper() -> None:
@@ -140,9 +140,9 @@ def test_high_throughput() -> None:
     assert not manager.is_gripper_attached
 
 
-def test_current_position(ot3_state_manager: OT3State) -> None:
+def test_current_position(ot3_state) -> None:
     """Confirms that .current_position returns correctly."""
-    current_position_dict = ot3_state_manager.current_position
+    current_position_dict = ot3_state.current_position
     assert set(current_position_dict.keys()) == {
         OT3Axis.X,
         OT3Axis.Y,
@@ -157,10 +157,10 @@ def test_current_position(ot3_state_manager: OT3State) -> None:
 
 
 def test_current_position_no_gripper_or_pipettes(
-    ot3_state_manager_no_pipettes_or_gripper: OT3State,
+    ot3_state_no_pipettes_or_gripper,
 ) -> None:
     """Confirms that .current_position returns correctly when no pipettes or gripper is attached."""
-    current_position_dict = ot3_state_manager_no_pipettes_or_gripper.current_position
+    current_position_dict = ot3_state_no_pipettes_or_gripper.current_position
     assert set(current_position_dict.keys()) == {
         OT3Axis.X,
         OT3Axis.Y,
@@ -179,43 +179,43 @@ def test_current_position_no_gripper_or_pipettes(
     )
 
 
-def test_update_current_position(ot3_state_manager: OT3State) -> None:
+def test_update_current_position(ot3_state) -> None:
     """Confirms that updating the current position works."""
-    ot3_state_manager.update_position(
+    ot3_state.update_position(
         axis_to_update=OT3Axis.X,
         current_position=5,
         encoder_position=0,
     )
-    assert ot3_state_manager.current_position[OT3Axis.X] == 5
+    assert ot3_state.current_position[OT3Axis.X] == 5
 
 
-def test_update_encoder_position(ot3_state_manager: OT3State) -> None:
+def test_update_encoder_position(ot3_state) -> None:
     """Confirms that updating the encoder position works."""
-    ot3_state_manager.update_position(
+    ot3_state.update_position(
         axis_to_update=OT3Axis.X,
         current_position=0,
         encoder_position=7,
     )
-    assert ot3_state_manager.encoder_position[OT3Axis.X] == 7
+    assert ot3_state.encoder_position[OT3Axis.X] == 7
 
 
-def test_update_multiple_positions(ot3_state_manager: OT3State) -> None:
+def test_update_multiple_positions(ot3_state) -> None:
     """Confirms that updating the multiple positions at the same time works."""
-    ot3_state_manager.update_position(
+    ot3_state.update_position(
         axis_to_update=OT3Axis.X,
         current_position=8,
         encoder_position=10,
     )
-    assert ot3_state_manager.current_position[OT3Axis.X] == 8
-    assert ot3_state_manager.encoder_position[OT3Axis.X] == 10
+    assert ot3_state.current_position[OT3Axis.X] == 8
+    assert ot3_state.encoder_position[OT3Axis.X] == 10
 
 
 def test_update_position_hardware_not_attached(
-    ot3_state_manager_no_pipettes_or_gripper: OT3State,
+    ot3_state_no_pipettes_or_gripper,
 ) -> None:
     """Confirms that updating a position of a piece of equipment, that is not attached, throws an exception."""
     with pytest.raises(ValueError) as err:
-        ot3_state_manager_no_pipettes_or_gripper.update_position(
+        ot3_state_no_pipettes_or_gripper.update_position(
             axis_to_update=OT3Axis.G,
             current_position=6,
             encoder_position=0,

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -12,8 +12,8 @@ from ot3_state_manager.util import Direction
 def ot3_state_manager() -> OT3State:
     """Returns OT3State with left/right pipette and a gripper."""
     return OT3State.build(
-        left_pipette_model=PipetteModel.SINGLE_20,
-        right_pipette_model=PipetteModel.MULTI_8_20,
+        left_pipette_model_name=PipetteModel.SINGLE_20.value,
+        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
         use_gripper=True,
     )
 
@@ -22,7 +22,7 @@ def ot3_state_manager() -> OT3State:
 def ot3_state_manager_no_pipettes_or_gripper() -> OT3State:
     """Returns OT3State without left/right pipette and a gripper."""
     return OT3State.build(
-        left_pipette_model=None, right_pipette_model=None, use_gripper=False
+        left_pipette_model_name=None, right_pipette_model_name=None, use_gripper=False
     )
 
 
@@ -44,8 +44,8 @@ def test_build(ot3_state_manager: OT3State) -> None:
 def test_build_no_gripper() -> None:
     """Confirms that when building OT3State no gripper that it is configured correctly."""
     manager = OT3State.build(
-        left_pipette_model=PipetteModel.SINGLE_20,
-        right_pipette_model=PipetteModel.MULTI_8_20,
+        left_pipette_model_name=PipetteModel.SINGLE_20.value,
+        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
         use_gripper=False,
     )
 
@@ -64,8 +64,8 @@ def test_build_no_gripper() -> None:
 def test_build_no_left_pipette() -> None:
     """Confirms that when building OT3State with no left pipette that it is configured correctly."""
     manager = OT3State.build(
-        left_pipette_model=None,
-        right_pipette_model=PipetteModel.MULTI_8_20,
+        left_pipette_model_name=None,
+        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
         use_gripper=True,
     )
 
@@ -84,8 +84,8 @@ def test_build_no_left_pipette() -> None:
 def test_build_no_right_pipette() -> None:
     """Confirms that when building OT3State with no right pipette that it is configured correctly."""
     manager = OT3State.build(
-        left_pipette_model=PipetteModel.SINGLE_20,
-        right_pipette_model=None,
+        left_pipette_model_name=PipetteModel.SINGLE_20.value,
+        right_pipette_model_name=None,
         use_gripper=True,
     )
 
@@ -105,8 +105,8 @@ def test_high_throughput_pipette_wrong_mount() -> None:
     """Confirms that exception is thrown when trying to mount high-throughput pipette to left pipette mount."""
     with pytest.raises(ValueError) as err:
         OT3State.build(
-            left_pipette_model=PipetteModel.MULTI_96_1000,
-            right_pipette_model=None,
+            left_pipette_model_name=PipetteModel.MULTI_96_1000.value,
+            right_pipette_model_name=None,
             use_gripper=True,
         )
     assert err.match("High-throughput pipette must be connected to right pipette mount")
@@ -116,8 +116,8 @@ def test_high_throughput_too_many_pipettes() -> None:
     """Confirms that exception is thrown when trying to a left pipette when a high-throughput pipette is being mounted to the right slot."""
     with pytest.raises(ValueError) as err:
         OT3State.build(
-            left_pipette_model=PipetteModel.SINGLE_20,
-            right_pipette_model=PipetteModel.MULTI_96_1000,
+            left_pipette_model_name=PipetteModel.SINGLE_20.value,
+            right_pipette_model_name=PipetteModel.MULTI_96_1000.value,
             use_gripper=True,
         )
     assert err.match(
@@ -129,8 +129,8 @@ def test_high_throughput_too_many_pipettes() -> None:
 def test_high_throughput() -> None:
     """Confirms that is_high_throughput_pipette_attached returns True when high-throughput pipette is mounted."""
     manager = OT3State.build(
-        left_pipette_model=None,
-        right_pipette_model=PipetteModel.MULTI_96_1000,
+        left_pipette_model_name=None,
+        right_pipette_model_name=PipetteModel.MULTI_96_1000.value,
         use_gripper=False,
     )
 
@@ -226,8 +226,12 @@ def test_update_position_hardware_not_attached(
 
 def test_pulse() -> None:
     """Confirms that pulsing works correctly."""
-    state_1 = OT3State.build(PipetteModel.SINGLE_20, PipetteModel.SINGLE_20, True)
-    state_2 = OT3State.build(PipetteModel.SINGLE_20, PipetteModel.SINGLE_20, True)
+    state_1 = OT3State.build(
+        PipetteModel.SINGLE_20.value, PipetteModel.SINGLE_20.value, True
+    )
+    state_2 = OT3State.build(
+        PipetteModel.SINGLE_20.value, PipetteModel.SINGLE_20.value, True
+    )
 
     state_1.pulse(axis=OT3Axis.X, direction=Direction.POSITIVE)
     assert state_1.axis_current_position(OT3Axis.X) == 1

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -244,3 +244,12 @@ def test_pulse() -> None:
     state_1.pulse(axis=OT3Axis.X, direction=Direction.NEGATIVE)
     assert state_1.axis_current_position(OT3Axis.X) == 1
     assert state_2.axis_current_position(OT3Axis.X) == 0
+
+
+def test_sync_pin(ot3_state: OT3State) -> None:
+    """Confirm that sync pin methods function correctly."""
+    assert not ot3_state.get_sync_pin_state()
+    ot3_state.set_sync_pin("HIGH")
+    assert ot3_state.get_sync_pin_state()
+    ot3_state.set_sync_pin("LOW")
+    assert not ot3_state.get_sync_pin_state()

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -8,14 +8,7 @@ from ot3_state_manager.pipette_model import PipetteModel
 from ot3_state_manager.util import Direction
 
 
-@pytest.fixture
-def ot3_state() -> OT3State:
-    """Returns OT3State with left/right pipette and a gripper."""
-    return OT3State.build(
-        left_pipette_model_name=PipetteModel.SINGLE_20.value,
-        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
-        use_gripper=True,
-    )
+
 
 
 @pytest.fixture

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -1,0 +1,241 @@
+"""OT3State object tests."""
+import pytest
+from opentrons.hardware_control.types import OT3Axis
+
+from ot3_state_manager.hardware import Gripper, LeftPipette, RightPipette
+from ot3_state_manager.ot3_state import OT3State
+from ot3_state_manager.pipette_model import PipetteModel
+from ot3_state_manager.util import Message
+
+
+@pytest.fixture
+def ot3_state_manager() -> OT3State:
+    """Returns OT3State with left/right pipette and a gripper."""
+    return OT3State.build(
+        left_pipette_model=PipetteModel.SINGLE_20,
+        right_pipette_model=PipetteModel.MULTI_8_20,
+        use_gripper=True,
+    )
+
+
+@pytest.fixture
+def ot3_state_manager_no_pipettes_or_gripper() -> OT3State:
+    """Returns OT3State without left/right pipette and a gripper."""
+    return OT3State.build(
+        left_pipette_model=None,
+        right_pipette_model=None,
+        use_gripper=False
+    )
+
+
+def test_build(ot3_state_manager: OT3State) -> None:
+    """Confirms that when building OT3State with pipettes and gripper that it is configured correctly."""
+    assert ot3_state_manager.left_pipette is not None
+    assert ot3_state_manager.right_pipette is not None
+    assert ot3_state_manager.gripper is not None
+
+    assert isinstance(ot3_state_manager.left_pipette, LeftPipette)
+    assert isinstance(ot3_state_manager.right_pipette, RightPipette)
+    assert isinstance(ot3_state_manager.gripper, Gripper)
+
+    assert ot3_state_manager.is_left_pipette_attached
+    assert ot3_state_manager.is_right_pipette_attached
+    assert ot3_state_manager.is_gripper_attached
+
+
+def test_build_no_gripper() -> None:
+    """Confirms that when building OT3State no gripper that it is configured correctly."""
+    manager = OT3State.build(
+        left_pipette_model=PipetteModel.SINGLE_20,
+        right_pipette_model=PipetteModel.MULTI_8_20,
+        use_gripper=False,
+    )
+
+    assert manager.left_pipette is not None
+    assert manager.right_pipette is not None
+    assert manager.gripper is None
+
+    assert isinstance(manager.left_pipette, LeftPipette)
+    assert isinstance(manager.right_pipette, RightPipette)
+
+    assert manager.is_left_pipette_attached
+    assert manager.is_right_pipette_attached
+    assert not manager.is_gripper_attached
+
+
+def test_build_no_left_pipette() -> None:
+    """Confirms that when building OT3State with no left pipette that it is configured correctly."""
+    manager = OT3State.build(
+        left_pipette_model=None,
+        right_pipette_model=PipetteModel.MULTI_8_20,
+        use_gripper=True,
+    )
+
+    assert manager.left_pipette is None
+    assert manager.right_pipette is not None
+    assert manager.gripper is not None
+
+    assert isinstance(manager.right_pipette, RightPipette)
+    assert isinstance(manager.gripper, Gripper)
+
+    assert not manager.is_left_pipette_attached
+    assert manager.is_right_pipette_attached
+    assert manager.is_gripper_attached
+
+
+def test_build_no_right_pipette() -> None:
+    """Confirms that when building OT3State with no right pipette that it is configured correctly."""
+    manager = OT3State.build(
+        left_pipette_model=PipetteModel.SINGLE_20,
+        right_pipette_model=None,
+        use_gripper=True,
+    )
+
+    assert manager.left_pipette is not None
+    assert manager.right_pipette is None
+    assert manager.gripper is not None
+
+    assert isinstance(manager.left_pipette, LeftPipette)
+    assert isinstance(manager.gripper, Gripper)
+
+    assert manager.is_left_pipette_attached
+    assert not manager.is_right_pipette_attached
+    assert manager.is_gripper_attached
+
+
+def test_high_throughput_pipette_wrong_mount() -> None:
+    """Confirms that exception is thrown when trying to mount high-throughput pipette to left pipette mount."""
+    with pytest.raises(ValueError) as err:
+        OT3State.build(
+            left_pipette_model=PipetteModel.MULTI_96_1000,
+            right_pipette_model=None,
+            use_gripper=True,
+        )
+    assert err.match("High-throughput pipette must be connected to right pipette mount")
+
+
+def test_high_throughput_too_many_pipettes() -> None:
+    """Confirms that exception is thrown when trying to a left pipette when a high-throughput pipette is being mounted to the right slot."""
+    with pytest.raises(ValueError) as err:
+        OT3State.build(
+            left_pipette_model=PipetteModel.SINGLE_20,
+            right_pipette_model=PipetteModel.MULTI_96_1000,
+            use_gripper=True,
+        )
+    assert err.match(
+        "When using high-throughput pipette you cannot have a pipette in the left "
+        "mount"
+    )
+
+
+def test_high_throughput() -> None:
+    """Confirms that is_high_throughput_pipette_attached returns True when high-throughput pipette is mounted."""
+    manager = OT3State.build(
+        left_pipette_model=None,
+        right_pipette_model=PipetteModel.MULTI_96_1000,
+        use_gripper=False,
+    )
+
+    assert manager.is_high_throughput_pipette_attached
+    assert not manager.is_left_pipette_attached
+    assert manager.is_right_pipette_attached
+    assert not manager.is_gripper_attached
+
+
+def test_current_position(ot3_state_manager: OT3State) -> None:
+    """Confirms that .current_position returns correctly."""
+    current_position_dict = ot3_state_manager.current_position
+    assert set(current_position_dict.keys()) == {
+        OT3Axis.X,
+        OT3Axis.Y,
+        OT3Axis.Z_L,
+        OT3Axis.Z_R,
+        OT3Axis.Z_G,
+        OT3Axis.P_L,
+        OT3Axis.P_R,
+        OT3Axis.G,
+    }
+    assert all([val == 0.0 for val in current_position_dict.values()])
+
+
+def test_current_position_no_gripper_or_pipettes(
+    ot3_state_manager_no_pipettes_or_gripper: OT3State,
+) -> None:
+    """Confirms that .current_position returns correctly when no pipettes or gripper is attached."""
+    current_position_dict = ot3_state_manager_no_pipettes_or_gripper.current_position
+    assert set(current_position_dict.keys()) == {
+        OT3Axis.X,
+        OT3Axis.Y,
+        OT3Axis.Z_L,
+        OT3Axis.Z_R,
+        OT3Axis.Z_G,
+        OT3Axis.P_L,
+        OT3Axis.P_R,
+        OT3Axis.G,
+    }
+    assert all(
+        [
+            current_position_dict[key] is None
+            for key in [OT3Axis.G, OT3Axis.P_L, OT3Axis.P_R]
+        ]
+    )
+
+
+def test_update_current_position(ot3_state_manager: OT3State) -> None:
+    """Confirms that updating the current position works."""
+    ot3_state_manager.update_position(
+        axis_to_update=OT3Axis.X,
+        current_position=5.0,
+        encoder_position=0.0,
+    )
+    assert ot3_state_manager.current_position[OT3Axis.X] == 5.0
+
+
+def test_update_encoder_position(ot3_state_manager: OT3State) -> None:
+    """Confirms that updating the encoder position works."""
+    ot3_state_manager.update_position(
+        axis_to_update=OT3Axis.X,
+        current_position=0.0,
+        encoder_position=7.0,
+    )
+    assert ot3_state_manager.encoder_position[OT3Axis.X] == 7.0
+
+
+def test_update_multiple_positions(ot3_state_manager: OT3State) -> None:
+    """Confirms that updating the multiple positions at the same time works."""
+    ot3_state_manager.update_position(
+        axis_to_update=OT3Axis.X,
+        current_position=8.0,
+        encoder_position=10.0,
+    )
+    assert ot3_state_manager.current_position[OT3Axis.X] == 8.0
+    assert ot3_state_manager.encoder_position[OT3Axis.X] == 10.0
+
+
+def test_update_position_hardware_not_attached(
+    ot3_state_manager_no_pipettes_or_gripper: OT3State,
+) -> None:
+    """Confirms that updating a position of a piece of equipment, that is not attached, throws an exception."""
+    with pytest.raises(ValueError) as err:
+        ot3_state_manager_no_pipettes_or_gripper.update_position(
+            axis_to_update=OT3Axis.G,
+            current_position=6.0,
+            encoder_position=0.0,
+        )
+
+    assert err.match('Axis "G" is not available. Cannot update it\'s position.')
+
+
+async def test_pulse():
+    state_1 = OT3State.build(PipetteModel.SINGLE_20, PipetteModel.SINGLE_20, True)
+    state_2 = OT3State.build(PipetteModel.SINGLE_20, PipetteModel.SINGLE_20, True)
+
+    state_1.pulse(Message.to_message("+ X"))
+    assert state_1.axis_current_position(OT3Axis.X) == 1
+    assert state_2.axis_current_position(OT3Axis.X) == 0
+    state_1.pulse(Message.to_message("+ X"))
+    assert state_1.axis_current_position(OT3Axis.X) == 2
+    assert state_2.axis_current_position(OT3Axis.X) == 0
+    state_1.pulse(Message.to_message("- X"))
+    assert state_1.axis_current_position(OT3Axis.X) == 1
+    assert state_2.axis_current_position(OT3Axis.X) == 0

--- a/ot3_state_manager/tests/test_ot3_state_manager.py
+++ b/ot3_state_manager/tests/test_ot3_state_manager.py
@@ -1,17 +1,15 @@
+"""Test for OT3StateManager object."""
+
 import asyncio
-import socket
+from typing import Generator
 
 import pytest
-
 from opentrons.hardware_control.types import OT3Axis
-from ot3_state_manager.ot3_state_manager import OT3StateManager
-from ot3_state_manager.ot3_state import OT3State
-from ot3_state_manager.pipette_model import PipetteModel
 
-from ot3_state_manager.util import (
-    Direction,
-    get_md5_hash,
-)
+from ot3_state_manager.ot3_state import OT3State
+from ot3_state_manager.ot3_state_manager import OT3StateManager
+from ot3_state_manager.pipette_model import PipetteModel
+from ot3_state_manager.util import get_md5_hash
 
 HOST = "localhost"
 PORT = 8088
@@ -19,18 +17,15 @@ PORT = 8088
 
 @pytest.fixture(scope="function")
 def ot3_state() -> OT3State:
-    return OT3State.build(
-        PipetteModel.SINGLE_20,
-        PipetteModel.SINGLE_20,
-        True
-    )
+    """Create OT3State object."""
+    return OT3State.build(PipetteModel.SINGLE_20, PipetteModel.SINGLE_20, True)
 
 
 @pytest.fixture
-def server(event_loop, ot3_state: OT3State) -> None:
+def server(event_loop: asyncio.AbstractEventLoop, ot3_state: OT3State) -> Generator:
+    """Start OT3StateManager server."""
     cancel_handle = asyncio.ensure_future(
-        OT3StateManager(HOST, PORT, ot3_state).start_message_handler()
-        , loop=event_loop
+        OT3StateManager(HOST, PORT, ot3_state).start_server(), loop=event_loop
     )
     event_loop.run_until_complete(asyncio.sleep(0.01))
 
@@ -41,6 +36,7 @@ def server(event_loop, ot3_state: OT3State) -> None:
 
 
 async def send_message(message: str) -> str:
+    """Send message to OT3StateManager server."""
     reader, writer = await asyncio.open_connection(HOST, PORT)
     writer.write(message.encode())
     await writer.drain()
@@ -53,14 +49,16 @@ async def send_message(message: str) -> str:
 
 
 @pytest.mark.parametrize(
-    "message,expected_val", (
+    "message,expected_val",
+    (
         pytest.param("+ X", 1, id="pos_pulse"),
         pytest.param("- X", -1, id="neg_pulse"),
-    )
+    ),
 )
 async def test_pulse(
     message: str, expected_val: int, server: None, ot3_state: OT3State
 ) -> None:
+    """Confirm that pulse messages work correctly."""
     expected_ack = get_md5_hash(message.encode())
     ack = await send_message(message)
     assert ack == expected_ack.decode()
@@ -68,27 +66,42 @@ async def test_pulse(
 
 
 @pytest.mark.parametrize(
-    "message, error", (
+    "message,expected_val",
+    (
+        pytest.param("SYNC_PIN HIGH", True, id="sync_pin_high"),
+        pytest.param("SYNC_PIN LOW", False, id="sync_pin_low"),
+    ),
+)
+async def test_sync_pin_state(
+    message: str, expected_val: bool, server: None, ot3_state: OT3State
+) -> None:
+    """Confirm that SyncPinMessages work correctly"""
+    expected_ack = get_md5_hash(message.encode())
+    ack = await send_message(message)
+    assert ack == expected_ack.decode()
+    assert ot3_state.get_sync_pin_state() == expected_val
+
+
+@pytest.mark.parametrize(
+    "message, error",
+    (
         pytest.param(
             "A Bad Message",
-            "ERROR: Bad Message Format. Expects \"<axis> <direction>\". You passed \"A Bad Message\"",  # noqa: E501
-            id="bad_message_format"
+            'ERROR: Not able to parse message: "A Bad Message"',
+            id="bad_message_format",
         ),
         pytest.param(
-            "+ F",
-            "ERROR: Invalid Axis Passed. You passed \"F\"",
-            id="invalid_axis"
+            "+ F", 'ERROR: Not able to parse message: "+ F"', id="invalid_axis"
         ),
         pytest.param(
-            "= X",
-            "ERROR: Symbol \"=\" is not valid. Valid symbols are \"+\" and \"-\"",
-            id="invalid_direction"
+            "= X", 'ERROR: Not able to parse message: "= X"', id="invalid_direction"
         ),
-    )
+    ),
 )
 async def test_bad_message(
     message: str, error: str, server: None, ot3_state: OT3State
 ) -> None:
+    """Confirm that unsupported messages throw exceptions."""
     response = await send_message(message)
     assert response == error
     assert all([value == 0 for value in ot3_state.current_position.values()])

--- a/ot3_state_manager/tests/test_ot3_state_manager.py
+++ b/ot3_state_manager/tests/test_ot3_state_manager.py
@@ -1,239 +1,65 @@
-"""OT3StateManager object tests."""
+import asyncio
 import pytest
-from opentrons.hardware_control.types import OT3Axis
 
-from ot3_state_manager.hardware import Gripper, LeftPipette, RightPipette
+from opentrons.hardware_control.types import OT3Axis
 from ot3_state_manager.ot3_state_manager import OT3StateManager
+from ot3_state_manager.ot3_state import OT3State
 from ot3_state_manager.pipette_model import PipetteModel
 
+from ot3_state_manager.util import (
+    Direction,
+    get_md5_hash,
+)
 
-@pytest.fixture
-def ot3_state_manager() -> OT3StateManager:
-    """Returns OT3StateManager with left/right pipette and a gripper."""
-    return OT3StateManager.build(
-        left_pipette_model=PipetteModel.SINGLE_20,
-        right_pipette_model=PipetteModel.MULTI_8_20,
-        use_gripper=True,
+HOST = "localhost"
+PORT = 8088
+
+
+@pytest.fixture(scope="function")
+def ot3_state() -> OT3State:
+    return OT3State.build(
+        PipetteModel.SINGLE_20,
+        PipetteModel.SINGLE_20,
+        True
     )
 
 
 @pytest.fixture
-def ot3_state_manager_no_pipettes_or_gripper() -> OT3StateManager:
-    """Returns OT3StateManager without left/right pipette and a gripper."""
-    return OT3StateManager.build(
-        left_pipette_model=None, right_pipette_model=None, use_gripper=False
+def server(event_loop, ot3_state: OT3State):
+    cancel_handle = asyncio.ensure_future(
+        OT3StateManager(HOST, PORT, ot3_state).start_message_handler()
+        , loop=event_loop
     )
+    event_loop.run_until_complete(asyncio.sleep(0.01))
+
+    try:
+        yield
+    finally:
+        cancel_handle.cancel()
 
 
-def test_build(ot3_state_manager: OT3StateManager) -> None:
-    """Confirms that when building OT3StateManager with pipettes and gripper that it is configured correctly."""
-    assert ot3_state_manager.left_pipette is not None
-    assert ot3_state_manager.right_pipette is not None
-    assert ot3_state_manager.gripper is not None
+async def send_message(message: str) -> str:
+    reader, writer = await asyncio.open_connection(HOST, PORT)
+    writer.write(message.encode())
+    await writer.drain()
 
-    assert isinstance(ot3_state_manager.left_pipette, LeftPipette)
-    assert isinstance(ot3_state_manager.right_pipette, RightPipette)
-    assert isinstance(ot3_state_manager.gripper, Gripper)
+    data = await reader.read(1000)
+    writer.close()
+    await writer.wait_closed()
 
-    assert ot3_state_manager.is_left_pipette_attached
-    assert ot3_state_manager.is_right_pipette_attached
-    assert ot3_state_manager.is_gripper_attached
+    return data.decode()
 
 
-def test_build_no_gripper() -> None:
-    """Confirms that when building OT3StateManager no gripper that it is configured correctly."""
-    manager = OT3StateManager.build(
-        left_pipette_model=PipetteModel.SINGLE_20,
-        right_pipette_model=PipetteModel.MULTI_8_20,
-        use_gripper=False,
-    )
-
-    assert manager.left_pipette is not None
-    assert manager.right_pipette is not None
-    assert manager.gripper is None
-
-    assert isinstance(manager.left_pipette, LeftPipette)
-    assert isinstance(manager.right_pipette, RightPipette)
-
-    assert manager.is_left_pipette_attached
-    assert manager.is_right_pipette_attached
-    assert not manager.is_gripper_attached
+@pytest.mark.asyncio
+async def test_ack(server, ot3_state):
+    message = "- X"
+    expected_ack = get_md5_hash(message.encode())
+    ack = await send_message(message)
+    assert ack == expected_ack.decode()
 
 
-def test_build_no_left_pipette() -> None:
-    """Confirms that when building OT3StateManager with no left pipette that it is configured correctly."""
-    manager = OT3StateManager.build(
-        left_pipette_model=None,
-        right_pipette_model=PipetteModel.MULTI_8_20,
-        use_gripper=True,
-    )
-
-    assert manager.left_pipette is None
-    assert manager.right_pipette is not None
-    assert manager.gripper is not None
-
-    assert isinstance(manager.right_pipette, RightPipette)
-    assert isinstance(manager.gripper, Gripper)
-
-    assert not manager.is_left_pipette_attached
-    assert manager.is_right_pipette_attached
-    assert manager.is_gripper_attached
-
-
-def test_build_no_right_pipette() -> None:
-    """Confirms that when building OT3StateManager with no right pipette that it is configured correctly."""
-    manager = OT3StateManager.build(
-        left_pipette_model=PipetteModel.SINGLE_20,
-        right_pipette_model=None,
-        use_gripper=True,
-    )
-
-    assert manager.left_pipette is not None
-    assert manager.right_pipette is None
-    assert manager.gripper is not None
-
-    assert isinstance(manager.left_pipette, LeftPipette)
-    assert isinstance(manager.gripper, Gripper)
-
-    assert manager.is_left_pipette_attached
-    assert not manager.is_right_pipette_attached
-    assert manager.is_gripper_attached
-
-
-def test_high_throughput_pipette_wrong_mount() -> None:
-    """Confirms that exception is thrown when trying to mount high-throughput pipette to left pipette mount."""
-    with pytest.raises(ValueError) as err:
-        OT3StateManager.build(
-            left_pipette_model=PipetteModel.MULTI_96_1000,
-            right_pipette_model=None,
-            use_gripper=True,
-        )
-    assert err.match("High-throughput pipette must be connected to right pipette mount")
-
-
-def test_high_throughput_too_many_pipettes() -> None:
-    """Confirms that exception is thrown when trying to a left pipette when a high-throughput pipette is being mounted to the right slot."""
-    with pytest.raises(ValueError) as err:
-        OT3StateManager.build(
-            left_pipette_model=PipetteModel.SINGLE_20,
-            right_pipette_model=PipetteModel.MULTI_96_1000,
-            use_gripper=True,
-        )
-    assert err.match(
-        "When using high-throughput pipette you cannot have a pipette in the left "
-        "mount"
-    )
-
-
-def test_high_throughput() -> None:
-    """Confirms that is_high_throughput_pipette_attached returns True when high-throughput pipette is mounted."""
-    manager = OT3StateManager.build(
-        left_pipette_model=None,
-        right_pipette_model=PipetteModel.MULTI_96_1000,
-        use_gripper=False,
-    )
-
-    assert manager.is_high_throughput_pipette_attached
-    assert not manager.is_left_pipette_attached
-    assert manager.is_right_pipette_attached
-    assert not manager.is_gripper_attached
-
-
-def test_current_position(ot3_state_manager: OT3StateManager) -> None:
-    """Confirms that .current_position returns correctly."""
-    current_position_dict = ot3_state_manager.current_position
-    assert set(current_position_dict.keys()) == {
-        OT3Axis.X,
-        OT3Axis.Y,
-        OT3Axis.Z_L,
-        OT3Axis.Z_R,
-        OT3Axis.Z_G,
-        OT3Axis.P_L,
-        OT3Axis.P_R,
-        OT3Axis.G,
-    }
-    assert all([val == 0.0 for val in current_position_dict.values()])
-
-
-def test_current_position_no_gripper_or_pipettes(
-    ot3_state_manager_no_pipettes_or_gripper: OT3StateManager,
-) -> None:
-    """Confirms that .current_position returns correctly when no pipettes or gripper is attached."""
-    current_position_dict = ot3_state_manager_no_pipettes_or_gripper.current_position
-    assert set(current_position_dict.keys()) == {
-        OT3Axis.X,
-        OT3Axis.Y,
-        OT3Axis.Z_L,
-        OT3Axis.Z_R,
-        OT3Axis.Z_G,
-        OT3Axis.P_L,
-        OT3Axis.P_R,
-        OT3Axis.G,
-    }
-    assert all(
-        [
-            current_position_dict[key] is None
-            for key in [OT3Axis.G, OT3Axis.P_L, OT3Axis.P_R]
-        ]
-    )
-
-
-def test_update_current_position(ot3_state_manager: OT3StateManager) -> None:
-    """Confirms that updating the current position works."""
-    ot3_state_manager.update_position(
-        axis_to_update=OT3Axis.X,
-        current_position=5.0,
-        commanded_position=0.0,
-        encoder_position=0.0,
-    )
-    assert ot3_state_manager.current_position[OT3Axis.X] == 5.0
-
-
-def test_update_commanded_position(ot3_state_manager: OT3StateManager) -> None:
-    """Confirms that updating the commanded position works."""
-    ot3_state_manager.update_position(
-        axis_to_update=OT3Axis.X,
-        current_position=0.0,
-        commanded_position=6.0,
-        encoder_position=0.0,
-    )
-    assert ot3_state_manager.commanded_position[OT3Axis.X] == 6.0
-
-
-def test_update_encoder_position(ot3_state_manager: OT3StateManager) -> None:
-    """Confirms that updating the encoder position works."""
-    ot3_state_manager.update_position(
-        axis_to_update=OT3Axis.X,
-        current_position=0.0,
-        commanded_position=0.0,
-        encoder_position=7.0,
-    )
-    assert ot3_state_manager.encoder_position[OT3Axis.X] == 7.0
-
-
-def test_update_multiple_positions(ot3_state_manager: OT3StateManager) -> None:
-    """Confirms that updating the multiple positions at the same time works."""
-    ot3_state_manager.update_position(
-        axis_to_update=OT3Axis.X,
-        current_position=8.0,
-        commanded_position=9.0,
-        encoder_position=10.0,
-    )
-    assert ot3_state_manager.current_position[OT3Axis.X] == 8.0
-    assert ot3_state_manager.commanded_position[OT3Axis.X] == 9.0
-    assert ot3_state_manager.encoder_position[OT3Axis.X] == 10.0
-
-
-def test_update_position_hardware_not_attached(
-    ot3_state_manager_no_pipettes_or_gripper: OT3StateManager,
-) -> None:
-    """Confirms that updating a position of a piece of equipment, that is not attached, throws an exception."""
-    with pytest.raises(ValueError) as err:
-        ot3_state_manager_no_pipettes_or_gripper.update_position(
-            axis_to_update=OT3Axis.G,
-            current_position=6.0,
-            commanded_position=0.0,
-            encoder_position=0.0,
-        )
-
-    assert err.match('Axis "G" is not available. Cannot update it\'s position.')
+@pytest.mark.asyncio
+async def test_pulse(server, ot3_state):
+    message = "- X"
+    await send_message(message)
+    print(ot3_state.gantry_x.position.current_position)

--- a/ot3_state_manager/tests/test_ot3_state_manager.py
+++ b/ot3_state_manager/tests/test_ot3_state_manager.py
@@ -18,7 +18,9 @@ PORT = 8088
 @pytest.fixture(scope="function")
 def ot3_state() -> OT3State:
     """Create OT3State object."""
-    return OT3State.build(PipetteModel.SINGLE_20, PipetteModel.SINGLE_20, True)
+    return OT3State.build(
+        PipetteModel.SINGLE_20.value, PipetteModel.SINGLE_20.value, True
+    )
 
 
 @pytest.fixture

--- a/ot3_state_manager/tests/test_ot3_state_manager.py
+++ b/ot3_state_manager/tests/test_ot3_state_manager.py
@@ -1,17 +1,15 @@
 """Test for OT3StateManager object."""
 
 import asyncio
-from typing import Generator
+from typing import AsyncGenerator, Generator
+from unittest.mock import Mock, patch
 
 import pytest
-from opentrons.hardware_control.types import OT3Axis
 
 from ot3_state_manager.ot3_state import OT3State
 from ot3_state_manager.ot3_state_manager import OT3StateManager
 from ot3_state_manager.pipette_model import PipetteModel
-from tests.udp_client import (
-    EchoClientProtocol,
-)
+from tests.udp_client import EchoClientProtocol
 
 HOST = "localhost"
 PORT = 8088
@@ -24,47 +22,47 @@ def ot3_state() -> OT3State:
         PipetteModel.SINGLE_20.value, PipetteModel.SINGLE_20.value, True
     )
 
+
 @pytest.fixture
-def loop(event_loop: asyncio.AbstractEventLoop) -> asyncio.AbstractEventLoop:
+def loop(
+    event_loop: asyncio.AbstractEventLoop,
+) -> Generator[asyncio.AbstractEventLoop, None, None]:
+    """Create and yield event_loop."""
     yield event_loop
 
+
 @pytest.fixture
-def server(loop: asyncio.AbstractEventLoop, ot3_state: OT3State) -> Generator:
+async def server(
+    loop: asyncio.AbstractEventLoop, ot3_state: OT3State
+) -> AsyncGenerator[OT3StateManager, None]:
     """Start OT3StateManager server."""
-    cancel_handle = asyncio.ensure_future(
-        OT3StateManager(ot3_state).start_server(HOST, PORT), loop=loop
-    )
-    loop.run_until_complete(asyncio.sleep(0.01))
+    server = await OT3StateManager(ot3_state).start_server(HOST, PORT)
+    await server.is_connected()
+    yield server
+    await server.close()
 
-    try:
-        yield
-    finally:
-        cancel_handle.cancel()
 
 @pytest.fixture
-async def client(loop: asyncio.AbstractEventLoop) -> EchoClientProtocol:
+async def client(
+    loop: asyncio.AbstractEventLoop,
+) -> AsyncGenerator[EchoClientProtocol, None]:
+    """Create UDP Client."""
     client = await EchoClientProtocol.build(HOST, PORT, loop)
     await client.is_connected()
     yield client
     await client.close()
 
 
-@pytest.mark.parametrize(
-    "message,expected_val",
-    (
-        pytest.param("+ X", 1, id="pos_pulse"),
-        pytest.param("- X", -1, id="neg_pulse"),
-    ),
-)
+@patch.object(OT3StateManager, "datagram_received")
 async def test_message_received(
-    message: str,
-    expected_val: int,
-    server: None,
+    patched_object: Mock,
+    server: OT3StateManager,
     client: EchoClientProtocol,
     loop: asyncio.AbstractEventLoop,
-    ot3_state: OT3State
+    ot3_state: OT3State,
 ) -> None:
     """Confirm that pulse messages work correctly."""
-    await asyncio.ensure_future(client.send_message(message), loop=loop)
-    print("Performing assert")
-    assert ot3_state.axis_current_position(OT3Axis.X) == expected_val
+    client.send_message("+ X")
+    await asyncio.wait_for(server.is_connected(), 15.0)
+    datagram_received_data_arg_content = patched_object.call_args.args[0]
+    assert datagram_received_data_arg_content == b"+ X"

--- a/ot3_state_manager/tests/udp_client.py
+++ b/ot3_state_manager/tests/udp_client.py
@@ -1,0 +1,34 @@
+import asyncio
+
+
+class EchoClientProtocol:
+    def __init__(self, message, on_con_lost):
+        self.message = message
+        self.on_con_lost = on_con_lost
+        self.transport = None
+
+    def connection_made(self, transport):
+        print("Client: Connection Made")
+        self.transport = transport
+        print('Sending message:', self.message)
+        self.transport.sendto(self.message.encode())
+
+    @staticmethod
+    def datagram_received(data, addr):
+        print("Received from server:", data.decode())
+
+    def error_received(self, exc):
+        print('Error received:', exc)
+
+    def connection_lost(self, exc):
+        print("Connection closed")
+        self.on_con_lost.set_result(True)
+
+async def send_message(host: str, port: int, message: str):
+    loop = asyncio.get_running_loop()
+    on_con_lost = loop.create_future()
+
+    transport, protocol = await loop.create_datagram_endpoint(
+        lambda: EchoClientProtocol(message, on_con_lost),
+        remote_addr=(host, port)
+    )

--- a/ot3_state_manager/tests/udp_client.py
+++ b/ot3_state_manager/tests/udp_client.py
@@ -1,34 +1,62 @@
+"""UDP Client for testing."""
+
+from __future__ import annotations
+
 import asyncio
+from asyncio import BaseProtocol
+from typing import Optional, Tuple, cast
 
 
-class EchoClientProtocol:
-    def __init__(self, message, on_con_lost):
-        self.message = message
-        self.on_con_lost = on_con_lost
+class EchoClientProtocol(BaseProtocol):
+    """UDP Client for testing."""
+
+    def __init__(self) -> None:
+        """Create EchoClientProtocol object."""
         self.transport = None
+        self.connected = False
 
-    def connection_made(self, transport):
-        print("Client: Connection Made")
+    def connection_made(self, transport) -> None:  # noqa: ANN001
+        """Called when connection is made."""
         self.transport = transport
-        print('Sending message:', self.message)
-        self.transport.sendto(self.message.encode())
+        self.connected = True
 
     @staticmethod
-    def datagram_received(data, addr):
-        print("Received from server:", data.decode())
+    def datagram_received(data: bytes, addr: Tuple[str, str]) -> None:
+        """Called when datagram is received."""
+        pass
 
-    def error_received(self, exc):
-        print('Error received:', exc)
+    def error_received(self, exc) -> None:  # noqa: ANN001
+        """Called when error is received."""
+        pass
 
-    def connection_lost(self, exc):
-        print("Connection closed")
-        self.on_con_lost.set_result(True)
+    def connection_lost(self, exc) -> None:  # noqa: ANN001
+        """Called when connection is lost."""
+        self.connected = False
 
-async def send_message(host: str, port: int, message: str):
-    loop = asyncio.get_running_loop()
-    on_con_lost = loop.create_future()
+    async def is_connected(self) -> bool:
+        """Called when connected to server."""
+        return self.connected
 
-    transport, protocol = await loop.create_datagram_endpoint(
-        lambda: EchoClientProtocol(message, on_con_lost),
-        remote_addr=(host, port)
-    )
+    async def close(self) -> None:
+        """Close connection to server."""
+        if self.transport is not None:
+            self.transport.close()
+        self.connected = False
+
+    def send_message(self, message: str) -> None:
+        """Send message to server."""
+        if self.transport is not None:
+            self.transport.sendto(message.encode())
+
+    @classmethod
+    async def build(
+        cls, host: str, port: int, loop: Optional[asyncio.AbstractEventLoop] = None
+    ) -> EchoClientProtocol:
+        """Build EchoClientProtocol object."""
+        if loop is None:
+            loop = asyncio.get_running_loop()
+
+        transport, protocol = await loop.create_datagram_endpoint(
+            lambda: EchoClientProtocol(), remote_addr=(host, port)
+        )
+        return cast(EchoClientProtocol, protocol)  # Casting for mypy


### PR DESCRIPTION
# Overview

Added asyncio socket communication layer to OT-3 State Manager
See requirements doc [here](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3322773722/OT3+Emulation+State+Manager#Phase-2%3A-Connect-to-Emulation-(In-Progress))

# Changelog

- Rename `OT3StateManager` to `OT3State` and have it be the only thing that handles update to the overall state view of OT-3
- Create `OT3StateManager` which is responsible for communicating over socket and parsing received messages into update commands for the `OT3State` class to make.
- Add SyncPin` class which represents the OT-3 Sync Pin
- Refactor all classes in `hardware.py` to normal Python classes instead of dataclasses

# Review Requests

- What do you think about the format of the messages? 
- In `hardware.py` I had to refactor all the dataclasses to normal python classes because default values are stored as Class Variables for dataclasses. This led to state being shared across multiple instances of a hardware class. Any suggestions for how to remedy this. See [stdlib docs](https://docs.python.org/3/library/dataclasses.html#mutable-default-values)
- The `_handle_message` method inside of OT3StateManager is way too complex and confusing. Any suggestions for parsing this in a cleaner way? 
- Any suggestions for reporting errors back across the socket communication? Currently it feels very hacky and flakey.

