### PR TITLE
fix(sensors): fix a halving error in the capacitive sensor

### DIFF
--- a/include/motor-control/core/utils.hpp
+++ b/include/motor-control/core/utils.hpp
@@ -7,6 +7,8 @@
  * functions to account for different radix positions.
  */
 
+static constexpr int S15Q16_RADIX = 16;
+
 auto convert_to_fixed_point(float value, int to_radix) -> sq0_31;
 
 auto convert_to_fixed_point_64_bit(float value, int to_radix) -> sq31_31;

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <limits>
+#include <cstdlib>
+#include "common/core/logging.h"
+
 
 // TODO (lc 02-16-2022) We should refactor the fixed point
 // helper functions such that they live in a shared location.
@@ -69,8 +72,8 @@ constexpr float MAX_CAPDAC_PF =
 constexpr std::size_t CONVERSION_BITS = 24;
 constexpr float MAX_MEASUREMENT_PF = 15;
 constexpr float MAX_RAW_MEASUREMENT =
-    float(std::numeric_limits<int32_t>::max() >>
-          ((sizeof(int32_t) * 8) - CONVERSION_BITS));
+    float(std::numeric_limits<int32_t>::max() >> 8);
+//          ((sizeof(uint32_t) * 8) - CONVERSION_BITS));
 
 // Because we're doing big gantry moves, we'll probably have to handle
 // the parasitic capacitance of the system shifting around a lot. We'll

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -73,9 +73,7 @@ constexpr std::size_t CONVERSION_BITS = 24;
 constexpr float MAX_MEASUREMENT_PF = 15;
 constexpr float MAX_RAW_MEASUREMENT =
     float(std::numeric_limits<int32_t>::max() >>
-          (sizeof(uint32_t) * 8) - CONVERSION_BITS);
-//    float(std::numeric_limits<int32_t>::max() >> 8);
-//          ((sizeof(uint32_t) * 8) - CONVERSION_BITS));
+          ((sizeof(uint32_t) * 8) - CONVERSION_BITS));
 
 // Because we're doing big gantry moves, we'll probably have to handle
 // the parasitic capacitance of the system shifting around a lot. We'll

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <limits>
 #include <cstdlib>
-#include "common/core/logging.h"
+#include <limits>
 
+#include "common/core/logging.h"
 
 // TODO (lc 02-16-2022) We should refactor the fixed point
 // helper functions such that they live in a shared location.
@@ -71,7 +71,9 @@ constexpr float MAX_CAPDAC_PF =
 // Our +-15pF comes in 24 bits, left shifted across two 16 bit registers.
 constexpr std::size_t CONVERSION_BITS = 24;
 constexpr float MAX_MEASUREMENT_PF = 15;
-constexpr float MAX_RAW_MEASUREMENT = float(std::numeric_limits<int32_t>::max() >> (sizeof(uint32_t) * 8) - CONVERSION_BITS);
+constexpr float MAX_RAW_MEASUREMENT =
+    float(std::numeric_limits<int32_t>::max() >>
+          (sizeof(uint32_t) * 8) - CONVERSION_BITS);
 //    float(std::numeric_limits<int32_t>::max() >> 8);
 //          ((sizeof(uint32_t) * 8) - CONVERSION_BITS));
 

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -73,7 +73,7 @@ constexpr std::size_t CONVERSION_BITS = 24;
 constexpr float MAX_MEASUREMENT_PF = 15;
 constexpr float MAX_RAW_MEASUREMENT =
     float(std::numeric_limits<int32_t>::max() >>
-          ((sizeof(uint32_t) * 8) - CONVERSION_BITS));
+          ((sizeof(int32_t) * 8) - CONVERSION_BITS));
 
 // Because we're doing big gantry moves, we'll probably have to handle
 // the parasitic capacitance of the system shifting around a lot. We'll

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -71,8 +71,8 @@ constexpr float MAX_CAPDAC_PF =
 // Our +-15pF comes in 24 bits, left shifted across two 16 bit registers.
 constexpr std::size_t CONVERSION_BITS = 24;
 constexpr float MAX_MEASUREMENT_PF = 15;
