### PR TITLE
refactor(tmc2160): use the correct method of setting current

### DIFF
--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -103,22 +103,20 @@ struct motion_controller::HardwareConfig motor_pins_y {
 };
 
 static tmc2160::configs::TMC2160DriverConfig motor_driver_config{
-    .registers =
-        {
-            .gconfig = {.en_pwm_mode = 1},
-            .ihold_irun = {.hold_current = 16,
-                           .run_current = 31,
-                           .hold_current_delay = 0x7},
-            .tcoolthrs = {.threshold = 0},
-            .thigh = {.threshold = 0xFFFFF},
-            .chopconf = {.toff = 0x3,
-                         .hstrt = 0x5,
-                         .hend = 0x2,
-                         .tbl = 0x2,
-                         .tpfd = 0x4,
-                         .mres = 0x3},
-            .coolconf = {.sgt = 0x6},
-        },
+    .registers = {.gconfig = {.en_pwm_mode = 1},
+                  .ihold_irun = {.hold_current = 16,
+                                 .run_current = 31,
+                                 .hold_current_delay = 0x7},
+                  .tcoolthrs = {.threshold = 0},
+                  .thigh = {.threshold = 0xFFFFF},
+                  .chopconf = {.toff = 0x3,
+                               .hstrt = 0x5,
+                               .hend = 0x2,
+                               .tbl = 0x2,
+                               .tpfd = 0x4,
+                               .mres = 0x3},
+                  .coolconf = {.sgt = 0x6},
+                  .glob_scale = {.global_scaler = 0xA7}},
     .current_config =
         {
             .r_sense = 0.1,

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -135,22 +135,20 @@ struct motor_hardware::HardwareConfig pin_configurations_right {
 
 // TODO clean up the head main file by using interfaces.
 static tmc2160::configs::TMC2160DriverConfig motor_driver_configs_right{
-    .registers =
-        {
-            .gconfig = {.en_pwm_mode = 1},
-            .ihold_irun = {.hold_current = 16,
-                           .run_current = 31,
-                           .hold_current_delay = 0x7},
-            .tcoolthrs = {.threshold = 0},
-            .thigh = {.threshold = 0xFFFFF},
-            .chopconf = {.toff = 0x3,
-                         .hstrt = 0x5,
-                         .hend = 0x2,
-                         .tbl = 0x2,
-                         .tpfd = 0x4,
-                         .mres = 0x4},
-            .coolconf = {.sgt = 0x6},
-        },
+    .registers = {.gconfig = {.en_pwm_mode = 1},
+                  .ihold_irun = {.hold_current = 16,
+                                 .run_current = 31,
+                                 .hold_current_delay = 0x7},
+                  .tcoolthrs = {.threshold = 0},
+                  .thigh = {.threshold = 0xFFFFF},
+                  .chopconf = {.toff = 0x3,
+                               .hstrt = 0x5,
+                               .hend = 0x2,
+                               .tbl = 0x2,
+                               .tpfd = 0x4,
+                               .mres = 0x4},
+                  .coolconf = {.sgt = 0x6},
+                  .glob_scale = {.global_scaler = 0xA7}},
     .current_config =
         {
             .r_sense = 0.1,
@@ -163,22 +161,20 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_configs_right{
     }};
 
 static tmc2160::configs::TMC2160DriverConfig motor_driver_configs_left{
-    .registers =
-        {
-            .gconfig = {.en_pwm_mode = 1},
-            .ihold_irun = {.hold_current = 16,
-                           .run_current = 31,
-                           .hold_current_delay = 0x7},
-            .tcoolthrs = {.threshold = 0},
-            .thigh = {.threshold = 0xFFFFF},
-            .chopconf = {.toff = 0x3,
-                         .hstrt = 0x5,
-                         .hend = 0x2,
-                         .tbl = 0x2,
-                         .tpfd = 0x4,
-                         .mres = 0x4},
-            .coolconf = {.sgt = 0x6},
-        },
+    .registers = {.gconfig = {.en_pwm_mode = 1},
+                  .ihold_irun = {.hold_current = 16,
+                                 .run_current = 31,
+                                 .hold_current_delay = 0x7},
+                  .tcoolthrs = {.threshold = 0},
+                  .thigh = {.threshold = 0xFFFFF},
+                  .chopconf = {.toff = 0x3,
+                               .hstrt = 0x5,
+                               .hend = 0x2,
+                               .tbl = 0x2,
+                               .tpfd = 0x4,
+                               .mres = 0x4},
+                  .coolconf = {.sgt = 0x6},
+                  .glob_scale = {.global_scaler = 0xA7}},
     .current_config =
         {
             .r_sense = 0.1,

--- a/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/tmc2160_motor_driver_task.hpp
@@ -85,12 +85,15 @@ class MotorDriverMessageHandler {
         LOG("Received write motor current request: hold_current=%d, "
             "run_current=%d",
             m.hold_current, m.run_current);
-
+        if (m.hold_current != 0U) {
+            driver.get_register_map().ihold_irun.hold_current =
+                driver.convert_to_tmc2160_current_value(m.hold_current);
+        };
         if (m.run_current != 0U) {
-            driver.get_register_map().glob_scale.global_scaler =
+            driver.get_register_map().ihold_irun.run_current =
                 driver.convert_to_tmc2160_current_value(m.run_current);
         }
-        driver.set_glob_scaler(driver.get_register_map().glob_scale);
+        driver.set_current_control(driver.get_register_map().ihold_irun);
     }
 
     tmc2160::driver::TMC2160<Writer, TaskQueue> driver;

--- a/motor-control/tests/test_motor_driver.cpp
+++ b/motor-control/tests/test_motor_driver.cpp
@@ -68,7 +68,7 @@ struct TMC2160Container {
                                    .tbl = 0x2,
                                    .mres = 0x3},
                       .coolconf = {.sgt = 0b110},
-                      .glob_scale = {.global_scaler = 112}},
+                      .glob_scale = {.global_scaler = 0xA7}},
         .current_config = {
             .r_sense = 0.1,
             .v_sf = 0.325,
@@ -120,6 +120,19 @@ TEST_CASE("Setup a tmc2130 motor driver") {
 TEST_CASE("Setup a tmc2160 motor driver") {
     TMC2160Container subject{};
 
+    GIVEN("A call to global scaler set driver") {
+        WHEN(
+            "Set the value to 32 if global scaler is calculated to be "
+            "below 32") {
+            subject.driver.get_register_map().glob_scale.global_scaler = 1;
+            subject.driver.set_glob_scaler(
+                subject.driver.get_register_map().glob_scale);
+            REQUIRE(
+                subject.driver.get_register_map().glob_scale.global_scaler ==
+                32);
+        }
+    }
+
     GIVEN("a tmc2160 motor driver") {
         WHEN("Setup is called") {
             subject.driver.write_config();
@@ -156,30 +169,20 @@ TEST_CASE("Setup a tmc2160 motor driver") {
 
         WHEN("Changing the current") {
             constexpr uint32_t two_amps = 2 << 16;
-            constexpr uint32_t global_scaler_2amps = 221;
+            constexpr uint32_t cs_2amps = 31;
 
             constexpr uint32_t one_amp = 1 << 16;
-            constexpr uint32_t global_scaler_1amps = 110;
+            constexpr uint32_t cs_one_amp = 20;
             auto register_config = subject.driver_config.registers;
-            REQUIRE(
-                subject.driver.get_register_map().glob_scale.global_scaler ==
-                register_config.glob_scale.global_scaler);
-            THEN("The global scaler value is correct") {
+            REQUIRE(subject.driver.get_register_map().ihold_irun.run_current ==
+                    register_config.ihold_irun.run_current);
+            THEN("The CS current value is correct") {
                 auto two_amps_gs =
                     subject.driver.convert_to_tmc2160_current_value(two_amps);
-                REQUIRE(two_amps_gs == global_scaler_2amps);
+                REQUIRE(two_amps_gs == cs_2amps);
                 auto one_amps_gs =
                     subject.driver.convert_to_tmc2160_current_value(one_amp);
-                REQUIRE(one_amps_gs == global_scaler_1amps);
-            }
-            AND_THEN(
-                "Set the value to 32 if global scaler is calculated to be "
-                "below 32") {
-                subject.driver.get_register_map().glob_scale.global_scaler = 1;
-                subject.driver.set_glob_scaler(
-                    subject.driver.get_register_map().glob_scale);
-                REQUIRE(subject.driver.get_register_map()
-                            .glob_scale.global_scaler == 32);
+                REQUIRE(one_amps_gs == cs_one_amp);
             }
         }
     }

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -25,7 +25,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                                            .tbl = 0x2,
                                            .mres = 0x3},
                               .coolconf = {.sgt = 0x6},
-                              .glob_scale = {.global_scaler = 0x70}},
+                              .glob_scale = {.global_scaler = 0xA7}},
                 .current_config =
                     {
                         .r_sense = 0.1,

--- a/pipettes/firmware_l5/motor_configurations.cpp
+++ b/pipettes/firmware_l5/motor_configurations.cpp
@@ -25,7 +25,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                                            .tbl = 0x2,
                                            .mres = 0x3},
                               .coolconf = {.sgt = 0x6},
-                              .glob_scale = {.global_scaler = 0x70}},
+                              .glob_scale = {.global_scaler = 0xA7}},
                 .current_config =
                     {
                         .r_sense = 0.1,

--- a/pipettes/simulator/motor_configurations.cpp
+++ b/pipettes/simulator/motor_configurations.cpp
@@ -22,7 +22,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                                            .tbl = 0x2,
                                            .mres = 0x3},
                               .coolconf = {.sgt = 0x6},
-                              .glob_scale = {.global_scaler = 0x70}},
+                              .glob_scale = {.global_scaler = 0xA7}},
                 .current_config =
                     {
                         .r_sense = 0.1,


### PR DESCRIPTION
Erroneously, we thought that you needed to set the global scaler rather than the ihold/irun registers directly on the tmc2160. In actuality, you only adjust the global scaler to find a good default value. The EEs have calculated that ~167 is an acceptable value to get us to a max current of 1.5amps when irun is 31.

RET#1261