### PR TITLE
fix(gripper-motor): use the tmc2130 emergency stop pin to reflect new board change

### DIFF
--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -67,7 +67,7 @@ static motor_hardware::MotorHardware motor_hardware_iface(motor_pins, &htim7,
  * Motor driver configuration.
  */
 static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
-    .registers = {.gconfig = {.en_pwm_mode = 0x0},
+    .registers = {.gconfig = {.en_pwm_mode = 0x0, .stop_enable = 0x1},
                   .ihold_irun = {.hold_current = 0x2,  // 0.177A
                                  .run_current = 0xA,   // 0.648A
                                  .hold_current_delay = 0x7},


### PR DESCRIPTION
The tmc2130 has a config register that enables an extra emergency_stop pin on the driver. for the gripper we re-worked the mcu board so that the e-stop line coming from the SoM board is routed to this pin instead of the motor-enable pin.
This has the effect of leaving the motor enabled when the e-stop is triggered but the motor driver no longer accepts any steps that are sent to it.
this means that during estop the gripper z motor won't fall straight into the deck and hold steady wherever it is.

The re-work also holds the motor enable pin to ground so the motor driver is always enabled