-constexpr float MAX_RAW_MEASUREMENT =
-    float(std::numeric_limits<int32_t>::max() >> 8);
+constexpr float MAX_RAW_MEASUREMENT = float(std::numeric_limits<int32_t>::max() >> (sizeof(uint32_t) * 8) - CONVERSION_BITS);
+//    float(std::numeric_limits<int32_t>::max() >> 8);
 //          ((sizeof(uint32_t) * 8) - CONVERSION_BITS));
 
 // Because we're doing big gantry moves, we'll probably have to handle

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -265,7 +265,7 @@ struct __attribute__((packed, __may_alias__)) Temperature {
     [[nodiscard]] static auto to_temperature(uint32_t reg) -> sq15_16 {
         float temperature =
             CONVERT_TO_CELSIUS * (static_cast<float>(reg) / MAX_SIZE);
-        return convert_to_fixed_point(temperature, 15);
+        return convert_to_fixed_point(temperature, 16);
     }
 };
 

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -204,7 +204,7 @@ struct __attribute__((packed, __may_alias__)) Pressure {
         }
         float pressure =
             static_cast<float>(static_cast<int32_t>(reg)) * PA_PER_COUNT;
-        return convert_to_fixed_point(pressure, 16);
+        return convert_to_fixed_point(pressure, S15Q16_RADIX);
     }
 };
 
@@ -238,7 +238,7 @@ struct __attribute__((packed, __may_alias__)) LowPassPressure {
         }
 
         float pressure = static_cast<float>(reg) * PA_PER_COUNT;
-        return convert_to_fixed_point(pressure, 16);
+        return convert_to_fixed_point(pressure, S15Q16_RADIX);
     }
 };
 
@@ -265,7 +265,7 @@ struct __attribute__((packed, __may_alias__)) Temperature {
     [[nodiscard]] static auto to_temperature(uint32_t reg) -> sq15_16 {
         float temperature =
             CONVERT_TO_CELSIUS * (static_cast<float>(reg) / MAX_SIZE);
-        return convert_to_fixed_point(temperature, 16);
+        return convert_to_fixed_point(temperature, S15Q16_RADIX);
     }
 };
 

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -45,8 +45,8 @@ struct ReadCapacitanceCallback {
         auto capacitance = convert_capacitance(
             convert_reads(polling_results[0], polling_results[1]), 1,
             current_offset_pf);
-        auto new_offset = update_offset(capacitance, current_offset_pf);
-        set_offset(new_offset);
+//        auto new_offset = update_offset(capacitance, current_offset_pf);
+//        set_offset(new_offset);
         if (bind_sync) {
             if (capacitance > zero_threshold_pf) {
                 hardware.set_sync();
@@ -89,8 +89,8 @@ struct ReadCapacitanceCallback {
                 .sensor_data = convert_to_fixed_point(capacitance, 15)};
             can_client.send_can_message(can::ids::NodeId::host, message);
         }
-        auto new_offset = update_offset(capacitance, current_offset_pf);
-        set_offset(new_offset);
+//        auto new_offset = update_offset(capacitance, current_offset_pf);
+//        set_offset(new_offset);
     }
 
     void reset_limited() {

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -60,7 +60,7 @@ struct ReadCapacitanceCallback {
                 can::messages::ReadFromSensorResponse{
                     .sensor = can::ids::SensorType::capacitive,
                     .sensor_id = sensor_id,
-                    .sensor_data = convert_to_fixed_point(capacitance, 15)});
+                    .sensor_data = convert_to_fixed_point(capacitance, 16)});
         }
     }
 
