### PR TITLE
refactor(pipettes): add delay on boot to detect the correct id

### DIFF
--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -169,7 +169,7 @@ auto main() -> int {
     adc_init();
     initialize_enc(PIPETTE_TYPE);
 
-    delay_start(400);
+    delay_start(500);
 
     auto id = pipette_mounts::detect_id();
 

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -35,7 +35,6 @@
 #pragma GCC diagnostic ignored "-Wvolatile"
 #include "motor_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
-#include "stm32g4xx_hal.h"
 #pragma GCC diagnostic pop
 
 constexpr auto PIPETTE_TYPE = get_pipette_type();

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -33,9 +33,8 @@
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
 #pragma GCC diagnostic ignored "-Wvolatile"
-//#include "motor_encoder_hardware.h"
+#include "stm32g4xx_hal.h"
 #include "motor_hardware.h"
-//#include "motor_timer_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
 #pragma GCC diagnostic pop
 
@@ -162,12 +161,18 @@ auto initialize_motor_tasks(
         peripheral_tasks::get_spi_client(), conf.linear_motor, id);
 }
 
+
 auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
     utility_gpio_init();
     adc_init();
     initialize_enc(PIPETTE_TYPE);
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_6, GPIO_PIN_SET);
+
+    delay_start(400);
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_6, GPIO_PIN_RESET);
+
     auto id = pipette_mounts::detect_id();
 
     i2c_setup(&i2chandler_struct);

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -33,9 +33,9 @@
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
 #pragma GCC diagnostic ignored "-Wvolatile"
-#include "stm32g4xx_hal.h"
 #include "motor_hardware.h"
 #include "pipettes/firmware/i2c_setup.h"
+#include "stm32g4xx_hal.h"
 #pragma GCC diagnostic pop
 
 constexpr auto PIPETTE_TYPE = get_pipette_type();
@@ -160,7 +160,6 @@ auto initialize_motor_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
         peripheral_tasks::get_spi_client(), conf.linear_motor, id);
 }
-
 
 auto main() -> int {
     HardwareInit();

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -168,10 +168,8 @@ auto main() -> int {
     utility_gpio_init();
     adc_init();
     initialize_enc(PIPETTE_TYPE);
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_6, GPIO_PIN_SET);
 
     delay_start(400);
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_6, GPIO_PIN_RESET);
 
     auto id = pipette_mounts::detect_id();
 

--- a/pipettes/firmware/system_stm32g4xx.c
+++ b/pipettes/firmware/system_stm32g4xx.c
@@ -321,6 +321,26 @@ void SystemCoreClockUpdate(void) {
     SystemCoreClock >>= tmp;
 }
 
+
+void __attribute__ ((noinline)) delay_start(int ms) {
+    SysTick->CTRL = 0;
+    SysTick->LOAD = 0;
+    SysTick->VAL = 0;
+    int cycles_per_mssec = SystemCoreClock / 1000;
+    const int total_instruction_cycles = 4;
+    int duration = cycles_per_mssec * ms;
+    int loops = duration / total_instruction_cycles;
+    asm ("movs r3, #0\n"
+         "loopstart:\n"
+         "adds r3, #1\n"
+         "cmp %[duration], r3\n"
+         "bne.n loopstart\n"
+    :
+    : [duration] "r" (loops)
+    : "r3", "cc", "memory");
+}
+
+
 void HardwareInit(void) {
     HAL_Init();
     SystemClock_Config();

--- a/pipettes/firmware/system_stm32g4xx.h
+++ b/pipettes/firmware/system_stm32g4xx.h
@@ -88,6 +88,7 @@ extern const uint8_t APBPrescTable[8];  /*!< APB prescalers table values */
 extern void SystemInit(void);
 extern void SystemCoreClockUpdate(void);
 void HardwareInit(void);
+void __attribute__ ((noinline)) delay_start(int ms);
 /**
  * @}
  */


### PR DESCRIPTION
## Overview

The right mount has a much higher goal tool id voltage than the left mount. When the pipette is hot-plugged into the robot, it takes close to 400ms for the tool id line to settle into the expected voltage.

To get around this, we should delay when we actually sample the tool id line on the pipette to determine what mount it's connected to.