### PR TITLE
fix(simulator): use correct register width for environment sensor

### DIFF
--- a/include/sensors/simulation/hdc3020.hpp
+++ b/include/sensors/simulation/hdc3020.hpp
@@ -15,7 +15,7 @@ class HDC3020 : public I2CRegisterMap<uint8_t, uint64_t> {
               hdc3020::ADDRESS,
               {{static_cast<uint8_t>(
                     hdc3020::Registers::TRIGGER_ON_DEMAND_MODE),
-                0x509031209631},
+                0x5090312096310000},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_1M2S),
                 0x00},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_1M1S),
@@ -27,7 +27,7 @@ class HDC3020 : public I2CRegisterMap<uint8_t, uint64_t> {
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_10M1S),
                 0x00},
                {static_cast<uint8_t>(hdc3020::Registers::AUTO_MEASURE_STATUS),
-                0x509031209631}}) {}
+                0x5090312096310000}}) {}
 
     auto handle_write(const uint8_t *data, uint16_t size) -> bool {
         auto *iter = data;


### PR DESCRIPTION
Integration tests are failing (partly) due to the environment sensor register values being wrong. This corrects the values of the temperature and humidity registers. Requires a corresponding PR in the monorepo to pass integration tests.