### PR TITLE
chore: Allow for breaking of cache in run_emulation github action

### DIFF
--- a/.github/workflows/run_emulation.yaml
+++ b/.github/workflows/run_emulation.yaml
@@ -1,6 +1,11 @@
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      cache-break:
+        description: Break the Cache
+        required: false
+        default: default
 
 
 env:


### PR DESCRIPTION
Add cache invalidation capabilities to workflow_dispatch of run_emulation.yaml