### PR TITLE
refactor: increase motor interrupt freqs and usteps

### DIFF
--- a/gantry/core/utils.cpp
+++ b/gantry/core/utils.cpp
@@ -24,14 +24,14 @@ auto utils::linear_motion_sys_config_by_axis(enum GantryAxisType which)
             return lms::LinearMotionSystemConfig<lms::BeltConfig>{
                 .mech_config = lms::BeltConfig{.pulley_diameter = 12.7},
                 .steps_per_rev = 200,
-                .microstep = 32,
+                .microstep = 64,
                 .encoder_pulses_per_rev = 1000,
             };
         case GantryAxisType::gantry_y:
             return lms::LinearMotionSystemConfig<lms::BeltConfig>{
                 .mech_config = lms::BeltConfig{.pulley_diameter = 12.7254},
                 .steps_per_rev = 200,
-                .microstep = 32,
+                .microstep = 64,
                 .encoder_pulses_per_rev = 1000,
             };
         default:

--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -112,7 +112,7 @@ static tmc2130::configs::TMC2130DriverConfig gantry_x_driver_configs{
                                .hstrt = 0x5,
                                .hend = 0x3,
                                .tbl = 0x2,
-                               .mres = 0x3},
+                               .mres = 0x2},
                   .coolconf = {.sgt = 0x6}},
     .current_config =
         {
@@ -135,7 +135,7 @@ static tmc2130::configs::TMC2130DriverConfig gantry_y_driver_configs{
                                .hstrt = 0x5,
                                .hend = 0x3,
                                .tbl = 0x2,
-                               .mres = 0x3},
+                               .mres = 0x2},
                   .coolconf = {.sgt = 0x6}},
     .current_config =
         {

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -114,7 +114,7 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_config{
                                .hend = 0x2,
                                .tbl = 0x2,
                                .tpfd = 0x4,
-                               .mres = 0x3},
+                               .mres = 0x2},
                   .coolconf = {.sgt = 0x6},
                   .glob_scale = {.global_scaler = 0xA7}},
     .current_config =

--- a/gantry/firmware/motor_hardware.c
+++ b/gantry/firmware/motor_hardware.c
@@ -141,11 +141,16 @@ void MX_GPIO_Init(void) {
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 }
 
+// motor timer: 200kHz from
+// 170MHz sysclk
+// /1 AHB
+// /2 APB1
+// /425 prescaler = 200kHz
 void MX_TIM7_Init(void) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
 
     htim7.Instance = TIM7;
