### PR TITLE
refactor(pipettes): correct a few more bugs in the 96 channel firmware

### DIFF
--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -122,6 +122,10 @@ void EXTI3_IRQHandler(void) {
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
 }
 
+void EXTI15_10_IRQHandler(void) {
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_11);
+}
+
 // TODO refer to schematic to check and see that the data ready
 // pin is the same across values.
 

--- a/pipettes/firmware/stm32g4xx_it.h
+++ b/pipettes/firmware/stm32g4xx_it.h
@@ -45,9 +45,8 @@ void DMA1_Channel3_IRQHandler(void);
 void FDCAN1_IT0_IRQHandler(void);
 void TIM7_IRQHandler(void);
 void TIM6_DAC_IRQHandler(void);
-void EXTI8_IRQHandler(void);
-void EXTI9_IRQHandler(void);
-void EXTI15_IRQHandler(void);
+void EXTI3_IRQHandler(void);
+void EXTI15_10_IRQHandler(void);
 
 #ifdef __cplusplus
 }

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -56,7 +56,7 @@ void limit_switch_gpio_init() {
     if (pipette_type == NINETY_SIX_CHANNEL) {
         /*
          * Right gear -> PC10
-         * Left gear -> PB11
+         * Left gear -> PB12
          * Plunger -> PA4
          */
         enable_gpio_port(GPIOC);
@@ -64,7 +64,7 @@ void limit_switch_gpio_init() {
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
         enable_gpio_port(GPIOB);
-        GPIO_InitStruct.Pin = GPIO_PIN_11;
+        GPIO_InitStruct.Pin = GPIO_PIN_12;
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
         enable_gpio_port(GPIOA);


### PR DESCRIPTION
Had some incorrect interrupt names for the G4 board + 96 channel data ready line. The GPIO pin for one of the limit switches was also incorrect