### PR TITLE
feat(simulators): add state manager messaging

### DIFF
--- a/common/simulation/CMakeLists.txt
+++ b/common/simulation/CMakeLists.txt
@@ -11,8 +11,11 @@ set_target_properties(common-simulation
         PROPERTIES CXX_STANDARD 20
         CXX_STANDARD_REQUIRED TRUE)
 
-target_include_directories(common-simulation
-        PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(common-simulation PUBLIC 
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/cpp-utils/include
+        ${CMAKE_BINARY_DIR} # To include state manager headers
+        )
 
 target_compile_options(common-simulation
         PRIVATE

--- a/common/simulation/CMakeLists.txt
+++ b/common/simulation/CMakeLists.txt
@@ -7,6 +7,8 @@ target_link_libraries(common-simulation PUBLIC can-core Boost::boost Boost::date
 
 target_compile_definitions(common-simulation PUBLIC ENABLE_LOGGING)
 
+add_dependencies(common-simulation state-manager-headers)
+
 set_target_properties(common-simulation
         PROPERTIES CXX_STANDARD 20
         CXX_STANDARD_REQUIRED TRUE)

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -27,7 +27,9 @@ static auto spi_comms = spi::hardware::SimSpiDeviceBase();
 /**
  * The motor interface.
  */
-static auto motor_interface = sim_motor_hardware_iface::SimMotorHardwareIface();
+static auto motor_interface = sim_motor_hardware_iface::SimMotorHardwareIface(
+    get_axis_type() == GantryAxisType::gantry_x ? MoveMessageHardware::x
+                                                : MoveMessageHardware::y);
 
 /**
  * The pending move queue
@@ -110,6 +112,7 @@ void interfaces::initialize_sim(int argc, char** argv) {
 
     state_manager_connection = state_manager::create<
         freertos_synchronization::FreeRTOSCriticalSection>(options);
+    motor_interface.provide_state_manager(state_manager_connection);
 }
 
 std::shared_ptr<can::bus::CanBus> canbus;

--- a/gripper/simulator/interfaces.cpp
+++ b/gripper/simulator/interfaces.cpp
@@ -128,3 +128,8 @@ auto z_motor_iface::get_z_motor_interface()
     -> sim_motor_hardware_iface::SimMotorHardwareIface& {
     return motor_interface;
 }
+
+auto z_motor_iface::get_brushed_motor_interface()
+    -> sim_motor_hardware_iface::SimBrushedMotorHardwareIface& {
+    return brushed_motor_hardware_iface;
+}

--- a/gripper/simulator/interfaces.cpp
+++ b/gripper/simulator/interfaces.cpp
@@ -2,6 +2,7 @@
 
 #include "can/simlib/transport.hpp"
 #include "gripper/core/tasks.hpp"
+#include "gripper/simulation/sim_interfaces.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
@@ -17,7 +18,8 @@ static auto spi_comms = spi::hardware::SimSpiDeviceBase();
 /**
  * The motor interface.
  */
-static auto motor_interface = sim_motor_hardware_iface::SimMotorHardwareIface();
+static auto motor_interface =
+    sim_motor_hardware_iface::SimMotorHardwareIface(MoveMessageHardware::z_g);
 
 /**
  * The pending move queue
@@ -120,4 +122,9 @@ auto grip_motor_iface::get_grip_motor()
 auto z_motor_iface::get_tmc2130_driver_configs()
     -> tmc2130::configs::TMC2130DriverConfig& {
     return MotorDriverConfigurations;
+}
+
+auto z_motor_iface::get_z_motor_interface()
+    -> sim_motor_hardware_iface::SimMotorHardwareIface& {
+    return motor_interface;
 }

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -90,6 +90,8 @@ int main(int argc, char** argv) {
 
     z_motor_iface::get_z_motor_interface().provide_state_manager(
         state_manager_connection);
+    z_motor_iface::get_brushed_motor_interface().provide_state_manager(
+        state_manager_connection);
     fake_sensor_hw.provide_state_manager(state_manager_connection);
 
     auto sim_eeprom =

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -90,6 +90,7 @@ int main(int argc, char** argv) {
 
     z_motor_iface::get_z_motor_interface().provide_state_manager(
         state_manager_connection);
+    fake_sensor_hw.provide_state_manager(state_manager_connection);
 
     auto sim_eeprom =
         std::make_shared<eeprom::simulator::EEProm>(options, TEMPORARY_SERIAL);

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -12,6 +12,7 @@
 #include "eeprom/simulation/eeprom.hpp"
 #include "gripper/core/interfaces.hpp"
 #include "gripper/core/tasks.hpp"
+#include "gripper/simulation/sim_interfaces.hpp"
 #include "i2c/simulation/i2c_sim.hpp"
 #include "sensors/simulation/fdc1004.hpp"
 #include "sensors/simulation/mock_hardware.hpp"
@@ -86,6 +87,9 @@ int main(int argc, char** argv) {
 
     state_manager_connection = state_manager::create<
         freertos_synchronization::FreeRTOSCriticalSection>(options);
+
+    z_motor_iface::get_z_motor_interface().provide_state_manager(
+        state_manager_connection);
 
     auto sim_eeprom =
         std::make_shared<eeprom::simulator::EEProm>(options, TEMPORARY_SERIAL);

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -35,9 +35,9 @@ static auto spi_comms_left = spi::hardware::SimSpiDeviceBase();
  * The motor interfaces.
  */
 static auto motor_interface_right =
-    sim_motor_hardware_iface::SimMotorHardwareIface();
+    sim_motor_hardware_iface::SimMotorHardwareIface(MoveMessageHardware::z_r);
 static auto motor_interface_left =
-    sim_motor_hardware_iface::SimMotorHardwareIface();
+    sim_motor_hardware_iface::SimMotorHardwareIface(MoveMessageHardware::z_l);
 
 static freertos_message_queue::FreeRTOSMessageQueue<motor_messages::Move>
     motor_queue_right("Motor Queue Right");
@@ -152,6 +152,9 @@ int main(int argc, char** argv) {
 
     state_manager_connection = state_manager::create<
         freertos_synchronization::FreeRTOSCriticalSection>(options);
+
+    motor_interface_right.provide_state_manager(state_manager_connection);
+    motor_interface_left.provide_state_manager(state_manager_connection);
 
     auto canbus = std::make_shared<can::sim::bus::SimCANBus>(
         can::sim::transport::create(options));

--- a/include/common/simulation/state_manager.hpp
+++ b/include/common/simulation/state_manager.hpp
@@ -24,6 +24,13 @@
 
 #include "common/core/logging.h"
 #include "common/core/synchronization.hpp"
+#include "ot_utils/core/bit_utils.hpp"
+
+// Message types
+#include "common/simulation/direction.hpp"
+#include "common/simulation/message_ids.hpp"
+#include "common/simulation/move_message_hw_ids.hpp"
+#include "common/simulation/sync_pin_state.hpp"
 
 namespace state_manager {
 
@@ -51,17 +58,44 @@ class StateManagerConnection {
     StateManagerConnection &&operator=(const StateManagerConnection &&) =
         delete;
 
-    template <size_t N>
-    auto send(std::array<uint8_t, N> data) -> bool {
-        auto lock = synchronization::Lock(critical_section);
-        LOG("Sending %d bytes to state manager", N);
-        return _socket.send_to(boost::asio::const_buffer(data.data(), N),
-                               _endpoint) == N;
+    /**
+     * @brief Send a Move message to the state manager, indicating an axis on
+     * the robot moved a single microstep.
+     *
+     * @param id The id of the axis
+     * @param direction The direction the axis moved
+     * @return true if the message sent succesfully, false otherwise
+     */
+    auto send_move_msg(MoveMessageHardware id, Direction direction) -> bool {
+        std::array<uint8_t, 4> message;
+        auto itr = ot_utils::bit_utils::int_to_bytes(
+            static_cast<uint8_t>(MessageID::move), message.begin(),
+            message.end());
+        itr = ot_utils::bit_utils::int_to_bytes(static_cast<uint16_t>(id), itr,
+                                                message.end());
+        itr = ot_utils::bit_utils::int_to_bytes(static_cast<uint8_t>(direction),
+                                                itr, message.end());
+        return send(message);
     }
 
-    // TODO:
-    //   - Add message class
-    //   - Write Message, accepting a message instance
+    /**
+     * @brief Send a Sync pin message to the state manager, indicating the
+     * sync pin on the OT-3 changed state.
+     *
+     * @param state The updated state of the sync pin
+     * @return true if the message sent succesfully, false otherwise
+     */
+    auto send_sync_msg(SyncPinState state) -> bool {
+        std::array<uint8_t, 4> message;
+        auto itr = ot_utils::bit_utils::int_to_bytes(
+            static_cast<uint8_t>(MessageID::sync_pin), message.begin(),
+            message.end());
+        itr = ot_utils::bit_utils::int_to_bytes(static_cast<uint16_t>(0), itr,
+                                                message.end());
+        itr = ot_utils::bit_utils::int_to_bytes(static_cast<uint8_t>(state),
+                                                itr, message.end());
+        return send(message);
+    }
 
   private:
     auto open() -> bool {
@@ -92,6 +126,13 @@ class StateManagerConnection {
             LOG("Closing state manager socket to %s:%d", _host.c_str(), _port);
             _socket.close();
         }
+    }
+
+    template <size_t N>
+    auto send(const std::array<uint8_t, N> &data) -> bool {
+        auto lock = synchronization::Lock(critical_section);
+        return _socket.send_to(boost::asio::const_buffer(data.data(), N),
+                               _endpoint) == N;
     }
 
     std::string _host;

--- a/include/common/simulation/state_manager.hpp
+++ b/include/common/simulation/state_manager.hpp
@@ -164,15 +164,6 @@ auto create(const boost::program_options::variables_map &options)
     auto port = options["state-mgr-port"].as<std::uint16_t>();
     auto ret =
         std::make_shared<StateManagerConnection<CriticalSection>>(host, port);
-    ret->send_sync_msg(SyncPinState::LOW);
-    for (long i = 0; i < 10000; ++i) {
-        ret->send_move_msg(MoveMessageHardware::z_l, Direction::POSITIVE);
-    }
-    auto sync = ret->get_sync_state();
-    LOG("SyncState: %d", sync);
-    ret->send_sync_msg(SyncPinState::HIGH);
-    sync = ret->get_sync_state();
-    LOG("SyncState: %d", sync);
     return ret;
 }
 

--- a/include/common/simulation/state_manager.hpp
+++ b/include/common/simulation/state_manager.hpp
@@ -150,6 +150,9 @@ auto create(const boost::program_options::variables_map &options)
     auto port = options["state-mgr-port"].as<std::uint16_t>();
     auto ret =
         std::make_shared<StateManagerConnection<CriticalSection>>(host, port);
+    for (int i = 0; i < 100; ++i) {
+        ret->send_move_msg(MoveMessageHardware::z_l, Direction::POSITIVE);
+    }
     return ret;
 }
 

--- a/include/gripper/simulation/sim_interfaces.hpp
+++ b/include/gripper/simulation/sim_interfaces.hpp
@@ -7,4 +7,7 @@ namespace z_motor_iface {
 auto get_z_motor_interface()
     -> sim_motor_hardware_iface::SimMotorHardwareIface&;
 
-}
+auto get_brushed_motor_interface()
+    -> sim_motor_hardware_iface::SimBrushedMotorHardwareIface&;
+
+}  // namespace z_motor_iface

--- a/include/gripper/simulation/sim_interfaces.hpp
+++ b/include/gripper/simulation/sim_interfaces.hpp
@@ -4,6 +4,7 @@
 
 namespace z_motor_iface {
 
-auto get_z_motor_interface() -> sim_motor_hardware_iface::SimMotorHardwareIface&;
+auto get_z_motor_interface()
+    -> sim_motor_hardware_iface::SimMotorHardwareIface&;
 
 }

--- a/include/gripper/simulation/sim_interfaces.hpp
+++ b/include/gripper/simulation/sim_interfaces.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "motor-control/simulation/sim_motor_hardware_iface.hpp"
+
+namespace z_motor_iface {
+
+auto get_z_motor_interface() -> sim_motor_hardware_iface::SimMotorHardwareIface&;
+
+}

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -1,17 +1,31 @@
 #pragma once
 
+#include <memory>
+
+#include "common/core/freertos_synchronization.hpp"
 #include "common/core/logging.h"
+#include "common/simulation/state_manager.hpp"
 #include "motor-control/core/motor_hardware_interface.hpp"
 #include "ot_utils/core/pid.hpp"
 
 namespace sim_motor_hardware_iface {
 
+using StateManager = state_manager::StateManagerConnection<
+    freertos_synchronization::FreeRTOSCriticalSection>;
+using StateManagerHandle = std::shared_ptr<StateManager>;
+
 class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
   public:
-    void step() final {}
+    SimMotorHardwareIface(MoveMessageHardware id)
+        : motor_hardware::StepperMotorHardwareIface(), _id(id) {}
+    void step() final {
+        if (_state_manager) {
+            _state_manager->send_move_msg(_id, _direction);
+        }
+    }
     void unstep() final {}
-    void positive_direction() final {}
-    void negative_direction() final {}
+    void positive_direction() final { _direction = Direction::POSITIVE; }
+    void negative_direction() final { _direction = Direction::NEGATIVE; }
     void activate_motor() final {}
     void deactivate_motor() final {}
     void start_timer_interrupt() final {}
@@ -30,9 +44,18 @@ class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
     int32_t get_encoder_pulses() final { return test_pulses; }
     void sim_set_encoder_pulses(uint32_t pulses) { test_pulses = pulses; }
 
+    void change_hardware_id(MoveMessageHardware id) { _id = id; }
+
+    void provide_state_manager(StateManagerHandle handle) {
+        _state_manager = handle;
+    }
+
   private:
     bool limit_switch_status = false;
     int32_t test_pulses = 0;
+    MoveMessageHardware _id;
+    StateManagerHandle _state_manager = nullptr;
+    Direction _direction = Direction::POSITIVE;
 };
 
 class SimBrushedMotorHardwareIface

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -39,7 +39,12 @@ class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
     }
     void set_LED(bool) final {}
     void trigger_limit_switch() { limit_switch_status = true; }
-    bool check_sync_in() final { return true; }
+    bool check_sync_in() final {
+        if (_state_manager) {
+            return _state_manager->get_sync_state() == SyncPinState::HIGH;
+        }
+        return true;
+    }
     void reset_encoder_pulses() final { test_pulses = 0; }
     int32_t get_encoder_pulses() final { return test_pulses; }
     void sim_set_encoder_pulses(uint32_t pulses) { test_pulses = pulses; }

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -82,7 +82,12 @@ class SimBrushedMotorHardwareIface
     void grip() final {}
     void ungrip() final {}
     void stop_pwm() final {}
-    bool check_sync_in() final { return true; }
+    bool check_sync_in() final {
+        if (_state_manager) {
+            return _state_manager->get_sync_state() == SyncPinState::HIGH;
+        }
+        return true;
+    }
     void reset_encoder_pulses() final { test_pulses = 0; }
     int32_t get_encoder_pulses() final { return 0; }
     void sim_set_encoder_pulses(int32_t pulses) { test_pulses = pulses; }
@@ -92,6 +97,10 @@ class SimBrushedMotorHardwareIface
     }
     void reset_control() { controller_loop.reset(); }
 
+    void provide_state_manager(StateManagerHandle handle) {
+        _state_manager = handle;
+    }
+
   private:
     bool limit_switch_status = false;
     uint32_t test_pulses = 0;
@@ -100,6 +109,7 @@ class SimBrushedMotorHardwareIface
     // when the "motor" instantly goes to top speed then instantly stops
     ot_utils::pid::PID controller_loop{0.008,         0.0045, 0.000015,
                                        1.F / 32000.0, 7,      -7};
+    StateManagerHandle _state_manager = nullptr;
 };
 
 class SimGearMotorHardwareIface
@@ -129,16 +139,26 @@ class SimGearMotorHardwareIface
     }
     void set_LED(bool) final {}
     void trigger_limit_switch() { limit_switch_status = true; }
