### PR TITLE
fix(sensors): environmental sensor bringup

### DIFF
--- a/include/sensors/core/hdc3020.hpp
+++ b/include/sensors/core/hdc3020.hpp
@@ -94,6 +94,8 @@ struct __attribute__((packed, __may_alias__)) AutoMeasureStatus {
     static constexpr bool writable = true;
     static constexpr uint32_t value_mask = (1 << 8) - 1;
 
+    static constexpr uint8_t GET_READINGS_CMD = 0x00;
+
     uint8_t initialize : 1 = 1;
     uint8_t minimum_temperature : 1 = 0;
     uint8_t maximum_temperature : 1 = 0;

--- a/include/sensors/core/tasks/environment_driver.hpp
+++ b/include/sensors/core/tasks/environment_driver.hpp
@@ -177,6 +177,8 @@ class HDC3020 {
                 case hdc3020::Registers::TRIGGER_ON_DEMAND_MODE:
                     _registers.trigger_measurement.humidity = humidity;
                     _registers.trigger_measurement.temperature = temperature;
+                    send_hdc3020_data(humidity, temperature);
+                    return;
                     break;
                 case hdc3020::Registers::AUTO_MEASURE_1M2S:
                     _registers.measure_mode_1m2s.humidity = humidity;
@@ -201,7 +203,7 @@ class HDC3020 {
                 default:
                     break;
             }
-            if (sensor_binding & static_cast<uint8_t>(can::ids::SensorOutputBinding::report)) {
+            if ((sensor_binding & static_cast<uint8_t>(can::ids::SensorOutputBinding::report))) {
                 // TODO we need to store the humidity/temp values on
                 // eeprom at some point. TBD on implementation details.
                 send_hdc3020_data(humidity, temperature);

--- a/include/sensors/core/tasks/environment_driver.hpp
+++ b/include/sensors/core/tasks/environment_driver.hpp
@@ -222,7 +222,7 @@ class HDC3020 {
     // (TODO: lc 7-26-2022) we need a can message that
     // allows a user to select the power consumption mode
     // to use for different commands.
-    hdc3020::LowPowerMode POWER_MODE{3};
+    hdc3020::LowPowerMode POWER_MODE{1};
     uint8_t sensor_binding{2};
     I2CQueueWriter &writer;
     I2CQueuePoller &poller;

--- a/include/sensors/core/tasks/environment_driver.hpp
+++ b/include/sensors/core/tasks/environment_driver.hpp
@@ -39,7 +39,7 @@ class HDC3020 {
     auto get_sensor_id() -> can::ids::SensorId { return sensor_id; }
 
     auto set_bind_flags(uint8_t binding) -> void {
-        sensor_binding = static_cast<can::ids::SensorOutputBinding>(binding);
+        sensor_binding = binding;
     }
 
     auto initialize() -> void {
@@ -164,9 +164,9 @@ class HDC3020 {
         uint32_t raw_temperature = 0x0;
         const auto *iter = tm.read_buffer.cbegin();
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        iter = bit_utils::bytes_to_int(iter, iter + 3, raw_humidity);
+        iter = bit_utils::bytes_to_int(iter, iter + 3, raw_temperature);
         iter = bit_utils::bytes_to_int(iter, tm.read_buffer.cend(),
-                                       raw_temperature);
+                                       raw_humidity);
 
         if (raw_humidity != 0x0 || raw_temperature != 0x0) {
             auto humidity_temp = check_data(raw_humidity, raw_temperature);
@@ -201,7 +201,7 @@ class HDC3020 {
                 default:
                     break;
             }
-            if (sensor_binding == can::ids::SensorOutputBinding::report) {
+            if (sensor_binding & static_cast<uint8_t>(can::ids::SensorOutputBinding::report)) {
                 // TODO we need to store the humidity/temp values on
                 // eeprom at some point. TBD on implementation details.
                 send_hdc3020_data(humidity, temperature);
@@ -222,8 +222,8 @@ class HDC3020 {
     // (TODO: lc 7-26-2022) we need a can message that
     // allows a user to select the power consumption mode
     // to use for different commands.
-    hdc3020::LowPowerMode POWER_MODE{1};
-    can::ids::SensorOutputBinding sensor_binding{2};
+    hdc3020::LowPowerMode POWER_MODE{3};
+    uint8_t sensor_binding{2};
     I2CQueueWriter &writer;
     I2CQueuePoller &poller;
     CanClient &can_client;

--- a/include/sensors/core/tasks/environment_driver.hpp
+++ b/include/sensors/core/tasks/environment_driver.hpp
@@ -38,9 +38,7 @@ class HDC3020 {
 
     auto get_sensor_id() -> can::ids::SensorId { return sensor_id; }
 
-    auto set_bind_flags(uint8_t binding) -> void {
-        sensor_binding = binding;
-    }
+    auto set_bind_flags(uint8_t binding) -> void { sensor_binding = binding; }
 
     auto initialize() -> void {
         std::array<uint8_t, 2> write_buffer{
@@ -165,8 +163,8 @@ class HDC3020 {
         const auto *iter = tm.read_buffer.cbegin();
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         iter = bit_utils::bytes_to_int(iter, iter + 3, raw_temperature);
-        iter = bit_utils::bytes_to_int(iter, tm.read_buffer.cend(),
-                                       raw_humidity);
+        iter =
+            bit_utils::bytes_to_int(iter, tm.read_buffer.cend(), raw_humidity);
 
         if (raw_humidity != 0x0 || raw_temperature != 0x0) {
             auto humidity_temp = check_data(raw_humidity, raw_temperature);
@@ -203,7 +201,8 @@ class HDC3020 {
                 default:
                     break;
             }
-            if ((sensor_binding & static_cast<uint8_t>(can::ids::SensorOutputBinding::report))) {
+            if ((sensor_binding &
+                 static_cast<uint8_t>(can::ids::SensorOutputBinding::report))) {
                 // TODO we need to store the humidity/temp values on
                 // eeprom at some point. TBD on implementation details.
                 send_hdc3020_data(humidity, temperature);

--- a/include/sensors/core/tasks/environment_driver.hpp
+++ b/include/sensors/core/tasks/environment_driver.hpp
@@ -201,8 +201,7 @@ class HDC3020 {
                 default:
                     break;
             }
-            if ((sensor_binding &
-                 static_cast<uint8_t>(can::ids::SensorOutputBinding::report))) {
+            if (report_flag_set()) {
                 // TODO we need to store the humidity/temp values on
                 // eeprom at some point. TBD on implementation details.
                 send_hdc3020_data(humidity, temperature);
@@ -254,6 +253,12 @@ class HDC3020 {
             175.0 * (temperature * (1.0 / MAXIMUM_DATA_SIZE)) - 45.0;
         LOG("Temperature in celsius: %.4f", temp_celsius);
         return convert_to_fixed_point(temp_celsius, S15Q16_RADIX);
+    }
+
+    [[nodiscard]] auto report_flag_set() const -> bool {
+        return (sensor_binding &
+                static_cast<uint8_t>(can::ids::SensorOutputBinding::report)) ==
+               static_cast<uint8_t>(can::ids::SensorOutputBinding::report);
     }
 };
 

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -78,7 +78,7 @@ class EnvironmentSensorMessageHandler {
         // for the hdc sensor to at least set the power mode and
         // auto measure frequency.
         driver.set_bind_flags(m.binding);
-        driver.auto_measure_mode(hdc3020::Registers::AUTO_MEASURE_10M1S);
+        driver.auto_measure_mode(hdc3020::Registers::AUTO_MEASURE_1M1S);
     }
 
     void visit(const can::messages::PeripheralStatusRequest &m) {

--- a/include/sensors/simulation/hdc3020.hpp
+++ b/include/sensors/simulation/hdc3020.hpp
@@ -15,19 +15,19 @@ class HDC3020 : public I2CRegisterMap<uint8_t, uint64_t> {
               hdc3020::ADDRESS,
               {{static_cast<uint8_t>(
                     hdc3020::Registers::TRIGGER_ON_DEMAND_MODE),
-                0x209631509031},
+                0x509031209631},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_1M2S),
-                0x209631509031},
+                0x00},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_1M1S),
-                0x209631509031},
+                0x00},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_2M1S),
-                0x209631509031},
+                0x00},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_4M1S),
-                0x209631509031},
+                0x00},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_10M1S),
-                0x209631509031},
+                0x00},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_STATUS),
-                0x0}}) {}
+                0x509031209631}}) {}
 
     auto handle_write(const uint8_t *data, uint16_t size) -> bool {
         auto *iter = data;

--- a/sensors/tests/test_environment_driver.cpp
+++ b/sensors/tests/test_environment_driver.cpp
@@ -78,7 +78,7 @@ SCENARIO("Test HDC3020 environment sensor driver") {
                 auto sensor_response = i2c::messages::TransactionResponse{
                     .id = id,
                     .bytes_read = 6,
-                    .read_buffer = {0x20, 0x96, 0x31, 0x50, 0x90, 0x31, 0x0,
+                    .read_buffer = {0x50, 0x90, 0x31, 0x20, 0x96, 0x31, 0x0,
                                     0x0, 0x0}};
                 driver.handle_response(sensor_response);
                 THEN(


### PR DESCRIPTION
This PR adds a few fixes necessary to bring up the environmental sensor

* To read from the sensor, you first need to write the command for the autoread mode you want; then you read the data by writing to `AUTO_MEASURE_STATUS`, not the autoread mode setting register
* The polling frequency was 10Hz, which the datasheet claims can lead to internal heat buildup. 1Hz prevents this.
* The polling flags were not being read correctly, so if the host set the flags to sync _and_ report no data would be sent back
* When the host requested a single read, nothing was being sent back because data is only reported if the `report` flag is set
* The data coming back was being read in reverse order. The sensor sends back temperature and then humidity, but the firmware was reading in reverse order.

Tested on an OT3 using both a script to 1) poll one reading at a time 2) bind a report request and watch the data coming back. Temperature is right around room temp, humidity stays at 40%-ish and then goes up if you breathe on the sensor.