### PR TITLE
fix(gantry): update mres value to set correct microstep value

### DIFF
--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -116,7 +116,7 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_config{
                          .hend = 0x2,
                          .tbl = 0x2,
                          .tpfd = 0x4,
-                         .mres = 0x4},
+                         .mres = 0x3},
             .coolconf = {.sgt = 0x6},
         },
     .current_config =


### PR DESCRIPTION
Sets 32 microstep instead of 16 for both gantry x & y.