### PR TITLE
feat(pipette): Read pipette information from serial

### DIFF
--- a/bootloader/simulator/CMakeLists.txt
+++ b/bootloader/simulator/CMakeLists.txt
@@ -54,7 +54,7 @@ target_compile_definitions(bootloader-simulator PUBLIC ENABLE_LOGGING)
 
 target_can_simlib(bootloader-simulator)
 
-target_link_libraries(bootloader-simulator PRIVATE can-core freertos-bootloader pthread bootloader-core common-simulation Boost::boost)
+target_link_libraries(bootloader-simulator PRIVATE can-core freertos-bootloader pthread bootloader-core common-simulation Boost::boost Boost::program_options)
 
 set_target_properties(bootloader-simulator
         PROPERTIES CXX_STANDARD 20

--- a/bootloader/simulator/main.cpp
+++ b/bootloader/simulator/main.cpp
@@ -1,6 +1,12 @@
 #include <signal.h>
 
+
 #include <cstring>
+#include <string>
+#include <iostream>
+#include <memory>
+
+#include "boost/program_options.hpp"
 
 #include "FreeRTOS.h"
 #include "bootloader/core/message_handler.h"
@@ -10,13 +16,12 @@
 #include "common/core/logging.h"
 #include "task.h"
 
-/** The simulator's bootloader */
-CANNodeId get_node_id(void) { return can_nodeid_pipette_left_bootloader; }
+namespace po = boost::program_options;
 
-/**
- * The CAN bus.
- */
-static auto canbus = can::sim::bus::SimCANBus(can::sim::transport::create());
+static CANNodeId g_node_id = can_nodeid_pipette_left_bootloader;
+
+/** The simulator's bootloader */
+CANNodeId get_node_id(void) { return g_node_id; }
 
 /**
  * Handle a new can message
@@ -25,10 +30,10 @@ static auto canbus = can::sim::bus::SimCANBus(can::sim::transport::create());
  * @param data data
  * @param length length of data
  */
-void on_can_message(void*, uint32_t identifier, uint8_t* data, uint8_t length) {
+void on_can_message(void* ctx, uint32_t identifier, uint8_t* data, uint8_t length) {
     Message message;
     Message response;
-
+    auto* canbus = static_cast<can::sim::bus::SimCANBus*>(ctx);
     message.arbitration_id.id = identifier;
     message.size = length;
     std::memcpy(
@@ -42,7 +47,7 @@ void on_can_message(void*, uint32_t identifier, uint8_t* data, uint8_t length) {
             break;
         case handle_message_has_response:
             LOG("Message ok. Has response");
-            canbus.send(response.arbitration_id.id, response.data,
+            canbus->send(response.arbitration_id.id, response.data,
                         static_cast<CanFDMessageLength>(response.size));
             break;
         case handle_message_error:
@@ -59,15 +64,82 @@ void signal_handler(int signum) {
     exit(signum);
 }
 
-int main() {
-    signal(SIGINT, signal_handler);
+auto node_from_arg(std::string const& val) -> CANNodeId{
+    if (val == "pipette_left") {
+        return can_nodeid_pipette_left_bootloader;
+    } else if (val == "pipette_right") {
+        return can_nodeid_pipette_right_bootloader;
+    } else if (val == "gantry_x") {
+        return can_nodeid_gantry_x_bootloader;
+    } else if (val == "gantry_y") {
+        return can_nodeid_gantry_y_bootloader;
+    } else if (val == "head") {
+        return can_nodeid_head_bootloader;
+    } else if (val == "gripper") {
+        return can_nodeid_gripper_bootloader;
+    } else {
+        throw po::validation_error(po::validation_error::invalid_option_value);
+    }
+}
 
+// this function is automatically called by program options to validate inputs;
+// if it throws, that's a validation failure.
+void validate(boost::any& v,
+              std::vector<std::string> const& values,
+              CANNodeId*,
+              int) {
+    po::validators::check_first_occurrence(v);
+    auto const& string_val = po::validators::get_single_string(values);
+    // this throws appropriately if the arg is wrong
+    v = boost::any(node_from_arg(string_val));
+}
+
+auto handle_options(int argc, char** argv) -> po::variables_map {
+    auto cmdlinedesc = po::options_description("simulator for OT-3 pipettes");
+    auto envdesc = po::options_description("");
+    cmdlinedesc.add_options()("help,h", "Show this help message.");
+    cmdlinedesc.add_options()(
+        "node,n", po::value<CANNodeId>()->default_value(can_nodeid_pipette_left_bootloader),
+        "Which node id to use. Maybe  May be specified in an "
+        "environment variable called NODE_ID. Accepted values: pipette_left, "
+        "pipette_right, gantry_x, gantry_y, head, gripper");
+    envdesc.add_options()("NODE_ID",
+                          po::value<CANNodeId>()->default_value(can_nodeid_pipette_left_bootloader));
+    auto can_arg_xform = can::sim::transport::add_options(cmdlinedesc, envdesc);
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, cmdlinedesc), vm);
+    if (vm.count("help")) {
+        std::cout << cmdlinedesc << std::endl;
+        std::exit(0);
+    }
+    po::store(po::parse_environment(
+                  envdesc,
+                  [can_arg_xform](
+                      const std::string& input_val) -> std::string {
+                      if (input_val == "NODE_ID") {
+                          return "node";
+                      };
+                      return can_arg_xform(input_val);
+                  }),
+              vm);
+    po::notify(vm);
+    return vm;
+}
+
+
+int main(int argc, char** argv) {
+    signal(SIGINT, signal_handler);
     LOG_INIT("BOOTLOADER", []() -> const char* {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
 
-    canbus.setup_node_id_filter(static_cast<can::ids::NodeId>(get_node_id()));
-    canbus.set_incoming_message_callback(nullptr, on_can_message);
+    auto options = handle_options(argc, argv);
+    auto canbus = std::make_shared<can::sim::bus::SimCANBus>(can::sim::transport::create(options));
+    g_node_id = options["node"].as<CANNodeId>();
+    LOG("Running bootloader for node id %d", g_node_id);
+    canbus->setup_node_id_filter(static_cast<can::ids::NodeId>(get_node_id()));
+    canbus->set_incoming_message_callback(canbus.get(), on_can_message);
 
     vTaskStartScheduler();
 }

--- a/can/simlib/transport.cpp
+++ b/can/simlib/transport.cpp
@@ -59,7 +59,8 @@ auto can::sim::transport::create(
     const boost::program_options::variables_map& options)
     -> std::shared_ptr<can::sim::transport::BusTransportBase> {
 #ifdef USE_SOCKETCAN
-    auto channel = options["can-channel"].as<std::string>() auto transport =
+    auto channel = options["can-channel"].as<std::string>();
+    auto transport =
         std::make_shared<can::sim::transport::socketcan::SocketCanTransport<
             freertos_synchronization::FreeRTOSCriticalSection>>(channel);
 #else

--- a/can/simlib/transport.cpp
+++ b/can/simlib/transport.cpp
@@ -1,5 +1,8 @@
 #include "can/simlib/transport.hpp"
 
+#include <string>
+
+#include "boost/program_options.hpp"
 #include "common/core/freertos_synchronization.hpp"
 #ifdef USE_SOCKETCAN
 #include "can/simlib/socketcan_transport.hpp"
@@ -7,37 +10,65 @@
 #include "can/simlib/socket_transport.hpp"
 #endif
 
+namespace po = boost::program_options;
+
+auto can::sim::transport::add_options(po::options_description& cmdline_desc,
+                                      po::options_description& env_desc)
+    -> std::function<std::string(std::string)> {
+#ifdef USE_SOCKETCAN
+    cmdline_desc.add_options()("can-channel,c",
+                               po::value<std::string>()->default_value("vcan0"),
+                               "can channel identifier. May be specified in an "
+                               "environment variable called CAN_CHANNEL.");
+    env_desc.add_options()("CAN_CHANNEL",
+                           po::value<std::string>()->default_value("vcan0"));
+    return [](std::string input_val) -> std::string {
+        if (input_val == "CAN_CHANNEL") {
+            return "can-channel";
+        }
+        return "";
+    }
+#else
+    cmdline_desc.add_options()(
+        "server-host,s", po::value<std::string>()->default_value("localhost"),
+        "can server to connect to. May be specified in an environment variable "
+        "called CAN_SERVER_HOST.")(
+        "port,p", po::value<uint16_t>()->default_value(9898),
+        "port for the can server. May be specified in an environment variable "
+        "called CAN_PORT.");
+    env_desc.add_options()("CAN_SERVER_HOST",
+                           po::value<std::string>()->default_value("localhost"),
+                           "can server to connect to")(
+        "CAN_PORT", po::value<uint16_t>()->default_value(9898));
+    return [](std::string input_val) -> std::string {
+        if (input_val == "CAN_SERVER_HOST") {
+            return "server-host";
+        } else if (input_val == "CAN_PORT") {
+            return "port";
+        }
+        return "";
+    };
+#endif
+}
+
 /**
  * Create simulating bus transport
  * @return pointer to bus transport
  */
-auto can::sim::transport::create()
+auto can::sim::transport::create(
+    const boost::program_options::variables_map& options)
     -> std::shared_ptr<can::sim::transport::BusTransportBase> {
 #ifdef USE_SOCKETCAN
-    auto constexpr ChannelEnvironmentVariableName = "CAN_CHANNEL";
-    auto constexpr DefaultChannel = "vcan0";
-
-    const char* env_channel_val = std::getenv(ChannelEnvironmentVariableName);
-    auto channel = env_channel_val ? env_channel_val : DefaultChannel;
-    auto transport =
+    auto channel = options["can-channel"].as<std::string>() auto transport =
         std::make_shared<can::sim::transport::socketcan::SocketCanTransport<
             freertos_synchronization::FreeRTOSCriticalSection>>(channel);
 #else
-    auto constexpr ServerHostEnvironmentVariableName = "CAN_SERVER_HOST";
-    auto constexpr DefaultServerHost = "localhost";
-    auto constexpr PortEnvironmentVariableName = "CAN_PORT";
-    auto constexpr DefaultPort = 9898;
-
-    const char* env_server_host_val =
-        std::getenv(ServerHostEnvironmentVariableName);
-    auto host = env_server_host_val ? env_server_host_val : DefaultServerHost;
-    const char* env_port_val = std::getenv(PortEnvironmentVariableName);
-    auto port =
-        env_port_val ? std::strtoul(env_port_val, nullptr, 10) : DefaultPort;
+    auto server = options["server-host"].as<std::string>();
+    auto port = options["port"].as<std::uint16_t>();
 
     auto transport =
         std::make_shared<can::sim::transport::socket::SocketTransport<
-            freertos_synchronization::FreeRTOSCriticalSection>>(host, port);
+            freertos_synchronization::FreeRTOSCriticalSection>>(server, port);
 
 #endif
     return transport;

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -228,7 +228,7 @@ SCENARIO("message serializing works") {
                 REQUIRE(len == sizeof(data));
                 // check that the data has been serialized till the end of the
                 // buffer
-                for (uint i = 0; i < data.size() && iter < arr.end(); i++) {
+                for (size_t i = 0; i < data.size() && iter < arr.end(); i++) {
                     REQUIRE(*(iter++) == data[i]);
                 }
             }
@@ -253,11 +253,11 @@ SCENARIO("message serializing works") {
                 // check length was serialized correctly
                 REQUIRE(len == sizeof(data));
                 // check that the data has been serialized
-                for (uint i = 0; i < data.size() && iter < arr.end(); i++) {
+                for (size_t i = 0; i < data.size() && iter < arr.end(); i++) {
                     REQUIRE(*(iter++) == data[i]);
                 }
                 // check that the remainder of the buffer is 0x00
-                for (uint i = data.size();
+                for (size_t i = data.size();
                      i < eeprom::types::max_data_length && iter < arr.end();
                      i++) {
                     REQUIRE(*(iter++) == 0x00);

--- a/eeprom/tests/test_data_rev.cpp
+++ b/eeprom/tests/test_data_rev.cpp
@@ -30,7 +30,7 @@ SCENARIO("Writing data revision") {
                          0));
                 message::WriteEepromMessage write_message;
                 types::data_length expected_bytes;
-                for (ulong i = 0; i < queue_client.messages.size(); i++) {
+                for (size_t i = 0; i < queue_client.messages.size(); i++) {
                     expected_bytes =
                         ((addresses::data_revision_length -
                           (i * types::max_data_length)) > types::max_data_length
@@ -76,7 +76,7 @@ SCENARIO("Reading data revision") {
 
                 types::data_length expected_bytes;
                 message::ReadEepromMessage read_message;
-                for (ulong i = 0; i < queue_client.messages.size(); i++) {
+                for (size_t i = 0; i < queue_client.messages.size(); i++) {
                     expected_bytes =
                         ((addresses::data_revision_length -
                           (i * types::max_data_length)) > types::max_data_length

--- a/eeprom/tests/test_revision.cpp
+++ b/eeprom/tests/test_revision.cpp
@@ -28,7 +28,7 @@ SCENARIO("Writing revision") {
                          0));
                 message::WriteEepromMessage write_message;
                 types::data_length expected_bytes;
-                for (ulong i = 0; i < queue_client.messages.size(); i++) {
+                for (size_t i = 0; i < queue_client.messages.size(); i++) {
                     expected_bytes =
                         ((addresses::revision_length -
                           (i * types::max_data_length)) > types::max_data_length
@@ -73,7 +73,7 @@ SCENARIO("Reading revision") {
 
                 types::data_length expected_bytes;
                 message::ReadEepromMessage read_message;
-                for (ulong i = 0; i < queue_client.messages.size(); i++) {
+                for (size_t i = 0; i < queue_client.messages.size(); i++) {
                     expected_bytes =
                         ((addresses::revision_length -
                           (i * types::max_data_length)) > types::max_data_length

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -11,9 +11,9 @@ SCENARIO("Writing serial number") {
     auto queue_client = MockEEPromTaskClient{};
     auto read_listener = MockListener{};
     auto sn_buffer = serial_number::SerialNumberType{};
-    auto sn_data = serial_number::SerialNumberType{'P', '1', 'K', 'S', 'V', '2',
+    auto sn_data = serial_number::SerialNumberType{0x00, 0x01, 0x00, 0x1f, '2',
                                                    '0', '2', '0', '1', '9', '0',
-                                                   '7', '2', '4', '3', '0'};
+                                                   '7', 'A', '0', '3'};
     auto subject = serial_number::SerialNumberAccessor{
         queue_client, read_listener, sn_buffer};
 
@@ -30,7 +30,7 @@ SCENARIO("Writing serial number") {
                          0));
                 message::WriteEepromMessage write_message;
                 types::data_length expected_bytes;
-                for (ulong i = 0; i < queue_client.messages.size(); i++) {
+                for (size_t i = 0; i < queue_client.messages.size(); i++) {
                     expected_bytes =
                         ((sn_data.size() - (i * types::max_data_length)) >
                                  types::max_data_length
@@ -77,7 +77,7 @@ SCENARIO("Reading serial number") {
 
                 types::data_length expected_bytes;
                 message::ReadEepromMessage read_message;
-                for (ulong i = 0; i < queue_client.messages.size(); i++) {
+                for (size_t i = 0; i < queue_client.messages.size(); i++) {
                     expected_bytes =
                         ((addresses::serial_number_length -
                           (i * types::max_data_length)) > types::max_data_length

--- a/eeprom/tests/test_serial_number.cpp
+++ b/eeprom/tests/test_serial_number.cpp
@@ -12,8 +12,8 @@ SCENARIO("Writing serial number") {
     auto read_listener = MockListener{};
     auto sn_buffer = serial_number::SerialNumberType{};
     auto sn_data = serial_number::SerialNumberType{0x00, 0x01, 0x00, 0x1f, '2',
-                                                   '0', '2', '0', '1', '9', '0',
-                                                   '7', 'A', '0', '3'};
+                                                   '0',  '2',  '0',  '1',  '9',
+                                                   '0',  '7',  'A',  '0',  '3'};
     auto subject = serial_number::SerialNumberAccessor{
         queue_client, read_listener, sn_buffer};
 

--- a/gantry/simulator/CMakeLists.txt
+++ b/gantry/simulator/CMakeLists.txt
@@ -51,7 +51,7 @@ foreach(AXIS IN LISTS AXES)
 
   target_ot_motor_control(gantry-${AXIS}-simulator)
 
-  target_link_libraries(gantry-${AXIS}-simulator PRIVATE can-core common-simulation freertos-gantry pthread Boost::boost)
+  target_link_libraries(gantry-${AXIS}-simulator PRIVATE can-core common-simulation freertos-gantry pthread Boost::boost Boost::program_options)
 
   set_target_properties(gantry-${AXIS}-simulator
         PROPERTIES CXX_STANDARD 20

--- a/gantry/simulator/main.cpp
+++ b/gantry/simulator/main.cpp
@@ -4,6 +4,7 @@
 #include "gantry/core/axis_type.h"
 #include "gantry/core/interfaces_proto.hpp"
 #include "gantry/core/tasks_proto.hpp"
+#include "gantry/simulator/interfaces.hpp"
 #include "task.h"
 
 void signal_handler(int signum) {
@@ -11,7 +12,7 @@ void signal_handler(int signum) {
     exit(signum);
 }
 
-int main() {
+int main(int argc, char** argv) {
     signal(SIGINT, signal_handler);
 
     LOG_INIT(
@@ -21,6 +22,7 @@ int main() {
         });
 
     interfaces::initialize();
+    interfaces::initialize_sim(argc, argv);
 
     gantry::tasks::start_tasks(
         interfaces::get_can_bus(), interfaces::get_motor().motion_controller,

--- a/gripper/simulator/CMakeLists.txt
+++ b/gripper/simulator/CMakeLists.txt
@@ -52,7 +52,7 @@ target_ot_motor_control(gripper-simulator)
 
 target_i2c_simlib(gripper-simulator)
 
-target_link_libraries(gripper-simulator PRIVATE can-core common-simulation freertos-gripper pthread Boost::boost)
+target_link_libraries(gripper-simulator PRIVATE can-core common-simulation freertos-gripper pthread Boost::boost Boost::program_options)
 
 set_target_properties(gripper-simulator
         PROPERTIES CXX_STANDARD 20

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -1,6 +1,11 @@
 #include <signal.h>
 
+#include <iostream>
+#include <memory>
+#include <string>
+
 #include "FreeRTOS.h"
+#include "boost/program_options.hpp"
 #include "can/simlib/sim_canbus.hpp"
 #include "eeprom/simulation/eeprom.hpp"
 #include "gripper/core/interfaces.hpp"
@@ -10,6 +15,8 @@
 #include "sensors/simulation/mock_hardware.hpp"
 #include "task.h"
 
+namespace po = boost::program_options;
+
 void signal_handler(int signum) {
     LOG("Interrupt signal (%d) received.", signum);
     exit(signum);
@@ -18,33 +25,65 @@ void signal_handler(int signum) {
 /**
  * The CAN bus.
  */
-static auto canbus = can::sim::bus::SimCANBus(can::sim::transport::create());
 
 static auto capsensor = fdc1004_simulator::FDC1004{};
-static auto sim_eeprom = eeprom::simulator::EEProm{};
 static auto sensor_map =
     i2c::hardware::SimI2C::DeviceMap{{capsensor.get_address(), capsensor}};
 static auto i2c2 = i2c::hardware::SimI2C{sensor_map};
-static auto i2c_device_map =
-    i2c::hardware::SimI2C::DeviceMap{{sim_eeprom.get_address(), sim_eeprom}};
-static auto i2c3 = i2c::hardware::SimI2C{i2c_device_map};
 
 static test_mocks::MockSensorHardware fake_sensor_hw{};
 
-int main() {
+auto handle_options(int argc, char** argv) -> po::variables_map {
+    auto cmdlinedesc =
+        po::options_description("simulator for the OT-3 gripper");
+    auto envdesc = po::options_description("");
+    cmdlinedesc.add_options()("help,h", "Show this help message.");
+    auto can_arg_xform = can::sim::transport::add_options(cmdlinedesc, envdesc);
+    auto eeprom_arg_xform =
+        eeprom::simulator::EEProm::add_options(cmdlinedesc, envdesc);
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, cmdlinedesc), vm);
+    if (vm.count("help")) {
+        std::cout << cmdlinedesc << std::endl;
+        std::exit(0);
+    }
+    po::store(po::parse_environment(
+                  envdesc,
+                  [can_arg_xform, eeprom_arg_xform](
+                      const std::string& input_val) -> std::string {
+                      auto can_xformed = can_arg_xform(input_val);
+                      if (can_xformed != "") {
+                          return can_xformed;
+                      }
+                      auto eeprom_xformed = eeprom_arg_xform(input_val);
+                      return eeprom_xformed;
+                  }),
+              vm);
+    po::notify(vm);
+    return vm;
+}
+
+int main(int argc, char** argv) {
     signal(SIGINT, signal_handler);
 
     LOG_INIT("GRIPPER", []() -> const char* {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
-
+    auto options = handle_options(argc, argv);
+    auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(options);
+    auto i2c_device_map = i2c::hardware::SimI2C::DeviceMap{
+        {sim_eeprom->get_address(), *sim_eeprom}};
+    auto i2c3 = std::make_shared<i2c::hardware::SimI2C>(i2c_device_map);
+    static auto canbus =
+        can::sim::bus::SimCANBus(can::sim::transport::create(options));
     z_motor_iface::initialize();
     grip_motor_iface::initialize();
     gripper_tasks::start_tasks(canbus, z_motor_iface::get_z_motor(),
                                grip_motor_iface::get_grip_motor(),
                                z_motor_iface::get_spi(),
                                z_motor_iface::get_tmc2130_driver_configs(),
-                               i2c2, i2c3, fake_sensor_hw, sim_eeprom);
+                               i2c2, *i2c3, fake_sensor_hw, *sim_eeprom);
 
     vTaskStartScheduler();
 }

--- a/head/simulator/CMakeLists.txt
+++ b/head/simulator/CMakeLists.txt
@@ -45,7 +45,7 @@ target_head_core_proto(head-simulator)
 
 target_ot_motor_control(head-simulator)
 
-target_link_libraries(head-simulator PRIVATE can-core common-simulation freertos-head pthread Boost::boost)
+target_link_libraries(head-simulator PRIVATE can-core common-simulation freertos-head pthread Boost::boost Boost::program_options)
 
 set_target_properties(head-simulator
         PROPERTIES CXX_STANDARD 20

--- a/include/can/simlib/socket_transport.hpp
+++ b/include/can/simlib/socket_transport.hpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <boost/asio.hpp>
+#include <string>
 
 #include "can/core/message_core.hpp"
 #include "common/core/logging.h"
@@ -17,7 +18,7 @@ using boost::asio::ip::tcp;
 template <synchronization::LockableProtocol CriticalSection>
 class SocketTransport : public can::sim::transport::BusTransportBase {
   public:
-    explicit SocketTransport(const char *host, uint32_t port)
+    explicit SocketTransport(std::string host, uint32_t port)
         : host{host}, port{port}, socket{context} {}
     ~SocketTransport() {}
     SocketTransport(const SocketTransport &) = delete;

--- a/include/can/simlib/socketcan_transport.hpp
+++ b/include/can/simlib/socketcan_transport.hpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <string>
 
 #include "common/core/logging.h"
 #include "common/core/synchronization.hpp"
@@ -20,7 +21,7 @@ namespace can::sim::transport::socketcan {
 template <synchronization::LockableProtocol CriticalSection>
 class SocketCanTransport : public can::sim::transport::BusTransportBase {
   public:
-    explicit SocketCanTransport(const char *address) : address{address} {}
+    explicit SocketCanTransport(std::string address) : address{address} {}
     ~SocketCanTransport() { close(); };
     SocketCanTransport(const SocketCanTransport &) = delete;
     SocketCanTransport(const SocketCanTransport &&) = delete;

--- a/include/can/simlib/transport.hpp
+++ b/include/can/simlib/transport.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <boost/program_options.hpp>
+#include <functional>
 #include <memory>
+#include <string>
 
 namespace can::sim::transport {
 
@@ -49,6 +52,10 @@ class BusTransportBase {
  *
  * @return pointer to BusTransportBase.
  */
-auto create() -> std::shared_ptr<BusTransportBase>;
+auto create(const boost::program_options::variables_map& options)
+    -> std::shared_ptr<BusTransportBase>;
+auto add_options(boost::program_options::options_description& cmdline_desc,
+                 boost::program_options::options_description& env_desc)
+    -> std::function<std::string(std::string)>;
 
 }  // namespace can::sim::transport

--- a/include/eeprom/core/serial_number.hpp
+++ b/include/eeprom/core/serial_number.hpp
@@ -8,7 +8,7 @@ namespace eeprom {
 namespace serial_number {
 
 using SerialNumberType = std::array<uint8_t, addresses::serial_number_length>;
-using SerialDataCodeType = std::array<uint8_t, 12>;
+using SerialDataCodeType = std::array<uint8_t, 16>;
 /**
  * Class that reads and writes serial numbers.
  *

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <array>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
 #include <functional>
+#include <iterator>
 #include <string>
 
 #include "boost/program_options.hpp"
@@ -49,10 +53,9 @@ class EEProm : public I2CDeviceBase,
         if (data_size > 0) {
             if (!write_protected) {
                 // Let the exception happen. Catch errors!
-                std::copy_n(iter, data_size,
-                            backing.value().begin() + current_address);
                 LOG("Writing %d bytes to address %X", data_size,
                     current_address);
+                backing.write(iter, current_address, data_size);
             } else {
                 LOG("Write protect is enabled. Cannot write.");
             }
@@ -65,9 +68,8 @@ class EEProm : public I2CDeviceBase,
 
     auto handle_read(uint8_t* data, uint16_t size) -> bool {
         LOG("Reading %d bytes from address %X", size, current_address);
-        for (auto i = 0; i < size; i++) {
-            data[i] = backing.value()[current_address++];
-        }
+        backing.read(data, current_address, size);
+        current_address += size;
         return true;
     }
 
@@ -79,14 +81,69 @@ class EEProm : public I2CDeviceBase,
 
     struct BackingStore {
         static constexpr std::string_view TEMPFILE_KEY = "<temp file>";
-        using BackingType =
-            std::array<uint8_t,
-                       static_cast<size_t>(
-                           hardware_iface::EEpromMemorySize::ST_16_KBYTE)>;
-        explicit BackingStore(const po::variables_map& variables) {
-            auto filename = variables["eeprom-filename"].as<std::string>();
-            LOG("Using eeprom backing store %s", filename.c_str());
-            backing.fill(0xff);
+        static constexpr size_t BACKING_SIZE =
+            static_cast<size_t>(hardware_iface::EEpromMemorySize::ST_16_KBYTE);
+        BackingStore(const BackingStore&) = delete;
+        auto operator=(const BackingStore&) -> BackingStore& = delete;
+        BackingStore(BackingStore&&) = delete;
+        auto operator=(BackingStore&&) -> BackingStore&& = delete;
+        explicit BackingStore(const po::variables_map& variables)
+            : backing(get_prepped_backing_file(variables)) {}
+        ~BackingStore() {
+            if (backing) {
+                if (!std::ferror(backing)) {
+                    std::fflush(backing);
+                }
+                std::fclose(backing);
+            }
+        }
+        static auto get_temp_file() -> std::FILE* {
+            auto tempdir = std::filesystem::temp_directory_path();
+            auto temp_path = tempdir / "eeprom.bin";
+            LOG("Backing up eeprom with tempfile at %s", temp_path.c_str());
+            return std::fopen(temp_path.c_str(), "w+b");
+        }
+        static auto get_backing_file(std::string pathstr) -> std::FILE* {
+            auto path = std::filesystem::path(pathstr);
+            path.make_preferred();
+            LOG("Backing up eeprom with %s", path.c_str());
+            return std::fopen(path.c_str(), "a+b");
+        }
+        static auto get_prepped_backing_file(std::string pathstr)
+            -> std::FILE* {
+            auto file = ((pathstr == TEMPFILE_KEY) ? get_temp_file()
+                                                   : get_backing_file(pathstr));
+            if (!file) {
+                fprintf(stderr, "Could not open backing file %s: %d %s\n",
+                        pathstr.c_str(), errno, strerror(errno));
+                std::abort();
+            }
+            // what's the current end of the file? (we may open with append)
+            auto start = std::ftell(file);
+            std::fseek(file, 0, SEEK_END);
+            auto size = static_cast<size_t>(std::ftell(file));
+            // extend file if necessary but don't truncate
+            if (size < BACKING_SIZE) {
+                std::fseek(file, BACKING_SIZE, SEEK_SET);
+                std::fseek(file, start, SEEK_SET);
+                auto tmp_backing = std::array<char, BACKING_SIZE>{};
+                tmp_backing.fill(0xff);
+                std::fwrite(tmp_backing.data(), sizeof(tmp_backing[0]),
+                            BACKING_SIZE - start, file);
+                std::fflush(file);
+                LOG("Extended backing file to %uB by writing %uB from %ld",
+                    BACKING_SIZE, BACKING_SIZE - start, start);
+            }
+            // pointer back to 0, though we'll be doing a lot of SEEK_SET so it
+            // doesn't really matter
+            std::fseek(file, 0, SEEK_SET);
+            LOG("got file at %p\n", file);
+            return file;
+        }
+        static auto get_prepped_backing_file(const po::variables_map& variables)
+            -> FILE* {
+            return get_prepped_backing_file(
+                variables["eeprom-filename"].as<std::string>());
         }
         static auto add_options(po::options_description& cmdline,
                                 po::options_description& env)
@@ -108,10 +165,64 @@ class EEProm : public I2CDeviceBase,
                 return "";
             };
         }
-        auto value() -> BackingType& { return backing; }
+        auto read(uint8_t* readbuf, uint16_t address, size_t size) -> void {
+            if (std::fseek(backing, address, SEEK_SET)) {
+                fprintf(stderr,
+                        "fseek to %d for EEPROM read on file %p failed: eof=%d "
+                        "err=%d %d %s",
+                        address, backing, std::feof(backing),
+                        std::ferror(backing), errno, strerror(errno));
+            }
+            auto read_count =
+                std::fread(readbuf, sizeof(readbuf[0]), size, backing);
+            if (read_count != size) {
+                if (std::feof(backing)) {
+                    fprintf(stderr,
+                            "EEPROM read of %ld bytes from %d read only %ld "
+                            "and hit eof\n",
+                            size, address, read_count);
+                    std::abort();
+                } else if (std::ferror(backing)) {
+                    fprintf(stderr,
+                            "EEPROM read of %ld bytes from %d on file %p read "
+                            "only %ld hit error: %d %s\n",
+                            size, address, backing, read_count, errno,
+                            strerror(errno));
+                    std::abort();
+                }
+            }
+        }
+
+        auto write(const uint8_t* writebuf, uint16_t address, size_t size)
+            -> void {
+            if (std::fseek(backing, address, SEEK_SET)) {
+                fprintf(stderr,
+                        "fseek to %d on file %p for EEPROM write failed: "
+                        "eof=%d err=%d %d %s",
+                        address, backing, std::feof(backing),
+                        std::ferror(backing), errno, strerror(errno));
+            }
+
+            auto write_count =
+                std::fwrite(writebuf, sizeof(writebuf[0]), size, backing);
+            if (write_count != size) {
+                if (std::feof(backing)) {
+                    fprintf(stderr, "EEPROM write of %ld bytes to %d hit eof\n",
+                            size, address);
+                    std::abort();
+                } else if (std::ferror(backing)) {
+                    fprintf(stderr,
+                            "EEPROM write of %ld bytes to %d on file %p caused "
+                            "error: %d %s\n",
+                            size, address, backing, errno, strerror(errno));
+                    std::abort();
+                }
+            }
+            std::fflush(backing);
+        }
 
       private:
-        BackingType backing{};
+        std::FILE* backing;
     };
 
   private:

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <array>
+#include <functional>
+#include <string>
 
+#include "boost/program_options.hpp"
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.h"
 #include "eeprom/core/hardware_iface.hpp"
@@ -12,19 +15,25 @@ namespace eeprom {
 namespace simulator {
 
 using namespace i2c::hardware;
+namespace po = boost::program_options;
 
 class EEProm : public I2CDeviceBase,
                public hardware_iface::EEPromHardwareIface {
   public:
-    EEProm() : I2CDeviceBase(types::DEVICE_ADDRESS) { backing.fill(0xFF); }
-    EEProm(hardware_iface::EEPromChipType chip)
-        : I2CDeviceBase(types::DEVICE_ADDRESS),
-          hardware_iface::EEPromHardwareIface(chip) {
-        backing.fill(0xFF);
+    static auto add_options(po::options_description& cmdline_desc,
+                            po::options_description& env_desc)
+        -> std::function<std::string(std::string)> {
+        return BackingStore::add_options(cmdline_desc, env_desc);
     }
+    explicit EEProm(po::variables_map& options)
+        : I2CDeviceBase(types::DEVICE_ADDRESS), backing(options) {}
+    EEProm(hardware_iface::EEPromChipType chip, po::variables_map& options)
+        : I2CDeviceBase(types::DEVICE_ADDRESS),
+          hardware_iface::EEPromHardwareIface(chip),
+          backing(options) {}
 
-    auto handle_write(const uint8_t *data, uint16_t size) -> bool {
-        auto *iter = data;
+    auto handle_write(const uint8_t* data, uint16_t size) -> bool {
+        auto* iter = data;
 
         // Read the address
         iter = bit_utils::bytes_to_int(
@@ -40,7 +49,8 @@ class EEProm : public I2CDeviceBase,
         if (data_size > 0) {
             if (!write_protected) {
                 // Let the exception happen. Catch errors!
-                std::copy_n(iter, data_size, backing.begin() + current_address);
+                std::copy_n(iter, data_size,
+                            backing.value().begin() + current_address);
                 LOG("Writing %d bytes to address %X", data_size,
                     current_address);
             } else {
@@ -53,10 +63,10 @@ class EEProm : public I2CDeviceBase,
         return true;
     }
 
-    auto handle_read(uint8_t *data, uint16_t size) -> bool {
+    auto handle_read(uint8_t* data, uint16_t size) -> bool {
         LOG("Reading %d bytes from address %X", size, current_address);
         for (auto i = 0; i < size; i++) {
-            data[i] = backing[current_address++];
+            data[i] = backing.value()[current_address++];
         }
         return true;
     }
@@ -67,10 +77,45 @@ class EEProm : public I2CDeviceBase,
         write_protected = enabled;
     }
 
+    struct BackingStore {
+        static constexpr std::string_view TEMPFILE_KEY = "<temp file>";
+        using BackingType =
+            std::array<uint8_t,
+                       static_cast<size_t>(
+                           hardware_iface::EEpromMemorySize::ST_16_KBYTE)>;
+        explicit BackingStore(const po::variables_map& variables) {
+            auto filename = variables["eeprom-filename"].as<std::string>();
+            LOG("Using eeprom backing store %s", filename.c_str());
+            backing.fill(0xff);
+        }
+        static auto add_options(po::options_description& cmdline,
+                                po::options_description& env)
+            -> std::function<std::string(std::string)> {
+            cmdline.add_options()(
+                "eeprom-filename,f",
+                po::value<std::string>()->default_value(
+                    std::string(TEMPFILE_KEY)),
+                "path to backing file for eeprom. if unspecified, a temp will "
+                "be used. May be specified in an environment file called "
+                "EEPROM_FILENAME.");
+            env.add_options()("EEPROM_FILENAME",
+                              po::value<std::string>()->default_value(
+                                  std::string(TEMPFILE_KEY)));
+            return [](std::string input_val) -> std::string {
+                if (input_val == "EEPROM_FILENAME") {
+                    return "eeprom-filename";
+                }
+                return "";
+            };
+        }
+        auto value() -> BackingType& { return backing; }
+
+      private:
+        BackingType backing{};
+    };
+
   private:
-    std::array<uint8_t, static_cast<size_t>(
-                            hardware_iface::EEpromMemorySize::ST_16_KBYTE)>
-        backing{};
+    BackingStore backing;
     types::address current_address{0};
     bool write_protected{true};
 };

--- a/include/gantry/simulator/interfaces.hpp
+++ b/include/gantry/simulator/interfaces.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+/*
+** Simulator-specific interfaces
+*/
+
+namespace interfaces {
+    void initialize_sim(int argc, char** argv);
+};

--- a/include/gantry/simulator/interfaces.hpp
+++ b/include/gantry/simulator/interfaces.hpp
@@ -5,5 +5,5 @@
 */
 
 namespace interfaces {
-    void initialize_sim(int argc, char** argv);
+void initialize_sim(int argc, char** argv);
 };

--- a/include/pipettes/core/pipette_info.hpp
+++ b/include/pipettes/core/pipette_info.hpp
@@ -15,20 +15,24 @@ namespace pipette_info {
 using namespace can::ids;
 using namespace can::messages;
 
-// These defines are u    sed to help parse pipette serials, which are stored in
-// a structured binary +     ascii format:
+// These defines are used to help parse pipette serials, which are stored in
+// a structured binary + ascii format:
 // +-----+--------+------+
 // |0x00 |name    |binary|
 // |0x01 |        |      |
 // +-----+--------+------+
-// |0x02 |model   |binary|and individual data code [name]P1K [model]SV
-// [data_code] 20201907243 |0x03 |        |      |
+// |0x02 |model   |binary|
 // +-----+--------+------+
 // |0x04 |datecode|ascii |
 // |0x13 |        |      |
 // +-----+--------+------+
 // The binary name is a uint16 that is a lookup into the pipette name table.
-// The binary model is a uint16 that is a number.
+// The binary model is a uint16 that is a number. Finally, the datecode is
+// ascii and is the remnant of the serial. For instance, serial
+// P1KV3120210214A02 would be stored as
+// name: 0x0000 (p1000_single)
+// model: 0x001f (model 31)
+// datecode: "20210214A02" (datecode for second unit produced on 14/02/21)
 constexpr size_t PIPETTE_NAME_FIELD_START = 0;
 constexpr size_t PIPETTE_NAME_FIELD_LEN = 2;
 constexpr size_t PIPETTE_MODEL_FIELD_START = PIPETTE_NAME_FIELD_LEN;

--- a/include/pipettes/core/pipette_info.hpp
+++ b/include/pipettes/core/pipette_info.hpp
@@ -126,7 +126,8 @@ class PipetteInfoMessageHandler : eeprom::accessor::ReadListener {
         const auto *iter = serial.cbegin();
         const auto *bound = serial.cbegin();
         std::advance(iter, PIPETTE_MODEL_FIELD_START);
-        std::advance(iter, PIPETTE_MODEL_FIELD_START + PIPETTE_MODEL_FIELD_LEN);
+        std::advance(bound,
+                     PIPETTE_MODEL_FIELD_START + PIPETTE_MODEL_FIELD_LEN);
         iter = bit_utils::bytes_to_int(iter, bound, model);
         return model;
     }
@@ -137,7 +138,7 @@ class PipetteInfoMessageHandler : eeprom::accessor::ReadListener {
         const auto *iter = serial.cbegin();
         const auto *bound = serial.cbegin();
         std::advance(iter, PIPETTE_NAME_FIELD_START);
-        std::advance(iter, PIPETTE_NAME_FIELD_START + PIPETTE_NAME_FIELD_LEN);
+        std::advance(bound, PIPETTE_NAME_FIELD_START + PIPETTE_NAME_FIELD_LEN);
         iter = bit_utils::bytes_to_int(iter, bound, name);
         return name;
     }

--- a/include/pipettes/core/pipette_info.hpp
+++ b/include/pipettes/core/pipette_info.hpp
@@ -15,29 +15,22 @@ namespace pipette_info {
 using namespace can::ids;
 using namespace can::messages;
 
-enum class PipetteName {
-    P1000_SINGLE = 0,
-    P1000_MULTI = 1,
-    P1000_96 = 2,
-    P1000_384 = 3,
-};
-
-struct PipetteInfo {
-    PipetteName name;
-    uint16_t model;
-    eeprom::serial_number::SerialNumberType serial;
-};
-
-// This is currently implemented in pipette-type-specific source files in core
-// e.g. pipettes/core/pipette_type_single.cpp but could probably also be parsed
-// from the serial number like the model below
-PipetteName get_name();
-
-// These defines are used to help parse pipette serials
-// A full Serial number looks like P1KSV20201907243 and contains the name, model
-// and individual data code [name]P1K [model]SV [data_code] 20201907243
+// These defines are u    sed to help parse pipette serials, which are stored in
+// a structured binary +     ascii format:
+// +-----+--------+------+
+// |0x00 |name    |binary|
+// |0x01 |        |      |
+// +-----+--------+------+
+// |0x02 |model   |binary|and individual data code [name]P1K [model]SV
+// [data_code] 20201907243 |0x03 |        |      |
+// +-----+--------+------+
+// |0x04 |datecode|ascii |
+// |0x13 |        |      |
+// +-----+--------+------+
+// The binary name is a uint16 that is a lookup into the pipette name table.
+// The binary model is a uint16 that is a number.
 constexpr size_t PIPETTE_NAME_FIELD_START = 0;
-constexpr size_t PIPETTE_NAME_FIELD_LEN = 3;
+constexpr size_t PIPETTE_NAME_FIELD_LEN = 2;
 constexpr size_t PIPETTE_MODEL_FIELD_START = PIPETTE_NAME_FIELD_LEN;
 constexpr size_t PIPETTE_MODEL_FIELD_LEN = 2;
 constexpr size_t PIPETTE_DATACODE_START =
@@ -95,7 +88,7 @@ class PipetteInfoMessageHandler : eeprom::accessor::ReadListener {
         writer.send_can_message(
             can::ids::NodeId::host,
             can::messages::PipetteInfoResponse{
-                .name = static_cast<uint16_t>(get_name()),
+                .name = get_name(sn_accessor_backing),
                 .model = get_model(sn_accessor_backing),
                 .serial = get_data_code(sn_accessor_backing)});
     }
@@ -130,13 +123,25 @@ class PipetteInfoMessageHandler : eeprom::accessor::ReadListener {
     static auto get_model(const eeprom::serial_number::SerialNumberType &serial)
         -> uint16_t {
         uint16_t model = 0;
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        const auto *iter = serial.begin() + PIPETTE_MODEL_FIELD_START;
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        iter = bit_utils::bytes_to_int(iter, iter + PIPETTE_MODEL_FIELD_LEN,
-                                       model);
+        const auto *iter = serial.cbegin();
+        const auto *bound = serial.cbegin();
+        std::advance(iter, PIPETTE_MODEL_FIELD_START);
+        std::advance(iter, PIPETTE_MODEL_FIELD_START + PIPETTE_MODEL_FIELD_LEN);
+        iter = bit_utils::bytes_to_int(iter, bound, model);
         return model;
     }
+
+    static auto get_name(const eeprom::serial_number::SerialNumberType &serial)
+        -> uint16_t {
+        uint16_t name = 0;
+        const auto *iter = serial.cbegin();
+        const auto *bound = serial.cbegin();
+        std::advance(iter, PIPETTE_NAME_FIELD_START);
+        std::advance(iter, PIPETTE_NAME_FIELD_START + PIPETTE_NAME_FIELD_LEN);
+        iter = bit_utils::bytes_to_int(iter, bound, name);
+        return name;
+    }
+
     static auto get_data_code(
         const eeprom::serial_number::SerialNumberType &serial)
         -> eeprom::serial_number::SerialDataCodeType {

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -70,8 +70,10 @@ class CapacitiveMessageHandler {
         if (utils::tag_in_token(m.id.token,
                                 utils::ResponseTag::POLL_IS_CONTINUOUS)) {
             capacitance_handler.handle_ongoing_response(m);
+            LOG("continuous transaction response");
         } else {
             capacitance_handler.handle_baseline_response(m);
+            LOG("limited transaction response");
         }
     }
 
@@ -106,7 +108,7 @@ class CapacitiveMessageHandler {
     }
 
     void visit(can::messages::BaselineSensorRequest &m) {
-        LOG("Received request to read from %d sensor", m.sensor);
+        LOG("Received request to baseline %d sensor", m.sensor);
         capacitance_handler.reset_limited();
         capacitance_handler.set_number_of_reads(m.sample_rate);
         std::array tags{utils::ResponseTag::IS_PART_OF_POLL,

--- a/include/sensors/simulation/fdc1004.hpp
+++ b/include/sensors/simulation/fdc1004.hpp
@@ -13,8 +13,8 @@ class FDC1004 : public I2CRegisterMap<uint8_t, uint16_t> {
         : I2CRegisterMap(fdc1004::ADDRESS,
                          {{fdc1004::CONFIGURATION_MEASUREMENT, 0},
                           {fdc1004::FDC_CONFIGURATION, 0},
-                          {fdc1004::MSB_MEASUREMENT_1, 2000},
-                          {fdc1004::LSB_MEASUREMENT_1, 200},
+                          {fdc1004::MSB_MEASUREMENT_1, 100},
+                          {fdc1004::LSB_MEASUREMENT_1, 0},
                           {fdc1004::DEVICE_ID_REGISTER, fdc1004::DEVICE_ID}}) {}
 };
 

--- a/pipettes/core/CMakeLists.txt
+++ b/pipettes/core/CMakeLists.txt
@@ -20,7 +20,6 @@ function(target_pipettes_core_single TARGET REVISION)
     target_pipettes_core_common(${TARGET} ${REVISION})
     target_compile_definitions(${TARGET} PUBLIC PIPETTE_TYPE_DEFINE=SINGLE_CHANNEL)
     target_sources(${TARGET} PUBLIC
-            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_single.cpp
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/can_task_low_throughput.cpp)
 endfunction()
 
@@ -28,7 +27,6 @@ function(target_pipettes_core_multi TARGET REVISION)
     target_pipettes_core_common(${TARGET} ${REVISION})
     target_compile_definitions(${TARGET} PUBLIC PIPETTE_TYPE_DEFINE=EIGHT_CHANNEL)
     target_sources(${TARGET} PUBLIC
-            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_multi.cpp
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/can_task_low_throughput.cpp)
 endfunction()
 
@@ -36,7 +34,6 @@ function(target_pipettes_core_96 TARGET REVISION)
     target_pipettes_core_common(${TARGET} ${REVISION})
     target_compile_definitions(${TARGET} PUBLIC PIPETTE_TYPE_DEFINE=NINETY_SIX_CHANNEL)
     target_sources(${TARGET} PUBLIC
-            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_96.cpp
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/can_task_high_throughput.cpp)
 endfunction()
 
@@ -44,6 +41,5 @@ function(target_pipettes_core_384 TARGET REVISION)
     target_pipettes_core_common(${TARGET} ${REVISION})
     target_compile_definitions(${TARGET} PUBLIC PIPETTE_TYPE_DEFINE=THREE_EIGHTY_FOUR_CHANNEL)
     target_sources(${TARGET} PUBLIC
-            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/pipette_type_384.cpp
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/can_task_high_throughput.cpp)
 endfunction()

--- a/pipettes/core/pipette_type_384.cpp
+++ b/pipettes/core/pipette_type_384.cpp
@@ -1,6 +1,0 @@
-#include "pipettes/core/pipette_info.hpp"
-
-namespace pipette_info {
-auto get_name() -> PipetteName { return PipetteName::P1000_384; }
-
-};  // namespace pipette_info

--- a/pipettes/core/pipette_type_96.cpp
+++ b/pipettes/core/pipette_type_96.cpp
@@ -1,6 +1,0 @@
-#include "pipettes/core/pipette_info.hpp"
-
-namespace pipette_info {
-auto get_name() -> PipetteName { return PipetteName::P1000_96; }
-
-};  // namespace pipette_info

--- a/pipettes/core/pipette_type_multi.cpp
+++ b/pipettes/core/pipette_type_multi.cpp
@@ -1,6 +1,0 @@
-#include "pipettes/core/pipette_info.hpp"
-
-namespace pipette_info {
-auto get_name() -> PipetteName { return PipetteName::P1000_MULTI; }
-
-};  // namespace pipette_info

--- a/pipettes/core/pipette_type_single.cpp
+++ b/pipettes/core/pipette_type_single.cpp
@@ -1,6 +1,0 @@
-#include "pipettes/core/pipette_info.hpp"
-
-namespace pipette_info {
-auto get_name() -> PipetteName { return PipetteName::P1000_SINGLE; }
-
-};  // namespace pipette_info

--- a/pipettes/simulator/CMakeLists.txt
+++ b/pipettes/simulator/CMakeLists.txt
@@ -61,7 +61,7 @@ function(add_simulator_executable TARGET)
         message(FATAL_ERROR "Invalid pipette target provided.")
     endif ()
 
-    target_link_libraries(${TARGET} PRIVATE can-core common-simulation freertos-pipettes pthread Boost::boost)
+    target_link_libraries(${TARGET} PRIVATE can-core common-simulation freertos-pipettes pthread Boost::boost Boost::program_options)
 
     # Set up the include directories
     target_include_directories(

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 #include "FreeRTOS.h"
 #include "boost/program_options.hpp"

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -2,8 +2,10 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 
 #include "FreeRTOS.h"
+#include "boost/program_options.hpp"
 #include "can/core/ids.hpp"
 #include "can/simlib/sim_canbus.hpp"
 #include "can/simlib/transport.hpp"
@@ -28,7 +30,7 @@
 
 constexpr auto PIPETTE_TYPE = get_pipette_type();
 
-static auto can_bus_1 = can::sim::bus::SimCANBus{can::sim::transport::create()};
+namespace po = boost::program_options;
 
 static spi::hardware::SimSpiDeviceBase spi_comms{};
 
@@ -55,35 +57,17 @@ static auto gear_interrupts =
 static auto gear_motion_control =
     interfaces::gear_motor::get_motion_control(gear_hardware, interrupt_queues);
 
-static auto hdcsensor = hdc3020_simulator::HDC3020{};
-static auto capsensor = fdc1004_simulator::FDC1004{};
-static auto sim_eeprom = eeprom::simulator::EEProm{};
-static test_mocks::MockSensorHardware fake_sensor_hw{};
-mmr920C04_simulator::MMR920C04 pressuresensor(fake_sensor_hw);
-i2c::hardware::SimI2C::DeviceMap sensor_map_i2c1 = {
-    {hdcsensor.get_address(), hdcsensor},
-    {capsensor.get_address(), capsensor},
-    {pressuresensor.get_address(), pressuresensor}};
-
-i2c::hardware::SimI2C::DeviceMap sensor_map_i2c3 = {
-    {sim_eeprom.get_address(), sim_eeprom}};
-static auto i2c3_comms = i2c::hardware::SimI2C{sensor_map_i2c3};
-
-static auto i2c1_comms = i2c::hardware::SimI2C{sensor_map_i2c1};
-
-static auto node_from_env(const char* env) -> can::ids::NodeId {
-    if (!env) {
-        LOG("On left mount by default");
+static auto node_from_options(const po::variables_map& options)
+    -> can::ids::NodeId {
+    auto side = options["mount"].as<std::string>();
+    if (side == "left") {
+        LOG("On left mount");
         return can::ids::NodeId::pipette_left;
-    }
-    if (strncmp(env, "left", strlen("left")) == 0) {
-        LOG("On left mount from env var");
-        return can::ids::NodeId::pipette_left;
-    } else if (strncmp(env, "right", strlen("right")) == 0) {
+    } else if (side == "right") {
         LOG("On right mount from env var");
         return can::ids::NodeId::pipette_right;
     } else {
-        LOG("On left mount from invalid env var");
+        LOG("On left mount from invalid option %s", side.c_str());
         return can::ids::NodeId::pipette_left;
     }
 }
@@ -100,7 +84,9 @@ static const char* PipetteTypeString[] = {
 auto initialize_motor_tasks(
     can::ids::NodeId id,
     motor_configs::HighThroughputPipetteDriverHardware& conf,
-    interfaces::gear_motor::GearMotionControl& gear_motion) {
+    interfaces::gear_motor::GearMotionControl& gear_motion,
+    test_mocks::MockSensorHardware& fake_sensor_hw,
+    eeprom::simulator::EEProm& sim_eeprom) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
                               peripheral_tasks::get_i2c1_client(),
@@ -120,7 +106,9 @@ auto initialize_motor_tasks(
 auto initialize_motor_tasks(
     can::ids::NodeId id,
     motor_configs::LowThroughputPipetteDriverHardware& conf,
-    interfaces::gear_motor::UnavailableGearMotionControl&) {
+    interfaces::gear_motor::UnavailableGearMotionControl&,
+    test_mocks::MockSensorHardware& fake_sensor_hw,
+    eeprom::simulator::EEProm& sim_eeprom) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
                               peripheral_tasks::get_i2c1_client(),
@@ -131,16 +119,74 @@ auto initialize_motor_tasks(
         peripheral_tasks::get_spi_client(), conf.linear_motor, id);
 }
 
-int main() {
+auto handle_options(int argc, char** argv) -> po::variables_map {
+    auto cmdlinedesc = po::options_description("simulator for OT-3 pipettes");
+    auto envdesc = po::options_description("");
+    cmdlinedesc.add_options()("help,h", "Show this help message.");
+    cmdlinedesc.add_options()(
+        "mount,m", po::value<std::string>()->default_value("left"),
+        "Which mount ('right' or 'left') to attach to. May be specified in an "
+        "environment variable called MOUNT.");
+    envdesc.add_options()("MOUNT",
+                          po::value<std::string>()->default_value("left"));
+    auto can_arg_xform = can::sim::transport::add_options(cmdlinedesc, envdesc);
+    auto eeprom_arg_xform =
+        eeprom::simulator::EEProm::add_options(cmdlinedesc, envdesc);
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, cmdlinedesc), vm);
+    if (vm.count("help")) {
+        std::cout << cmdlinedesc << std::endl;
+        std::exit(0);
+    }
+    po::store(po::parse_environment(
+                  envdesc,
+                  [can_arg_xform, eeprom_arg_xform](
+                      const std::string& input_val) -> std::string {
+                      if (input_val == "MOUNT") {
+                          return "mount";
+                      };
+                      auto can_xformed = can_arg_xform(input_val);
+                      if (can_xformed != "") {
+                          return can_xformed;
+                      }
+                      auto eeprom_xformed = eeprom_arg_xform(input_val);
+                      return eeprom_xformed;
+                  }),
+              vm);
+    po::notify(vm);
+    return vm;
+}
+
+int main(int argc, char** argv) {
     signal(SIGINT, signal_handler);
     LOG_INIT(PipetteTypeString[PIPETTE_TYPE], []() -> const char* {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
+    auto options = handle_options(argc, argv);
+    auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
+    auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();
+    auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(options);
+    auto fake_sensor_hw = std::make_shared<test_mocks::MockSensorHardware>();
+    auto pressuresensor =
+        std::make_shared<mmr920C04_simulator::MMR920C04>(*fake_sensor_hw);
+    i2c::hardware::SimI2C::DeviceMap sensor_map_i2c1 = {
+        {hdcsensor->get_address(), *hdcsensor},
+        {capsensor->get_address(), *capsensor},
+        {pressuresensor->get_address(), *pressuresensor}};
 
-    central_tasks::start_tasks(can_bus_1, node_from_env(std::getenv("MOUNT")));
-    peripheral_tasks::start_tasks(i2c3_comms, i2c1_comms, spi_comms);
-    initialize_motor_tasks(node_from_env(std::getenv("MOUNT")),
-                           motor_config.driver_configs, gear_motion_control);
+    i2c::hardware::SimI2C::DeviceMap sensor_map_i2c3 = {
+        {sim_eeprom->get_address(), *sim_eeprom}};
+    auto i2c3_comms = std::make_shared<i2c::hardware::SimI2C>(sensor_map_i2c3);
+
+    auto i2c1_comms = std::make_shared<i2c::hardware::SimI2C>(sensor_map_i2c1);
+    auto can_bus_1 = std::make_shared<can::sim::bus::SimCANBus>(
+        can::sim::transport::create(options));
+    auto node = node_from_options(options);
+    central_tasks::start_tasks(*can_bus_1, node);
+    peripheral_tasks::start_tasks(*i2c3_comms, *i2c1_comms, spi_comms);
+    initialize_motor_tasks(node, motor_config.driver_configs,
+                           gear_motion_control, *fake_sensor_hw, *sim_eeprom);
 
     vTaskStartScheduler();
 }

--- a/run_simulators.sh
+++ b/run_simulators.sh
@@ -4,7 +4,7 @@ trap "kill 0" EXIT
 ./build-host/head/simulator/head-simulator &
 ./build-host/gantry/simulator/gantry-x-simulator &
 ./build-host/gantry/simulator/gantry-y-simulator &
-./build-host/pipettes/simulator/pipettes-single-simulator &
+./build-host/pipettes/simulator/pipettes-single-simulator --eeprom-filename=left-single-eeprom.bin &
 ./build-host/gripper/simulator/gripper-simulator &
 ./build-host/bootloader/simulator/bootloader-simulator &
 


### PR DESCRIPTION
On the OT-2, we store the literal serial number of a pipette on its EEPROM. When we detect whether it's connected, we read that serial number and parse it out in python.

We could do that here, but we have access to a lot more smarts on the pipette now, so instead let's parse the serial at flash time and store a binary-packed value for the name and model. The datecode part is still stored literally. This is unfortunately right now all based on python-side changes in https://github.com/Opentrons/opentrons/pull/11349

When we're sending the data back, we can therefore pull two ints and a bunch of ascii out of the eeprom and send it on back to the host.

To make it a lot easier to make integration tests for this, we can use a file as the backup for the eeprom. We'll just write() and read() the exact same binary data we'd already send the eeprom. This ends up being a lot of code because, well, c++, but it's not that many actual operations.

When we're using a file backing store, we'd really like to be able to say where it is. That makes it a lot easier to use data from a previous operation, after all. We have this pattern of using environment variables for this, but that's annoying. Instead, let's use `boost::program_options` ([(not that) friendly intro](https://theboostcpplibraries.com/boost.program_options), [truly awful main docs](https://www.boost.org/doc/libs/1_71_0/doc/html/program_options.html)) which will let us parse the command line flags and environment variables in parallel, and add flags for the can and new eeprom stuff.

You can try this out! `run_simulators.sh` has been set up to provide a consistent filename for the backing store, so if you run the socket simulator, you can send a serial write; get the pipette info and see that it's good; stop the simulator and start it back up again, and get the same value. Pretty cool!

# TODO
- [x] tests for the gross filesystem stuff

Closes RET-1169

