### PR TITLE
fix(sensors): correctly mask capdac value

### DIFF
--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -142,7 +142,7 @@ inline auto update_offset(float capacitance_pf, float current_offset_pf)
 }
 
 inline constexpr auto device_configuration_msb(uint8_t capdac_raw) -> uint8_t {
-    return (DEVICE_CONFIGURATION_MSB | ((capdac_raw >> 3) & 0x7));
+    return (DEVICE_CONFIGURATION_MSB | ((capdac_raw >> 3) & 0x3));
 }
 
 inline constexpr auto device_configuration_lsb(uint8_t capdac_raw) -> uint8_t {


### PR DESCRIPTION
There was a bug in the capacitive sensor driver related to masking the offset capacitance value. An offset of high enough pF would overflow into the CHB configuration field, effectively changing the channel being read to an invalid value and causing all future readings to be exactly the same. 

Before this fix, touching a capacitive sensor (or otherwise driving the capacitance high enough) would cause the sensor to latch onto a value indefinitely. After this fix, the sensor behaves properly.