-    bool check_sync_in() final { return true; }
+    bool check_sync_in() final {
+        if (_state_manager) {
+            return _state_manager->get_sync_state() == SyncPinState::HIGH;
+        }
+        return true;
+    }
     void reset_encoder_pulses() final { test_pulses = 0; }
     int32_t get_encoder_pulses() final { return test_pulses; }
     void sim_set_encoder_pulses(int32_t pulses) { test_pulses = pulses; }
     void trigger_tip_sense() { tip_sense_status = true; }
 
+    void provide_state_manager(StateManagerHandle handle) {
+        _state_manager = handle;
+    }
+
   private:
     bool limit_switch_status = false;
     bool tip_sense_status = false;
     int32_t test_pulses = 0;
+    StateManagerHandle _state_manager = nullptr;
 };
 
 }  // namespace sim_motor_hardware_iface

--- a/include/sensors/simulation/mock_hardware.hpp
+++ b/include/sensors/simulation/mock_hardware.hpp
@@ -1,16 +1,29 @@
 #pragma once
 
+#include "common/core/freertos_synchronization.hpp"
+#include "common/simulation/state_manager.hpp"
 #include "sensors/core/sensor_hardware_interface.hpp"
+
+using StateManager = state_manager::StateManagerConnection<
+    freertos_synchronization::FreeRTOSCriticalSection>;
+using StateManagerHandle = std::shared_ptr<StateManager>;
+
 namespace test_mocks {
 class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
   public:
     auto set_sync() -> void override {
         sync_state = true;
         sync_set_calls++;
+        if (_state_manager) {
+            _state_manager->send_sync_msg(SyncPinState::HIGH);
+        }
     }
     auto reset_sync() -> void override {
         sync_state = false;
         sync_reset_calls++;
+        if (_state_manager) {
+            _state_manager->send_sync_msg(SyncPinState::LOW);
+        }
     }
     std::array<std::function<void()>, 5> data_ready_callbacks = {};
     auto add_data_ready_callback(std::function<void()> callback)
@@ -32,6 +45,11 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
             }
         }
     }
