### PR TITLE
fix(sensors): convert pressure data correctly

### DIFF
--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -229,16 +229,8 @@ struct __attribute__((packed, __may_alias__)) LowPassPressure {
     uint32_t C0 : 1 = 0;
     uint32_t reading : 24 = 0;
 
-    [[nodiscard]] static auto to_pressure(uint32_t reg) -> sq15_16 {
-        // Sign extend pressure result
-        if ((reg & 0x00800000) != 0) {
-            reg |= 0xFF000000;
-        } else {
-            reg &= 0x007FFFFF;
-        }
-
-        float pressure = static_cast<float>(reg) * PA_PER_COUNT;
-        return convert_to_fixed_point(pressure, S15Q16_RADIX);
+    [[nodiscard]] static auto to_pressure(uint32_t reg) -> float {
+        return Pressure::to_pressure(reg);
     }
 };
 

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -261,7 +261,7 @@ class MMR920C04 {
         const auto *iter = tm.read_buffer.cbegin();
         // Pressure is always a three-byte value
         iter = bit_utils::bytes_to_int(iter, tm.read_buffer.cend(), raw_data);
-        data = raw_data >> 8;
+        data = static_cast<int32_t>(raw_data >> 8);
         auto pressure = mmr920C04::Pressure::to_pressure(data);
         switch (static_cast<mmr920C04::Registers>(tm.id.token)) {
             case mmr920C04::Registers::PRESSURE_READ:

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -320,7 +320,6 @@ class MMR920C04 {
     OwnQueue &own_queue;
     hardware::SensorHardwareBase &hardware;
     const can::ids::SensorId &sensor_id;
-    static constexpr size_t PRESSURE_DATA_BYTES = 3;
 
     template <mmr920C04::MMR920C04Register Reg>
     requires registers::WritableRegister<Reg>

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -102,7 +102,7 @@ SCENARIO("Read pressure sensor values") {
                             can_msg.message);
                     float check_data =
                         fixed_point_to_float(response_msg.sensor_data, 16);
-                    float expected = 33.0;
+                    float expected = 33.53677;
                     REQUIRE(check_data == Approx(expected));
                     REQUIRE(hardware.get_sync_state_mock() == false);
                 }
@@ -307,7 +307,7 @@ SCENARIO("Read pressure sensor values") {
                             can_msg.message);
                     float check_data =
                         fixed_point_to_float(response_msg.sensor_data, 16);
-                    float expected = 33.0;
+                    float expected = 33.53677;
                     REQUIRE(check_data == Approx(expected));
                     REQUIRE(hardware.get_sync_state_mock() == false);
                 }


### PR DESCRIPTION
This PR fixes some issues with how the pressure sensor data was being read:

* Pressure data value of 0 is perfectly reasonable
* Pressure data was being read as an `int32_t` and then right shifted. This ends up not working correctly because it is a signed 24-bit value. Instead, we want to right shift it _as a uint32_t_ to preserve the signedness 
* The pressure was being converted to a float and then stored into a `uint32_t` which 1) clobbered the accuracy 2) prevented negative values from being stored.