@@ -86,7 +86,7 @@ struct ReadCapacitanceCallback {
             auto message = can::messages::ReadFromSensorResponse{
                 .sensor = SensorType::capacitive,
                 .sensor_id = sensor_id,
-                .sensor_data = convert_to_fixed_point(capacitance, 15)};
+                .sensor_data = convert_to_fixed_point(capacitance, 16)};
             can_client.send_can_message(can::ids::NodeId::host, message);
         }
 //        auto new_offset = update_offset(capacitance, current_offset_pf);
@@ -140,7 +140,7 @@ struct ReadCapacitanceCallback {
         auto message = can::messages::SensorThresholdResponse{
             .sensor = SensorType::capacitive,
             .sensor_id = sensor_id,
-            .threshold = convert_to_fixed_point(zero_threshold_pf, 15),
+            .threshold = convert_to_fixed_point(zero_threshold_pf, 16),
             .mode = from_mode};
         can_client.send_can_message(can::ids::NodeId::host, message);
     }

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -45,10 +45,10 @@ struct ReadCapacitanceCallback {
         auto capacitance = convert_capacitance(
             convert_reads(polling_results[0], polling_results[1]), 1,
             current_offset_pf);
-        // TODO (lc 1-2-2022) we should figure out a better strategy for adjusting
-        // the capdac. I am leaving this commented out as a reminder.
-//        auto new_offset = update_offset(capacitance, current_offset_pf);
-//        set_offset(new_offset);
+        // TODO (lc 1-2-2022) we should figure out a better strategy for
+        // adjusting the capdac. I am leaving this commented out as a reminder.
+        //        auto new_offset = update_offset(capacitance,
+        //        current_offset_pf); set_offset(new_offset);
         if (bind_sync) {
             if (capacitance > zero_threshold_pf) {
                 hardware.set_sync();
@@ -91,10 +91,10 @@ struct ReadCapacitanceCallback {
                 .sensor_data = convert_to_fixed_point(capacitance, 16)};
             can_client.send_can_message(can::ids::NodeId::host, message);
         }
-        // TODO (lc 1-2-2022) we should figure out a better strategy for adjusting
-        // the capdac. I am leaving this commented out as a reminder.
-//        auto new_offset = update_offset(capacitance, current_offset_pf);
-//        set_offset(new_offset);
+        // TODO (lc 1-2-2022) we should figure out a better strategy for
+        // adjusting the capdac. I am leaving this commented out as a reminder.
+        //        auto new_offset = update_offset(capacitance,
+        //        current_offset_pf); set_offset(new_offset);
     }
 
     void reset_limited() {

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -45,6 +45,8 @@ struct ReadCapacitanceCallback {
         auto capacitance = convert_capacitance(
             convert_reads(polling_results[0], polling_results[1]), 1,
             current_offset_pf);
+        // TODO (lc 1-2-2022) we should figure out a better strategy for adjusting
+        // the capdac. I am leaving this commented out as a reminder.
 //        auto new_offset = update_offset(capacitance, current_offset_pf);
 //        set_offset(new_offset);
         if (bind_sync) {
@@ -89,6 +91,8 @@ struct ReadCapacitanceCallback {
                 .sensor_data = convert_to_fixed_point(capacitance, 16)};
             can_client.send_can_message(can::ids::NodeId::host, message);
         }
+        // TODO (lc 1-2-2022) we should figure out a better strategy for adjusting
+        // the capdac. I am leaving this commented out as a reminder.
 //        auto new_offset = update_offset(capacitance, current_offset_pf);
 //        set_offset(new_offset);
     }

--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -46,9 +46,9 @@ struct ReadCapacitanceCallback {
             convert_reads(polling_results[0], polling_results[1]), 1,
             current_offset_pf);
         // TODO (lc 1-2-2022) we should figure out a better strategy for
-        // adjusting the capdac. I am leaving this commented out as a reminder.
-        //        auto new_offset = update_offset(capacitance,
-        //        current_offset_pf); set_offset(new_offset);
+        // adjusting the capdac.
+        auto new_offset = update_offset(capacitance, current_offset_pf);
+        set_offset(new_offset);
         if (bind_sync) {
             if (capacitance > zero_threshold_pf) {
                 hardware.set_sync();
@@ -62,7 +62,8 @@ struct ReadCapacitanceCallback {
                 can::messages::ReadFromSensorResponse{
                     .sensor = can::ids::SensorType::capacitive,
                     .sensor_id = sensor_id,
-                    .sensor_data = convert_to_fixed_point(capacitance, 16)});
+                    .sensor_data =
+                        convert_to_fixed_point(capacitance, S15Q16_RADIX)});
         }
     }
 
