### PR TITLE
refactor(ot3_state_manager): Rework messages

### DIFF
--- a/ot3_state_manager/ot3_state_manager/messages.py
+++ b/ot3_state_manager/ot3_state_manager/messages.py
@@ -22,9 +22,6 @@ MESSAGE_BYTE_LENGTH = MESSAGE_ID_BYTE_LENGTH + MESSAGE_CONTENT_BYTE_LENGTH
 STRUCT_FORMAT_STRING = f"B{MESSAGE_CONTENT_BYTE_LENGTH}s"
 
 
-# mypy doesn't like that I am instantiating a dataclass based on an abstract class (ABC)
-# instead of a concrete class.
-@dataclass  # type: ignore[misc]
 class Message(ABC):
     """Parent level class for all Message objects.
 

--- a/ot3_state_manager/ot3_state_manager/messages.py
+++ b/ot3_state_manager/ot3_state_manager/messages.py
@@ -6,22 +6,21 @@ Also, location for all message handling functions.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional, Union
+from typing import Any, Dict, Literal, Optional
 
 from opentrons.hardware_control.types import OT3Axis
 
 from ot3_state_manager.ot3_state import OT3State
-from ot3_state_manager.util import Direction, get_md5_hash
+from ot3_state_manager.util import Direction
 
 
 @dataclass
 class Message:
     """Generic Message Type."""
 
-    @classmethod
-    def to_message(cls, string: str) -> Optional[Message]:
-        """Parse string into message."""
-        raise NotImplementedError
+    def to_bytes(self) -> bytes:
+        """Returns bytes value for Message."""
+        return MessageLookup.message_to_bytes(self)
 
 
 @dataclass
@@ -30,19 +29,13 @@ class SyncPinMessage(Message):
 
     state: Literal["HIGH", "LOW"]
 
-    @classmethod
-    def to_message(cls, string: str) -> Optional[SyncPinMessage]:
-        """Parse string into SyncPinMessage or None."""
-        if string.startswith("SYNC_PIN"):
-            split_string = string.split(" ")
-            if len(split_string) == 2:
-                sync_pin_state = split_string[1]
-                if sync_pin_state == "HIGH":
-                    return cls(state="HIGH")
-                elif sync_pin_state == "LOW":
-                    return cls(state="LOW")
+    def __eq__(self, other: Any) -> bool:
+        """Confirm that the 2 objects are equal"""
+        return isinstance(other, SyncPinMessage) and other.state == self.state
 
-        return None
+    def __hash__(self) -> int:
+        """Return hash for instance."""
+        return hash(str(self))
 
 
 @dataclass
@@ -52,47 +45,73 @@ class MoveMessage(Message):
     axis: OT3Axis
     direction: Direction
 
+    def __eq__(self, other: Any) -> bool:
+        """Confirm that the 2 objects are equal"""
+        return isinstance(other, MoveMessage) and (
+            self.axis == other.axis and self.direction == other.direction
+        )
+
+    def __hash__(self) -> int:
+        """Return hash for instance."""
+        return hash(str(self))
+
+
+class MessageLookup:
+    """Lookup class for mapping a message to a byte value."""
+
+    MESSAGE_LOOKUP_DICT: Dict[bytes, Message] = {
+        b"0x0000": MoveMessage(OT3Axis.X, Direction.NEGATIVE),
+        b"0x0001": MoveMessage(OT3Axis.X, Direction.POSITIVE),
+        b"0x0010": MoveMessage(OT3Axis.Y, Direction.NEGATIVE),
+        b"0x0011": MoveMessage(OT3Axis.Y, Direction.POSITIVE),
+        b"0x0020": MoveMessage(OT3Axis.Z_L, Direction.NEGATIVE),
+        b"0x0021": MoveMessage(OT3Axis.Z_L, Direction.POSITIVE),
+        b"0x0030": MoveMessage(OT3Axis.Z_R, Direction.NEGATIVE),
+        b"0x0031": MoveMessage(OT3Axis.Z_R, Direction.POSITIVE),
+        b"0x0040": MoveMessage(OT3Axis.Z_G, Direction.NEGATIVE),
+        b"0x0041": MoveMessage(OT3Axis.Z_G, Direction.POSITIVE),
+        b"0x0050": MoveMessage(OT3Axis.P_L, Direction.NEGATIVE),
+        b"0x0051": MoveMessage(OT3Axis.P_L, Direction.POSITIVE),
+        b"0x0060": MoveMessage(OT3Axis.P_R, Direction.NEGATIVE),
+        b"0x0061": MoveMessage(OT3Axis.P_R, Direction.POSITIVE),
+        b"0x0070": MoveMessage(OT3Axis.Q, Direction.NEGATIVE),
+        b"0x0071": MoveMessage(OT3Axis.Q, Direction.POSITIVE),
+        b"0x0080": MoveMessage(OT3Axis.G, Direction.NEGATIVE),
+        b"0x0081": MoveMessage(OT3Axis.G, Direction.POSITIVE),
+        b"0x1000": SyncPinMessage("LOW"),
+        b"0x1001": SyncPinMessage("HIGH"),
+    }
+
+    REVERSE_LOOKUP_DICT: Dict[Message, bytes] = {
+        val: key for key, val in MESSAGE_LOOKUP_DICT.items()
+    }
+
     @classmethod
-    def to_message(cls, string: str) -> Optional[MoveMessage]:
-        """Parse string to Message or None."""
-        split_string = string.split(" ")
+    def message_to_bytes(cls, message: Message) -> bytes:
+        """Looks up and returns byte value for message."""
+        if message not in cls.REVERSE_LOOKUP_DICT:
+            raise ValueError(f"Message {str(message)} not defined.")
 
-        if len(split_string) == 2:
-            try:
-                axis = OT3Axis[split_string[1]]
-            except KeyError:
-                axis = None
+        return cls.REVERSE_LOOKUP_DICT[message]
 
-            try:
-                direction = Direction.from_symbol(split_string[0])
-            except ValueError:
-                direction = None
+    @classmethod
+    def bytes_to_message(cls, byte_string: bytes) -> Message:
+        """Looks up and returns message for byte value."""
+        if byte_string not in cls.MESSAGE_LOOKUP_DICT:
+            raise ValueError(f"Message for byte string {str(byte_string)} not defined.")
 
-            if axis is not None and direction is not None:
-                return cls(axis=axis, direction=direction)
+        return cls.MESSAGE_LOOKUP_DICT[byte_string]
 
-        return None
-
-
-def parse_message(string: str) -> Union[SyncPinMessage, MoveMessage]:
-    """Parse string into a Message Type"""
-    sync_pin_message = SyncPinMessage.to_message(string)
-    move_message = MoveMessage.to_message(string)
-
-    if sync_pin_message is not None:
-        return sync_pin_message
-
-    if move_message is not None:
-        return move_message
-
-    raise ValueError(f'Not able to parse message: "{string}"')
+    def __init__(self) -> None:
+        """Do not try to instantiate this class."""
+        raise NotImplementedError
 
 
 def handle_message(data: bytes, ot3_state: OT3State) -> bytes:
     """Parse incoming message, react to it accordingly, and respond."""
     error_response: Optional[str] = None
     try:
-        message = parse_message(data.decode())
+        message = MessageLookup.bytes_to_message(data)
     except ValueError as err:
         error_response = f"{err.args[0]}"
     except:  # noqa: E722
@@ -100,7 +119,6 @@ def handle_message(data: bytes, ot3_state: OT3State) -> bytes:
     else:
         if isinstance(message, MoveMessage):
             ot3_state.pulse(message.axis, message.direction)
-            print(ot3_state.current_position)
         elif isinstance(message, SyncPinMessage):
             ot3_state.set_sync_pin(message.state)
         else:
@@ -109,6 +127,6 @@ def handle_message(data: bytes, ot3_state: OT3State) -> bytes:
     if error_response is not None:
         response = f"ERROR: {error_response}".encode()
     else:
-        response = get_md5_hash(data)
+        response = data
 
     return response

--- a/ot3_state_manager/ot3_state_manager/ot3_state.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state.py
@@ -18,7 +18,7 @@ from ot3_state_manager.hardware import (
 )
 from ot3_state_manager.measurable_states import Position
 from ot3_state_manager.pipette_model import PipetteModel
-from ot3_state_manager.util import Direction
+from ot3_state_manager.util import Direction, SyncPinState
 
 log = logging.getLogger(__name__)
 
@@ -227,9 +227,9 @@ class OT3State:
             encoder_position=axis_encoder_position + mod,
         )
 
-    def set_sync_pin(self, state: str) -> None:
+    def set_sync_pin(self, state: SyncPinState) -> None:
         """Sets sync pin high or low based off of state passed."""
-        if state == "HIGH":
+        if state is SyncPinState.HIGH:
             self.sync_pin.set_sync_pin_high()
         else:
             self.sync_pin.set_sync_pin_low()

--- a/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
+++ b/ot3_state_manager/ot3_state_manager/ot3_state_manager.py
@@ -80,7 +80,7 @@ async def main() -> None:
         action="store",
         default=None,
         choices=PIPETTE_NAMES,
-        help="The model name of the pipette to attach to the left mount. (Default none)",  # noqa: E501
+        help="The model name of the pipette to attach to the left mount. (Default none)",
         dest=LEFT_PIPETTE_DEST,
     )
     parser.add_argument(
@@ -88,7 +88,7 @@ async def main() -> None:
         action="store",
         default=None,
         choices=PIPETTE_NAMES,
-        help="The model name of the pipette to attach to the right mount. (Default none)",  # noqa: E501
+        help="The model name of the pipette to attach to the right mount. (Default none)",
         dest=RIGHT_PIPETTE_DEST,
     )
     parser.add_argument(

--- a/ot3_state_manager/ot3_state_manager/pipette_model.py
+++ b/ot3_state_manager/ot3_state_manager/pipette_model.py
@@ -27,3 +27,11 @@ class PipetteModel(Enum):
             PipetteModel.MULTI_96_1000.value: PipetteModel.MULTI_96_1000,
         }
         return lookup_dict[name]
+
+    def get_pipette_name(self) -> str:
+        """Get name of pipette.
+
+        This is the same as calling .value. But .value is not typed to a string and
+        this method is.
+        """
+        return str(self.value)

--- a/ot3_state_manager/ot3_state_manager/util.py
+++ b/ot3_state_manager/ot3_state_manager/util.py
@@ -46,19 +46,6 @@ class SyncPinState(int, enum.Enum):
 class MoveMessageHardware(Enum):
     """Enum representing a mapping of an integer hardware id to an OT3Axis object."""
 
-    def __new__(cls, hw_id: int, axis: OT3Axis) -> MoveMessageHardware:
-        """Create a new MoveMessageHardware object.
-
-        Lookup value will be by hw_id. So MoveMessageHardware(<hw_id>) can be used to
-        get a move message based off of the hw_id. If you want to lookup by OT3Axis use
-        MoveMessageHardware.from_axis(<ot3_axis).
-        """
-        obj = object.__new__(cls)
-        obj._value_ = hw_id
-        obj.hw_id = hw_id
-        obj.axis = axis
-        return obj
-
     def __init__(self, hw_id: int, axis: OT3Axis) -> None:
         """Create a MoveMessageHardware object."""
         self.hw_id = hw_id
@@ -83,3 +70,14 @@ class MoveMessageHardware(Enum):
                 return val
         else:
             raise ValueError(f"Could not find MoveMessageHardware with axis: {axis}.")
+
+    @classmethod
+    def from_id(cls, enum_id: int) -> MoveMessageHardware:
+        """Get MoveMessageHardware connect to passed enum_id."""
+        for val in cls:
+            if val.hw_id == enum_id:
+                return val
+        else:
+            raise ValueError(
+                f"Could not find MoveMessageHardware with hw_id: {enum_id}."
+            )

--- a/ot3_state_manager/ot3_state_manager/util.py
+++ b/ot3_state_manager/ot3_state_manager/util.py
@@ -17,16 +17,12 @@ class Direction(int, enum.Enum):
     @classmethod
     def from_int(cls, direction_val: int) -> Direction:
         """Parse integer into direction."""
-        if direction_val == Direction.NEGATIVE:
-            direction = Direction.NEGATIVE
-        elif direction_val == Direction.POSITIVE:
-            direction = Direction.POSITIVE
-        else:
+        if direction_val not in (Direction.NEGATIVE, Direction.POSITIVE):
             raise ValueError(
                 "Value for direction must be either 0 (Negative) or 1 "
                 f"(Positive). You passed {direction_val}."
             )
-        return direction
+        return Direction(direction_val)
 
 
 class SyncPinState(int, enum.Enum):
@@ -38,17 +34,12 @@ class SyncPinState(int, enum.Enum):
     @classmethod
     def from_int(cls, state_val: int) -> SyncPinState:
         """Parse integer into sync pin state."""
-        if state_val == 0:
-            state = SyncPinState.LOW
-        elif state_val == 1:
-            state = SyncPinState.HIGH
-        else:
+        if state_val not in (SyncPinState.LOW, SyncPinState.HIGH):
             raise ValueError(
                 "Value for state must either be 0 (LOW) or 1 (HIGH). "
                 f"You passed {state_val}."
             )
-
-        return state
+        return SyncPinState(state_val)
 
 
 @unique

--- a/ot3_state_manager/ot3_state_manager/util.py
+++ b/ot3_state_manager/ot3_state_manager/util.py
@@ -3,28 +3,92 @@
 from __future__ import annotations
 
 import enum
-import hashlib
+from enum import Enum, unique
+
+from opentrons.hardware_control.types import OT3Axis
 
 
-class Direction(enum.Enum):
+class Direction(int, enum.Enum):
     """Class representing direction to move axis in."""
 
-    POSITIVE = "+"
-    NEGATIVE = "-"
+    POSITIVE = 1
+    NEGATIVE = 0
 
     @classmethod
-    def from_symbol(cls, symbol: str) -> "Direction":
-        """Parse plus or minus symbol into direction."""
-        if symbol == "+":
-            return cls.POSITIVE
-        elif symbol == "-":
-            return cls.NEGATIVE
+    def from_int(cls, direction_val: int) -> Direction:
+        """Parse integer into direction."""
+        if direction_val == Direction.NEGATIVE:
+            direction = Direction.NEGATIVE
+        elif direction_val == Direction.POSITIVE:
+            direction = Direction.POSITIVE
         else:
             raise ValueError(
-                f'Symbol "{symbol}" is not valid.' f' Valid symbols are "+" and "-"'
+                "Value for direction must be either 0 (Negative) or 1 "
+                f"(Positive). You passed {direction_val}."
+            )
+        return direction
+
+
+class SyncPinState(int, enum.Enum):
+    """Class representing sync pin state."""
+
+    HIGH = 1
+    LOW = 0
+
+    @classmethod
+    def from_int(cls, state_val: int) -> SyncPinState:
+        """Parse integer into sync pin state."""
+        if state_val == 0:
+            state = SyncPinState.LOW
+        elif state_val == 1:
+            state = SyncPinState.HIGH
+        else:
+            raise ValueError(
+                "Value for state must either be 0 (LOW) or 1 (HIGH). "
+                f"You passed {state_val}."
             )
 
+        return state
 
-def get_md5_hash(data: bytes) -> bytes:
-    """Convert bytes into a md5 hash."""
-    return hashlib.md5(data).hexdigest().encode()
+
+@unique
+class MoveMessageHardware(Enum):
+    """Enum representing a mapping of an integer hardware id to an OT3Axis object."""
+
+    def __new__(cls, hw_id: int, axis: OT3Axis) -> MoveMessageHardware:
+        """Create a new MoveMessageHardware object.
+
+        Lookup value will be by hw_id. So MoveMessageHardware(<hw_id>) can be used to
+        get a move message based off of the hw_id. If you want to lookup by OT3Axis use
+        MoveMessageHardware.from_axis(<ot3_axis).
+        """
+        obj = object.__new__(cls)
+        obj._value_ = hw_id
+        obj.hw_id = hw_id
+        obj.axis = axis
+        return obj
+
+    def __init__(self, hw_id: int, axis: OT3Axis) -> None:
+        """Create a MoveMessageHardware object."""
+        self.hw_id = hw_id
+        self.axis = axis
+
+    # hw_id, axis
+    X_AXIS = 0x0000, OT3Axis.X
+    Y_AXIS = 0x0001, OT3Axis.Y
+    Z_L_AXIS = 0x0002, OT3Axis.Z_L
+    Z_R_AXIS = 0x0003, OT3Axis.Z_R
+    Z_G_AXIS = 0x0004, OT3Axis.Z_G
+    P_L_AXIS = 0x0005, OT3Axis.P_L
+    P_R_AXIS = 0x0006, OT3Axis.P_R
+    G_AXIS = 0x0007, OT3Axis.G
+    Q_AXIS = 0x0008, OT3Axis.Q
+
+    @classmethod
+    def from_axis(cls, axis: OT3Axis) -> MoveMessageHardware:
+        """Get MoveMessageHardware connected to passed OT3Axis object."""
+        for val in cls:
+            if val.axis == axis:
+                return val
+        else:
+            raise ValueError(f"Could not find MoveMessageHardware with axis: {axis}.")

--- a/ot3_state_manager/tests/conftest.py
+++ b/ot3_state_manager/tests/conftest.py
@@ -10,7 +10,7 @@ from ot3_state_manager.pipette_model import PipetteModel
 def ot3_state() -> OT3State:
     """Returns OT3State with left/right pipette and a gripper."""
     return OT3State.build(
-        left_pipette_model_name=PipetteModel.SINGLE_20.value,
-        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
+        left_pipette_model_name=PipetteModel.SINGLE_20.get_pipette_name(),
+        right_pipette_model_name=PipetteModel.MULTI_8_20.get_pipette_name(),
         use_gripper=True,
     )

--- a/ot3_state_manager/tests/test_messages.py
+++ b/ot3_state_manager/tests/test_messages.py
@@ -7,6 +7,7 @@ from ot3_state_manager.messages import (
     Message,
     MoveMessage,
     SyncPinMessage,
+    _parse_message,
     handle_message,
 )
 from ot3_state_manager.ot3_state import OT3State
@@ -155,7 +156,7 @@ def test_bad_messages(message: bytes, error: str, ot3_state: OT3State) -> None:
 )
 def test_message_parsing(message: bytes, expected_message: Message) -> None:
     """Confirm that Message.parse parses byte string into correct Message object."""
-    assert Message.parse(message) == expected_message
+    assert _parse_message(message) == expected_message
 
 
 @pytest.mark.parametrize(

--- a/ot3_state_manager/tests/test_messages.py
+++ b/ot3_state_manager/tests/test_messages.py
@@ -17,26 +17,26 @@ from ot3_state_manager.util import Direction
 @pytest.mark.parametrize(
     "byte_string,expected_message",
     [
-        (b"0x0000", MoveMessage(OT3Axis.X, Direction.NEGATIVE)),
-        (b"0x0001", MoveMessage(OT3Axis.X, Direction.POSITIVE)),
-        (b"0x0010", MoveMessage(OT3Axis.Y, Direction.NEGATIVE)),
-        (b"0x0011", MoveMessage(OT3Axis.Y, Direction.POSITIVE)),
-        (b"0x0020", MoveMessage(OT3Axis.Z_L, Direction.NEGATIVE)),
-        (b"0x0021", MoveMessage(OT3Axis.Z_L, Direction.POSITIVE)),
-        (b"0x0030", MoveMessage(OT3Axis.Z_R, Direction.NEGATIVE)),
-        (b"0x0031", MoveMessage(OT3Axis.Z_R, Direction.POSITIVE)),
-        (b"0x0040", MoveMessage(OT3Axis.Z_G, Direction.NEGATIVE)),
-        (b"0x0041", MoveMessage(OT3Axis.Z_G, Direction.POSITIVE)),
-        (b"0x0050", MoveMessage(OT3Axis.P_L, Direction.NEGATIVE)),
-        (b"0x0051", MoveMessage(OT3Axis.P_L, Direction.POSITIVE)),
-        (b"0x0060", MoveMessage(OT3Axis.P_R, Direction.NEGATIVE)),
-        (b"0x0061", MoveMessage(OT3Axis.P_R, Direction.POSITIVE)),
-        (b"0x0070", MoveMessage(OT3Axis.Q, Direction.NEGATIVE)),
-        (b"0x0071", MoveMessage(OT3Axis.Q, Direction.POSITIVE)),
-        (b"0x0080", MoveMessage(OT3Axis.G, Direction.NEGATIVE)),
-        (b"0x0081", MoveMessage(OT3Axis.G, Direction.POSITIVE)),
-        (b"0x1000", SyncPinMessage("LOW")),
-        (b"0x1001", SyncPinMessage("HIGH")),
+        (b"\x00\x00", MoveMessage(OT3Axis.X, Direction.NEGATIVE)),
+        (b"\x00\x01", MoveMessage(OT3Axis.X, Direction.POSITIVE)),
+        (b"\x00\x10", MoveMessage(OT3Axis.Y, Direction.NEGATIVE)),
+        (b"\x00\x11", MoveMessage(OT3Axis.Y, Direction.POSITIVE)),
+        (b"\x00\x20", MoveMessage(OT3Axis.Z_L, Direction.NEGATIVE)),
+        (b"\x00\x21", MoveMessage(OT3Axis.Z_L, Direction.POSITIVE)),
+        (b"\x00\x30", MoveMessage(OT3Axis.Z_R, Direction.NEGATIVE)),
+        (b"\x00\x31", MoveMessage(OT3Axis.Z_R, Direction.POSITIVE)),
+        (b"\x00\x40", MoveMessage(OT3Axis.Z_G, Direction.NEGATIVE)),
+        (b"\x00\x41", MoveMessage(OT3Axis.Z_G, Direction.POSITIVE)),
+        (b"\x00\x50", MoveMessage(OT3Axis.P_L, Direction.NEGATIVE)),
+        (b"\x00\x51", MoveMessage(OT3Axis.P_L, Direction.POSITIVE)),
+        (b"\x00\x60", MoveMessage(OT3Axis.P_R, Direction.NEGATIVE)),
+        (b"\x00\x61", MoveMessage(OT3Axis.P_R, Direction.POSITIVE)),
+        (b"\x00\x70", MoveMessage(OT3Axis.Q, Direction.NEGATIVE)),
+        (b"\x00\x71", MoveMessage(OT3Axis.Q, Direction.POSITIVE)),
+        (b"\x00\x80", MoveMessage(OT3Axis.G, Direction.NEGATIVE)),
+        (b"\x00\x81", MoveMessage(OT3Axis.G, Direction.POSITIVE)),
+        (b"\x10\x00", SyncPinMessage("LOW")),
+        (b"\x10\x01", SyncPinMessage("HIGH")),
     ],
 )
 def test_byte_string_to_message(byte_string: bytes, expected_message: Message) -> None:
@@ -47,15 +47,16 @@ def test_byte_string_to_message(byte_string: bytes, expected_message: Message) -
 
 @pytest.mark.parametrize(
     "byte_string",
-    [b"0x1111", b"0x1110"],
+    [b"\x11\x11", b"\x11\x10"],
 )
-def test_invalid_message_to_message(byte_string: bytes) -> None:
-    """Confirm that invalid move messages do not parse."""
+def test_nonexistent_message_to_message(byte_string: bytes) -> None:
+    """Confirm that trying to load a nonexistent message throws an error."""
     with pytest.raises(ValueError) as err:
         MessageLookup.bytes_to_message(byte_string)
 
     assert (
-        err.value.args[0] == f"Message for byte string {str(byte_string)} not defined."
+        err.value.args[0] == f"Message for hexadecimal byte string {byte_string!r} is "
+        f"not defined."
     )
 
 
@@ -70,6 +71,7 @@ def test_valid_handle_move_message(
     message: Message, expected_val: int, ot3_state: OT3State
 ) -> None:
     """Confirm that pulse messages work correctly."""
+    print(message.to_bytes())
     ack = handle_message(message.to_bytes(), ot3_state)
     assert ack == message.to_bytes()
     assert ot3_state.axis_current_position(OT3Axis.X) == expected_val
@@ -93,17 +95,20 @@ def test_valid_handle_sync_pin_message(ot3_state: OT3State) -> None:
     (
         pytest.param(
             "A Bad Message",
-            "ERROR: Message for byte string b'A Bad Message' not defined.",
+            "ERROR: Passed message, \"b'A Bad Message'\" is not a valid hexadecimal "
+            "byte string.",
             id="bad_message_format",
         ),
         pytest.param(
             "+ F",
-            "ERROR: Message for byte string b'+ F' not defined.",
+            "ERROR: Passed message, \"b'+ F'\" is not a valid hexadecimal "
+            "byte string.",
             id="invalid_axis",
         ),
         pytest.param(
             "= X",
-            "ERROR: Message for byte string b'= X' not defined.",
+            "ERROR: Passed message, \"b'= X'\" is not a valid hexadecimal "
+            "byte string.",
             id="invalid_direction",
         ),
     ),

--- a/ot3_state_manager/tests/test_messages.py
+++ b/ot3_state_manager/tests/test_messages.py
@@ -1,156 +1,90 @@
 """Test message functionality."""
 
-from typing import Type
-
 import pytest
 from opentrons.hardware_control.types import OT3Axis
 
 from ot3_state_manager.messages import (
+    Message,
+    MessageLookup,
     MoveMessage,
     SyncPinMessage,
     handle_message,
-    parse_message,
 )
 from ot3_state_manager.ot3_state import OT3State
-from ot3_state_manager.util import Direction, get_md5_hash
+from ot3_state_manager.util import Direction
 
 
 @pytest.mark.parametrize(
-    "message,expected_state",
+    "byte_string,expected_message",
     [
-        ["SYNC_PIN HIGH", "HIGH"],
-        ["SYNC_PIN LOW", "LOW"],
+        (b"0x0000", MoveMessage(OT3Axis.X, Direction.NEGATIVE)),
+        (b"0x0001", MoveMessage(OT3Axis.X, Direction.POSITIVE)),
+        (b"0x0010", MoveMessage(OT3Axis.Y, Direction.NEGATIVE)),
+        (b"0x0011", MoveMessage(OT3Axis.Y, Direction.POSITIVE)),
+        (b"0x0020", MoveMessage(OT3Axis.Z_L, Direction.NEGATIVE)),
+        (b"0x0021", MoveMessage(OT3Axis.Z_L, Direction.POSITIVE)),
+        (b"0x0030", MoveMessage(OT3Axis.Z_R, Direction.NEGATIVE)),
+        (b"0x0031", MoveMessage(OT3Axis.Z_R, Direction.POSITIVE)),
+        (b"0x0040", MoveMessage(OT3Axis.Z_G, Direction.NEGATIVE)),
+        (b"0x0041", MoveMessage(OT3Axis.Z_G, Direction.POSITIVE)),
+        (b"0x0050", MoveMessage(OT3Axis.P_L, Direction.NEGATIVE)),
+        (b"0x0051", MoveMessage(OT3Axis.P_L, Direction.POSITIVE)),
+        (b"0x0060", MoveMessage(OT3Axis.P_R, Direction.NEGATIVE)),
+        (b"0x0061", MoveMessage(OT3Axis.P_R, Direction.POSITIVE)),
+        (b"0x0070", MoveMessage(OT3Axis.Q, Direction.NEGATIVE)),
+        (b"0x0071", MoveMessage(OT3Axis.Q, Direction.POSITIVE)),
+        (b"0x0080", MoveMessage(OT3Axis.G, Direction.NEGATIVE)),
+        (b"0x0081", MoveMessage(OT3Axis.G, Direction.POSITIVE)),
+        (b"0x1000", SyncPinMessage("LOW")),
+        (b"0x1001", SyncPinMessage("HIGH")),
     ],
 )
-def test_sync_pin_message_to_message(message: str, expected_state: str) -> None:
-    """Confirm that sync pin messages parse correctly."""
-    sync_pin_message = SyncPinMessage.to_message(message)
-    assert sync_pin_message is not None
-    assert sync_pin_message.state == expected_state
-
-
-@pytest.mark.parametrize(
-    "message",
-    [
-        "SYNC_PIN_HIGH",
-        "SYNC PIN HIGH",
-        "SYNC PIN_HIGH",
-        "SYNCPINHIGH",
-        "SYNCPIN_HIGH",
-        "SYNC_PINHIGH",
-        "BLARGH",
-        "SYNC_PIN TOGGLE",
-    ],
-)
-def test_invalid_sync_pin_message_to_message(message: str) -> None:
-    """Confirm invalid sync pin messages do not parse."""
-    assert SyncPinMessage.to_message(message) is None
-
-
-@pytest.mark.parametrize(
-    "message,expected_axis,expected_direction",
-    [
-        ["+ X", OT3Axis.X, Direction.POSITIVE],
-        ["- X", OT3Axis.X, Direction.NEGATIVE],
-        ["+ Y", OT3Axis.Y, Direction.POSITIVE],
-        ["- Y", OT3Axis.Y, Direction.NEGATIVE],
-        ["+ Z_L", OT3Axis.Z_L, Direction.POSITIVE],
-        ["- Z_L", OT3Axis.Z_L, Direction.NEGATIVE],
-        ["+ Z_R", OT3Axis.Z_R, Direction.POSITIVE],
-        ["- Z_R", OT3Axis.Z_R, Direction.NEGATIVE],
-        ["+ Z_G", OT3Axis.Z_G, Direction.POSITIVE],
-        ["- Z_G", OT3Axis.Z_G, Direction.NEGATIVE],
-        ["+ P_L", OT3Axis.P_L, Direction.POSITIVE],
-        ["- P_L", OT3Axis.P_L, Direction.NEGATIVE],
-        ["+ P_R", OT3Axis.P_R, Direction.POSITIVE],
-        ["- P_R", OT3Axis.P_R, Direction.NEGATIVE],
-        ["+ Q", OT3Axis.Q, Direction.POSITIVE],
-        ["- Q", OT3Axis.Q, Direction.NEGATIVE],
-        ["+ G", OT3Axis.G, Direction.POSITIVE],
-        ["- G", OT3Axis.G, Direction.NEGATIVE],
-    ],
-)
-def test_move_message_to_message(
-    message: str, expected_axis: OT3Axis, expected_direction: Direction
-) -> None:
+def test_byte_string_to_message(byte_string: bytes, expected_message: Message) -> None:
     """Confirm that move messages are parsed correctly."""
-    move_message = MoveMessage.to_message(message)
-    assert move_message is not None
-    assert move_message.axis == expected_axis
-    assert move_message.direction == expected_direction
+    message = MessageLookup.bytes_to_message(byte_string)
+    assert message == expected_message
 
 
 @pytest.mark.parametrize(
-    "message",
-    [
-        "X",
-        "X +",
-        "= X",
-        "+ F",
-        "F",
-    ],
+    "byte_string",
+    [b"0x1111", b"0x1110"],
 )
-def test_invalid_move_message_to_message(message: str) -> None:
+def test_invalid_message_to_message(byte_string: bytes) -> None:
     """Confirm that invalid move messages do not parse."""
-    assert MoveMessage.to_message(message) is None
-
-
-@pytest.mark.parametrize(
-    "message,expected_type",
-    [
-        ["+ X", MoveMessage],
-        ["SYNC_PIN HIGH", SyncPinMessage],
-    ],
-)
-def test_parse_message(message: str, expected_type: Type) -> None:
-    """Confirm that parse_message function works correctly."""
-    assert isinstance(parse_message(message), expected_type)
-
-
-@pytest.mark.parametrize(
-    "message",
-    [
-        "X",
-        "X +",
-        "= X",
-        "+ F",
-        "F",
-    ],
-)
-def test_invalid_parse_message(message: str) -> None:
-    """Confirm parse_message throws ValueError when unable parse to a known message."""
     with pytest.raises(ValueError) as err:
-        parse_message(message)
-        assert err.value == f'Not able to parse message: "{message}"'
+        MessageLookup.bytes_to_message(byte_string)
+
+    assert (
+        err.value.args[0] == f"Message for byte string {str(byte_string)} not defined."
+    )
 
 
 @pytest.mark.parametrize(
     "message,expected_val",
     (
-        pytest.param("+ X", 1, id="pos_pulse"),
-        pytest.param("- X", -1, id="neg_pulse"),
+        pytest.param(MoveMessage(OT3Axis.X, Direction.POSITIVE), 1, id="pos_pulse"),
+        pytest.param(MoveMessage(OT3Axis.X, Direction.NEGATIVE), -1, id="neg_pulse"),
     ),
 )
 def test_valid_handle_move_message(
-    message: str, expected_val: int, ot3_state: OT3State
+    message: Message, expected_val: int, ot3_state: OT3State
 ) -> None:
     """Confirm that pulse messages work correctly."""
-    ack = handle_message(message.encode(), ot3_state)
-    assert ack == get_md5_hash(message.encode())
+    ack = handle_message(message.to_bytes(), ot3_state)
+    assert ack == message.to_bytes()
     assert ot3_state.axis_current_position(OT3Axis.X) == expected_val
 
 
 def test_valid_handle_sync_pin_message(ot3_state: OT3State) -> None:
     """Confirm that pulse messages work correctly."""
-    HIGH_MESSAGE = "SYNC_PIN HIGH"
-    LOW_MESSAGE = "SYNC_PIN LOW"
-
-    ack = handle_message(HIGH_MESSAGE.encode(), ot3_state)
-    assert ack == get_md5_hash(HIGH_MESSAGE.encode())
+    HIGH_MESSAGE = SyncPinMessage("HIGH")
+    LOW_MESSAGE = SyncPinMessage("LOW")
+    ack = handle_message(HIGH_MESSAGE.to_bytes(), ot3_state)
+    assert ack == HIGH_MESSAGE.to_bytes()
     assert ot3_state.get_sync_pin_state()
 
-    ack = handle_message(LOW_MESSAGE.encode(), ot3_state)
-    assert ack == get_md5_hash(LOW_MESSAGE.encode())
+    ack = handle_message(LOW_MESSAGE.to_bytes(), ot3_state)
+    assert ack == LOW_MESSAGE.to_bytes()
     assert not ot3_state.get_sync_pin_state()
 
 
@@ -159,14 +93,18 @@ def test_valid_handle_sync_pin_message(ot3_state: OT3State) -> None:
     (
         pytest.param(
             "A Bad Message",
-            'ERROR: Not able to parse message: "A Bad Message"',
+            "ERROR: Message for byte string b'A Bad Message' not defined.",
             id="bad_message_format",
         ),
         pytest.param(
-            "+ F", 'ERROR: Not able to parse message: "+ F"', id="invalid_axis"
+            "+ F",
+            "ERROR: Message for byte string b'+ F' not defined.",
+            id="invalid_axis",
         ),
         pytest.param(
-            "= X", 'ERROR: Not able to parse message: "= X"', id="invalid_direction"
+            "= X",
+            "ERROR: Message for byte string b'= X' not defined.",
+            id="invalid_direction",
         ),
     ),
 )

--- a/ot3_state_manager/tests/test_messages.py
+++ b/ot3_state_manager/tests/test_messages.py
@@ -28,7 +28,7 @@ from ot3_state_manager.util import Direction, SyncPinState
         ),
         pytest.param(
             b"\x00\xFF\xFF\x01",
-            "ERROR: 65535 is not a valid MoveMessageHardware",
+            "ERROR: Could not find MoveMessageHardware with hw_id: 65535.",
             id="MOVE_MESSAGE_INVALID_HW_ID",
         ),
         pytest.param(

--- a/ot3_state_manager/tests/test_messages.py
+++ b/ot3_state_manager/tests/test_messages.py
@@ -1,63 +1,271 @@
-"""Test message functionality."""
+"""Test message functionality"""
 
 import pytest
 from opentrons.hardware_control.types import OT3Axis
 
 from ot3_state_manager.messages import (
     Message,
-    MessageLookup,
     MoveMessage,
     SyncPinMessage,
     handle_message,
 )
 from ot3_state_manager.ot3_state import OT3State
-from ot3_state_manager.util import Direction
+from ot3_state_manager.util import Direction, SyncPinState
 
 
 @pytest.mark.parametrize(
-    "byte_string,expected_message",
+    "message, error",
     [
-        (b"\x00\x00", MoveMessage(OT3Axis.X, Direction.NEGATIVE)),
-        (b"\x00\x01", MoveMessage(OT3Axis.X, Direction.POSITIVE)),
-        (b"\x00\x10", MoveMessage(OT3Axis.Y, Direction.NEGATIVE)),
-        (b"\x00\x11", MoveMessage(OT3Axis.Y, Direction.POSITIVE)),
-        (b"\x00\x20", MoveMessage(OT3Axis.Z_L, Direction.NEGATIVE)),
-        (b"\x00\x21", MoveMessage(OT3Axis.Z_L, Direction.POSITIVE)),
-        (b"\x00\x30", MoveMessage(OT3Axis.Z_R, Direction.NEGATIVE)),
-        (b"\x00\x31", MoveMessage(OT3Axis.Z_R, Direction.POSITIVE)),
-        (b"\x00\x40", MoveMessage(OT3Axis.Z_G, Direction.NEGATIVE)),
-        (b"\x00\x41", MoveMessage(OT3Axis.Z_G, Direction.POSITIVE)),
-        (b"\x00\x50", MoveMessage(OT3Axis.P_L, Direction.NEGATIVE)),
-        (b"\x00\x51", MoveMessage(OT3Axis.P_L, Direction.POSITIVE)),
-        (b"\x00\x60", MoveMessage(OT3Axis.P_R, Direction.NEGATIVE)),
-        (b"\x00\x61", MoveMessage(OT3Axis.P_R, Direction.POSITIVE)),
-        (b"\x00\x70", MoveMessage(OT3Axis.Q, Direction.NEGATIVE)),
-        (b"\x00\x71", MoveMessage(OT3Axis.Q, Direction.POSITIVE)),
-        (b"\x00\x80", MoveMessage(OT3Axis.G, Direction.NEGATIVE)),
-        (b"\x00\x81", MoveMessage(OT3Axis.G, Direction.POSITIVE)),
-        (b"\x10\x00", SyncPinMessage("LOW")),
-        (b"\x10\x01", SyncPinMessage("HIGH")),
+        pytest.param(
+            b"\x00\x00\x00\x00\xFF",
+            "ERROR: Message length must be 4 bytes. Your message was 5 bytes.",
+            id="MESSAGE_TOO_LONG",
+        ),
+        pytest.param(
+            b"\x00\x00\x00",
+            "ERROR: Message length must be 4 bytes. Your message was 3 bytes.",
+            id="MESSAGE_TOO_SHORT",
+        ),
+        pytest.param(
+            b"\x00\xFF\xFF\x01",
+            "ERROR: 65535 is not a valid MoveMessageHardware",
+            id="MOVE_MESSAGE_INVALID_HW_ID",
+        ),
+        pytest.param(
+            b"\x00\x00\x00\x02",
+            "ERROR: Value for direction must be either 0 (Negative) or 1 (Positive). You passed 2.",
+            id="MOVE_MESSAGE_INVALID_DIRECTION",
+        ),
+        pytest.param(
+            b"\x01\x00\x00\x02",
+            "ERROR: Value for state must either be 0 (LOW) or 1 (HIGH). You passed 2.",
+            id="SYNC_PIN_MESSAGE_INVALID_STATE",
+        ),
     ],
 )
-def test_byte_string_to_message(byte_string: bytes, expected_message: Message) -> None:
-    """Confirm that move messages are parsed correctly."""
-    message = MessageLookup.bytes_to_message(byte_string)
-    assert message == expected_message
+def test_bad_messages(message: bytes, error: str, ot3_state: OT3State) -> None:
+    """Confirm that if too long/short of a message is passed an exception is thrown."""
+    assert handle_message(message, ot3_state).decode() == error
 
 
 @pytest.mark.parametrize(
-    "byte_string",
-    [b"\x11\x11", b"\x11\x10"],
+    "message,expected_message",
+    (
+        pytest.param(
+            b"\x00\x00\x00\x00",
+            MoveMessage(OT3Axis.X, Direction.NEGATIVE),
+            id="MOVE_X_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x00\x01",
+            MoveMessage(OT3Axis.X, Direction.POSITIVE),
+            id="MOVE_X_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x01\x00",
+            MoveMessage(OT3Axis.Y, Direction.NEGATIVE),
+            id="MOVE_Y_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x01\x01",
+            MoveMessage(OT3Axis.Y, Direction.POSITIVE),
+            id="MOVE_Y_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x02\x00",
+            MoveMessage(OT3Axis.Z_L, Direction.NEGATIVE),
+            id="MOVE_Z_L_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x02\x01",
+            MoveMessage(OT3Axis.Z_L, Direction.POSITIVE),
+            id="MOVE_Z_L_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x03\x00",
+            MoveMessage(OT3Axis.Z_R, Direction.NEGATIVE),
+            id="MOVE_Z_R_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x03\x01",
+            MoveMessage(OT3Axis.Z_R, Direction.POSITIVE),
+            id="MOVE_Z_R_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x04\x00",
+            MoveMessage(OT3Axis.Z_G, Direction.NEGATIVE),
+            id="MOVE_Z_G_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x04\x01",
+            MoveMessage(OT3Axis.Z_G, Direction.POSITIVE),
+            id="MOVE_Z_G_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x05\x00",
+            MoveMessage(OT3Axis.P_L, Direction.NEGATIVE),
+            id="MOVE_P_L_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x05\x01",
+            MoveMessage(OT3Axis.P_L, Direction.POSITIVE),
+            id="MOVE_P_L_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x06\x00",
+            MoveMessage(OT3Axis.P_R, Direction.NEGATIVE),
+            id="MOVE_P_R_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x06\x01",
+            MoveMessage(OT3Axis.P_R, Direction.POSITIVE),
+            id="MOVE_P_R_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x07\x00",
+            MoveMessage(OT3Axis.G, Direction.NEGATIVE),
+            id="MOVE_G_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x07\x01",
+            MoveMessage(OT3Axis.G, Direction.POSITIVE),
+            id="MOVE_G_POSITIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x08\x00",
+            MoveMessage(OT3Axis.Q, Direction.NEGATIVE),
+            id="MOVE_Q_NEGATIVE",
+        ),
+        pytest.param(
+            b"\x00\x00\x08\x01",
+            MoveMessage(OT3Axis.Q, Direction.POSITIVE),
+            id="MOVE_Q_POSITIVE",
+        ),
+        pytest.param(
+            b"\x01\x00\x00\x00",
+            SyncPinMessage(SyncPinState.LOW),
+            id="SYNC_LOW",
+        ),
+        pytest.param(
+            b"\x01\x00\x00\x01",
+            SyncPinMessage(SyncPinState.HIGH),
+            id="SYNC_HIGH",
+        ),
+    ),
 )
-def test_nonexistent_message_to_message(byte_string: bytes) -> None:
-    """Confirm that trying to load a nonexistent message throws an error."""
-    with pytest.raises(ValueError) as err:
-        MessageLookup.bytes_to_message(byte_string)
+def test_message_parsing(message: bytes, expected_message: Message) -> None:
+    """Confirm that Message.parse parses byte string into correct Message object."""
+    assert Message.parse(message) == expected_message
 
-    assert (
-        err.value.args[0] == f"Message for hexadecimal byte string {byte_string!r} is "
-        f"not defined."
-    )
+
+@pytest.mark.parametrize(
+    "message, expected_bytes",
+    (
+        pytest.param(
+            MoveMessage(OT3Axis.X, Direction.NEGATIVE),
+            b"\x00\x00\x00\x00",
+            id="MOVE_X_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.X, Direction.POSITIVE),
+            b"\x00\x00\x00\x01",
+            id="MOVE_X_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Y, Direction.NEGATIVE),
+            b"\x00\x00\x01\x00",
+            id="MOVE_Y_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Y, Direction.POSITIVE),
+            b"\x00\x00\x01\x01",
+            id="MOVE_Y_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Z_L, Direction.NEGATIVE),
+            b"\x00\x00\x02\x00",
+            id="MOVE_Z_L_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Z_L, Direction.POSITIVE),
+            b"\x00\x00\x02\x01",
+            id="MOVE_Z_L_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Z_R, Direction.NEGATIVE),
+            b"\x00\x00\x03\x00",
+            id="MOVE_Z_R_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Z_R, Direction.POSITIVE),
+            b"\x00\x00\x03\x01",
+            id="MOVE_Z_R_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Z_G, Direction.NEGATIVE),
+            b"\x00\x00\x04\x00",
+            id="MOVE_Z_G_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Z_G, Direction.POSITIVE),
+            b"\x00\x00\x04\x01",
+            id="MOVE_Z_G_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.P_L, Direction.NEGATIVE),
+            b"\x00\x00\x05\x00",
+            id="MOVE_P_L_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.P_L, Direction.POSITIVE),
+            b"\x00\x00\x05\x01",
+            id="MOVE_P_L_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.P_R, Direction.NEGATIVE),
+            b"\x00\x00\x06\x00",
+            id="MOVE_P_R_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.P_R, Direction.POSITIVE),
+            b"\x00\x00\x06\x01",
+            id="MOVE_P_R_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.G, Direction.NEGATIVE),
+            b"\x00\x00\x07\x00",
+            id="MOVE_G_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.G, Direction.POSITIVE),
+            b"\x00\x00\x07\x01",
+            id="MOVE_G_POSITIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Q, Direction.NEGATIVE),
+            b"\x00\x00\x08\x00",
+            id="MOVE_Q_NEGATIVE",
+        ),
+        pytest.param(
+            MoveMessage(OT3Axis.Q, Direction.POSITIVE),
+            b"\x00\x00\x08\x01",
+            id="MOVE_Q_POSITIVE",
+        ),
+        pytest.param(
+            SyncPinMessage(SyncPinState.LOW),
+            b"\x01\x00\x00\x00",
+            id="SYNC_LOW",
+        ),
+        pytest.param(
+            SyncPinMessage(SyncPinState.HIGH),
+            b"\x01\x00\x00\x01",
+            id="SYNC_HIGH",
+        ),
+    ),
+)
+def test_convert_message_to_bytes(message: Message, expected_bytes: bytes) -> None:
+    """Confirm that converting a message into bytes works correctly."""
+    assert message.to_bytes() == expected_bytes
 
 
 @pytest.mark.parametrize(
@@ -79,8 +287,8 @@ def test_valid_handle_move_message(
 
 def test_valid_handle_sync_pin_message(ot3_state: OT3State) -> None:
     """Confirm that pulse messages work correctly."""
-    HIGH_MESSAGE = SyncPinMessage("HIGH")
-    LOW_MESSAGE = SyncPinMessage("LOW")
+    HIGH_MESSAGE = SyncPinMessage(SyncPinState.HIGH)
+    LOW_MESSAGE = SyncPinMessage(SyncPinState.LOW)
     ack = handle_message(HIGH_MESSAGE.to_bytes(), ot3_state)
     assert ack == HIGH_MESSAGE.to_bytes()
     assert ot3_state.get_sync_pin_state()
@@ -88,36 +296,3 @@ def test_valid_handle_sync_pin_message(ot3_state: OT3State) -> None:
     ack = handle_message(LOW_MESSAGE.to_bytes(), ot3_state)
     assert ack == LOW_MESSAGE.to_bytes()
     assert not ot3_state.get_sync_pin_state()
-
-
-@pytest.mark.parametrize(
-    "message, expected_error",
-    (
-        pytest.param(
-            "A Bad Message",
-            "ERROR: Passed message, \"b'A Bad Message'\" is not a valid hexadecimal "
-            "byte string.",
-            id="bad_message_format",
-        ),
-        pytest.param(
-            "+ F",
-            "ERROR: Passed message, \"b'+ F'\" is not a valid hexadecimal "
-            "byte string.",
-            id="invalid_axis",
-        ),
-        pytest.param(
-            "= X",
-            "ERROR: Passed message, \"b'= X'\" is not a valid hexadecimal "
-            "byte string.",
-            id="invalid_direction",
-        ),
-    ),
-)
-def test_invalid_handle_message(
-    message: str, expected_error: str, ot3_state: OT3State
-) -> None:
-    """Confirm that invalid messages respond with the correct error."""
-    response = handle_message(message.encode(), ot3_state)
-    assert response.decode() == expected_error
-    assert all([value == 0 for value in ot3_state.current_position.values()])
-    assert all([value == 0 for value in ot3_state.encoder_position.values()])

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -5,7 +5,7 @@ from opentrons.hardware_control.types import OT3Axis
 from ot3_state_manager.hardware import Gripper, LeftPipette, RightPipette
 from ot3_state_manager.ot3_state import OT3State
 from ot3_state_manager.pipette_model import PipetteModel
-from ot3_state_manager.util import Direction
+from ot3_state_manager.util import Direction, SyncPinState
 
 
 @pytest.fixture
@@ -243,7 +243,7 @@ def test_pulse() -> None:
 def test_sync_pin(ot3_state: OT3State) -> None:
     """Confirm that sync pin methods function correctly."""
     assert not ot3_state.get_sync_pin_state()
-    ot3_state.set_sync_pin("HIGH")
+    ot3_state.set_sync_pin(SyncPinState.HIGH)
     assert ot3_state.get_sync_pin_state()
-    ot3_state.set_sync_pin("LOW")
+    ot3_state.set_sync_pin(SyncPinState.LOW)
     assert not ot3_state.get_sync_pin_state()

--- a/ot3_state_manager/tests/test_ot3_state.py
+++ b/ot3_state_manager/tests/test_ot3_state.py
@@ -34,8 +34,8 @@ def test_build(ot3_state: OT3State) -> None:
 def test_build_no_gripper() -> None:
     """Confirms that when building OT3State no gripper that it is configured correctly."""
     manager = OT3State.build(
-        left_pipette_model_name=PipetteModel.SINGLE_20.value,
-        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
+        left_pipette_model_name=PipetteModel.SINGLE_20.get_pipette_name(),
+        right_pipette_model_name=PipetteModel.MULTI_8_20.get_pipette_name(),
         use_gripper=False,
     )
 
@@ -55,7 +55,7 @@ def test_build_no_left_pipette() -> None:
     """Confirms that when building OT3State with no left pipette that it is configured correctly."""
     manager = OT3State.build(
         left_pipette_model_name=None,
-        right_pipette_model_name=PipetteModel.MULTI_8_20.value,
+        right_pipette_model_name=PipetteModel.MULTI_8_20.get_pipette_name(),
         use_gripper=True,
     )
 
@@ -74,7 +74,7 @@ def test_build_no_left_pipette() -> None:
 def test_build_no_right_pipette() -> None:
     """Confirms that when building OT3State with no right pipette that it is configured correctly."""
     manager = OT3State.build(
-        left_pipette_model_name=PipetteModel.SINGLE_20.value,
+        left_pipette_model_name=PipetteModel.SINGLE_20.get_pipette_name(),
         right_pipette_model_name=None,
         use_gripper=True,
     )
@@ -95,7 +95,7 @@ def test_high_throughput_pipette_wrong_mount() -> None:
     """Confirms that exception is thrown when trying to mount high-throughput pipette to left pipette mount."""
     with pytest.raises(ValueError) as err:
         OT3State.build(
-            left_pipette_model_name=PipetteModel.MULTI_96_1000.value,
+            left_pipette_model_name=PipetteModel.MULTI_96_1000.get_pipette_name(),
             right_pipette_model_name=None,
             use_gripper=True,
         )
@@ -106,8 +106,8 @@ def test_high_throughput_too_many_pipettes() -> None:
     """Confirms that exception is thrown when trying to a left pipette when a high-throughput pipette is being mounted to the right slot."""
     with pytest.raises(ValueError) as err:
         OT3State.build(
-            left_pipette_model_name=PipetteModel.SINGLE_20.value,
-            right_pipette_model_name=PipetteModel.MULTI_96_1000.value,
+            left_pipette_model_name=PipetteModel.SINGLE_20.get_pipette_name(),
+            right_pipette_model_name=PipetteModel.MULTI_96_1000.get_pipette_name(),
             use_gripper=True,
         )
     assert err.match(
@@ -120,7 +120,7 @@ def test_high_throughput() -> None:
     """Confirms that is_high_throughput_pipette_attached returns True when high-throughput pipette is mounted."""
     manager = OT3State.build(
         left_pipette_model_name=None,
-        right_pipette_model_name=PipetteModel.MULTI_96_1000.value,
+        right_pipette_model_name=PipetteModel.MULTI_96_1000.get_pipette_name(),
         use_gripper=False,
     )
 
@@ -217,10 +217,14 @@ def test_update_position_hardware_not_attached(
 def test_pulse() -> None:
     """Confirms that pulsing works correctly."""
     state_1 = OT3State.build(
-        PipetteModel.SINGLE_20.value, PipetteModel.SINGLE_20.value, True
+        PipetteModel.SINGLE_20.get_pipette_name(),
+        PipetteModel.SINGLE_20.get_pipette_name(),
+        True,
     )
     state_2 = OT3State.build(
-        PipetteModel.SINGLE_20.value, PipetteModel.SINGLE_20.value, True
+        PipetteModel.SINGLE_20.get_pipette_name(),
+        PipetteModel.SINGLE_20.get_pipette_name(),
+        True,
     )
 
     state_1.pulse(axis=OT3Axis.X, direction=Direction.POSITIVE)

--- a/ot3_state_manager/tests/test_ot3_state_manager.py
+++ b/ot3_state_manager/tests/test_ot3_state_manager.py
@@ -5,10 +5,13 @@ from typing import AsyncGenerator, Generator
 from unittest.mock import Mock, patch
 
 import pytest
+from opentrons.hardware_control.types import OT3Axis
 
+from ot3_state_manager.messages import MoveMessage
 from ot3_state_manager.ot3_state import OT3State
 from ot3_state_manager.ot3_state_manager import OT3StateManager
 from ot3_state_manager.pipette_model import PipetteModel
+from ot3_state_manager.util import Direction
 from tests.udp_client import EchoClientProtocol
 
 HOST = "localhost"
@@ -62,7 +65,8 @@ async def test_message_received(
     ot3_state: OT3State,
 ) -> None:
     """Confirm that pulse messages work correctly."""
-    client.send_message("+ X")
+    move_message_bytes = MoveMessage(OT3Axis.X, Direction.POSITIVE).to_bytes()
+    client.send_message(move_message_bytes)
     await asyncio.wait_for(server.is_connected(), 15.0)
     datagram_received_data_arg_content = patched_object.call_args.args[0]
-    assert datagram_received_data_arg_content == b"+ X"
+    assert datagram_received_data_arg_content == move_message_bytes

--- a/ot3_state_manager/tests/udp_client.py
+++ b/ot3_state_manager/tests/udp_client.py
@@ -43,10 +43,10 @@ class EchoClientProtocol(BaseProtocol):
             self.transport.close()
         self.connected = False
 
-    def send_message(self, message: str) -> None:
+    def send_message(self, message: bytes) -> None:
         """Send message to server."""
         if self.transport is not None:
-            self.transport.sendto(message.encode())
+            self.transport.sendto(message)
 
     @classmethod
     async def build(


### PR DESCRIPTION
# Overview

Each message is now mapped to an int value instead using arbitrary string parsing

[Related Docs](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3322773722/OT3+Emulation+State+Manager#Phase-2%3A-Connect-to-Emulation-(In-Progress))

# Changelog

- Remove `to_message` method from all `Message` classes
- Changed format of messages. All message are now 4 bytes long and have the following format: `<message-id><message-content>` where the length of `message-id` is a single byte and the length of `message-content` is 3 bytes.
- Replace `to_message` method and `parse_message` function with `Message` ABC.
  - Each concrete concrete class of Message is required to implement a `build` and `to_bytes` message
- The `_parse_message` method looks at the `message-id` byte and based off of the value passes `message-content` to the `build` method of the appropriate concrete implementation of `Message`
- Remove hashing of message value as response. Instead just return bytes value.
- Update tests accordingly

# Review Requests

None

# Risk

None

