### PR TITLE
refactor(head): change the instrument values reported by the ADC

### DIFF
--- a/common/core/tool_detection.cpp
+++ b/common/core/tool_detection.cpp
@@ -9,7 +9,7 @@ constexpr static auto pipette_chan_z_bounds =
     ToolCheckBounds{.upper = 580, .lower = 540};
 
 constexpr static auto pipette_chan_a_bounds =
-    ToolCheckBounds{.upper = 2950, .lower = 3050};
+    ToolCheckBounds{.upper = 3050, .lower = 2900};
 
 constexpr static auto nothing_connected_z_bounds =
     ToolCheckBounds{.upper = 5, .lower = 0};
@@ -37,9 +37,6 @@ static std::array tool_list(std::to_array<Tool>({
     Tool{.tool_type = can::ids::ToolType::nothing_attached,
          .tool_carrier = Z_CARRIER,
          .bounds = nothing_connected_z_bounds},
-    Tool{.tool_type = can::ids::ToolType::undefined_tool,
-         .tool_carrier = Z_CARRIER,
-         .bounds = undefined_bounds},
     Tool{.tool_type = can::ids::ToolType::tool_error,
          .tool_carrier = Z_CARRIER,
          .bounds = failure_bounds},
@@ -49,9 +46,6 @@ static std::array tool_list(std::to_array<Tool>({
     Tool{.tool_type = can::ids::ToolType::nothing_attached,
          .tool_carrier = A_CARRIER,
          .bounds = nothing_connected_a_bounds},
-    Tool{.tool_type = can::ids::ToolType::undefined_tool,
-         .tool_carrier = A_CARRIER,
-         .bounds = undefined_bounds},
     Tool{.tool_type = can::ids::ToolType::tool_error,
          .tool_carrier = A_CARRIER,
          .bounds = failure_bounds},
@@ -65,7 +59,7 @@ static std::array tool_list(std::to_array<Tool>({
          .tool_carrier = GRIPPER_CARRIER,
          .bounds = failure_bounds},
     Tool{.tool_type = can::ids::ToolType::undefined_tool,
-         .tool_carrier = GRIPPER_CARRIER,
+         .tool_carrier = UNKNOWN,
          .bounds = undefined_bounds},
 }));
 

--- a/common/core/tool_detection.cpp
+++ b/common/core/tool_detection.cpp
@@ -5,17 +5,17 @@
 
 using namespace tool_detection;
 
-constexpr static auto pipette_chan_z_bounds =
-    ToolCheckBounds{.upper = 580, .lower = 540};
+constexpr static auto pipette_z_bounds =
+    ToolCheckBounds{.upper = 1500, .lower = 201};
 
-constexpr static auto pipette_chan_a_bounds =
-    ToolCheckBounds{.upper = 3050, .lower = 2900};
+constexpr static auto pipette_a_bounds =
+    ToolCheckBounds{.upper = 3000, .lower = 1500};
 
 constexpr static auto nothing_connected_z_bounds =
-    ToolCheckBounds{.upper = 5, .lower = 0};
+    ToolCheckBounds{.upper = 200, .lower = 0};
 
 constexpr static auto nothing_connected_a_bounds =
-    ToolCheckBounds{.upper = 50, .lower = 5};
+    ToolCheckBounds{.upper = 200, .lower = 5};
 
 // revisit these, not sure if EE has a calculation for gripper carrier bounds
 constexpr static auto nothing_connected_gripper_bounds =
@@ -24,31 +24,22 @@ constexpr static auto nothing_connected_gripper_bounds =
 constexpr static auto gripper_bounds =
     ToolCheckBounds{.upper = 3000, .lower = 55};
 
-constexpr static auto undefined_bounds =
-    ToolCheckBounds{.upper = 4000, .lower = 3100};
-
 constexpr static auto failure_bounds =
-    ToolCheckBounds{.upper = 4095, .lower = 4000};
+    ToolCheckBounds{.upper = 4095, .lower = 3001};
 
 static std::array tool_list(std::to_array<Tool>({
     Tool{.tool_type = can::ids::ToolType::pipette,
          .tool_carrier = Z_CARRIER,
-         .bounds = pipette_chan_z_bounds},
+         .bounds = pipette_z_bounds},
     Tool{.tool_type = can::ids::ToolType::nothing_attached,
          .tool_carrier = Z_CARRIER,
          .bounds = nothing_connected_z_bounds},
-    Tool{.tool_type = can::ids::ToolType::tool_error,
-         .tool_carrier = Z_CARRIER,
-         .bounds = failure_bounds},
     Tool{.tool_type = can::ids::ToolType::pipette,
          .tool_carrier = A_CARRIER,
-         .bounds = pipette_chan_a_bounds},
+         .bounds = pipette_a_bounds},
     Tool{.tool_type = can::ids::ToolType::nothing_attached,
          .tool_carrier = A_CARRIER,
          .bounds = nothing_connected_a_bounds},
-    Tool{.tool_type = can::ids::ToolType::tool_error,
-         .tool_carrier = A_CARRIER,
-         .bounds = failure_bounds},
     Tool{.tool_type = can::ids::ToolType::gripper,
          .tool_carrier = GRIPPER_CARRIER,
          .bounds = gripper_bounds},
@@ -56,11 +47,8 @@ static std::array tool_list(std::to_array<Tool>({
          .tool_carrier = GRIPPER_CARRIER,
          .bounds = nothing_connected_gripper_bounds},
     Tool{.tool_type = can::ids::ToolType::tool_error,
-         .tool_carrier = GRIPPER_CARRIER,
-         .bounds = failure_bounds},
-    Tool{.tool_type = can::ids::ToolType::undefined_tool,
          .tool_carrier = UNKNOWN,
-         .bounds = undefined_bounds},
+         .bounds = failure_bounds},
 }));
 
 std::span<Tool> tool_detection::lookup_table() { return std::span(tool_list); }

--- a/common/core/tool_detection.cpp
+++ b/common/core/tool_detection.cpp
@@ -5,70 +5,68 @@
 
 using namespace tool_detection;
 
-constexpr static auto pipette_384_chan_z_bounds =
-    ToolCheckBounds{.upper = 1883, .lower = 1850};
+constexpr static auto pipette_chan_z_bounds =
+    ToolCheckBounds{.upper = 580, .lower = 540};
 
-constexpr static auto pipette_96_chan_z_bounds =
-    ToolCheckBounds{.upper = 1417, .lower = 1400};
-
-constexpr static auto pipette_single_chan_z_bounds =
-    ToolCheckBounds{.upper = 460, .lower = 444};
-
-constexpr static auto pipette_multiple_chan_z_bounds =
-    ToolCheckBounds{.upper = 945, .lower = 918};
-
-constexpr static auto pipette_single_chan_a_bounds =
-    ToolCheckBounds{.upper = 2389, .lower = 2362};
-
-constexpr static auto pipette_multiple_chan_a_bounds =
-    ToolCheckBounds{.upper = 2859, .lower = 2844};
+constexpr static auto pipette_chan_a_bounds =
+    ToolCheckBounds{.upper = 2950, .lower = 3050};
 
 constexpr static auto nothing_connected_z_bounds =
-    ToolCheckBounds{.upper = 3, .lower = 1};
+    ToolCheckBounds{.upper = 5, .lower = 0};
 
 constexpr static auto nothing_connected_a_bounds =
-    ToolCheckBounds{.upper = 52, .lower = 15};
+    ToolCheckBounds{.upper = 50, .lower = 5};
 
 // revisit these, not sure if EE has a calculation for gripper carrier bounds
 constexpr static auto nothing_connected_gripper_bounds =
-    ToolCheckBounds{.upper = 54, .lower = 16};
+    ToolCheckBounds{.upper = 54, .lower = 0};
 
 constexpr static auto gripper_bounds =
     ToolCheckBounds{.upper = 3000, .lower = 55};
 
 constexpr static auto undefined_bounds =
-    ToolCheckBounds{.upper = 0, .lower = 0};
+    ToolCheckBounds{.upper = 4000, .lower = 3100};
 
-static std::array tool_list(std::to_array<Tool>(
-    {Tool{.tool_type = can::ids::ToolType::pipette_384_chan,
-          .tool_carrier = Z_CARRIER,
-          .bounds = pipette_384_chan_z_bounds},
-     Tool{.tool_type = can::ids::ToolType::pipette_96_chan,
-          .tool_carrier = Z_CARRIER,
-          .bounds = pipette_96_chan_z_bounds},
-     Tool{.tool_type = can::ids::ToolType::pipette_single_chan,
-          .tool_carrier = Z_CARRIER,
-          .bounds = pipette_single_chan_z_bounds},
-     Tool{.tool_type = can::ids::ToolType::pipette_multi_chan,
-          .tool_carrier = Z_CARRIER,
-          .bounds = pipette_multiple_chan_z_bounds},
-     Tool{.tool_type = can::ids::ToolType::nothing_attached,
-          .tool_carrier = Z_CARRIER,
-          .bounds = nothing_connected_z_bounds},
-     Tool{.tool_type = can::ids::ToolType::pipette_single_chan,
-          .tool_carrier = A_CARRIER,
-          .bounds = pipette_single_chan_a_bounds},
-     Tool{.tool_type = can::ids::ToolType::pipette_multi_chan,
-          .tool_carrier = A_CARRIER,
-          .bounds = pipette_multiple_chan_a_bounds},
-     Tool{.tool_type = can::ids::ToolType::nothing_attached,
-          .tool_carrier = A_CARRIER,
-          .bounds = nothing_connected_a_bounds},
-     Tool{.tool_type = can::ids::ToolType::gripper,
-          .tool_carrier = GRIPPER_CARRIER,
-          .bounds = gripper_bounds},
-     Tool{.tool_type = can::ids::ToolType::nothing_attached,
-          .tool_carrier = GRIPPER_CARRIER,
-          .bounds = nothing_connected_gripper_bounds}}));
+constexpr static auto failure_bounds =
+    ToolCheckBounds{.upper = 4095, .lower = 4000};
+
+static std::array tool_list(std::to_array<Tool>({
+    Tool{.tool_type = can::ids::ToolType::pipette,
+         .tool_carrier = Z_CARRIER,
+         .bounds = pipette_chan_z_bounds},
+    Tool{.tool_type = can::ids::ToolType::nothing_attached,
+         .tool_carrier = Z_CARRIER,
+         .bounds = nothing_connected_z_bounds},
+    Tool{.tool_type = can::ids::ToolType::undefined_tool,
+         .tool_carrier = Z_CARRIER,
+         .bounds = undefined_bounds},
+    Tool{.tool_type = can::ids::ToolType::tool_error,
+         .tool_carrier = Z_CARRIER,
+         .bounds = failure_bounds},
+    Tool{.tool_type = can::ids::ToolType::pipette,
+         .tool_carrier = A_CARRIER,
+         .bounds = pipette_chan_a_bounds},
+    Tool{.tool_type = can::ids::ToolType::nothing_attached,
+         .tool_carrier = A_CARRIER,
+         .bounds = nothing_connected_a_bounds},
+    Tool{.tool_type = can::ids::ToolType::undefined_tool,
+         .tool_carrier = A_CARRIER,
+         .bounds = undefined_bounds},
+    Tool{.tool_type = can::ids::ToolType::tool_error,
+         .tool_carrier = A_CARRIER,
+         .bounds = failure_bounds},
+    Tool{.tool_type = can::ids::ToolType::gripper,
+         .tool_carrier = GRIPPER_CARRIER,
+         .bounds = gripper_bounds},
+    Tool{.tool_type = can::ids::ToolType::nothing_attached,
+         .tool_carrier = GRIPPER_CARRIER,
+         .bounds = nothing_connected_gripper_bounds},
+    Tool{.tool_type = can::ids::ToolType::tool_error,
+         .tool_carrier = GRIPPER_CARRIER,
+         .bounds = failure_bounds},
+    Tool{.tool_type = can::ids::ToolType::undefined_tool,
+         .tool_carrier = GRIPPER_CARRIER,
+         .bounds = undefined_bounds},
+}));
 
 std::span<Tool> tool_detection::lookup_table() { return std::span(tool_list); }

--- a/common/tests/test_tool_detection.cpp
+++ b/common/tests/test_tool_detection.cpp
@@ -12,7 +12,6 @@ TEMPLATE_TEST_CASE_SIG("tool list by Tool Type type", "",
                        ((can::ids::ToolType TT), TT),
                        (can::ids::ToolType::pipette),
                        (can::ids::ToolType::tool_error),
-                       (can::ids::ToolType::undefined_tool),
                        (can::ids::ToolType::gripper),
                        (can::ids::ToolType::nothing_attached)) {
     SECTION("lookup table filtering") {
@@ -52,54 +51,11 @@ SCENARIO("ot3 tools list for tool detection") {
         }
         WHEN("you pass in an out-of-bounds read") {
             uint16_t reading = 3200;
-            THEN("the tool and carrier are undefined") {
+            THEN("the tool and carrier are errored and unknown") {
                 REQUIRE(tool_detection::tooltype_from_reading(reading) ==
-                        can::ids::ToolType::undefined_tool);
-                REQUIRE(tool_detection::carrier_from_reading(reading) ==
-                        tool_detection::Carrier::UNKNOWN);
-            }
-        }
-        WHEN("checking holes in the bounds set for tool mounts") {
-            auto which_tool = GENERATE(tool_detection::Carrier::A_CARRIER,
-                                       tool_detection::Carrier::Z_CARRIER);
-            // can't modify the lookup table, gotta copy
-            auto filtered = tool_detection::lookup_table_filtered(which_tool);
-            auto copied = std::vector(filtered.begin(), filtered.end());
-            std::sort(copied.begin(), copied.end(),
-                      [](const tool_detection::Tool& a,
-                         const tool_detection::Tool& b) {
-                          return a.bounds.upper < b.bounds.upper;
-                      });
-            auto trailer =
-                std::ranges::subrange(copied.begin(), --copied.end());
-            auto leader = std::ranges::subrange(++copied.begin(), copied.end());
-            for (auto trailer_it = trailer.begin(), leader_it = leader.begin();
-                 trailer_it != trailer.end() && leader_it != leader.end();
-                 trailer_it++, leader_it++) {
-                INFO("Checking tool detection for carrier "
-                     << static_cast<uint32_t>(which_tool) << ", tool type "
-                     << static_cast<uint32_t>(trailer_it->tool_type) << " ("
-                     << trailer_it->bounds.lower << "->"
-                     << trailer_it->bounds.upper << "mV) -> "
-                     << static_cast<uint32_t>(leader_it->tool_type) << " ("
-                     << leader_it->bounds.lower << "->"
-                     << leader_it->bounds.upper << "mV)");
-                // Just above the upper range of the first
-                REQUIRE(tool_detection::tooltype_from_reading(
-                            trailer_it->bounds.upper, filtered) ==
-                        can::ids::ToolType::undefined_tool);
-                // Just below the lower range of the second
-                REQUIRE(tool_detection::tooltype_from_reading(
-                            leader_it->bounds.lower - 1, filtered) ==
-                        can::ids::ToolType::undefined_tool);
-                // Dead-on in the middle
-                auto mid_value =
-                    (trailer_it->bounds.upper + leader_it->bounds.lower) / 2;
-                INFO("Bounds gap mid value " << mid_value
-                                             << " matched to a tool");
-                REQUIRE(tool_detection::tooltype_from_reading(mid_value,
-                                                              filtered) ==
-                        can::ids::ToolType::undefined_tool);
+                        can::ids::ToolType::tool_error);
+                auto value = tool_detection::carrier_from_reading(reading);
+                REQUIRE(value == tool_detection::Carrier::UNKNOWN);
             }
         }
     }

--- a/common/tests/test_tool_detection.cpp
+++ b/common/tests/test_tool_detection.cpp
@@ -8,12 +8,11 @@
 
 // Filter tests - no BDD here because these macros don't have
 // BDD equivalents
-TEMPLATE_TEST_CASE_SIG("tool list by pipette type", "",
+TEMPLATE_TEST_CASE_SIG("tool list by Tool Type type", "",
                        ((can::ids::ToolType TT), TT),
-                       (can::ids::ToolType::pipette_96_chan),
-                       (can::ids::ToolType::pipette_384_chan),
-                       (can::ids::ToolType::pipette_single_chan),
-                       (can::ids::ToolType::pipette_multi_chan),
+                       (can::ids::ToolType::pipette),
+                       (can::ids::ToolType::tool_error),
+                       (can::ids::ToolType::undefined_tool),
                        (can::ids::ToolType::gripper),
                        (can::ids::ToolType::nothing_attached)) {
     SECTION("lookup table filtering") {
@@ -52,7 +51,7 @@ SCENARIO("ot3 tools list for tool detection") {
             }
         }
         WHEN("you pass in an out-of-bounds read") {
-            uint16_t reading = 0;
+            uint16_t reading = 3200;
             THEN("the tool and carrier are undefined") {
                 REQUIRE(tool_detection::tooltype_from_reading(reading) ==
                         can::ids::ToolType::undefined_tool);

--- a/head/tests/test_presence_sensing_driver.cpp
+++ b/head/tests/test_presence_sensing_driver.cpp
@@ -29,34 +29,37 @@ SCENARIO("get_tool called on presence sensing driver") {
                 AND_WHEN("Tools switch to invalid voltages") {
                     adc_comms.get_z_channel().mock_set_reading_by_voltage(3300);
                     std::tie(updated, tools) = ps.update_tools();
-                    THEN("The invalid reading is ignored") {
-                        REQUIRE(!updated);
-                        REQUIRE(tools.z_motor == can::ids::ToolType::pipette);
+                    THEN("An error is reported") {
+                        REQUIRE(updated);
+                        REQUIRE(tools.z_motor ==
+                                can::ids::ToolType::tool_error);
                     }
                 }
             }
         }
         WHEN("get_tool func is called and raw ADC readings are out of bounds") {
-            auto adc_comms = adc::MockADC(5000, 4000, 3400);
+            auto adc_comms = adc::MockADC(100, 40, 10);
             auto ps = presence_sensing_driver::PresenceSensingDriver(adc_comms);
             attached_tools::AttachedTools tools;
             bool updated;
             std::tie(updated, tools) = ps.update_tools();
             THEN("Tools remain invalid mapped to voltage reading") {
                 REQUIRE(!updated);
-                REQUIRE(tools.gripper == can::ids::ToolType::undefined_tool);
-                REQUIRE(tools.a_motor == can::ids::ToolType::undefined_tool);
-                REQUIRE(tools.z_motor == can::ids::ToolType::undefined_tool);
+                REQUIRE(tools.gripper == can::ids::ToolType::nothing_attached);
+                REQUIRE(tools.a_motor == can::ids::ToolType::nothing_attached);
+                REQUIRE(tools.z_motor == can::ids::ToolType::nothing_attached);
                 AND_WHEN("tools switch to valid voltages") {
-                    adc_comms.get_a_channel().mock_set_reading_by_voltage(2950);
+                    adc_comms.get_a_channel().mock_set_reading(2950);
+                    INFO("Value from voltage "
+                         << static_cast<int>(adc_comms.get_a_channel()._value));
                     std::tie(updated, tools) = ps.update_tools();
                     THEN("the valid tool is read out") {
                         REQUIRE(updated);
                         REQUIRE(tools.a_motor == can::ids::ToolType::pipette);
                         REQUIRE(tools.z_motor ==
-                                can::ids::ToolType::undefined_tool);
+                                can::ids::ToolType::nothing_attached);
                         REQUIRE(tools.gripper ==
-                                can::ids::ToolType::undefined_tool);
+                                can::ids::ToolType::nothing_attached);
                     }
                 }
             }
@@ -70,8 +73,8 @@ SCENARIO("get_tool called on presence sensing driver") {
             bool updated;
             std::tie(updated, tools) = ps.update_tools();
 
-            THEN("Tools mapped to voltage reading") {
-                REQUIRE(updated);
+            THEN("Tools stay in nothing attached state") {
+                REQUIRE(!updated);
                 REQUIRE(tools.gripper == can::ids::ToolType::nothing_attached);
                 REQUIRE(tools.a_motor == can::ids::ToolType::nothing_attached);
                 REQUIRE(tools.z_motor == can::ids::ToolType::nothing_attached);

--- a/head/tests/test_presence_sensing_driver.cpp
+++ b/head/tests/test_presence_sensing_driver.cpp
@@ -10,17 +10,13 @@ SCENARIO("get_tool called on presence sensing driver") {
         "PresenceSensingDriver instance with valid and invalid ADC readings") {
         /*
         Within bounds valid raw ADC readings
-        2335 - PIPETTE_384_CHAN_Z_CARRIER_DETECTION_UPPER_BOUND
-        3548 - PIPETTE_MULTI_A_CARRIER_DETECTION_UPPER_BOUND
-        1778 - PIPETTE_96_CHAN_Z_CARRIER_DETECTION_UPPER_BOUND
-        569 - PIPETTE_SINGLE_Z_CARRIER_DETECTION_UPPER_BOUND
-        1171 - PIPETTE_MULTI_Z_CARRIER_DETECTION_UPPER_BOUND
-        2 - NOTHING_CONNECTED_Z_CARRIER_UPPER_BOUND
-        20 - NOTHING_CONNECTED_A_CARRIER
+        580 - PIPETTE_Z_CARRIER_DETECTION_UPPER_BOUND
+        5 - NOTHING_CONNECTED_Z_CARRIER_UPPER_BOUND
+        50 - NOTHING_CONNECTED_A_CARRIER_UPPER_BOUND
         */
 
         WHEN("get_tool func is called and raw ADC readings are within bounds") {
-            auto adc_comms = adc::MockADC(1855, 2850, 666);
+            auto adc_comms = adc::MockADC(570, 2950, 666);
             auto ps = presence_sensing_driver::PresenceSensingDriver(adc_comms);
             attached_tools::AttachedTools tools;
             bool updated;
@@ -28,16 +24,14 @@ SCENARIO("get_tool called on presence sensing driver") {
             THEN("Tools mapped to voltage reading") {
                 REQUIRE(updated);
                 REQUIRE(tools.gripper == can::ids::ToolType::gripper);
-                REQUIRE(tools.a_motor ==
-                        can::ids::ToolType::pipette_multi_chan);
-                REQUIRE(tools.z_motor == can::ids::ToolType::pipette_384_chan);
+                REQUIRE(tools.a_motor == can::ids::ToolType::pipette);
+                REQUIRE(tools.z_motor == can::ids::ToolType::pipette);
                 AND_WHEN("Tools switch to invalid voltages") {
                     adc_comms.get_z_channel().mock_set_reading_by_voltage(3300);
                     std::tie(updated, tools) = ps.update_tools();
                     THEN("The invalid reading is ignored") {
                         REQUIRE(!updated);
-                        REQUIRE(tools.z_motor ==
-                                can::ids::ToolType::pipette_384_chan);
+                        REQUIRE(tools.z_motor == can::ids::ToolType::pipette);
                     }
                 }
             }
@@ -54,12 +48,11 @@ SCENARIO("get_tool called on presence sensing driver") {
                 REQUIRE(tools.a_motor == can::ids::ToolType::undefined_tool);
                 REQUIRE(tools.z_motor == can::ids::ToolType::undefined_tool);
                 AND_WHEN("tools switch to valid voltages") {
-                    adc_comms.get_a_channel().mock_set_reading_by_voltage(2850);
+                    adc_comms.get_a_channel().mock_set_reading_by_voltage(2950);
                     std::tie(updated, tools) = ps.update_tools();
                     THEN("the valid tool is read out") {
                         REQUIRE(updated);
-                        REQUIRE(tools.a_motor ==
-                                can::ids::ToolType::pipette_multi_chan);
+                        REQUIRE(tools.a_motor == can::ids::ToolType::pipette);
                         REQUIRE(tools.z_motor ==
                                 can::ids::ToolType::undefined_tool);
                         REQUIRE(tools.gripper ==

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -125,12 +125,10 @@ typedef enum {
 /** Tool types detected on Head. */
 typedef enum {
     can_tooltype_undefined_tool = 0x0,
-    can_tooltype_pipette_96_chan = 0x1,
-    can_tooltype_pipette_384_chan = 0x2,
-    can_tooltype_pipette_single_chan = 0x3,
-    can_tooltype_pipette_multi_chan = 0x4,
-    can_tooltype_gripper = 0x5,
-    can_tooltype_nothing_attached = 0x6,
+    can_tooltype_pipette = 0x1,
+    can_tooltype_gripper = 0x2,
+    can_tooltype_nothing_attached = 0x3,
+    can_tooltype_tool_error = 0x4,
 } CANToolType;
 
 /** Sensor types available. */

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -124,11 +124,10 @@ typedef enum {
 
 /** Tool types detected on Head. */
 typedef enum {
-    can_tooltype_undefined_tool = 0x0,
-    can_tooltype_pipette = 0x1,
-    can_tooltype_gripper = 0x2,
-    can_tooltype_nothing_attached = 0x3,
-    can_tooltype_tool_error = 0x4,
+    can_tooltype_pipette = 0x0,
+    can_tooltype_gripper = 0x1,
+    can_tooltype_nothing_attached = 0x2,
+    can_tooltype_tool_error = 0x3,
 } CANToolType;
 
 /** Sensor types available. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -126,11 +126,10 @@ enum class ErrorCode {
 
 /** Tool types detected on Head. */
 enum class ToolType {
-    undefined_tool = 0x0,
-    pipette = 0x1,
-    gripper = 0x2,
-    nothing_attached = 0x3,
-    tool_error = 0x4,
+    pipette = 0x0,
+    gripper = 0x1,
+    nothing_attached = 0x2,
+    tool_error = 0x3,
 };
 
 /** Sensor types available. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -127,12 +127,10 @@ enum class ErrorCode {
 /** Tool types detected on Head. */
 enum class ToolType {
     undefined_tool = 0x0,
-    pipette_96_chan = 0x1,
-    pipette_384_chan = 0x2,
-    pipette_single_chan = 0x3,
-    pipette_multi_chan = 0x4,
-    gripper = 0x5,
-    nothing_attached = 0x6,
+    pipette = 0x1,
+    gripper = 0x2,
+    nothing_attached = 0x3,
+    tool_error = 0x4,
 };
 
 /** Sensor types available. */

--- a/include/common/core/tool_detection.hpp
+++ b/include/common/core/tool_detection.hpp
@@ -104,9 +104,9 @@ auto tool_from_reading(millivolts_t reading, Lookup with_lookup) -> Tool {
             return element;
         }
     }
-    return Tool{.tool_type = can::ids::ToolType::undefined_tool,
+    return Tool{.tool_type = can::ids::ToolType::tool_error,
                 .tool_carrier = Carrier::UNKNOWN,
-                .bounds = {0, 0}};
+                .bounds = {4094, 3001}};
 }
 
 inline auto tool_from_reading(millivolts_t reading) -> Tool {
@@ -148,18 +148,6 @@ auto filter_lookup_table(can::ids::ToolType filter_by, Lookup from_table) {
 template <typename Lookup>
 auto filter_lookup_table(Carrier filter_by, Lookup from_table) {
     return from_table;
-}
-
-template <typename Lookup>
-auto tool_from_reading(millivolts_t reading, Lookup with_lookup) -> Tool {
-    for (const auto& element : with_lookup) {
-        if (element.within_bounds(reading)) {
-            return element;
-        }
-    }
-    return Tool{.tool_type = can::ids::ToolType::undefined_tool,
-                .tool_carrier = Carrier::UNKNOWN,
-                .bounds = {0, 0}};
 }
 
 inline auto tool_from_reading(millivolts_t reading) -> Tool {

--- a/include/common/core/tool_detection.hpp
+++ b/include/common/core/tool_detection.hpp
@@ -150,6 +150,18 @@ auto filter_lookup_table(Carrier filter_by, Lookup from_table) {
     return from_table;
 }
 
+template <typename Lookup>
+auto tool_from_reading(millivolts_t reading, Lookup with_lookup) -> Tool {
+    for (const auto& element : with_lookup) {
+        if (element.within_bounds(reading)) {
+            return element;
+        }
+    }
+    return Tool{.tool_type = can::ids::ToolType::tool_error,
+                .tool_carrier = Carrier::UNKNOWN,
+                .bounds = {4094, 3001}};
+}
+
 inline auto tool_from_reading(millivolts_t reading) -> Tool {
     return tool_from_reading(reading, lookup_table());
 }

--- a/include/head/core/attached_tools.hpp
+++ b/include/head/core/attached_tools.hpp
@@ -11,9 +11,9 @@ namespace attached_tools {
 using namespace tool_detection;
 
 struct AttachedTools {
-    can::ids::ToolType z_motor = can::ids::ToolType::undefined_tool;
-    can::ids::ToolType a_motor = can::ids::ToolType::undefined_tool;
-    can::ids::ToolType gripper = can::ids::ToolType::undefined_tool;
+    can::ids::ToolType z_motor = can::ids::ToolType::nothing_attached;
+    can::ids::ToolType a_motor = can::ids::ToolType::nothing_attached;
+    can::ids::ToolType gripper = can::ids::ToolType::nothing_attached;
     AttachedTools() = default;
     AttachedTools(adc::MillivoltsReadings reading)
         : z_motor(tooltype_from_reading(

--- a/include/head/core/presence_sensing_driver.hpp
+++ b/include/head/core/presence_sensing_driver.hpp
@@ -64,7 +64,7 @@ class PresenceSensingDriver {
     [[nodiscard]] constexpr static auto should_use_new_value(
         can::ids::ToolType old_tool, can::ids::ToolType new_tool) -> bool {
         return (old_tool != new_tool) &&
-               (new_tool != can::ids::ToolType::undefined_tool);
+               (new_tool != can::ids::ToolType::nothing_attached);
     }
 
     [[nodiscard]] constexpr static auto should_update(
@@ -77,8 +77,8 @@ class PresenceSensingDriver {
     [[nodiscard]] constexpr static auto update_tool(can::ids::ToolType old_tool,
                                                     can::ids::ToolType new_tool)
         -> can::ids::ToolType {
-        return (new_tool == can::ids::ToolType::undefined_tool) ? old_tool
-                                                                : new_tool;
+        return (new_tool == can::ids::ToolType::nothing_attached) ? old_tool
+                                                                  : new_tool;
     }
     [[nodiscard]] constexpr static auto update_tools(
         const attached_tools::AttachedTools& old_tools,

--- a/pipettes/tests/test_mount_detection.cpp
+++ b/pipettes/tests/test_mount_detection.cpp
@@ -6,7 +6,7 @@ SCENARIO("Initial mount detection") {
     GIVEN("A mount detector") {
         WHEN("Checking left-side voltages") {
             // Use a list of voltages that are rough midpoints of Z mount bounds
-            auto voltage = GENERATE(1860, 1430, 450, 920);
+            auto voltage = GENERATE(1490, 1430, 450, 920);
             THEN("the mount should always be left") {
                 INFO("Checking voltage " << voltage);
                 REQUIRE(pipette_mounts::decide_id(voltage) ==
@@ -23,7 +23,7 @@ SCENARIO("Initial mount detection") {
             }
         }
         WHEN("Checking out of bounds voltages") {
-            auto voltage = GENERATE(3200, 0);
+            auto voltage = GENERATE(3001, 4095);
             THEN("the mount should always be left") {
                 INFO("Checking voltage " << voltage);
                 REQUIRE(pipette_mounts::decide_id(voltage) ==


### PR DESCRIPTION
## Overview
Awhile ago, we no longer wanted to try and determine the instrument type based on the ADC because it
was too variable. Now, we are cutting down what values are valid and also changing the ranges
provided in [this confluence doc](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/940834928/OT-3+Tool+ID+Implementation).