### PR TITLE
refactor(pipettes): make all motors on the EVT 96 chan use the tmc2160

### DIFF
--- a/include/pipettes/core/gear_motor_tasks.hpp
+++ b/include/pipettes/core/gear_motor_tasks.hpp
@@ -4,8 +4,8 @@
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
-#include "motor-control/core/stepper_motor/tmc2130.hpp"
-#include "motor-control/core/tasks/tmc2130_motor_driver_task.hpp"
+#include "motor-control/core/stepper_motor/tmc2160.hpp"
+#include "motor-control/core/tasks/tmc2160_motor_driver_task.hpp"
 #include "pipettes/core/interfaces.hpp"
 #include "pipettes/core/motor_configurations.hpp"
 #include "pipettes/core/tasks/gear_move_status_reporter_task.hpp"
@@ -19,7 +19,7 @@
  * All tasks that deal with motion control related to the 96 channel
  * pick up/drop tip motors.
  *
- * Both motors are driven by a tmc2130 driver.
+ * Both motors are driven by a tmc2160 driver.
  */
 namespace gear_motor_tasks {
 
@@ -39,7 +39,7 @@ void start_tasks(
  * Access to all the gear motion tasks.
  */
 struct Tasks {
-    tmc2130::tasks::MotorDriverTask<
+    tmc2160::tasks::MotorDriverTask<
         freertos_message_queue::FreeRTOSMessageQueue>* driver{nullptr};
 
     pipettes::tasks::motion_controller_task::MotionControllerTask<
@@ -62,7 +62,7 @@ struct QueueClient : can::message_writer::MessageWriter {
     void send_motion_controller_queue(
         const pipettes::tasks::motion_controller_task::TaskMessage& m);
 
-    void send_motor_driver_queue(const tmc2130::tasks::TaskMessage& m);
+    void send_motor_driver_queue(const tmc2160::tasks::TaskMessage& m);
 
     void send_move_group_queue(
         const pipettes::tasks::move_group_task::TaskMessage& m);
@@ -81,7 +81,7 @@ struct QueueClient : can::message_writer::MessageWriter {
         pipettes::tasks::gear_move_status::TaskMessage>*
         move_status_report_queue{nullptr};
 
-    freertos_message_queue::FreeRTOSMessageQueue<tmc2130::tasks::TaskMessage>*
+    freertos_message_queue::FreeRTOSMessageQueue<tmc2160::tasks::TaskMessage>*
         driver_queue{nullptr};
 };
 

--- a/include/pipettes/core/motor_configurations.hpp
+++ b/include/pipettes/core/motor_configurations.hpp
@@ -14,12 +14,12 @@ using namespace tmc2130::configs;
 using namespace tmc2160::configs;
 
 enum class TMC2130PipetteAxis {
-    left_gear_motor,
-    right_gear_motor,
     linear_motor,
 };
 
 enum class TMC2160PipetteAxis {
+    left_gear_motor,
+    right_gear_motor,
     linear_motor,
 };
 
@@ -28,8 +28,8 @@ struct LowThroughputPipetteDriverHardware {
 };
 
 struct HighThroughputPipetteDriverHardware {
-    TMC2130DriverConfig right_gear_motor;
-    TMC2130DriverConfig left_gear_motor;
+    TMC2160DriverConfig right_gear_motor;
+    TMC2160DriverConfig left_gear_motor;
     TMC2160DriverConfig linear_motor;
 };
 

--- a/pipettes/core/gear_motor_tasks.cpp
+++ b/pipettes/core/gear_motor_tasks.cpp
@@ -13,8 +13,8 @@ static auto right_queue_client = gear_motor_tasks::QueueClient{};
 // left gear motor tasks
 static auto mc_task_builder_left = freertos_task::TaskStarter<
     512, pipettes::tasks::motion_controller_task::MotionControllerTask>{};
-static auto tmc2130_driver_task_builder_left =
-    freertos_task::TaskStarter<512, tmc2130::tasks::MotorDriverTask>{};
+static auto tmc2160_driver_task_builder_left =
+    freertos_task::TaskStarter<512, tmc2160::tasks::MotorDriverTask>{};
 
 static auto move_group_task_builder_left = freertos_task::TaskStarter<
     512, pipettes::tasks::move_group_task::MoveGroupTask>{};
@@ -24,8 +24,8 @@ static auto move_status_task_builder_left = freertos_task::TaskStarter<
 // right gear motor tasks
 static auto mc_task_builder_right = freertos_task::TaskStarter<
     512, pipettes::tasks::motion_controller_task::MotionControllerTask>{};
-static auto tmc2130_driver_task_builder_right =
-    freertos_task::TaskStarter<512, tmc2130::tasks::MotorDriverTask>{};
+static auto tmc2160_driver_task_builder_right =
+    freertos_task::TaskStarter<512, tmc2160::tasks::MotorDriverTask>{};
 
 static auto move_group_task_builder_right = freertos_task::TaskStarter<
     512, pipettes::tasks::move_group_task::MoveGroupTask>{};
@@ -49,8 +49,8 @@ void gear_motor_tasks::start_tasks(
     // Left Gear Motor Tasks
     auto& motion_left = mc_task_builder_left.start(
         5, "motion controller", motion_controllers.left, left_queues);
-    auto& tmc2130_driver_left = tmc2130_driver_task_builder_left.start(
-        5, "tmc2130 driver", gear_driver_configs.left_gear_motor, left_queues,
+    auto& tmc2160_driver_left = tmc2160_driver_task_builder_left.start(
+        5, "tmc2160 driver", gear_driver_configs.left_gear_motor, left_queues,
         spi_writer);
     auto& move_group_left = move_group_task_builder_left.start(
         5, "move group", left_queues, left_queues);
@@ -58,13 +58,13 @@ void gear_motor_tasks::start_tasks(
         5, "move status", left_queues,
         motion_controllers.left.get_mechanical_config());
 
-    left_tasks.driver = &tmc2130_driver_left;
+    left_tasks.driver = &tmc2160_driver_left;
     left_tasks.motion_controller = &motion_left;
     left_tasks.move_group = &move_group_left;
     left_tasks.move_status_reporter = &move_status_reporter_left;
 
     left_queues.set_queue(&can_writer.get_queue());
-    left_queues.driver_queue = &tmc2130_driver_left.get_queue();
+    left_queues.driver_queue = &tmc2160_driver_left.get_queue();
     left_queues.motion_queue = &motion_left.get_queue();
     left_queues.move_group_queue = &move_group_left.get_queue();
     left_queues.move_status_report_queue =
@@ -73,8 +73,8 @@ void gear_motor_tasks::start_tasks(
     // Right Gear Motor Tasks
     auto& motion_right = mc_task_builder_right.start(
         5, "motion controller", motion_controllers.right, right_queues);
-    auto& tmc2130_driver_right = tmc2130_driver_task_builder_right.start(
-        5, "tmc2130 driver", gear_driver_configs.right_gear_motor, right_queues,
+    auto& tmc2160_driver_right = tmc2160_driver_task_builder_right.start(
+        5, "tmc2160 driver", gear_driver_configs.right_gear_motor, right_queues,
         spi_writer);
     auto& move_group_right = move_group_task_builder_right.start(
         5, "move group", right_queues, right_queues);
@@ -82,13 +82,13 @@ void gear_motor_tasks::start_tasks(
         5, "move status", right_queues,
         motion_controllers.right.get_mechanical_config());
 
-    right_tasks.driver = &tmc2130_driver_left;
+    right_tasks.driver = &tmc2160_driver_left;
     right_tasks.motion_controller = &motion_left;
     right_tasks.move_group = &move_group_left;
     right_tasks.move_status_reporter = &move_status_reporter_left;
 
     right_queues.set_queue(&can_writer.get_queue());
-    right_queues.driver_queue = &tmc2130_driver_right.get_queue();
+    right_queues.driver_queue = &tmc2160_driver_right.get_queue();
     right_queues.motion_queue = &motion_right.get_queue();
     right_queues.move_group_queue = &move_group_right.get_queue();
     right_queues.move_status_report_queue =
@@ -106,7 +106,7 @@ void gear_motor_tasks::QueueClient::send_motion_controller_queue(
 }
 
 void gear_motor_tasks::QueueClient::send_motor_driver_queue(
-    const tmc2130::tasks::TaskMessage& m) {
+    const tmc2160::tasks::TaskMessage& m) {
     driver_queue->try_write(m);
 }
 

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -8,43 +8,10 @@
 
 auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
     -> tmc2160::configs::TMC2160DriverConfig {
-    switch (which) {
-        case TMC2160PipetteAxis::linear_motor:
-        default:
-            return tmc2160::configs::TMC2160DriverConfig{
-                .registers = {.gconfig = {.en_pwm_mode = 1},
-                              .ihold_irun = {.hold_current = 16,
-                                             .run_current = 31,
-                                             .hold_current_delay = 0x7},
-                              .tpowerdown = {},
-                              .tcoolthrs = {.threshold = 0},
-                              .thigh = {.threshold = 0xFFFFF},
-                              .chopconf = {.toff = 0x5,
-                                           .hstrt = 0x5,
-                                           .hend = 0x3,
-                                           .tbl = 0x2,
-                                           .mres = 0x3},
-                              .coolconf = {.sgt = 0x6},
-                              .glob_scale = {.global_scaler = 0xA7}},
-                .current_config =
-                    {
-                        .r_sense = 0.1,
-                        .v_sf = 0.325,
-                    },
-                .chip_select = {
-                    .cs_pin = GPIO_PIN_6,
-                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                    .GPIO_handle = GPIOC,
-                }};
-    }
-}
-
-auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
-    -> tmc2130::configs::TMC2130DriverConfig {
-    tmc2130::configs::TMC2130DriverConfig tmc2130_conf{
+    tmc2160::configs::TMC2160DriverConfig tmc2160_conf{
         .registers = {.gconfig = {.en_pwm_mode = 1},
-                      .ihold_irun = {.hold_current = 0x2,
-                                     .run_current = 0x10,
+                      .ihold_irun = {.hold_current = 16,
+                                     .run_current = 31,
                                      .hold_current_delay = 0x7},
                       .tpowerdown = {},
                       .tcoolthrs = {.threshold = 0},
@@ -54,103 +21,74 @@ auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
                                    .hend = 0x3,
                                    .tbl = 0x2,
                                    .mres = 0x3},
-                      .coolconf = {.sgt = 0x6}},
+                      .coolconf = {.sgt = 0x6},
+                      .glob_scale = {.global_scaler = 0xA7}},
         .current_config =
             {
                 .r_sense = 0.1,
                 .v_sf = 0.325,
             },
         .chip_select = {
-            .cs_pin = GPIO_PIN_9,
+            .cs_pin = GPIO_PIN_6,
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             .GPIO_handle = GPIOC,
         }};
     switch (which) {
-        case TMC2130PipetteAxis::left_gear_motor:
-            return tmc2130_conf;
-        case TMC2130PipetteAxis::right_gear_motor:
-            tmc2130_conf.chip_select = {
+        case TMC2160PipetteAxis::left_gear_motor:
+            tmc2160_conf.chip_select = {
+                .cs_pin = GPIO_PIN_9,
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                .GPIO_handle = GPIOC,
+            };
+            return tmc2160_conf;
+        case TMC2160PipetteAxis::right_gear_motor:
+            tmc2160_conf.chip_select = {
                 .cs_pin = GPIO_PIN_10,
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .GPIO_handle = GPIOC,
             };
-            return tmc2130_conf;
+            return tmc2160_conf;
+        case TMC2160PipetteAxis::linear_motor:
+        default:
+            return tmc2160_conf;
+    }
+}
+
+auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
+    -> tmc2130::configs::TMC2130DriverConfig {
+    switch (which) {
         case TMC2130PipetteAxis::linear_motor:
         default:
-            tmc2130_conf.chip_select = {
-                .cs_pin = GPIO_PIN_12,
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                .GPIO_handle = GPIOB,
-            };
-            return tmc2130_conf;
+            return tmc2130::configs::TMC2130DriverConfig{
+                .registers = {.gconfig = {.en_pwm_mode = 1},
+                              .ihold_irun = {.hold_current = 0x2,
+                                             .run_current = 0x10,
+                                             .hold_current_delay = 0x7},
+                              .tpowerdown = {},
+                              .tcoolthrs = {.threshold = 0},
+                              .thigh = {.threshold = 0xFFFFF},
+                              .chopconf = {.toff = 0x5,
+                                           .hstrt = 0x5,
+                                           .hend = 0x3,
+                                           .tbl = 0x2,
+                                           .mres = 0x3},
+                              .coolconf = {.sgt = 0x6}},
+                .current_config =
+                    {
+                        .r_sense = 0.1,
+                        .v_sf = 0.325,
+                    },
+                .chip_select = {
+                    .cs_pin = GPIO_PIN_12,
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .GPIO_handle = GPIOB,
+                }};
     }
 }
 
 auto motor_configs::hardware_config_by_axis(TMC2130PipetteAxis which)
     -> pipette_motor_hardware::HardwareConfig {
     switch (which) {
-        case TMC2130PipetteAxis::right_gear_motor:
-            return pipette_motor_hardware::HardwareConfig{
-                .direction =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_7,
-                     .active_setting = GPIO_PIN_SET},
-                .step =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_2,
-                     .active_setting = GPIO_PIN_SET},
-                .enable =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOA,
-                     .pin = GPIO_PIN_10,
-                     .active_setting = GPIO_PIN_SET},
-                .limit_switch =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_10,
-                     .active_setting = GPIO_PIN_SET},
-                // LED PIN C11, active setting low
-                .led = {},
-                .tip_sense =
-                    {// Located on the back sensor board
-                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_7,
-                     .active_setting = GPIO_PIN_SET},
-            };
-        case TMC2130PipetteAxis::left_gear_motor:
-            return pipette_motor_hardware::HardwareConfig{
-                .direction =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_0,
-                     .active_setting = GPIO_PIN_SET},
-                .step =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_1,
-                     .active_setting = GPIO_PIN_SET},
-                .enable =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOA,
-                     .pin = GPIO_PIN_10,
-                     .active_setting = GPIO_PIN_SET},
-                .limit_switch =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_12,
-                     .active_setting = GPIO_PIN_SET},
-                // LED PIN C11, active setting low
-                .led = {},
-                .tip_sense =
-                    {// Located on the front sensor board
-                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_12,
-                     .active_setting = GPIO_PIN_SET},
-            };
         case TMC2130PipetteAxis::linear_motor:
         default:
             return pipette_motor_hardware::HardwareConfig{
@@ -188,6 +126,68 @@ auto motor_configs::hardware_config_by_axis(TMC2130PipetteAxis which)
 auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
     -> pipette_motor_hardware::HardwareConfig {
     switch (which) {
+        case TMC2160PipetteAxis::right_gear_motor:
+            return pipette_motor_hardware::HardwareConfig{
+                .direction =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_7,
+                     .active_setting = GPIO_PIN_SET},
+                .step =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_2,
+                     .active_setting = GPIO_PIN_SET},
+                .enable =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOA,
+                     .pin = GPIO_PIN_10,
+                     .active_setting = GPIO_PIN_SET},
+                .limit_switch =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_10,
+                     .active_setting = GPIO_PIN_SET},
+                // LED PIN C11, active setting low
+                .led = {},
+                .tip_sense =
+                    {// Located on the back sensor board
+                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_7,
+                     .active_setting = GPIO_PIN_SET},
+            };
+        case TMC2160PipetteAxis::left_gear_motor:
+            return pipette_motor_hardware::HardwareConfig{
+                .direction =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_0,
+                     .active_setting = GPIO_PIN_SET},
+                .step =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_1,
+                     .active_setting = GPIO_PIN_SET},
+                .enable =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOA,
+                     .pin = GPIO_PIN_10,
+                     .active_setting = GPIO_PIN_SET},
+                .limit_switch =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_12,
+                     .active_setting = GPIO_PIN_SET},
+                // LED PIN C11, active setting low
+                .led = {},
+                .tip_sense =
+                    {// Located on the front sensor board
+                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_12,
+                     .active_setting = GPIO_PIN_SET},
+            };
         case TMC2160PipetteAxis::linear_motor:
         default:
             return pipette_motor_hardware::HardwareConfig{
@@ -252,16 +252,16 @@ auto motor_configs::motor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
     -> motor_configs::HighThroughputMotorConfigurations {
     auto configs = motor_configs::HighThroughputPipetteDriverHardware{
         .right_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             driver_config_by_axis(TMC2160PipetteAxis::linear_motor)};
     auto pins = motor_configs::HighThroughputPipetteMotorHardware{
         .right_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             hardware_config_by_axis(TMC2160PipetteAxis::linear_motor),
     };
@@ -275,16 +275,16 @@ auto motor_configs::motor_configurations<
     -> motor_configs::HighThroughputMotorConfigurations {
     auto configs = motor_configs::HighThroughputPipetteDriverHardware{
         .right_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             driver_config_by_axis(TMC2160PipetteAxis::linear_motor)};
     auto pins = motor_configs::HighThroughputPipetteMotorHardware{
         .right_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             hardware_config_by_axis(TMC2160PipetteAxis::linear_motor),
     };

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -136,7 +136,7 @@ auto initialize_motor_tasks(
                               sensor_hardware, id, eeprom_hardware_iface);
 
     initialize_linear_timer(plunger_callback);
-//    initialize_gear_timer(gear_callback_wrapper);
+    //    initialize_gear_timer(gear_callback_wrapper);
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
         peripheral_tasks::get_spi_client(), conf.linear_motor, id);

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -128,7 +128,7 @@ static constexpr auto can_bit_timings =
 auto initialize_motor_tasks(
     can::ids::NodeId id,
     motor_configs::HighThroughputPipetteDriverHardware& conf,
-    interfaces::gear_motor::GearMotionControl& gear_motion) {
+    interfaces::gear_motor::GearMotionControl&) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
                               peripheral_tasks::get_i2c1_client(),
@@ -136,13 +136,15 @@ auto initialize_motor_tasks(
                               sensor_hardware, id, eeprom_hardware_iface);
 
     initialize_linear_timer(plunger_callback);
-    initialize_gear_timer(gear_callback_wrapper);
+//    initialize_gear_timer(gear_callback_wrapper);
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
         peripheral_tasks::get_spi_client(), conf.linear_motor, id);
-    gear_motor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
-                                  gear_motion,
-                                  peripheral_tasks::get_spi_client(), conf, id);
+    // This now no longer works on the L5 for the 96 channel board.
+    //    gear_motor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
+    //                                  gear_motion,
+    //                                  peripheral_tasks::get_spi_client(),
+    //                                  conf, id);
 }
 auto initialize_motor_tasks(
     can::ids::NodeId id,

--- a/pipettes/firmware_l5/motor_configurations.cpp
+++ b/pipettes/firmware_l5/motor_configurations.cpp
@@ -8,13 +8,61 @@
 
 auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
     -> tmc2160::configs::TMC2160DriverConfig {
+    tmc2160::configs::TMC2160DriverConfig tmc2160_conf{
+        .registers = {.gconfig = {.en_pwm_mode = 1},
+                      .ihold_irun = {.hold_current = 16,
+                                     .run_current = 31,
+                                     .hold_current_delay = 0x7},
+                      .tpowerdown = {},
+                      .tcoolthrs = {.threshold = 0},
+                      .thigh = {.threshold = 0xFFFFF},
+                      .chopconf = {.toff = 0x5,
+                                   .hstrt = 0x5,
+                                   .hend = 0x3,
+                                   .tbl = 0x2,
+                                   .mres = 0x3},
+                      .coolconf = {.sgt = 0x6},
+                      .glob_scale = {.global_scaler = 0xA7}},
+        .current_config =
+            {
+                .r_sense = 0.1,
+                .v_sf = 0.325,
+            },
+        .chip_select = {
+            .cs_pin = GPIO_PIN_6,
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            .GPIO_handle = GPIOC,
+        }};
     switch (which) {
+        case TMC2160PipetteAxis::left_gear_motor:
+            tmc2160_conf.chip_select = {
+                .cs_pin = GPIO_PIN_9,
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                .GPIO_handle = GPIOC,
+            };
+            return tmc2160_conf;
+        case TMC2160PipetteAxis::right_gear_motor:
+            tmc2160_conf.chip_select = {
+                .cs_pin = GPIO_PIN_10,
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                .GPIO_handle = GPIOC,
+            };
+            return tmc2160_conf;
         case TMC2160PipetteAxis::linear_motor:
         default:
-            return tmc2160::configs::TMC2160DriverConfig{
+            return tmc2160_conf;
+    }
+}
+
+auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
+    -> tmc2130::configs::TMC2130DriverConfig {
+    switch (which) {
+        case TMC2130PipetteAxis::linear_motor:
+        default:
+            return tmc2130::configs::TMC2130DriverConfig{
                 .registers = {.gconfig = {.en_pwm_mode = 1},
-                              .ihold_irun = {.hold_current = 16,
-                                             .run_current = 31,
+                              .ihold_irun = {.hold_current = 0x2,
+                                             .run_current = 0x10,
                                              .hold_current_delay = 0x7},
                               .tpowerdown = {},
                               .tcoolthrs = {.threshold = 0},
@@ -24,8 +72,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                                            .hend = 0x3,
                                            .tbl = 0x2,
                                            .mres = 0x3},
-                              .coolconf = {.sgt = 0x6},
-                              .glob_scale = {.global_scaler = 0xA7}},
+                              .coolconf = {.sgt = 0x6}},
                 .current_config =
                     {
                         .r_sense = 0.1,
@@ -39,118 +86,9 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
     }
 }
 
-auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
-    -> tmc2130::configs::TMC2130DriverConfig {
-    tmc2130::configs::TMC2130DriverConfig tmc2130_conf{
-        .registers = {.gconfig = {.en_pwm_mode = 1},
-                      .ihold_irun = {.hold_current = 0x2,
-                                     .run_current = 0x10,
-                                     .hold_current_delay = 0x7},
-                      .tpowerdown = {},
-                      .tcoolthrs = {.threshold = 0},
-                      .thigh = {.threshold = 0xFFFFF},
-                      .chopconf = {.toff = 0x5,
-                                   .hstrt = 0x5,
-                                   .hend = 0x3,
-                                   .tbl = 0x2,
-                                   .mres = 0x3},
-                      .coolconf = {.sgt = 0x6}},
-        .current_config =
-            {
-                .r_sense = 0.1,
-                .v_sf = 0.325,
-            },
-        .chip_select = {
-            .cs_pin = GPIO_PIN_9,
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .GPIO_handle = GPIOC,
-        }};
-    switch (which) {
-        case TMC2130PipetteAxis::left_gear_motor:
-            return tmc2130_conf;
-        case TMC2130PipetteAxis::right_gear_motor:
-            tmc2130_conf.chip_select = {
-                .cs_pin = GPIO_PIN_10,
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                .GPIO_handle = GPIOC,
-            };
-            return tmc2130_conf;
-        case TMC2130PipetteAxis::linear_motor:
-        default:
-            tmc2130_conf.chip_select = {
-                .cs_pin = GPIO_PIN_6,
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                .GPIO_handle = GPIOC,
-            };
-            return tmc2130_conf;
-    }
-}
-
 auto motor_configs::hardware_config_by_axis(TMC2130PipetteAxis which)
     -> pipette_motor_hardware::HardwareConfig {
     switch (which) {
-        case TMC2130PipetteAxis::right_gear_motor:
-            return pipette_motor_hardware::HardwareConfig{
-                .direction =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_13,
-                     .active_setting = GPIO_PIN_SET},
-                .step =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_8,
-                     .active_setting = GPIO_PIN_SET},
-                .enable =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOD,
-                     .pin = GPIO_PIN_2,
-                     .active_setting = GPIO_PIN_SET},
-                .limit_switch =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_14,
-                     .active_setting = GPIO_PIN_SET},
-                // LED PIN C11, active setting low
-                .led = {},
-                .tip_sense =
-                    {// Located on the back sensor board
-                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_12,
-                     .active_setting = GPIO_PIN_SET},
-            };
-        case TMC2130PipetteAxis::left_gear_motor:
-            return pipette_motor_hardware::HardwareConfig{
-                .direction =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_7,
-                     .active_setting = GPIO_PIN_SET},
-                .step =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_8,
-                     .active_setting = GPIO_PIN_SET},
-                .enable =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOD,
-                     .pin = GPIO_PIN_2,
-                     .active_setting = GPIO_PIN_SET},
-                .limit_switch =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOA,
-                     .pin = GPIO_PIN_10,
-                     .active_setting = GPIO_PIN_SET},
-                // LED PIN C11, active setting low
-                .led = {},
-                .tip_sense =
-                    {// Located on the front sensor board
-                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOH,
-                     .pin = GPIO_PIN_1,
-                     .active_setting = GPIO_PIN_SET},
-            };
         case TMC2130PipetteAxis::linear_motor:
         default:
             return pipette_motor_hardware::HardwareConfig{
@@ -188,6 +126,68 @@ auto motor_configs::hardware_config_by_axis(TMC2130PipetteAxis which)
 auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
     -> pipette_motor_hardware::HardwareConfig {
     switch (which) {
+        case TMC2160PipetteAxis::right_gear_motor:
+            return pipette_motor_hardware::HardwareConfig{
+                .direction =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_13,
+                     .active_setting = GPIO_PIN_SET},
+                .step =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_8,
+                     .active_setting = GPIO_PIN_SET},
+                .enable =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOD,
+                     .pin = GPIO_PIN_2,
+                     .active_setting = GPIO_PIN_SET},
+                .limit_switch =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_14,
+                     .active_setting = GPIO_PIN_SET},
+                // LED PIN C11, active setting low
+                .led = {},
+                .tip_sense =
+                    {// Located on the back sensor board
+                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_12,
+                     .active_setting = GPIO_PIN_SET},
+            };
+        case TMC2160PipetteAxis::left_gear_motor:
+            return pipette_motor_hardware::HardwareConfig{
+                .direction =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_7,
+                     .active_setting = GPIO_PIN_SET},
+                .step =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOC,
+                     .pin = GPIO_PIN_8,
+                     .active_setting = GPIO_PIN_SET},
+                .enable =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOD,
+                     .pin = GPIO_PIN_2,
+                     .active_setting = GPIO_PIN_SET},
+                .limit_switch =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOA,
+                     .pin = GPIO_PIN_10,
+                     .active_setting = GPIO_PIN_SET},
+                // LED PIN C11, active setting low
+                .led = {},
+                .tip_sense =
+                    {// Located on the front sensor board
+                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOH,
+                     .pin = GPIO_PIN_1,
+                     .active_setting = GPIO_PIN_SET},
+            };
         case TMC2160PipetteAxis::linear_motor:
         default:
             return pipette_motor_hardware::HardwareConfig{
@@ -252,16 +252,16 @@ auto motor_configs::motor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
     -> motor_configs::HighThroughputMotorConfigurations {
     auto configs = motor_configs::HighThroughputPipetteDriverHardware{
         .right_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             driver_config_by_axis(TMC2160PipetteAxis::linear_motor)};
     auto pins = motor_configs::HighThroughputPipetteMotorHardware{
         .right_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             hardware_config_by_axis(TMC2160PipetteAxis::linear_motor),
     };
@@ -275,16 +275,16 @@ auto motor_configs::motor_configurations<
     -> motor_configs::HighThroughputMotorConfigurations {
     auto configs = motor_configs::HighThroughputPipetteDriverHardware{
         .right_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             driver_config_by_axis(TMC2160PipetteAxis::linear_motor)};
     auto pins = motor_configs::HighThroughputPipetteMotorHardware{
         .right_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            hardware_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            hardware_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             hardware_config_by_axis(TMC2160PipetteAxis::linear_motor),
     };

--- a/pipettes/simulator/motor_configurations.cpp
+++ b/pipettes/simulator/motor_configurations.cpp
@@ -5,39 +5,7 @@ int dummy_gpio = 0x1000;
 
 auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
     -> tmc2160::configs::TMC2160DriverConfig {
-    switch (which) {
-        case TMC2160PipetteAxis::linear_motor:
-        default:
-            return tmc2160::configs::TMC2160DriverConfig{
-                .registers = {.gconfig = {.en_pwm_mode = 1},
-                              .ihold_irun = {.hold_current = 0x2,
-                                             .run_current = 0x10,
-                                             .hold_current_delay = 0x7},
-                              .tpowerdown = {},
-                              .tcoolthrs = {.threshold = 0},
-                              .thigh = {.threshold = 0xFFFFF},
-                              .chopconf = {.toff = 0x5,
-                                           .hstrt = 0x5,
-                                           .hend = 0x3,
-                                           .tbl = 0x2,
-                                           .mres = 0x3},
-                              .coolconf = {.sgt = 0x6},
-                              .glob_scale = {.global_scaler = 0xA7}},
-                .current_config =
-                    {
-                        .r_sense = 0.1,
-                        .v_sf = 0.325,
-                    },
-                .chip_select = {
-                    .cs_pin = 64,
-                    .GPIO_handle = GPIO_C_DEF,
-                }};
-    }
-}
-
-auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
-    -> tmc2130::configs::TMC2130DriverConfig {
-    tmc2130::configs::TMC2130DriverConfig tmc2130_conf{
+    tmc2160::configs::TMC2160DriverConfig tmc2160_conf{
         .registers = {.gconfig = {.en_pwm_mode = 1},
                       .ihold_irun = {.hold_current = 0x2,
                                      .run_current = 0x10,
@@ -50,32 +18,56 @@ auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
                                    .hend = 0x3,
                                    .tbl = 0x2,
                                    .mres = 0x3},
-                      .coolconf = {.sgt = 0x6}},
+                      .coolconf = {.sgt = 0x6},
+                      .glob_scale = {.global_scaler = 0xA7}},
         .current_config =
             {
                 .r_sense = 0.1,
                 .v_sf = 0.325,
             },
         .chip_select = {
-            .cs_pin = 512,
+            .cs_pin = 64,
             .GPIO_handle = GPIO_C_DEF,
         }};
     switch (which) {
-        case TMC2130PipetteAxis::left_gear_motor:
-            return tmc2130_conf;
-        case TMC2130PipetteAxis::right_gear_motor:
-            tmc2130_conf.chip_select = {
-                .cs_pin = 64,
-                .GPIO_handle = GPIO_C_DEF,
-            };
-            return tmc2130_conf;
+        case TMC2160PipetteAxis::left_gear_motor:
+            return tmc2160_conf;
+        case TMC2160PipetteAxis::right_gear_motor:
+            return tmc2160_conf;
+        case TMC2160PipetteAxis::linear_motor:
+        default:
+            return tmc2160_conf;
+    }
+}
+
+auto motor_configs::driver_config_by_axis(TMC2130PipetteAxis which)
+    -> tmc2130::configs::TMC2130DriverConfig {
+    switch (which) {
         case TMC2130PipetteAxis::linear_motor:
         default:
-            tmc2130_conf.chip_select = {
-                .cs_pin = 64,
-                .GPIO_handle = GPIO_C_DEF,
-            };
-            return tmc2130_conf;
+            return tmc2130::configs::TMC2130DriverConfig{
+                .registers = {.gconfig = {.en_pwm_mode = 1},
+                              .ihold_irun = {.hold_current = 0x2,
+                                             .run_current = 0x10,
+                                             .hold_current_delay = 0x7},
+                              .tpowerdown = {},
+                              .tcoolthrs = {.threshold = 0},
+                              .thigh = {.threshold = 0xFFFFF},
+                              .chopconf = {.toff = 0x5,
+                                           .hstrt = 0x5,
+                                           .hend = 0x3,
+                                           .tbl = 0x2,
+                                           .mres = 0x3},
+                              .coolconf = {.sgt = 0x6}},
+                .current_config =
+                    {
+                        .r_sense = 0.1,
+                        .v_sf = 0.325,
+                    },
+                .chip_select = {
+                    .cs_pin = 64,
+                    .GPIO_handle = GPIO_C_DEF,
+                }};
     }
 }
 
@@ -106,9 +98,9 @@ auto motor_configs::motor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
     -> motor_configs::HighThroughputMotorConfigurations {
     auto configs = motor_configs::HighThroughputPipetteDriverHardware{
         .right_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             driver_config_by_axis(TMC2160PipetteAxis::linear_motor)};
     auto pins = motor_configs::HighThroughputPipetteMotorHardware{};
@@ -122,9 +114,9 @@ auto motor_configs::motor_configurations<
     -> motor_configs::HighThroughputMotorConfigurations {
     auto configs = motor_configs::HighThroughputPipetteDriverHardware{
         .right_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::right_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::right_gear_motor),
         .left_gear_motor =
-            driver_config_by_axis(TMC2130PipetteAxis::left_gear_motor),
+            driver_config_by_axis(TMC2160PipetteAxis::left_gear_motor),
         .linear_motor =
             driver_config_by_axis(TMC2160PipetteAxis::linear_motor)};
     auto pins = motor_configs::HighThroughputPipetteMotorHardware{};


### PR DESCRIPTION
All of the motors are now using the tmc2160 motor driver. I made an executive decision to no longer support the gear motors on the L5 boards for the 96 channel because it was getting to be gross to try and support both configurations.

We will only be using the old L5 proto board for plunger testing on the 96 channel.