-    htim7.Init.Prescaler = 849;
+    htim7.Init.Prescaler = 424;
     htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim7.Init.Period = 1;
     htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -62,7 +62,7 @@ static motor_class::Motor motor{
     lms::LinearMotionSystemConfig<lms::BeltConfig>{
         .mech_config = lms::BeltConfig{.pulley_diameter = 12.7},
         .steps_per_rev = 200,
-        .microstep = 32,
+        .microstep = 64,
         .encoder_pulses_per_rev = 1000},
     motor_interface,
     motor_messages::MotionConstraints{.min_velocity = 1,

--- a/gantry/tests/test_linear_motion_config.cpp
+++ b/gantry/tests/test_linear_motion_config.cpp
@@ -7,7 +7,7 @@ TEST_CASE("Linear motion system using a belt") {
     GIVEN("OT2 X,Y gantry config") {
         struct LinearMotionSystemConfig<BeltConfig> linearConfig {
             .mech_config = BeltConfig{.pulley_diameter = 12.7},
-            .steps_per_rev = 200, .microstep = 32,
+            .steps_per_rev = 200, .microstep = 64,
             .encoder_pulses_per_rev = 1000,
         };
         REQUIRE(linearConfig.get_steps_per_mm() == 160.40813f);

--- a/gantry/tests/test_linear_motion_config.cpp
+++ b/gantry/tests/test_linear_motion_config.cpp
@@ -7,7 +7,7 @@ TEST_CASE("Linear motion system using a belt") {
     GIVEN("OT2 X,Y gantry config") {
         struct LinearMotionSystemConfig<BeltConfig> linearConfig {
             .mech_config = BeltConfig{.pulley_diameter = 12.7},
-            .steps_per_rev = 200, .microstep = 64,
+            .steps_per_rev = 200, .microstep = 32,
             .encoder_pulses_per_rev = 1000,
         };
         REQUIRE(linearConfig.get_steps_per_mm() == 160.40813f);

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -78,7 +78,7 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
                                .hstrt = 0x5,
                                .hend = 0x3,
                                .tbl = 0x2,
-                               .mres = 0x4},
+                               .mres = 0x3},
                   .coolconf = {.sgt = 0x6},
                   .pwmconf = {.freewheel = 0x2}},
     .current_config =
@@ -105,7 +105,7 @@ static motor_class::Motor z_motor{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
         .steps_per_rev = 200,
-        .microstep = 16,
+        .microstep = 32,
         .encoder_pulses_per_rev = 0,
         .gear_ratio = 1.8},
     motor_hardware_iface,

--- a/gripper/firmware/motor_timer_hardware.c
+++ b/gripper/firmware/motor_timer_hardware.c
@@ -198,7 +198,7 @@ void MX_TIM7_Init(void) {
     /*
      * Setting counter clock frequency to 100 kHz
      */
-    htim7.Init.Prescaler = 849;
+    htim7.Init.Prescaler = 425;
     htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim7.Init.Period = 1;
     htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -152,7 +152,7 @@ static tmc2130::configs::TMC2130DriverConfig motor_driver_configs_right{
                          .hstrt = 0x5,
                          .hend = 0x3,
                          .tbl = 0x2,
-                         .mres = 0x4},
+                         .mres = 0x3},
             .coolconf = {.sgt = 0x6},
         },
     .current_config =
@@ -179,7 +179,7 @@ static tmc2130::configs::TMC2130DriverConfig motor_driver_configs_left{
                          .hstrt = 0x5,
                          .hend = 0x3,
                          .tbl = 0x2,
-                         .mres = 0x4},
+                         .mres = 0x3},
             .coolconf = {.sgt = 0x6},
         },
     .current_config =
@@ -208,7 +208,7 @@ static motor_class::Motor motor_right{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
         .steps_per_rev = 200.0,
-        .microstep = 16.0,
+        .microstep = 32.0,
         .encoder_pulses_per_rev = 1000.0},
     motor_hardware_right,
     motor_messages::MotionConstraints{.min_velocity = 1,
@@ -226,7 +226,7 @@ static motor_class::Motor motor_left{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
         .steps_per_rev = 200.0,
-        .microstep = 16.0,
+        .microstep = 32.0,
         .encoder_pulses_per_rev = 1000.0},
     motor_hardware_left,
     motor_messages::MotionConstraints{.min_velocity = 1,

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -146,7 +146,7 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_configs_right{
                                .hend = 0x2,
                                .tbl = 0x2,
                                .tpfd = 0x4,
-                               .mres = 0x4},
+                               .mres = 0x3},
                   .coolconf = {.sgt = 0x6},
                   .glob_scale = {.global_scaler = 0xA7}},
     .current_config =
@@ -172,7 +172,7 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_configs_left{
                                .hend = 0x2,
                                .tbl = 0x2,
                                .tpfd = 0x4,
-                               .mres = 0x4},
+                               .mres = 0x3},
                   .coolconf = {.sgt = 0x6},
                   .glob_scale = {.global_scaler = 0xA7}},
     .current_config =
@@ -201,7 +201,7 @@ static motor_class::Motor motor_right{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
         .steps_per_rev = 200,
-        .microstep = 16,
+        .microstep = 32,
         .encoder_pulses_per_rev = 1000.0,
         .gear_ratio = 4.0},
     motor_hardware_right,
@@ -220,7 +220,7 @@ static motor_class::Motor motor_left{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
         .steps_per_rev = 200,
-        .microstep = 16,
+        .microstep = 32,
         .encoder_pulses_per_rev = 1000.0,
         .gear_ratio = 4.0},
     motor_hardware_left,

