### PR TITLE
fix(pipettes): rev1: bring up M24128 eeprom

### DIFF
--- a/i2c/firmware/i2c.c
+++ b/i2c/firmware/i2c.c
@@ -1,4 +1,5 @@
 #include "platform_specific_hal_conf.h"
+#include "platform_specific_hal.h"
 #include "i2c/firmware/i2c.h"
 
 
@@ -7,14 +8,40 @@
  */
 bool hal_i2c_master_transmit(HAL_I2C_HANDLE handle, uint16_t DevAddress, uint8_t *data, uint16_t size, uint32_t timeout)
 {
-    return HAL_I2C_Master_Transmit(handle,
-                            DevAddress, data, size, timeout) == HAL_OK;
+    I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)handle;
+    uint32_t tickstart = HAL_GetTick();
+    HAL_StatusTypeDef tx_result = HAL_OK;
+    do {
+        tx_result = HAL_I2C_Master_Transmit(i2c_handle,
+                            DevAddress, data, size, timeout);
+        if (__HAL_I2C_GET_FLAG(i2c_handle, I2C_FLAG_AF)) {
+            __HAL_I2C_CLEAR_FLAG(i2c_handle, I2C_FLAG_AF);
+            tx_result = HAL_BUSY;
+        }
+        if (tx_result == HAL_OK) {
+            break;
+        }
+    } while ((HAL_GetTick() - tickstart) < timeout);
+    return tx_result == HAL_OK;
 }
 
 /**
  * Wrapper around HAL_I2C_Master_Receive
  */
 bool hal_i2c_master_receive(HAL_I2C_HANDLE handle, uint16_t DevAddress, uint8_t *data, uint16_t size, uint32_t timeout){
-    return HAL_I2C_Master_Receive(handle, DevAddress, data, size,
-                                  timeout) == HAL_OK;
+    I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)handle;
+    uint32_t tickstart = HAL_GetTick();
+    HAL_StatusTypeDef rx_result = HAL_OK;
+    do {
+        rx_result = HAL_I2C_Master_Receive(i2c_handle, DevAddress, data, size,
+                                           timeout);
+        if (__HAL_I2C_GET_FLAG(i2c_handle, I2C_FLAG_AF)){
+            __HAL_I2C_CLEAR_FLAG(i2c_handle, I2C_FLAG_AF);
+            rx_result = HAL_BUSY;
+        }
+        if (rx_result == HAL_OK) {
+            break;
+        }
+    } while ((HAL_GetTick() - tickstart) < timeout);
+    return rx_result == HAL_OK;
 }

--- a/include/i2c/core/messages.hpp
+++ b/include/i2c/core/messages.hpp
@@ -9,7 +9,7 @@ namespace i2c {
 namespace messages {
 
 using std::size_t;
-static constexpr std::size_t MAX_BUFFER_SIZE = 9;
+static constexpr std::size_t MAX_BUFFER_SIZE = 10;
 using MaxMessageBuffer = std::array<uint8_t, MAX_BUFFER_SIZE>;
 
 /*

--- a/include/i2c/core/tasks/i2c_task.hpp
+++ b/include/i2c/core/tasks/i2c_task.hpp
@@ -50,9 +50,9 @@ class I2CMessageHandler {
 
     i2c::hardware::I2CBase &i2c_interface;
 
-    // Default timeout should be 60 seconds
+    // Default timeout should be 1 second
     // freertos expects this time to be in milliseconds
-    static constexpr auto TIMEOUT = 60000;
+    static constexpr auto TIMEOUT = 1000;
 };
 
 /**

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -58,8 +58,12 @@ static auto i2c_comms3 = i2c::hardware::I2C();
 static auto i2c_comms2 = i2c::hardware::I2C();
 static I2CHandlerStruct i2chandler_struct{};
 
-class EEPromHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
+class PipetteEEPromHardwareIface
+    : public eeprom::hardware_iface::EEPromHardwareIface {
   public:
+    PipetteEEPromHardwareIface()
+        : eeprom::hardware_iface::EEPromHardwareIface(
+              eeprom::hardware_iface::EEPromChipType::ST_M24128) {}
     void set_write_protect(bool enable) final {
         if (enable) {
             disable_eeprom_write();
@@ -68,7 +72,7 @@ class EEPromHardwareIface : public eeprom::hardware_iface::EEPromHardwareIface {
         }
     }
 };
-static auto eeprom_hardware_iface = EEPromHardwareIface();
+static auto eeprom_hardware_iface = PipetteEEPromHardwareIface{};
 
 static auto motor_config = motor_configs::motor_configurations<PIPETTE_TYPE>();
 


### PR DESCRIPTION
The rev1 pipettes use an M24128 eeprom. We added code to handle this ahead of time, but it had a few issues that this PR fixes.
- rev1 pipettes use M24128 eeprom, not the older kind. Explicitly set them to do so.
- M24128 eeproms have a time period after they start a write during which they won't respond on I2C. We can fix this by retrying I2C messages when we get NAKs
   - An I2C NAK indicates that a device won't respond to a message. This can
     be for basically any reason, including that it doesn't recognize it, but
     one reason is that the device isn't ready yet. For instance, the M24128
     eeprom will NAK all incoming messages during its write delay. That means
     that the NAK can be a good way to get low-latency estimations of when a
     device is ready to transmit. By altering the i2c hardware interface code so that it retries a
     transaction if it failed because it was NAK'd, we can use that
     retryability to handle the write delay without an explicit sleep.
- Use 10-byte buffers instead of 9 because an M24128 address is 2 bytes, so we were cutting off one byte of an
   8-byte payload by using a 9-byte buffer

With this PR, we can write and read EVT pipette serial numbers.

Closes RLIQ-97
Closes RLIQ-98
Closes RLIQ-99

