### PR TITLE
fix(sensors): only set FDC register once on startup

### DIFF
--- a/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_callbacks.hpp
@@ -117,6 +117,12 @@ struct ReadCapacitanceCallback {
         hardware.reset_sync();
     }
 
+    void set_sample_rate() {
+        std::array configuration_data{FDC_CONFIGURATION, SAMPLE_RATE_MSB,
+                                      SAMPLE_RATE_LSB};
+        i2c_writer.write(ADDRESS, configuration_data);
+    }
+
     void set_offset(float new_offset) {
         new_offset = std::max(new_offset, 0.0F);
         if (new_offset != current_offset_pf) {
@@ -126,15 +132,13 @@ struct ReadCapacitanceCallback {
                               device_configuration_lsb(capdac_raw)};
             i2c_writer.write(ADDRESS, offset);
             current_offset_pf = new_offset;
-            std::array configuration_data{FDC_CONFIGURATION, SAMPLE_RATE_MSB,
-                                          SAMPLE_RATE_LSB};
-            i2c_writer.write(ADDRESS, configuration_data);
         }
     }
 
     void initialize() {
         current_offset_pf = -1;
         set_offset(0);
+        set_sample_rate();
     }
 
     auto prime_autothreshold(float next_autothresh_pf) -> void {


### PR DESCRIPTION
The capacitive sensor on the pipettes worked fine with recent changes, but the gripper sensors would lock up from time to time. We theorized that the issue was that our poller doesn't check the ready flag for the measurements, but I set up a branch to test that and it didn't help at all - one of the sensors still locked up from time to time.

The code for the capacitive sensors originally wrote to the FDC register _every_ time the offset changed. This is necessary on startup (to configure the sample rate and measurement channel), but it is unnecessary after initial startup. Modifying the code so that the FDC register does _not_ get written after initialization fixed the issue - running the code on a gripper and touching the sensors quickly used to cause them to lock up eventually, but now they work indefinitely.

_Note: It's likely that this was the original cause of the capsense issues on the pipettes as well, but other "fixes" were able to obfuscate the issue due to the lower range of those sensors._