### PR TITLE
refactor(gantry): change the direction of the X motor

### DIFF
--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -42,7 +42,7 @@ struct motion_controller::HardwareConfig motor_pins_x {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             .port = GPIOB,
             .pin = GPIO_PIN_1,
-            .active_setting = GPIO_PIN_RESET},
+            .active_setting = GPIO_PIN_SET},
     .step =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)


### PR DESCRIPTION
The X motor has been switched to the opposite side of the gantry/pulley and needs to have its direction switched.