### PR TITLE
fix(pipettes): update pressure sensor interrupt for stm32g4

### DIFF
--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -42,8 +42,9 @@ IRQn_Type get_interrupt_line(const PipetteType pipette_type) {
         case SINGLE_CHANNEL:
         case EIGHT_CHANNEL:
         default:
-            // External interrupt lines 15:10
-            return EXTI9_5_IRQn;
+            // External interrupt line 3
+            return EXTI3_IRQn;
+//            return EXTI9_5_IRQn;
     }
 }
 

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -44,7 +44,6 @@ IRQn_Type get_interrupt_line(const PipetteType pipette_type) {
         default:
             // External interrupt line 3
             return EXTI3_IRQn;
-//            return EXTI9_5_IRQn;
     }
 }
 

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -105,11 +105,16 @@ static auto pins_for_sensor =
 auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
+/*
+ * Callback for STM32L5xx, we may want to remove this later
+ *
 extern "C" void HAL_GPIO_EXTI_Falling_Callback(uint16_t GPIO_Pin) {
     if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
         sensor_hardware.data_ready();
     }
 }
+
+ */
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
         sensor_hardware.data_ready();

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -105,16 +105,6 @@ static auto pins_for_sensor =
 auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
-/*
- * Callback for STM32L5xx, we may want to remove this later
- *
-extern "C" void HAL_GPIO_EXTI_Falling_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
-        sensor_hardware.data_ready();
-    }
-}
-
- */
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
         sensor_hardware.data_ready();
@@ -181,9 +171,7 @@ auto main() -> int {
     adc_init();
     initialize_enc(PIPETTE_TYPE);
 
-    //    iwdg_refresh();
     delay_start(500);
-    //    iwdg_refresh();
     auto id = pipette_mounts::detect_id();
 
     i2c_setup(&i2chandler_struct);

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -110,6 +110,11 @@ extern "C" void HAL_GPIO_EXTI_Falling_Callback(uint16_t GPIO_Pin) {
         sensor_hardware.data_ready();
     }
 }
+extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
+    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
+        sensor_hardware.data_ready();
+    }
+}
 
 // Unfortunately, these numbers need to be literals or defines
 // to get the compile-time checks to work so we can't actually
@@ -171,8 +176,9 @@ auto main() -> int {
     adc_init();
     initialize_enc(PIPETTE_TYPE);
 
+    //    iwdg_refresh();
     delay_start(500);
-
+    //    iwdg_refresh();
     auto id = pipette_mounts::detect_id();
 
     i2c_setup(&i2chandler_struct);

--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -121,19 +121,8 @@ void EXTI3_IRQHandler(void) {
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
 }
 
-void EXTI8_IRQHandler(void) {
-    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_8);
-}
-
-//void EXTI9_IRQHandler(void) {
-//    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_9);
-//}
-
 // TODO refer to schematic to check and see that the data ready
 // pin is the same across values.
-void EXTI15_IRQHandler(void) {
-    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_15);
-}
 
 void DMA1_Channel2_IRQHandler(void)
 {

--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -117,13 +117,17 @@ void DebugMon_Handler(void) {}
 /*  file (startup_stm32g4xxxx.s).                                             */
 /******************************************************************************/
 
+void EXTI3_IRQHandler(void) {
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
+}
+
 void EXTI8_IRQHandler(void) {
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_8);
 }
 
-void EXTI9_IRQHandler(void) {
-    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_9);
-}
+//void EXTI9_IRQHandler(void) {
+//    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_9);
+//}
 
 // TODO refer to schematic to check and see that the data ready
 // pin is the same across values.

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -134,6 +134,7 @@ void data_ready_gpio_init() {
         /*Configure GPIO pin*/
         GPIO_InitTypeDef GPIO_InitStruct = {0};
         GPIO_InitStruct.Pin = hardware_rear.pin;
+//        GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
         GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
         GPIO_InitStruct.Pull = GPIO_PULLUP;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -134,7 +134,6 @@ void data_ready_gpio_init() {
         /*Configure GPIO pin*/
         GPIO_InitTypeDef GPIO_InitStruct = {0};
         GPIO_InitStruct.Pin = hardware_rear.pin;
-//        GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
         GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
         GPIO_InitStruct.Pull = GPIO_PULLUP;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;


### PR DESCRIPTION
Since the transition to the STM32G4 for the EVT pipettes, we need to make a couple of changes to our interrupt service routine:

- change the EXTI input line from `EXTI9_5_IRQn` to `EXTI3_IRQn`, to correspond with the change in the pressure sensor's data ready pin from `GPIO_PIN_9` to `GPIO_PIN_3`
- change the HAL function that gets implemented in our firmware from `HAL_GPIO_EXTI_Falling_Callback` to `HAL_GPIO_EXTI_Callback`, since the source code is slightly different between the STM32L5 and the STM32G4

This pr just allows the interrupt code in `pipettes/firmware/main.cpp` to be called and executed as expected.
