### PR TITLE
fix(simulators): parse environment properly

### DIFF
--- a/can/simlib/transport.cpp
+++ b/can/simlib/transport.cpp
@@ -36,8 +36,8 @@ auto can::sim::transport::add_options(po::options_description& cmdline_desc,
         "port,p", po::value<uint16_t>()->default_value(9898),
         "port for the can server. May be specified in an environment variable "
         "called CAN_PORT.");
-    env_desc.add_options()("server-host",
-                           po::value<std::string>()->default_value("localhost"))(
+    env_desc.add_options()(
+        "server-host", po::value<std::string>()->default_value("localhost"))(
         "port", po::value<uint16_t>()->default_value(9898));
     return [](std::string input_val) -> std::string {
         if (input_val == "CAN_SERVER_HOST") {

--- a/can/simlib/transport.cpp
+++ b/can/simlib/transport.cpp
@@ -20,7 +20,7 @@ auto can::sim::transport::add_options(po::options_description& cmdline_desc,
                                po::value<std::string>()->default_value("vcan0"),
                                "can channel identifier. May be specified in an "
                                "environment variable called CAN_CHANNEL.");
-    env_desc.add_options()("CAN_CHANNEL",
+    env_desc.add_options()("can-channel",
                            po::value<std::string>()->default_value("vcan0"));
     return [](std::string input_val) -> std::string {
         if (input_val == "CAN_CHANNEL") {
@@ -36,10 +36,9 @@ auto can::sim::transport::add_options(po::options_description& cmdline_desc,
         "port,p", po::value<uint16_t>()->default_value(9898),
         "port for the can server. May be specified in an environment variable "
         "called CAN_PORT.");
-    env_desc.add_options()("CAN_SERVER_HOST",
-                           po::value<std::string>()->default_value("localhost"),
-                           "can server to connect to")(
-        "CAN_PORT", po::value<uint16_t>()->default_value(9898));
+    env_desc.add_options()("server-host",
+                           po::value<std::string>()->default_value("localhost"))(
+        "port", po::value<uint16_t>()->default_value(9898));
     return [](std::string input_val) -> std::string {
         if (input_val == "CAN_SERVER_HOST") {
             return "server-host";

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -165,7 +165,7 @@ class EEProm : public I2CDeviceBase,
                 "path to backing file for eeprom. if unspecified, a temp will "
                 "be used. May be specified in an environment file called "
                 "EEPROM_FILENAME.");
-            env.add_options()("EEPROM_FILENAME",
+            env.add_options()("eeprom-filename",
                               po::value<std::string>()->default_value(
                                   std::string(TEMPFILE_KEY)));
             return [](std::string input_val) -> std::string {


### PR DESCRIPTION
The options specified through environment variables need to have the
same names as the command line options. You then define what variables
you support in the name transformation lambdas.

With this change we should now properly support environment variable
specification of options.