--- a/head/firmware/motor_hardware_common.c
+++ b/head/firmware/motor_hardware_common.c
@@ -279,11 +279,16 @@ void encoder_init(TIM_HandleTypeDef *htim) {
     HAL_TIM_Encoder_Start_IT(htim, TIM_CHANNEL_ALL);
 }
 
+// motor timer: 200kHz from
+// 170MHz sysclk
+// /1 AHB
+// /2 APB1
+// /425 prescaler = 200kHz
 void MX_TIM7_Init(void) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
 
     htim7.Instance = TIM7;
-    htim7.Init.Prescaler = 849;
+    htim7.Init.Prescaler = 425;
     htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim7.Init.Period = 1;
     htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -76,7 +76,7 @@ static motor_class::Motor motor_right{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
         .steps_per_rev = 200,
-        .microstep = 16,
+        .microstep = 32,
         .encoder_pulses_per_rev = 1000},
     motor_interface_right,
     motor_messages::MotionConstraints{.min_velocity = 1,
@@ -92,7 +92,7 @@ static motor_class::Motor motor_left{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
         .steps_per_rev = 200,
-        .microstep = 16,
+        .microstep = 32,
         .encoder_pulses_per_rev = 1000.0},
     motor_interface_left,
     motor_messages::MotionConstraints{.min_velocity = 1,

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -37,9 +37,6 @@ using namespace motor_messages;
  * Note: The position tracker should never be allowed to go below zero.
  */
 
-// (TODO lc): This should probably live in the motor configs.
-constexpr const int clk_frequency = 85000000 / (5001 * 2);
-
 template <template <class> class QueueImpl, class StatusClient,
           typename MotorMoveMessage>
 requires MessageQueue<QueueImpl<MotorMoveMessage>, MotorMoveMessage>

--- a/pipettes/core/configs.cpp
+++ b/pipettes/core/configs.cpp
@@ -8,7 +8,7 @@ auto configs::linear_motion_sys_config_by_axis(PipetteType which)
             return lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
                 .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 2},
                 .steps_per_rev = 200,
-                .microstep = 32};
+                .microstep = 64};
         case PipetteType::EIGHT_CHANNEL:
         case PipetteType::SINGLE_CHANNEL:
         default:

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -23,7 +23,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                                            .hstrt = 0x5,
                                            .hend = 0x3,
                                            .tbl = 0x2,
-                                           .mres = 0x3},
+                                           .mres = 0x2},
                               .coolconf = {.sgt = 0x6},
                               .glob_scale = {.global_scaler = 0xA7}},
                 .current_config =
@@ -53,7 +53,7 @@ auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
                                    .hstrt = 0x5,
                                    .hend = 0x3,
                                    .tbl = 0x2,
-                                   .mres = 0x3},
+                                   .mres = 0x2},
                       .coolconf = {.sgt = 0x6}},
         .current_config =
             {

--- a/pipettes/firmware/motor_timer_hardware.c
+++ b/pipettes/firmware/motor_timer_hardware.c
@@ -10,12 +10,16 @@ TIM_HandleTypeDef htim6;
 static linear_motor_interrupt_callback plunger_callback = NULL;
 static gear_motor_interrupt_callback gear_callback = NULL;
 
-
+// motor timer: 200kHz from
+// 170MHz sysclk
+// /1 AHB
+// /2 APB1
+// /425 prescaler * 1 count = 200kHz
 void MX_TIM7_Init(void) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
 
     htim7.Instance = TIM7;
-    htim7.Init.Prescaler = 849;
+    htim7.Init.Prescaler = 425;
     htim7.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim7.Init.Period = 1;
     htim7.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;


### PR DESCRIPTION
We'd like to increase the microstep ratios for all the stepper-controlled axes to make motion smoother and quieter. However, this doubles the steps/mm value for each axis, and therefore lowers the maximum speed we can command - we can only issue a step once each interrupt. So, double the interrupt frequency to 200khz to keep the same maximum speed.

This must be tested alongside https://github.com/Opentrons/opentrons/pull/11598 . If that PR isn't being used, the motors will move half as fast as they should.