### PR TITLE
refactor(pipettes): modify the steps per mm to 2133.33 steps per mm

### DIFF
--- a/pipettes/core/configs.cpp
+++ b/pipettes/core/configs.cpp
@@ -13,7 +13,7 @@ auto configs::linear_motion_sys_config_by_axis(PipetteType which)
         case PipetteType::SINGLE_CHANNEL:
         default:
             return lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-                .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 3.03},
+                .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 3},
                 .steps_per_rev = 200,
                 .microstep = 32};
     }


### PR DESCRIPTION
## Overview

Previously, the steps per mm we were using for pipettes was actually 2112.21 steps per mm. I
confirmed with hardware that the steps per mm we actually want to be using for the single and eight
channel pipettes is actually 2133.33 steps per mm.