+
+    void provide_state_manager(StateManagerHandle handle) {
+        _state_manager = handle;
+    }
+
     auto get_sync_state_mock() const -> bool { return sync_state; }
     auto get_sync_set_calls() const -> uint32_t { return sync_set_calls; }
     auto get_sync_reset_calls() const -> uint32_t { return sync_reset_calls; }
@@ -40,5 +58,6 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
     bool sync_state = false;
     uint32_t sync_set_calls = 0;
     uint32_t sync_reset_calls = 0;
+    StateManagerHandle _state_manager = nullptr;
 };
 };  // namespace test_mocks

--- a/pipettes/simulator/interfaces.cpp
+++ b/pipettes/simulator/interfaces.cpp
@@ -56,7 +56,8 @@ auto linear_motor::get_interrupt_driver(
 
 auto linear_motor::get_motor_hardware()
     -> sim_motor_hardware_iface::SimMotorHardwareIface {
-    return sim_motor_hardware_iface::SimMotorHardwareIface{};
+    return sim_motor_hardware_iface::SimMotorHardwareIface(
+        MoveMessageHardware::z_l);
 }
 
 auto linear_motor::get_motion_control(

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -213,7 +213,7 @@ int main(int argc, char** argv) {
     auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(
         options, TEMPORARY_PIPETTE_SERIAL);
     auto fake_sensor_hw = std::make_shared<test_mocks::MockSensorHardware>();
-    fake_sensor_hw.provide_state_manager(state_manager_connection);
+    fake_sensor_hw->provide_state_manager(state_manager_connection);
     auto pressuresensor =
         std::make_shared<mmr920C04_simulator::MMR920C04>(*fake_sensor_hw);
     i2c::hardware::SimI2C::DeviceMap sensor_map_i2c1 = {

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -189,6 +189,23 @@ uint32_t temporary_serial_number(const PipetteType pipette_type) {
     }
 }
 
+[[maybe_unused]] static auto provide_state(
+    interfaces::gear_motor::UnavailableGearHardware& hardware,
+    sim_motor_hardware_iface::StateManagerHandle state_manager_connection)
+    -> void {
+    // Do nothing for unavailable gear motor
+    static_cast<void>(hardware);
+    static_cast<void>(state_manager_connection);
+}
+
+[[maybe_unused]] static auto provide_state(
+    interfaces::gear_motor::GearHardware& hardware,
+    sim_motor_hardware_iface::StateManagerHandle state_manager_connection)
+    -> void {
+    hardware.left.provide_state_manager(state_manager_connection);
+    hardware.right.provide_state_manager(state_manager_connection);
+}
+
 int main(int argc, char** argv) {
     signal(SIGINT, signal_handler);
     LOG_INIT(PipetteTypeString[PIPETTE_TYPE], []() -> const char* {
@@ -208,6 +225,7 @@ int main(int argc, char** argv) {
         node == can::ids::NodeId::pipette_left ? MoveMessageHardware::z_l
                                                : MoveMessageHardware::z_r);
     linear_motor_hardware.provide_state_manager(state_manager_connection);
+    provide_state(gear_hardware, state_manager_connection);
 
     auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -213,6 +213,7 @@ int main(int argc, char** argv) {
     auto sim_eeprom = std::make_shared<eeprom::simulator::EEProm>(
         options, TEMPORARY_PIPETTE_SERIAL);
     auto fake_sensor_hw = std::make_shared<test_mocks::MockSensorHardware>();
+    fake_sensor_hw.provide_state_manager(state_manager_connection);
     auto pressuresensor =
         std::make_shared<mmr920C04_simulator::MMR920C04>(*fake_sensor_hw);
     i2c::hardware::SimI2C::DeviceMap sensor_map_i2c1 = {

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -199,8 +199,14 @@ int main(int argc, char** argv) {
         temporary_serial_number(PIPETTE_TYPE);
     auto options = handle_options(argc, argv);
 
+    auto node = node_from_options(options);
+
     state_manager_connection = state_manager::create<
         freertos_synchronization::FreeRTOSCriticalSection>(options);
+
+    linear_motor_hardware.change_hardware_id(
+        node == can::ids::NodeId::pipette_left ? MoveMessageHardware::z_l
+                                               : MoveMessageHardware::z_r);
 
     auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();
@@ -221,7 +227,6 @@ int main(int argc, char** argv) {
     auto i2c1_comms = std::make_shared<i2c::hardware::SimI2C>(sensor_map_i2c1);
     auto can_bus_1 = std::make_shared<can::sim::bus::SimCANBus>(
         can::sim::transport::create(options));
-    auto node = node_from_options(options);
     central_tasks::start_tasks(*can_bus_1, node);
     peripheral_tasks::start_tasks(*i2c3_comms, *i2c1_comms, spi_comms);
     initialize_motor_tasks(node, motor_config.driver_configs,

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -207,6 +207,7 @@ int main(int argc, char** argv) {
     linear_motor_hardware.change_hardware_id(
         node == can::ids::NodeId::pipette_left ? MoveMessageHardware::z_l
                                                : MoveMessageHardware::z_r);
+    linear_motor_hardware.provide_state_manager(state_manager_connection);
 
     auto hdcsensor = std::make_shared<hdc3020_simulator::HDC3020>();
     auto capsensor = std::make_shared<fdc1004_simulator::FDC1004>();


### PR DESCRIPTION
Adds support for the OT-3 firmware simulators to send messages to the state manager:
- When the motors are stepped (with the direction inferred from the last time the direction was set)
- When the sync pin is set 
- When reading the sync pin status

For now, every message sent to the state manager comes with a response, so the firmware must wait for that response in order to remain synchronized. This slows things down but will be modified in the future.

Was able to test this functionality through the following:
- Set up an OT3 emulator pulling the firmware from the latest commit on this branch
- Open a can-comm, set up a move group for an axis that will trigger a nonzero number of steps, and then start it
- Using a simple UDP python script, request the position of the aforementioned axis from the state manager.
Every time the move group is executed, the position increases. If the duration is long enough you can watch as the position increases over time.

This should not be merged until the matching [opentrons-emulation PR](https://github.com/Opentrons/opentrons-emulation/pull/214) is merged, otherwise the firmware will hang when trying to read responses.