### PR TITLE
Fix(gripper): reconfigure configure encoder inputs to solve MCU crash

### DIFF
--- a/gripper/firmware/motor_encoder_hardware_proto.c
+++ b/gripper/firmware/motor_encoder_hardware_proto.c
@@ -35,19 +35,15 @@ void Encoder_GPIO_Init(void) {
     GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    /*Configure GPIO pin : PA5 */
+    /* There is no need to configure GPIO pin : PA5
+     * for clarity I have left this here commented, as it describes the defualt
+     * state for this pin at startup
     GPIO_InitStruct.Pin = GPIO_PIN_5;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-
-    GPIO_InitStruct.Pin = GPIO_PIN_5;
-    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
-    GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    */
 }
 
 void TIM2_EncoderG_Init(void) {

--- a/gripper/firmware/motor_encoder_hardware_proto.c
+++ b/gripper/firmware/motor_encoder_hardware_proto.c
@@ -93,13 +93,15 @@ void TIM2_EncoderG_Init(void) {
  * travelling.
  *
  * TIM4 receives the encoder clock output signal from TIM2 (tim_trgo). It counts
- * at 1 MHz and captures the current count whenever an encoder pulse is
- * received, then resets its counter. The velocity would thus roughly be
- * (1 MHz / (count)). TIM2 is counting both rising and falling edges from channel A
- * + B. so this timer uses a DIV4 prescaller to count only complete ticks
+ * at 1 MHz and captures the current count whenever a full encoder tick
+ * (4 pulses)  is received, then resets its counter.
+ * The physical movement is 0.1637896203 um per pulse so is 0.655158481 um
+ * per full tick, so the velocity is ~(0.6552/count) um/us or ~(655.2/count) mm/s
+ * TIM2 is counting both rising and falling edges from channel A + B.
+ * so this timer uses a DIV4 prescaller to count only complete ticks
  *
  * The timer overflows 3 ms after an tick is received. This means any encoder
- * movement below 8Hz, which is about 0.00131 mm/s,
+ * movement below 333Hz, which is about 0.2184 mm/s
  * is rejected and that we can safely assume the encoder has stopped moving.
  **/
 void TIM4_EncoderGSpeed_Init(void) {

--- a/gripper/firmware/motor_encoder_hardware_proto.c
+++ b/gripper/firmware/motor_encoder_hardware_proto.c
@@ -95,11 +95,11 @@ void TIM2_EncoderG_Init(void) {
  * TIM4 receives the encoder clock output signal from TIM2 (tim_trgo). It counts
  * at 1 MHz and captures the current count whenever an encoder pulse is
  * received, then resets its counter. The velocity would thus roughly be
- * (1 MHz / (count * 4)). Counting both rising and falling edges from channel A
- * + B.
+ * (1 MHz / (count)). TIM2 is counting both rising and falling edges from channel A
+ * + B. so this timer uses a DIV4 prescaller to count only complete ticks
  *
- * The timer overflows 3 ms after an edge is received. This means any encoder
- * movement below 8Hz (1 MHz / (30000 * 4 count)), which is about 0.00131 mm/s,
+ * The timer overflows 3 ms after an tick is received. This means any encoder
+ * movement below 8Hz, which is about 0.00131 mm/s,
  * is rejected and that we can safely assume the encoder has stopped moving.
  **/
 void TIM4_EncoderGSpeed_Init(void) {
@@ -136,7 +136,7 @@ void TIM4_EncoderGSpeed_Init(void) {
     /* Initialize TIM4 input capture channel */
     sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
     sConfigIC.ICSelection = TIM_ICSELECTION_TRC;
-    sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
+    sConfigIC.ICPrescaler = TIM_ICPSC_DIV4;
     sConfigIC.ICFilter = 0;
     if (HAL_TIM_IC_ConfigChannel(&htim4, &sConfigIC, TIM_CHANNEL_1) != HAL_OK) {
         Error_Handler();


### PR DESCRIPTION
https://opentrons.atlassian.net/browse/RLAB-98
Found a bug that when the motor is driven at high speed, the number of encoder pulses that get sent to reset the slave speed timer is too great. While everything works fine in release mode, in debug mode this overruns the mcu and causes a crash.
Solution is to prescale the slave timer to 4, this reduces the reset from 4x per encoder tick (1 per each rising/falling edge) to 1 per complete encoder tick