### PR TITLE
refactor(all): use the external oscillator for the system clock

### DIFF
--- a/bootloader/firmware/stm32G4/stm32g4xx_hal_conf.h
+++ b/bootloader/firmware/stm32G4/stm32g4xx_hal_conf.h
@@ -115,7 +115,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    (24000000UL) /*!< Value of the External oscillator in Hz */
+  #define HSE_VALUE    (16000000UL) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)

--- a/bootloader/firmware/stm32G4/system_stm32g4xx.c
+++ b/bootloader/firmware/stm32G4/system_stm32g4xx.c
@@ -84,7 +84,7 @@
 #include "common/firmware/errors.h"
 
 #if !defined(HSE_VALUE)
-#define HSE_VALUE 24000000U /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE 16000000U /*!< Value of the External oscillator in Hz */
 #endif                      /* HSE_VALUE */
 
 #if !defined(HSI_VALUE)
@@ -211,9 +211,9 @@ void SystemClock_Config(void) {
     /** Initializes the RCC Oscillators according to the specified parameters
      * in the RCC_OscInitTypeDef structure.
      */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSIState = RCC_HSI_OFF;
+    RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
@@ -238,32 +238,7 @@ void SystemClock_Config(void) {
     {
         Error_Handler();
     }
-    /**
-     *  TODO (AL, 2021-15-07): Solidify clock configuration.
-     *   Above is copied directly from stm32_test project to
-     *   get CAN working.
-     *   Below is the original setup.
-     */
-    //
-    //  RCC_ClkInitTypeDef RCC_ClkInitStruct;
-    //  RCC_OscInitTypeDef RCC_OscInitStruct;
-    //
-    //  /* Enable HSE Oscillator and activate PLL with HSE as source */
-    //  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-    //  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-    //  RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    //  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    //  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
-    //  HAL_RCC_OscConfig(&RCC_OscInitStruct);
-    //
-    //  /* Select PLL as system clock source and configure the HCLK, PCLK1 and
-    //  PCLK2 clocks dividers */ RCC_ClkInitStruct.ClockType =
-    //  (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 |
-    //  RCC_CLOCKTYPE_PCLK2); RCC_ClkInitStruct.SYSCLKSource =
-    //  RCC_SYSCLKSOURCE_PLLCLK; RCC_ClkInitStruct.AHBCLKDivider =
-    //  RCC_SYSCLK_DIV1; RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
-    //  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-    //  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2);
+
 }
 
 /**

--- a/gantry/firmware/stm32g4xx_hal_conf.h
+++ b/gantry/firmware/stm32g4xx_hal_conf.h
@@ -115,7 +115,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    (24000000UL) /*!< Value of the External oscillator in Hz */
+  #define HSE_VALUE    (16000000UL) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)

--- a/gantry/firmware/system_stm32g4xx.c
+++ b/gantry/firmware/system_stm32g4xx.c
@@ -213,6 +213,7 @@ void SystemClock_Config(void) {
      */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+    RCC_OscInitStruct.HSIState = RCC_HSI_OFF;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;

--- a/gantry/firmware/system_stm32g4xx.c
+++ b/gantry/firmware/system_stm32g4xx.c
@@ -85,7 +85,7 @@
 #include "bootloader/firmware/constants.h"
 
 #if !defined(HSE_VALUE)
-#define HSE_VALUE 24000000U /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE 16000000U /*!< Value of the External oscillator in Hz */
 #endif                      /* HSE_VALUE */
 
 #if !defined(HSI_VALUE)
@@ -138,7 +138,7 @@
    there is no need to call the 2 first functions listed above, since
    SystemCoreClock variable is updated automatically.
 */
-uint32_t SystemCoreClock = HSI_VALUE;
+uint32_t SystemCoreClock = HSE_VALUE;
 
 const uint8_t AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
                                    1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
@@ -211,11 +211,10 @@ void SystemClock_Config(void) {
     /** Initializes the RCC Oscillators according to the specified parameters
      * in the RCC_OscInitTypeDef structure.
      */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
     RCC_OscInitStruct.PLL.PLLN = 85;
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;

--- a/gripper/firmware/stm32g4xx_hal_conf.h
+++ b/gripper/firmware/stm32g4xx_hal_conf.h
@@ -118,7 +118,7 @@ extern "C" {
  * PLL).
  */
 #if !defined(HSE_VALUE)
-#define HSE_VALUE (24000000UL) /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE (16000000UL) /*!< Value of the External oscillator in Hz */
 #endif                         /* HSE_VALUE */
 
 #if !defined(HSE_STARTUP_TIMEOUT)

--- a/gripper/firmware/system_stm32g4xx.c
+++ b/gripper/firmware/system_stm32g4xx.c
@@ -213,6 +213,7 @@ void SystemClock_Config(void) {
      */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+    RCC_OscInitStruct.HSIState = RCC_HSI_OFF;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;

--- a/gripper/firmware/system_stm32g4xx.c
+++ b/gripper/firmware/system_stm32g4xx.c
@@ -85,7 +85,7 @@
 #include "bootloader/firmware/constants.h"
 
 #if !defined(HSE_VALUE)
-#define HSE_VALUE 24000000U /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE 16000000U /*!< Value of the External oscillator in Hz */
 #endif                      /* HSE_VALUE */
 
 #if !defined(HSI_VALUE)
@@ -138,7 +138,7 @@
    there is no need to call the 2 first functions listed above, since
    SystemCoreClock variable is updated automatically.
 */
-uint32_t SystemCoreClock = HSI_VALUE;
+uint32_t SystemCoreClock = HSE_VALUE;
 
 const uint8_t AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
                                    1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
@@ -211,11 +211,10 @@ void SystemClock_Config(void) {
     /** Initializes the RCC Oscillators according to the specified parameters
      * in the RCC_OscInitTypeDef structure.
      */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
     RCC_OscInitStruct.PLL.PLLN = 85;
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;

--- a/head/firmware/stm32g4xx_hal_conf.h
+++ b/head/firmware/stm32g4xx_hal_conf.h
@@ -115,7 +115,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    (24000000UL) /*!< Value of the External oscillator in Hz */
+  #define HSE_VALUE    (16000000UL) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)

--- a/head/firmware/system_stm32g4xx.c
+++ b/head/firmware/system_stm32g4xx.c
@@ -85,7 +85,7 @@
 #include "bootloader/firmware/constants.h"
 
 #if !defined(HSE_VALUE)
-#define HSE_VALUE 24000000U /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE 16000000U /*!< Value of the External oscillator in Hz */
 #endif                      /* HSE_VALUE */
 
 #if !defined(HSI_VALUE)
@@ -140,7 +140,7 @@
    there is no need to call the 2 first functions listed above, since
    SystemCoreClock variable is updated automatically.
 */
-uint32_t SystemCoreClock = HSI_VALUE;
+uint32_t SystemCoreClock = HSE_VALUE;
 
 const uint8_t AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
                                    1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
@@ -213,11 +213,10 @@ void SystemClock_Config(void) {
     /** Initializes the RCC Oscillators according to the specified parameters
      * in the RCC_OscInitTypeDef structure.
      */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
     RCC_OscInitStruct.PLL.PLLN = 85;
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;

--- a/head/firmware/system_stm32g4xx.c
+++ b/head/firmware/system_stm32g4xx.c
@@ -214,6 +214,7 @@ void SystemClock_Config(void) {
      * in the RCC_OscInitTypeDef structure.
      */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSIState = RCC_HSI_OFF;
     RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;

--- a/pipettes/firmware/stm32g4xx_hal_conf.h
+++ b/pipettes/firmware/stm32g4xx_hal_conf.h
@@ -115,7 +115,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    (24000000UL) /*!< Value of the External oscillator in Hz */
+  #define HSE_VALUE    (16000000UL) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)

--- a/pipettes/firmware/system_stm32g4xx.c
+++ b/pipettes/firmware/system_stm32g4xx.c
@@ -213,6 +213,7 @@ void SystemClock_Config(void) {
      */
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+    RCC_OscInitStruct.HSIState = RCC_HSI_OFF;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;

--- a/pipettes/firmware/system_stm32g4xx.c
+++ b/pipettes/firmware/system_stm32g4xx.c
@@ -85,7 +85,7 @@
 #include "bootloader/firmware/constants.h"
 
 #if !defined(HSE_VALUE)
-#define HSE_VALUE 24000000U /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE 16000000U /*!< Value of the External oscillator in Hz */
 #endif                      /* HSE_VALUE */
 
 #if !defined(HSI_VALUE)
@@ -138,7 +138,7 @@
    there is no need to call the 2 first functions listed above, since
    SystemCoreClock variable is updated automatically.
 */
-uint32_t SystemCoreClock = HSI_VALUE;
+uint32_t SystemCoreClock = HSE_VALUE;
 
 const uint8_t AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
                                    1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
@@ -211,11 +211,10 @@ void SystemClock_Config(void) {
     /** Initializes the RCC Oscillators according to the specified parameters
      * in the RCC_OscInitTypeDef structure.
      */
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-    RCC_OscInitStruct.HSIState = RCC_HSI_ON;
-    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSEState = RCC_HSE_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
+    RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
     RCC_OscInitStruct.PLL.PLLN = 85;
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;


### PR DESCRIPTION
Since the external oscilator is the same frequency as the internal oscilator, we should be able to use the same clock divisors.