@@ -88,13 +89,14 @@ struct ReadCapacitanceCallback {
             auto message = can::messages::ReadFromSensorResponse{
                 .sensor = SensorType::capacitive,
                 .sensor_id = sensor_id,
-                .sensor_data = convert_to_fixed_point(capacitance, 16)};
+                .sensor_data =
+                    convert_to_fixed_point(capacitance, S15Q16_RADIX)};
             can_client.send_can_message(can::ids::NodeId::host, message);
         }
         // TODO (lc 1-2-2022) we should figure out a better strategy for
-        // adjusting the capdac. I am leaving this commented out as a reminder.
-        //        auto new_offset = update_offset(capacitance,
-        //        current_offset_pf); set_offset(new_offset);
+        // adjusting the capdac.
+        auto new_offset = update_offset(capacitance, current_offset_pf);
+        set_offset(new_offset);
     }
 
     void reset_limited() {
@@ -144,7 +146,8 @@ struct ReadCapacitanceCallback {
         auto message = can::messages::SensorThresholdResponse{
             .sensor = SensorType::capacitive,
             .sensor_id = sensor_id,
-            .threshold = convert_to_fixed_point(zero_threshold_pf, 16),
+            .threshold =
+                convert_to_fixed_point(zero_threshold_pf, S15Q16_RADIX),
             .mode = from_mode};
         can_client.send_can_message(can::ids::NodeId::host, message);
     }

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -91,7 +91,7 @@ class CapacitiveMessageHandler {
                 .sensor = SensorType::capacitive,
                 .sensor_id = sensor_id,
                 .sensor_data = convert_to_fixed_point(
-                    capacitance_handler.get_offset(), 15)};
+                    capacitance_handler.get_offset(), 16)};
             can_client.send_can_message(can::ids::NodeId::host, message);
         } else {
             capacitance_handler.reset_limited();
@@ -125,7 +125,7 @@ class CapacitiveMessageHandler {
             m.threshold, m.sensor);
         if (m.mode == can::ids::SensorThresholdMode::absolute) {
             capacitance_handler.set_threshold(
-                fixed_point_to_float(m.threshold, 15), m.mode);
+                fixed_point_to_float(m.threshold, 16), m.mode);
         } else {
             capacitance_handler.reset_limited();
             capacitance_handler.set_number_of_reads(10);
@@ -133,7 +133,7 @@ class CapacitiveMessageHandler {
                             utils::ResponseTag::IS_BASELINE,
                             utils::ResponseTag::IS_THRESHOLD_SENSE};
             capacitance_handler.prime_autothreshold(
-                fixed_point_to_float(m.threshold, 15));
+                fixed_point_to_float(m.threshold, 16));
             poller.multi_register_poll(
                 ADDRESS, MSB_MEASUREMENT_1, 2, LSB_MEASUREMENT_1, 2,
                 uint16_t(10), DELAY, own_queue,

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -91,7 +91,7 @@ class CapacitiveMessageHandler {
                 .sensor = SensorType::capacitive,
                 .sensor_id = sensor_id,
                 .sensor_data = convert_to_fixed_point(
-                    capacitance_handler.get_offset(), 16)};
+                    capacitance_handler.get_offset(), S15Q16_RADIX)};
             can_client.send_can_message(can::ids::NodeId::host, message);
         } else {
             capacitance_handler.reset_limited();
@@ -125,7 +125,7 @@ class CapacitiveMessageHandler {
             m.threshold, m.sensor);
         if (m.mode == can::ids::SensorThresholdMode::absolute) {
             capacitance_handler.set_threshold(
-                fixed_point_to_float(m.threshold, 16), m.mode);
+                fixed_point_to_float(m.threshold, S15Q16_RADIX), m.mode);
         } else {
             capacitance_handler.reset_limited();
             capacitance_handler.set_number_of_reads(10);
@@ -133,7 +133,7 @@ class CapacitiveMessageHandler {
                             utils::ResponseTag::IS_BASELINE,
                             utils::ResponseTag::IS_THRESHOLD_SENSE};
             capacitance_handler.prime_autothreshold(
-                fixed_point_to_float(m.threshold, 16));
+                fixed_point_to_float(m.threshold, S15Q16_RADIX));
             poller.multi_register_poll(
                 ADDRESS, MSB_MEASUREMENT_1, 2, LSB_MEASUREMENT_1, 2,
                 uint16_t(10), DELAY, own_queue,

--- a/include/sensors/core/tasks/environment_driver.hpp
+++ b/include/sensors/core/tasks/environment_driver.hpp
@@ -236,14 +236,14 @@ class HDC3020 {
     auto convert_humidity_to_fixed_point(int32_t humidity) -> int32_t {
         float rh_percent = humidity * (1.0 / MAXIMUM_DATA_SIZE) * 100.0;
         LOG("Relative humidity: %.4f", rh_percent);
-        return convert_to_fixed_point(rh_percent, 16);
+        return convert_to_fixed_point(rh_percent, S15Q16_RADIX);
     }
 
     auto convert_temperature_to_fixed_point(int32_t temperature) -> int32_t {
         float temp_celsius =
             175.0 * (temperature * (1.0 / MAXIMUM_DATA_SIZE)) - 45.0;
         LOG("Temperature in celsius: %.4f", temp_celsius);
-        return convert_to_fixed_point(temp_celsius, 16);
+        return convert_to_fixed_point(temp_celsius, S15Q16_RADIX);
     }
 };
 

--- a/sensors/tests/CMakeLists.txt
+++ b/sensors/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
         test_environment_driver.cpp
         test_pressure_sensor.cpp
         test_pressure_driver.cpp
+        test_capacitive_driver.cpp
 )
 
 target_include_directories(sensors PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/sensors/tests/test_capacitive_driver.cpp
+++ b/sensors/tests/test_capacitive_driver.cpp
@@ -20,10 +20,11 @@ SCENARIO("converting data to 24 bit value from IC registers") {
         constexpr int16_t LSB = 0xff00;
         int32_t converted_registers = sensors::fdc1004::convert_reads(MSB, LSB);
         LOG("the converted value: %d", converted_registers);
-        REQUIRE(float(converted_registers) == sensors::fdc1004::MAX_RAW_MEASUREMENT / 2);
-        int32_t capacitance = sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
+        REQUIRE(converted_registers == (int(sensors::fdc1004::MAX_RAW_MEASUREMENT) >> 1));
+        float capacitance = sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
+        float expected = 7.5;
         THEN("The capacitance should be equal to 7.5 pF") {
-            REQUIRE(capacitance == 7.5);
+            REQUIRE(capacitance == Approx(expected).epsilon(1e-4));
         }
     }
 

--- a/sensors/tests/test_capacitive_driver.cpp
+++ b/sensors/tests/test_capacitive_driver.cpp
@@ -1,7 +1,6 @@
 #include "catch2/catch.hpp"
-#include "sensors/core/fdc1004.hpp"
 #include "common/core/logging.h"
-
+#include "sensors/core/fdc1004.hpp"
 
 SCENARIO("converting data to 24 bit value from IC registers") {
     GIVEN("The max MSB and LSB values of the fdc1004") {
@@ -9,8 +8,10 @@ SCENARIO("converting data to 24 bit value from IC registers") {
         constexpr int16_t LSB = 0xff00;
         int32_t converted_registers = sensors::fdc1004::convert_reads(MSB, LSB);
         LOG("the converted value: %d", converted_registers);
-        REQUIRE(float(converted_registers) == sensors::fdc1004::MAX_RAW_MEASUREMENT);
-        int32_t capacitance = sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
+        REQUIRE(float(converted_registers) ==
+                sensors::fdc1004::MAX_RAW_MEASUREMENT);
+        int32_t capacitance =
+            sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
         THEN("The capacitance should be equal to 15 pF") {
             REQUIRE(capacitance == 15);
         }
@@ -20,12 +21,13 @@ SCENARIO("converting data to 24 bit value from IC registers") {
         constexpr int16_t LSB = 0xff00;
         int32_t converted_registers = sensors::fdc1004::convert_reads(MSB, LSB);
         LOG("the converted value: %d", converted_registers);
-        REQUIRE(converted_registers == (int(sensors::fdc1004::MAX_RAW_MEASUREMENT) >> 1));
-        float capacitance = sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
+        REQUIRE(converted_registers ==
+                (int(sensors::fdc1004::MAX_RAW_MEASUREMENT) >> 1));
+        float capacitance =
+            sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
         float expected = 7.5;
         THEN("The capacitance should be equal to 7.5 pF") {
             REQUIRE(capacitance == Approx(expected).epsilon(1e-4));
         }
     }
-
 }

--- a/sensors/tests/test_capacitive_driver.cpp
+++ b/sensors/tests/test_capacitive_driver.cpp
@@ -1,0 +1,19 @@
+#include "catch2/catch.hpp"
+#include "sensors/core/fdc1004.hpp"
+#include "common/core/logging.h"
+
+
+SCENARIO("converting data to 24 bit value from IC registers") {
+    GIVEN("The max MSB and LSB values of the fdc1004") {
+        constexpr int16_t MSB = 0x7fff;
+        constexpr int16_t LSB = 0x7f00;
+        int32_t converted_registers = sensors::fdc1004::convert_reads(MSB, LSB);
+        LOG("the converted value: %d", converted_registers);
+        REQUIRE(float(converted_registers) == sensors::fdc1004::MAX_RAW_MEASUREMENT);
+        int32_t capacitance = sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
+        THEN("The capacitance should be equal to 15 pF") {
+            REQUIRE(capacitance == 15);
+        }
+    }
+
+}

--- a/sensors/tests/test_capacitive_driver.cpp
+++ b/sensors/tests/test_capacitive_driver.cpp
@@ -6,13 +6,24 @@
 SCENARIO("converting data to 24 bit value from IC registers") {
     GIVEN("The max MSB and LSB values of the fdc1004") {
         constexpr int16_t MSB = 0x7fff;
-        constexpr int16_t LSB = 0x7f00;
+        constexpr int16_t LSB = 0xff00;
         int32_t converted_registers = sensors::fdc1004::convert_reads(MSB, LSB);
         LOG("the converted value: %d", converted_registers);
         REQUIRE(float(converted_registers) == sensors::fdc1004::MAX_RAW_MEASUREMENT);
         int32_t capacitance = sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
         THEN("The capacitance should be equal to 15 pF") {
             REQUIRE(capacitance == 15);
+        }
+    }
+    GIVEN("Half the max MSB and LSB values of the fdc1004") {
+        constexpr int16_t MSB = 0x3fff;
+        constexpr int16_t LSB = 0xff00;
+        int32_t converted_registers = sensors::fdc1004::convert_reads(MSB, LSB);
+        LOG("the converted value: %d", converted_registers);
+        REQUIRE(float(converted_registers) == sensors::fdc1004::MAX_RAW_MEASUREMENT / 2);
+        int32_t capacitance = sensors::fdc1004::convert_capacitance(converted_registers, 1, 0.0);
+        THEN("The capacitance should be equal to 7.5 pF") {
+            REQUIRE(capacitance == 7.5);
         }
     }
 

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -168,7 +168,7 @@ SCENARIO("read capacitance sensor values") {
                             can_msg.message);
                     float check_data = signed_fixed_point_to_float(
                         response_msg.sensor_data, 16);
-                    float expected = 7.5;
+                    float expected = 15;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
                 THEN(
@@ -207,7 +207,7 @@ SCENARIO("read capacitance sensor values") {
                         std::get<can::messages::ReadFromSensorResponse>(
                             can_msg.message);
                     float check_data = signed_fixed_point_to_float(
-                        response_msg.sensor_data, 15);
+                        response_msg.sensor_data, 16);
                     float expected = -15;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
@@ -346,7 +346,7 @@ SCENARIO("capacitance callback tests") {
                 REQUIRE(sent.sensor == can::ids::SensorType::capacitive);
                 // we're just checking that the data is faithfully represented,
                 // don't really care what it is
-                REQUIRE(sent.sensor_data == convert_to_fixed_point(15, 15));
+                REQUIRE(sent.sensor_data == convert_to_fixed_point(15, 16));
             }
             THEN("it should not touch the sync line") {
                 REQUIRE(mock_hw.get_sync_state_mock() == false);
@@ -523,7 +523,7 @@ SCENARIO("threshold configuration") {
                     sensor.handle_message(final_response_b);
                     THEN("the threshold is set to the proper value") {
                         REQUIRE(sensor.capacitance_handler.get_threshold() ==
-                                Approx(15.375).epsilon(1e-4));
+                                Approx(15.1875).epsilon(1e-4));
                     }
                     THEN(
                         "a message is sent on can informing that the threshold "
@@ -536,9 +536,9 @@ SCENARIO("threshold configuration") {
                             std::get<can::messages::SensorThresholdResponse>(
                                 can_msg.message);
                         float check_data = signed_fixed_point_to_float(
-                            response_msg.threshold, 15);
+                            response_msg.threshold, 16);
                         // the average value + 1
-                        float expected = 15.375;
+                        float expected = 15.1875;
                         REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                         REQUIRE(response_msg.mode ==
                                 can::ids::SensorThresholdMode::auto_baseline);
@@ -572,7 +572,7 @@ SCENARIO("threshold configuration") {
                         can::ids::SensorThresholdMode::absolute);
             }
             THEN("the sensor's threshold should be set") {
-                REQUIRE(sensor.capacitance_handler.get_threshold() == 10);
+                REQUIRE(sensor.capacitance_handler.get_threshold() == 5);
             }
         }
     }

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -167,7 +167,7 @@ SCENARIO("read capacitance sensor values") {
                         std::get<can::messages::ReadFromSensorResponse>(
                             can_msg.message);
                     float check_data = signed_fixed_point_to_float(
-                        response_msg.sensor_data, 16);
+                        response_msg.sensor_data, S15Q16_RADIX);
                     float expected = 15;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
@@ -207,7 +207,7 @@ SCENARIO("read capacitance sensor values") {
                         std::get<can::messages::ReadFromSensorResponse>(
                             can_msg.message);
                     float check_data = signed_fixed_point_to_float(
-                        response_msg.sensor_data, 16);
+                        response_msg.sensor_data, S15Q16_RADIX);
                     float expected = -15;
                     REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                 }
@@ -253,8 +253,8 @@ SCENARIO("read capacitance sensor values") {
                     std::get<can::messages::ReadFromSensorResponse>(
                         can_msg.message);
                 float expected = 0.3418;
-                float check_data =
-                    fixed_point_to_float(response_msg.sensor_data, 15);
+                float check_data = fixed_point_to_float(
+                    response_msg.sensor_data, S15Q16_RADIX);
                 REQUIRE(check_data >= Approx(expected).epsilon(1e-4));
             }
         }
@@ -346,7 +346,8 @@ SCENARIO("capacitance callback tests") {
                 REQUIRE(sent.sensor == can::ids::SensorType::capacitive);
                 // we're just checking that the data is faithfully represented,
                 // don't really care what it is
-                REQUIRE(sent.sensor_data == convert_to_fixed_point(15, 16));
+                REQUIRE(sent.sensor_data ==
+                        convert_to_fixed_point(15, S15Q16_RADIX));
             }
             THEN("it should not touch the sync line") {
                 REQUIRE(mock_hw.get_sync_state_mock() == false);
@@ -464,7 +465,7 @@ SCENARIO("threshold configuration") {
         auto autothreshold = sensors::utils::TaskMessage(
             can::messages::SetSensorThresholdRequest(
                 {}, can::ids::SensorType::capacitive, sensor_id,
-                convert_to_fixed_point(0.375, 15),
+                convert_to_fixed_point(0.375, S15Q16_RADIX),
                 can::ids::SensorThresholdMode::auto_baseline));
         WHEN("the message is received") {
             sensor.handle_message(autothreshold);
@@ -536,7 +537,7 @@ SCENARIO("threshold configuration") {
                             std::get<can::messages::SensorThresholdResponse>(
                                 can_msg.message);
                         float check_data = signed_fixed_point_to_float(
-                            response_msg.threshold, 16);
+                            response_msg.threshold, S15Q16_RADIX);
                         // the average value + 1
                         float expected = 15.1875;
                         REQUIRE(check_data == Approx(expected).epsilon(1e-4));
@@ -552,7 +553,7 @@ SCENARIO("threshold configuration") {
         auto specific_threshold = sensors::utils::TaskMessage(
             can::messages::SetSensorThresholdRequest(
                 {}, can::ids::SensorType::capacitive, sensor_id,
-                convert_to_fixed_point(10, 15),
+                convert_to_fixed_point(10, S15Q16_RADIX),
                 can::ids::SensorThresholdMode::absolute));
         WHEN("the message is received") {
             sensor.handle_message(specific_threshold);
@@ -567,7 +568,7 @@ SCENARIO("threshold configuration") {
                 REQUIRE(threshold_response.sensor ==
                         can::ids::SensorType::capacitive);
                 REQUIRE(threshold_response.threshold ==
-                        convert_to_fixed_point(10, 15));
+                        convert_to_fixed_point(10, S15Q16_RADIX));
                 REQUIRE(threshold_response.mode ==
                         can::ids::SensorThresholdMode::absolute);
             }

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -524,7 +524,7 @@ SCENARIO("threshold configuration") {
                     sensor.handle_message(final_response_b);
                     THEN("the threshold is set to the proper value") {
                         REQUIRE(sensor.capacitance_handler.get_threshold() ==
-                                Approx(15.1875).epsilon(1e-4));
+                                Approx(15.375).epsilon(1e-4));
                     }
                     THEN(
                         "a message is sent on can informing that the threshold "
@@ -539,7 +539,7 @@ SCENARIO("threshold configuration") {
                         float check_data = signed_fixed_point_to_float(
                             response_msg.threshold, S15Q16_RADIX);
                         // the average value + 1
-                        float expected = 15.1875;
+                        float expected = 15.375;
                         REQUIRE(check_data == Approx(expected).epsilon(1e-4));
                         REQUIRE(response_msg.mode ==
                                 can::ids::SensorThresholdMode::auto_baseline);
@@ -573,7 +573,7 @@ SCENARIO("threshold configuration") {
                         can::ids::SensorThresholdMode::absolute);
             }
             THEN("the sensor's threshold should be set") {
-                REQUIRE(sensor.capacitance_handler.get_threshold() == 5);
+                REQUIRE(sensor.capacitance_handler.get_threshold() == 10);
             }
         }
     }


### PR DESCRIPTION
## Overview

There was a mismatch on how we were converting values in the capacitive sensor to fixed point. I
decided to match everything to a radix of 16, which is what the python is currently doing.