### PR TITLE
fix(gripper): use a simpler serial

### DIFF
--- a/include/gripper/core/gripper_info.hpp
+++ b/include/gripper/core/gripper_info.hpp
@@ -100,8 +100,7 @@ class GripperInfoMessageHandler : eeprom::accessor::ReadListener {
             GripperInfoResponse{
                 .model = 0x0001,
                 .serial = eeprom::serial_number::SerialDataCodeType{
-                    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-                    0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}});
+                    0x01}});
     }
 
     /**

--- a/include/gripper/core/gripper_info.hpp
+++ b/include/gripper/core/gripper_info.hpp
@@ -98,8 +98,10 @@ class GripperInfoMessageHandler : eeprom::accessor::ReadListener {
         writer.send_can_message(
             can::ids::NodeId::host,
             GripperInfoResponse{
-                .model = 0x0001,                                                                                                                                                                                                        q
-                .serial = eeprom::serial_number::SerialDataCodeType{0x20,0x22,0x11,0x15}});
+                .model = 0x0001,
+                .serial = eeprom::serial_number::SerialDataCodeType{
+                    '2', '0',  '2',  '2',  '1',  '1',
+                    '1',  '5',  'A',  '0',  '1'}});
     }
 
     /**

--- a/include/gripper/core/gripper_info.hpp
+++ b/include/gripper/core/gripper_info.hpp
@@ -99,8 +99,7 @@ class GripperInfoMessageHandler : eeprom::accessor::ReadListener {
             can::ids::NodeId::host,
             GripperInfoResponse{
                 .model = 0x0001,
-                .serial = eeprom::serial_number::SerialDataCodeType{
-                    0x01}});
+                .serial = eeprom::serial_number::SerialDataCodeType{0x01}});
     }
 
     /**

--- a/include/gripper/core/gripper_info.hpp
+++ b/include/gripper/core/gripper_info.hpp
@@ -98,8 +98,8 @@ class GripperInfoMessageHandler : eeprom::accessor::ReadListener {
         writer.send_can_message(
             can::ids::NodeId::host,
             GripperInfoResponse{
-                .model = 0x0001,
-                .serial = eeprom::serial_number::SerialDataCodeType{0x01}});
+                .model = 0x0001,                                                                                                                                                                                                        q
+                .serial = eeprom::serial_number::SerialDataCodeType{0x20,0x22,0x11,0x15}});
     }
 
     /**

--- a/include/gripper/core/gripper_info.hpp
+++ b/include/gripper/core/gripper_info.hpp
@@ -100,8 +100,7 @@ class GripperInfoMessageHandler : eeprom::accessor::ReadListener {
             GripperInfoResponse{
                 .model = 0x0001,
                 .serial = eeprom::serial_number::SerialDataCodeType{
-                    '2', '0',  '2',  '2',  '1',  '1',
-                    '1',  '5',  'A',  '0',  '1'}});
+                    '2', '0', '2', '2', '1', '1', '1', '5', 'A', '0', '1'}});
     }
 
     /**


### PR DESCRIPTION
This allows us to parse the gripper id on the Python side so we can save the gripper offset during calibration. 