### PR TITLE
fix(head): motor driver & encoder config

### DIFF
--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -197,7 +197,7 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_configs_left{
  */
 
 static motor_hardware::MotorHardware motor_hardware_right(
-    pin_configurations_right, &htim7, &htim3);
+    pin_configurations_right, &htim7, &htim2);
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_hardware_right);
 
@@ -215,7 +215,7 @@ static motor_class::Motor motor_right{
     motor_queue_right};
 
 static motor_hardware::MotorHardware motor_hardware_left(
-    pin_configurations_left, &htim7, &htim2);
+    pin_configurations_left, &htim7, &htim3);
 static motor_handler::MotorInterruptHandler motor_interrupt_left(
     motor_queue_left, head_tasks::get_left_queues(), motor_hardware_left);
 

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -205,7 +205,8 @@ static motor_class::Motor motor_right{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
         .steps_per_rev = 200,
-        .microstep = 16},
+        .microstep = 16,
+        .encoder_pulses_per_rev = 1000.0},
     motor_hardware_right,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,
@@ -222,7 +223,8 @@ static motor_class::Motor motor_left{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
         .steps_per_rev = 200,
-        .microstep = 16},
+        .microstep = 16,
+        .encoder_pulses_per_rev = 1000.0},
     motor_hardware_left,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,

--- a/head/firmware/motor_hardware_common.c
+++ b/head/firmware/motor_hardware_common.c
@@ -1,29 +1,22 @@
-#include "motor_hardware.h"
-
 #include "common/firmware/errors.h"
+#include "motor_hardware.h"
 #include "stm32g4xx_hal.h"
 
 TIM_HandleTypeDef htim7;
 TIM_HandleTypeDef htim2 = {
     .Instance = TIM2,
-    .Init = {
-        .Prescaler = 0,
-        .CounterMode = TIM_COUNTERMODE_UP,
-        .Period = UINT16_MAX,
-        .ClockDivision = TIM_CLOCKDIVISION_DIV1,
-        .AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE
-    }
-};
+    .Init = {.Prescaler = 0,
+             .CounterMode = TIM_COUNTERMODE_UP,
+             .Period = UINT16_MAX,
+             .ClockDivision = TIM_CLOCKDIVISION_DIV1,
+             .AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE}};
 TIM_HandleTypeDef htim3 = {
     .Instance = TIM3,
-    .Init = {
-        .Prescaler = 0,
-        .CounterMode = TIM_COUNTERMODE_UP,
-        .Period = UINT16_MAX,
-        .ClockDivision = TIM_CLOCKDIVISION_DIV1,
-        .AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE
-    }
-};
+    .Init = {.Prescaler = 0,
+             .CounterMode = TIM_COUNTERMODE_UP,
+             .Period = UINT16_MAX,
+             .ClockDivision = TIM_CLOCKDIVISION_DIV1,
+             .AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE}};
 
 motor_interrupt_callback motor_callback = NULL;
 encoder_overflow_callback left_enc_overflow_callback = NULL;
@@ -91,15 +84,11 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi) {
         HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
         HAL_GPIO_WritePin(GPIOA, GPIO_PIN_4, GPIO_PIN_SET);
 
-        // Ctrl/Dir/Step pin for motor on SPI3 (Z-axis)
-        GPIO_InitStruct.Pin = GPIO_PIN_4;
-        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
+        // Dir/Step pin for motor on SPI3 (Z-axis)
         GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
         GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
         HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
                       &GPIO_InitStruct);
     }
@@ -257,7 +246,7 @@ void MX_GPIO_Init(void) {
     initialize_rev_specific_pins();
 }
 
-void encoder_init(TIM_HandleTypeDef* htim) {
+void encoder_init(TIM_HandleTypeDef *htim) {
     TIM_Encoder_InitTypeDef sConfig = {
         .EncoderMode = TIM_ENCODERMODE_TI12,
         .IC1Polarity = TIM_ICPOLARITY_RISING,
@@ -274,10 +263,8 @@ void encoder_init(TIM_HandleTypeDef* htim) {
     }
     TIM_MasterConfigTypeDef sMasterConfig = {
         .MasterOutputTrigger = TIM_TRGO_RESET,
-        .MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE
-    };
-    if (HAL_TIMEx_MasterConfigSynchronization(htim, &sMasterConfig) !=
-        HAL_OK) {
+        .MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE};
+    if (HAL_TIMEx_MasterConfigSynchronization(htim, &sMasterConfig) != HAL_OK) {
         Error_Handler();
     }
     /* Reset counter */
@@ -291,7 +278,6 @@ void encoder_init(TIM_HandleTypeDef* htim) {
     /* Enable encoder interface */
     HAL_TIM_Encoder_Start_IT(htim, TIM_CHANNEL_ALL);
 }
-
 
 void MX_TIM7_Init(void) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
@@ -352,7 +338,6 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
         HAL_NVIC_EnableIRQ(TIM3_IRQn);
     }
 }
-
 
 void initialize_timer(motor_interrupt_callback callback,
                       encoder_overflow_callback l_f_callback,

--- a/head/firmware/motor_hardware_rev1.c
+++ b/head/firmware/motor_hardware_rev1.c
@@ -15,7 +15,11 @@ void initialize_rev_specific_pins() {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_5 | GPIO_PIN_11;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-    
+
+    GPIO_InitStruct.Pin = GPIO_PIN_4;
+    HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                  &GPIO_InitStruct);
+
     // TODO: Handle brakes better, this just disengages
     // them at boot
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_5 | GPIO_PIN_0, GPIO_PIN_SET);

--- a/head/firmware/motor_hardware_rev1.c
+++ b/head/firmware/motor_hardware_rev1.c
@@ -5,15 +5,25 @@ void initialize_rev_specific_pins() {
     // on rev1, we have electromagnetic brakes
     // for both motors and a correct sense for
     // the right motor enable pin
+    // Left brake: PB5
+    // Left enable: PC4
+    // Right brake: PB0
+    // Right enable: PB11
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_5 | GPIO_PIN_11;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_0,
-                      GPIO_PIN_RESET);
+
+    GPIO_InitStruct.Pin = GPIO_PIN_4;
+    HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+                  &GPIO_InitStruct);
+
     // TODO: Handle brakes better, this just disengages
     // them at boot
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_5 | GPIO_PIN_11, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_5 | GPIO_PIN_0, GPIO_PIN_SET);
+
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_RESET);
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_4, GPIO_PIN_RESET);
 }

--- a/head/firmware/motor_hardware_rev1.c
+++ b/head/firmware/motor_hardware_rev1.c
@@ -15,11 +15,7 @@ void initialize_rev_specific_pins() {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_5 | GPIO_PIN_11;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
-
-    GPIO_InitStruct.Pin = GPIO_PIN_4;
-    HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-                  &GPIO_InitStruct);
-
+    
     // TODO: Handle brakes better, this just disengages
     // them at boot
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_5 | GPIO_PIN_0, GPIO_PIN_SET);


### PR DESCRIPTION
Makes the following changes to the Rev1 board:
1. Reverts the ihold irun value to match the proto board to solve motor movement issues
2. Flips the encoder timer (correct config: left -> tim3, right -> tim2)
3. Adds encoder config so we can actually get encoder position from Ack messages
