### PR TITLE
fix(pipettes): use correct i2c bus for multichannel pressure sensor

### DIFF
--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -32,6 +32,7 @@ using I2CPollerClient =
     i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>;
 
 void start_tasks(CanWriterTask& can_writer, I2CClient& i2c3_task_client,
+                 I2CPollerClient& i2c3_poller_client,
                  I2CClient& i2c1_task_client,
                  I2CPollerClient& i2c1_poller_client,
                  sensors::hardware::SensorHardwareBase& sensor_hardware,

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -2,6 +2,7 @@
 
 #include "can/core/ids.hpp"
 #include "common/core/freertos_task.hpp"
+#include "pipettes/core/pipette_type.h"
 
 static auto tasks = sensor_tasks::Tasks{};
 static auto queue_client = sensor_tasks::QueueClient{};
@@ -24,6 +25,7 @@ static auto pressure_sensor_task_builder =
 void sensor_tasks::start_tasks(
     sensor_tasks::CanWriterTask& can_writer,
     sensor_tasks::I2CClient& i2c3_task_client,
+    sensor_tasks::I2CPollerClient& i2c3_poller_client,
     sensor_tasks::I2CClient& i2c1_task_client,
     sensor_tasks::I2CPollerClient& i2c1_poller_client,
     sensors::hardware::SensorHardwareBase& sensor_hardware, can::ids::NodeId id,
@@ -32,12 +34,19 @@ void sensor_tasks::start_tasks(
     auto& queues = sensor_tasks::get_queues();
     auto& tasks = sensor_tasks::get_tasks();
 
+    auto& pressure_i2c_client = get_pipette_type() == EIGHT_CHANNEL
+                                    ? i2c3_task_client
+                                    : i2c1_task_client;
+    auto& pressure_i2c_poller = get_pipette_type() == EIGHT_CHANNEL
+                                    ? i2c3_poller_client
+                                    : i2c1_poller_client;
+
     auto& eeprom_task = eeprom_task_builder.start(5, "eeprom", i2c3_task_client,
                                                   eeprom_hardware);
     auto& environment_sensor_task = environment_sensor_task_builder.start(
         5, "enviro sensor", i2c1_task_client, i2c1_poller_client, queues);
     auto& pressure_sensor_task = pressure_sensor_task_builder.start(
-        5, "pressure sensor", i2c1_task_client, i2c1_poller_client, queues,
+        5, "pressure sensor", pressure_i2c_client, pressure_i2c_poller, queues,
         sensor_hardware);
     auto& capacitive_sensor_task_front =
         capacitive_sensor_task_builder_front.start(

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -148,6 +148,7 @@ auto initialize_motor_tasks(
     interfaces::gear_motor::GearMotionControl& gear_motion) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
+                              peripheral_tasks::get_i2c3_poller_client(),
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware, id, eeprom_hardware_iface);
@@ -168,8 +169,9 @@ auto initialize_motor_tasks(
     interfaces::gear_motor::UnavailableGearMotionControl&) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
-                              peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c3_poller_client(),
+                              peripheral_tasks::get_i2c1_client(),
+                              peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware, id, eeprom_hardware_iface);
 
     initialize_linear_timer(plunger_callback);

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -131,6 +131,7 @@ auto initialize_motor_tasks(
     interfaces::gear_motor::GearMotionControl&) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
+                              peripheral_tasks::get_i2c3_poller_client(),
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware, id, eeprom_hardware_iface);
@@ -152,6 +153,7 @@ auto initialize_motor_tasks(
     interfaces::gear_motor::UnavailableGearMotionControl&) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
+                              peripheral_tasks::get_i2c3_poller_client(),
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware, id, eeprom_hardware_iface);

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -104,6 +104,7 @@ auto initialize_motor_tasks(
     eeprom::simulator::EEProm& sim_eeprom) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
+                              peripheral_tasks::get_i2c3_poller_client(),
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
                               fake_sensor_hw, id, sim_eeprom);
@@ -126,6 +127,7 @@ auto initialize_motor_tasks(
     eeprom::simulator::EEProm& sim_eeprom) {
     sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                               peripheral_tasks::get_i2c3_client(),
+                              peripheral_tasks::get_i2c3_poller_client(),
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
                               fake_sensor_hw, id, sim_eeprom);


### PR DESCRIPTION
Closes RET-1280

The firmware was not set up to configure the right I2C bus for the pressure sensor on multichannel boards. This PR just adds that configuration. There is another pressure sensor on the other I2C bus, but it does not currently have the Data Ready line connected so it isn't usable until a sensor board revision.

Tested on a single-channel pipette:
* Flashed single-rev1 firmware and polled every sensor on the single-sensor board -> data came back fine
* Flashed multi-rev1 firmware and polled every sensor with a multi-sensor board attached -> data came back fine