### PR TITLE
refactor(tests): remove intedependencies between tests and simulations

### DIFF
--- a/common/simulation/CMakeLists.txt
+++ b/common/simulation/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(common-simulation STATIC
 
 target_link_libraries(common-simulation PUBLIC can-core Boost::boost Boost::date_time pthread)
 
+add_dependencies(common-simulation state_manager)
+
 target_compile_definitions(common-simulation PUBLIC ENABLE_LOGGING)
 
 set_target_properties(common-simulation

--- a/common/tests/CMakeLists.txt
+++ b/common/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ target_compile_options(common
   -Wextra-semi
   -Wctor-dtor-privacy
   -fno-rtti)
-target_link_libraries(common Catch2::Catch2 common-simulation common-core)
+target_link_libraries(common Catch2::Catch2 common-core)
 
 catch_discover_tests(common)
 add_build_and_test_target(common)

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -33,7 +33,7 @@ static auto sensor_map =
     i2c::hardware::SimI2C::DeviceMap{{capsensor.get_address(), capsensor}};
 static auto i2c2 = i2c::hardware::SimI2C{sensor_map};
 
-static test_mocks::MockSensorHardware fake_sensor_hw{};
+static sim_mocks::MockSensorHardware fake_sensor_hw{};
 
 static std::shared_ptr<state_manager::StateManagerConnection<
     freertos_synchronization::FreeRTOSCriticalSection>>

--- a/head/tests/CMakeLists.txt
+++ b/head/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ target_compile_options(head
         -Wctor-dtor-privacy
         -fno-rtti)
 
-target_link_libraries(head PUBLIC Catch2::Catch2 common-simulation common-core)
+target_link_libraries(head PUBLIC Catch2::Catch2 common-core)
 
 catch_discover_tests(head)
 add_build_and_test_target(head)

--- a/i2c/tests/CMakeLists.txt
+++ b/i2c/tests/CMakeLists.txt
@@ -34,7 +34,7 @@ target_compile_options(i2c
         -Wctor-dtor-privacy)
 
 target_i2c_simlib(i2c)
-target_link_libraries(i2c Catch2::Catch2 common-core common-simulation)
+target_link_libraries(i2c Catch2::Catch2 common-core)
 
 
 catch_discover_tests(i2c)

--- a/include/i2c/simulation/device.hpp
+++ b/include/i2c/simulation/device.hpp
@@ -5,7 +5,7 @@
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.h"
 #include "sensors/core/mmr920C04.hpp"
-#include "sensors/simulation/mock_hardware.hpp"
+#include "sensors/tests/mock_hardware.hpp"
 
 namespace i2c {
 namespace hardware {

--- a/include/i2c/simulation/device.hpp
+++ b/include/i2c/simulation/device.hpp
@@ -5,7 +5,6 @@
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.h"
 #include "sensors/core/mmr920C04.hpp"
-#include "sensors/tests/mock_hardware.hpp"
 
 namespace i2c {
 namespace hardware {
@@ -82,7 +81,6 @@ class I2CRegisterMap : public I2CDeviceBase {
 
   private:
     BackingMap register_map;
-    test_mocks::MockSensorHardware mock_sensor_hardware{};
     RegAddressType current_register{0};
 };
 

--- a/include/sensors/simulation/mmr920C04.hpp
+++ b/include/sensors/simulation/mmr920C04.hpp
@@ -2,6 +2,7 @@
 
 #include "i2c/simulation/device.hpp"
 #include "sensors/core/mmr920C04.hpp"
+#include "sensors/simulation/mock_hardware.hpp"
 
 namespace mmr920C04_simulator {
 
@@ -10,7 +11,7 @@ using namespace i2c::hardware;
 
 class MMR920C04 : public I2CRegisterMap<uint8_t, uint32_t> {
   public:
-    MMR920C04(test_mocks::MockSensorHardware &mock_sensor_hw)
+    MMR920C04(sim_mocks::MockSensorHardware &mock_sensor_hw)
         : I2CRegisterMap{mmr920C04::ADDRESS,
                          {{static_cast<uint8_t>(mmr920C04::Registers::STATUS),
                            0xED},
@@ -40,7 +41,7 @@ class MMR920C04 : public I2CRegisterMap<uint8_t, uint32_t> {
         return result;
     }
 
-    test_mocks::MockSensorHardware &mock_sensor_hardware;
+    sim_mocks::MockSensorHardware &mock_sensor_hardware;
 };
 
 };  // namespace mmr920C04_simulator

--- a/include/sensors/simulation/mock_hardware.hpp
+++ b/include/sensors/simulation/mock_hardware.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "sensors/core/sensor_hardware_interface.hpp"
-namespace test_mocks {
+namespace sim_mocks {
 class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
   public:
     auto set_sync() -> void override {
@@ -41,4 +41,4 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
     uint32_t sync_set_calls = 0;
     uint32_t sync_reset_calls = 0;
 };
-};  // namespace test_mocks
+};  // namespace sim_mocks

--- a/include/sensors/tests/mock_hardware.hpp
+++ b/include/sensors/tests/mock_hardware.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "sensors/core/sensor_hardware_interface.hpp"
+namespace test_mocks {
+class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
+  public:
+    auto set_sync() -> void override {
+        sync_state = true;
+        sync_set_calls++;
+    }
+    auto reset_sync() -> void override {
+        sync_state = false;
+        sync_reset_calls++;
+    }
+    std::array<std::function<void()>, 5> data_ready_callbacks = {};
+    auto add_data_ready_callback(std::function<void()> callback)
+        -> bool override {
+        for (auto &callback_function : data_ready_callbacks) {
+            if (callback_function) {
+                continue;
+            }
+            callback_function = callback;
+            return true;
+        }
+        return false;
+    }
+
+    auto data_ready() -> void {
+        for (auto &callback_function : data_ready_callbacks) {
+            if (callback_function) {
+                callback_function();
+            }
+        }
+    }
+
+    auto get_sync_state_mock() const -> bool { return sync_state; }
+    auto get_sync_set_calls() const -> uint32_t { return sync_set_calls; }
+    auto get_sync_reset_calls() const -> uint32_t { return sync_reset_calls; }
+
+  private:
+    bool sync_state = false;
+    uint32_t sync_set_calls = 0;
+    uint32_t sync_reset_calls = 0;
+};
+};  // namespace test_mocks

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ target_compile_options(motor-control
         -Wsign-promo
         -Wextra-semi
         -Wctor-dtor-privacy)
-target_link_libraries(motor-control PUBLIC Catch2::Catch2 common-simulation motor-utils)
+target_link_libraries(motor-control PUBLIC Catch2::Catch2 motor-utils)
 
 catch_discover_tests(motor-control)
 add_build_and_test_target(motor-control)

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -92,7 +92,7 @@ auto initialize_motor_tasks(
     can::ids::NodeId id,
     motor_configs::HighThroughputPipetteDriverHardware& conf,
     interfaces::gear_motor::GearMotionControl& gear_motion,
-    test_mocks::MockSensorHardware& fake_sensor_hw,
+    sim_mocks::MockSensorHardware& fake_sensor_hw,
     eeprom::simulator::EEProm& sim_eeprom) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
@@ -114,7 +114,7 @@ auto initialize_motor_tasks(
     can::ids::NodeId id,
     motor_configs::LowThroughputPipetteDriverHardware& conf,
     interfaces::gear_motor::UnavailableGearMotionControl&,
-    test_mocks::MockSensorHardware& fake_sensor_hw,
+    sim_mocks::MockSensorHardware& fake_sensor_hw,
     eeprom::simulator::EEProm& sim_eeprom) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();
     auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(
         options, TEMPORARY_PIPETTE_SERIAL);
-    auto fake_sensor_hw = std::make_shared<test_mocks::MockSensorHardware>();
+    auto fake_sensor_hw = std::make_shared<sim_mocks::MockSensorHardware>();
     auto pressuresensor =
         std::make_shared<mmr920C04_simulator::MMR920C04>(*fake_sensor_hw);
     i2c::hardware::SimI2C::DeviceMap sensor_map_i2c1 = {

--- a/pipettes/tests/CMakeLists.txt
+++ b/pipettes/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ target_compile_options(pipettes
         -Wextra-semi
         -Wctor-dtor-privacy)
 
-target_link_libraries(pipettes Catch2::Catch2 common-simulation common-core motor-utils)
+target_link_libraries(pipettes Catch2::Catch2 common-core motor-utils)
 target_i2c_simlib(pipettes)
 
 catch_discover_tests(pipettes)

--- a/sensors/tests/CMakeLists.txt
+++ b/sensors/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ target_compile_options(sensors
         -Wextra-semi
         -Wctor-dtor-privacy)
 
-target_link_libraries(sensors Catch2::Catch2 common-simulation common-core motor-utils)
+target_link_libraries(sensors Catch2::Catch2 common-core motor-utils)
 target_i2c_simlib(sensors)
 
 catch_discover_tests(sensors)

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -11,7 +11,7 @@
 #include "sensors/core/fdc1004.hpp"
 #include "sensors/core/tasks/capacitive_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
-#include "sensors/simulation/mock_hardware.hpp"
+#include "sensors/tests/mock_hardware.hpp"
 
 template <typename Message, typename Queue>
 auto get_message(Queue& q) -> Message {

--- a/sensors/tests/test_environment_driver.cpp
+++ b/sensors/tests/test_environment_driver.cpp
@@ -10,7 +10,7 @@
 #include "motor-control/core/utils.hpp"
 #include "sensors/core/tasks/environment_driver.hpp"
 #include "sensors/core/utils.hpp"
-#include "sensors/simulation/mock_hardware.hpp"
+#include "sensors/tests/mock_hardware.hpp"
 /*
  * NOTE: pressure_sensor_task.hpp is included here just because
  * the linter throws an unused-function error and NOLINT doesn't

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -11,7 +11,7 @@
 #include "sensors/core/tasks/pressure_driver.hpp"
 #include "sensors/core/tasks/pressure_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
-#include "sensors/simulation/mock_hardware.hpp"
+#include "sensors/tests/mock_hardware.hpp"
 /*
  * NOTE: pressure_sensor_task.hpp is included here just because
  * the linter throws an unused-function error and NOLINT doesn't

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -11,7 +11,7 @@
 #include "sensors/core/mmr920C04.hpp"
 #include "sensors/core/tasks/pressure_sensor_task.hpp"
 #include "sensors/core/utils.hpp"
-#include "sensors/simulation/mock_hardware.hpp"
+#include "sensors/tests/mock_hardware.hpp"
 
 template <typename Message, typename Queue>
 requires std::constructible_from<i2c::poller::TaskMessage, Message>

--- a/spi/simulation/spi.cpp
+++ b/spi/simulation/spi.cpp
@@ -7,6 +7,7 @@ bool spi::hardware::SimSpiDeviceBase::transmit_receive(
     const spi::utils::MaxMessageBuffer& transmit,
     spi::utils::MaxMessageBuffer& receive,
     spi::utils::ChipSelectInterface cs_intf) {
+    static_cast<void>(cs_intf);
     txrx_count++;
     uint8_t control = 0;
     uint32_t data = 0;

--- a/spi/tests/CMakeLists.txt
+++ b/spi/tests/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_options(spi
         -Wctor-dtor-privacy)
 
 target_spi_simlib(spi)
-target_link_libraries(spi Catch2::Catch2 common-core common-simulation)
+target_link_libraries(spi Catch2::Catch2 common-core)
 
 
 catch_discover_tests(spi)

--- a/state_manager/CMakeLists.txt
+++ b/state_manager/CMakeLists.txt
@@ -92,6 +92,8 @@ add_custom_target(
 	WORKING_DIRECTORY ../../state_manager
 )
 
+add_dependencies(state-manager-headers state-manager-setup)
+
 add_custom_target(
 	state-manager-update
 	COMMAND ${Poetry_EXECUTABLE} config virtualenvs.path ${VIRTUAL_ENVIRONMENTS_ROOT_PATH} --local


### PR DESCRIPTION
There was a bit of shared code and dependencies between test and simulation targets that was causing trouble in another branch, primarily due to header generation from the state manager. This PR refactors the tests and simulation targets to try to separate some of those inter-dependencies.

This PR also adds a dependency in common-simulation to ensure the headers are always generated from state manager, and that the state-manager environment is always initialized before header generation.