### PR TITLE
feat(pipettes): begin simulator with a valid pipette serial number

### DIFF
--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -33,7 +33,7 @@ class EEProm : public I2CDeviceBase,
         : I2CDeviceBase(types::DEVICE_ADDRESS),
           backing(options, backing_data) {}
     EEProm(hardware_iface::EEPromChipType chip, po::variables_map& options,
-           const uint32_t backing_data = 0)
+           const uint64_t backing_data = 0)
         : I2CDeviceBase(types::DEVICE_ADDRESS),
           hardware_iface::EEPromHardwareIface(chip),
           backing(options, backing_data) {}
@@ -142,7 +142,9 @@ class EEProm : public I2CDeviceBase,
                 std::fseek(file, start, SEEK_SET);
                 auto tmp_backing = std::array<char, BACKING_SIZE>{};
                 if (backing_data != 0) {
-                    tmp_backing.fill(backing_data);
+                    //                    tmp_backing.fill(backing_data);
+                    static_cast<void>(bit_utils::int_to_bytes(
+                        backing_data, tmp_backing.begin(), tmp_backing.end()));
                 } else {
                     tmp_backing.fill(0xff);
                 }

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -159,13 +159,33 @@ auto handle_options(int argc, char** argv) -> po::variables_map {
     return vm;
 }
 
+uint32_t temporary_serial_number(const PipetteType pipette_type) {
+    // TODO there is no pipette name for the ninety six or three eighty four
+    // channel pipette. For now they will come out as 'p50s and p50m' in
+    // the simulator
+    switch (pipette_type) {
+        case EIGHT_CHANNEL:
+            // Binary value equivalent to P1KMV3120200304A1
+            return 0x011F089D;
+        case NINETY_SIX_CHANNEL:
+            return 0x021F089D;
+        case THREE_EIGHTY_FOUR_CHANNEL:
+            return 0x031F089D;
+        case SINGLE_CHANNEL:
+        default:
+            // Binary value equivalent to P1KSV3120200304A1
+            return 0x001F089D;
+    }
+}
+
 int main(int argc, char** argv) {
     signal(SIGINT, signal_handler);
     LOG_INIT(PipetteTypeString[PIPETTE_TYPE], []() -> const char* {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
-    // Binary value equivalent to P1KSV3120200304A1
-    const uint64_t TEMPORARY_PIPETTE_SERIAL = 0x001f20220304A1;
+
+    const uint32_t TEMPORARY_PIPETTE_SERIAL =
+        temporary_serial_number(PIPETTE_TYPE);
     auto options = handle_options(argc, argv);
     auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -165,7 +165,7 @@ int main(int argc, char** argv) {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
     // Binary value equivalent to P1KSV3120200304A1
-    const uint64_t TEMPORARY_PIPETTE_SERIAL = 0x1f20200304A1;
+    const uint64_t TEMPORARY_PIPETTE_SERIAL = 0x001f20220304A1;
     auto options = handle_options(argc, argv);
     auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -165,8 +165,8 @@ int main(int argc, char** argv) {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
     // Binary value equivalent to P1KSV3120200304A1
-    const uint32_t TEMPORARY_PIPETTE_SERIAL = 0x1f20200304A1 auto options =
-        handle_options(argc, argv);
+    const uint64_t TEMPORARY_PIPETTE_SERIAL = 0x1f20200304A1;
+    auto options = handle_options(argc, argv);
     auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();
     auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -164,10 +164,13 @@ int main(int argc, char** argv) {
     LOG_INIT(PipetteTypeString[PIPETTE_TYPE], []() -> const char* {
         return pcTaskGetName(xTaskGetCurrentTaskHandle());
     });
-    auto options = handle_options(argc, argv);
+    // Binary value equivalent to P1KSV3120200304A1
+    const uint32_t TEMPORARY_PIPETTE_SERIAL = 0x1f20200304A1 auto options =
+        handle_options(argc, argv);
     auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();
-    auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(options);
+    auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(
+        options, TEMPORARY_PIPETTE_SERIAL);
     auto fake_sensor_hw = std::make_shared<test_mocks::MockSensorHardware>();
     auto pressuresensor =
         std::make_shared<mmr920C04_simulator::MMR920C04>(*fake_sensor_hw);


### PR DESCRIPTION
Closes RQA-288.

For now, the simulated pipette should start with a valid serial number. Eventually, the emulator should be able to set the serial number for the pipettes on boot.