### PR TITLE
change tools detected if nothing attached

### DIFF
--- a/head/tests/test_presence_sensing_driver.cpp
+++ b/head/tests/test_presence_sensing_driver.cpp
@@ -26,6 +26,26 @@ SCENARIO("get_tool called on presence sensing driver") {
                 REQUIRE(tools.gripper == can::ids::ToolType::gripper);
                 REQUIRE(tools.a_motor == can::ids::ToolType::pipette);
                 REQUIRE(tools.z_motor == can::ids::ToolType::pipette);
+                AND_WHEN(
+                    "get_tool is called again and adc detects the tools have "
+                    "been removed") {
+                    adc_comms.get_z_channel().mock_set_reading_by_voltage(10);
+                    adc_comms.get_a_channel().mock_set_reading_by_voltage(10);
+                    adc_comms.get_gripper_channel().mock_set_reading_by_voltage(
+                        10);
+                    std::tie(updated, tools) = ps.update_tools();
+                    THEN(
+                        "Tools detected == nothing attached, and tools_detected"
+                        "notification not sent") {
+                        REQUIRE(!updated);
+                        REQUIRE(tools.z_motor ==
+                                can::ids::ToolType::nothing_attached);
+                        REQUIRE(tools.a_motor ==
+                                can::ids::ToolType::nothing_attached);
+                        REQUIRE(tools.gripper ==
+                                can::ids::ToolType::nothing_attached);
+                    }
+                }
                 AND_WHEN("Tools switch to invalid voltages") {
                     adc_comms.get_z_channel().mock_set_reading_by_voltage(3300);
                     std::tie(updated, tools) = ps.update_tools();

--- a/head/tests/test_presence_sensing_driver.cpp
+++ b/head/tests/test_presence_sensing_driver.cpp
@@ -36,8 +36,8 @@ SCENARIO("get_tool called on presence sensing driver") {
                     std::tie(updated, tools) = ps.update_tools();
                     THEN(
                         "Tools detected == nothing attached, and tools_detected"
-                        "notification not sent") {
-                        REQUIRE(!updated);
+                        "notification gets sent") {
+                        REQUIRE(updated);
                         REQUIRE(tools.z_motor ==
                                 can::ids::ToolType::nothing_attached);
                         REQUIRE(tools.a_motor ==

--- a/include/head/core/presence_sensing_driver.hpp
+++ b/include/head/core/presence_sensing_driver.hpp
@@ -53,8 +53,7 @@ class PresenceSensingDriver {
         auto new_tools = attached_tools::AttachedTools(get_readings());
         bool notify = should_send_notification(current_tools, new_tools);
         current_tools = new_tools;
-        return std::make_pair(notify,
-                              current_tools);
+        return std::make_pair(notify, current_tools);
     }
 
   private:

--- a/include/head/core/presence_sensing_driver.hpp
+++ b/include/head/core/presence_sensing_driver.hpp
@@ -51,43 +51,25 @@ class PresenceSensingDriver {
     [[nodiscard]] auto update_tools()
         -> std::pair<bool, attached_tools::AttachedTools> {
         auto new_tools = attached_tools::AttachedTools(get_readings());
-
-        auto ret = std::make_pair(should_update(current_tools, new_tools),
-                                  update_tools(current_tools, new_tools));
-        if (ret.first) {
-            current_tools = ret.second;
-        }
-        return ret;
+        bool notify = should_send_notification(current_tools, new_tools);
+        current_tools = new_tools;
+        return std::make_pair(notify,
+                              current_tools);
     }
 
   private:
-    [[nodiscard]] constexpr static auto should_use_new_value(
+    [[nodiscard]] constexpr static auto new_tool_attached(
         can::ids::ToolType old_tool, can::ids::ToolType new_tool) -> bool {
         return (old_tool != new_tool) &&
                (new_tool != can::ids::ToolType::nothing_attached);
     }
 
-    [[nodiscard]] constexpr static auto should_update(
+    [[nodiscard]] constexpr static auto should_send_notification(
         const attached_tools::AttachedTools& old_tools,
         const attached_tools::AttachedTools& new_tools) -> bool {
-        return should_use_new_value(old_tools.z_motor, new_tools.z_motor) ||
-               should_use_new_value(old_tools.a_motor, new_tools.a_motor) ||
-               should_use_new_value(old_tools.gripper, new_tools.gripper);
-    }
-    [[nodiscard]] constexpr static auto update_tool(can::ids::ToolType old_tool,
-                                                    can::ids::ToolType new_tool)
-        -> can::ids::ToolType {
-        return (new_tool == can::ids::ToolType::nothing_attached) ? old_tool
-                                                                  : new_tool;
-    }
-    [[nodiscard]] constexpr static auto update_tools(
-        const attached_tools::AttachedTools& old_tools,
-        const attached_tools::AttachedTools& new_tools)
-        -> attached_tools::AttachedTools {
-        return attached_tools::AttachedTools(
-            update_tool(old_tools.z_motor, new_tools.z_motor),
-            update_tool(old_tools.a_motor, new_tools.a_motor),
-            update_tool(old_tools.gripper, new_tools.gripper));
+        return new_tool_attached(old_tools.z_motor, new_tools.z_motor) ||
+               new_tool_attached(old_tools.a_motor, new_tools.a_motor) ||
+               new_tool_attached(old_tools.gripper, new_tools.gripper);
     }
 
     adc::BaseADC& adc_comms;

--- a/include/head/core/presence_sensing_driver.hpp
+++ b/include/head/core/presence_sensing_driver.hpp
@@ -57,18 +57,17 @@ class PresenceSensingDriver {
     }
 
   private:
-    [[nodiscard]] constexpr static auto new_tool_attached(
+    [[nodiscard]] constexpr static auto tool_attached_changed(
         can::ids::ToolType old_tool, can::ids::ToolType new_tool) -> bool {
-        return (old_tool != new_tool) &&
-               (new_tool != can::ids::ToolType::nothing_attached);
+        return old_tool != new_tool;
     }
 
     [[nodiscard]] constexpr static auto should_send_notification(
         const attached_tools::AttachedTools& old_tools,
         const attached_tools::AttachedTools& new_tools) -> bool {
-        return new_tool_attached(old_tools.z_motor, new_tools.z_motor) ||
-               new_tool_attached(old_tools.a_motor, new_tools.a_motor) ||
-               new_tool_attached(old_tools.gripper, new_tools.gripper);
+        return tool_attached_changed(old_tools.z_motor, new_tools.z_motor) ||
+               tool_attached_changed(old_tools.a_motor, new_tools.a_motor) ||
+               tool_attached_changed(old_tools.gripper, new_tools.gripper);
     }
 
     adc::BaseADC& adc_comms;

--- a/include/head/core/tasks/presence_sensing_driver_task.hpp
+++ b/include/head/core/tasks/presence_sensing_driver_task.hpp
@@ -75,9 +75,8 @@ class PresenceSensingDriverMessageHandler {
 
     void visit(presence_sensing_driver_task_messages::CheckForToolChange&) {
         attached_tools::AttachedTools new_tools;
-        auto tool_update = driver.update_tools();
-        bool new_tool_detected = tool_update.first;
-        new_tools = tool_update.second;
+        bool new_tool_detected = false;
+        std::tie(new_tool_detected, new_tools) = driver.update_tools();
         if (new_tool_detected) {
             can_client.send_can_message(
                 can::ids::NodeId::host,

--- a/include/head/core/tasks/presence_sensing_driver_task.hpp
+++ b/include/head/core/tasks/presence_sensing_driver_task.hpp
@@ -75,9 +75,10 @@ class PresenceSensingDriverMessageHandler {
 
     void visit(presence_sensing_driver_task_messages::CheckForToolChange&) {
         attached_tools::AttachedTools new_tools;
-        bool updated = false;
-        std::tie(updated, new_tools) = driver.update_tools();
-        if (updated) {
+        auto tool_update = driver.update_tools();
+        bool new_tool_detected = tool_update.first;
+        new_tools = tool_update.second;
+        if (new_tool_detected) {
             can_client.send_can_message(
                 can::ids::NodeId::host,
                 can::messages::PushToolsDetectedNotification{


### PR DESCRIPTION
On [main](https://github.com/Opentrons/ot3-firmware) currently, a `tools_detected_notification` will appear when you attach an instrument. After taking off that instrument and sending an `attached_tools_request`, you'll still see the instrument that was previously attached.

This pr allows the detected tools to change following the removal of an instrument without sending an unnecessary `tools_detected_notification`.