### PR TITLE
feat(motor-control): add motor position validity flags

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -123,6 +123,7 @@ SCENARIO("message serializing works") {
                                      .seq_id = 2,
                                      .current_position_um = 0x3456789a,
                                      .encoder_position_um = 0x05803931,
+                                     .position_flags = 0x3,
                                      .ack_id = 1};
         auto arr = std::array<uint8_t, 12>{};
         auto body = std::span{arr};
@@ -139,9 +140,10 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[7] == 0x80);
                 REQUIRE(body.data()[8] == 0x39);
                 REQUIRE(body.data()[9] == 0x31);
-                REQUIRE(body.data()[10] == 1);
+                REQUIRE(body.data()[10] == 0x3);
+                REQUIRE(body.data()[11] == 1);
             }
-            THEN("size must be returned") { REQUIRE(size == 11); }
+            THEN("size must be returned") { REQUIRE(size == 12); }
         }
     }
 

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -202,6 +202,26 @@ SCENARIO("message serializing works") {
         }
     }
 
+    GIVEN("an encoder position response") {
+        auto message = EncoderPositionResponse{.encoder_position = 0xABEF,
+                                               .position_flags = 0x2};
+        auto arr = std::array<uint8_t, 7>{0, 0, 0, 0, 0, 0, 0};
+        auto body = std::span{arr};
+        WHEN("serialized into a buffer larger than needed") {
+            auto size = message.serialize(arr.begin(), arr.end());
+            THEN("it is fully written into the buffer") {
+                REQUIRE(body.data()[0] == 0x00);
+                REQUIRE(body.data()[1] == 0x00);
+                REQUIRE(body.data()[2] == 0xAB);
+                REQUIRE(body.data()[3] == 0xEF);
+                REQUIRE(body.data()[4] == 0x02);
+                REQUIRE(body.data()[5] == 0x00);
+                REQUIRE(body.data()[6] == 0x00);
+            }
+            THEN("size must be returned") { REQUIRE(size == 5); }
+        }
+    }
+
     GIVEN("a read from eeprom response") {
         auto data = std::array<uint8_t, 5>{0, 1, 2, 3, 4};
         auto message =

--- a/generate_header.py
+++ b/generate_header.py
@@ -33,6 +33,7 @@ def generate_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
         write_enum_cpp(constants_mod.SensorOutputBinding, output)
         write_enum_cpp(constants_mod.SensorThresholdMode, output)
         write_enum_cpp(constants_mod.PipetteTipActionType, output)
+        write_enum_cpp(constants_mod.MotorPositionFlags, output)
 
 
 def generate_c(output: io.StringIO, constants_mod: ModuleType, arbitration_id: ModuleType) -> None:
@@ -48,6 +49,7 @@ def generate_c(output: io.StringIO, constants_mod: ModuleType, arbitration_id: M
     write_enum_c(constants_mod.SensorOutputBinding, output, can)
     write_enum_c(constants_mod.SensorThresholdMode, output, can)
     write_enum_c(constants_mod.PipetteTipActionType, output, can)
+    write_enum_c(constants_mod.MotorPositionFlags, output, can)
     write_arbitration_id_c(output, can, arbitration_id)
 
 

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -171,6 +171,12 @@ typedef enum {
     can_pipettetipactiontype_drop = 0x1,
 } CANPipetteTipActionType;
 
+/** Flags for motor position validity. */
+typedef enum {
+    can_motorpositionflags_stepper_position_ok = 0x1,
+    can_motorpositionflags_encoder_position_ok = 0x2,
+} CANMotorPositionFlags;
+
 /** A bit field of the arbitration id parts. */
 typedef struct {
     unsigned int function_code: 4;

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -180,4 +180,3 @@ enum class MotorPositionFlags {
 };
 
 }  // namespace can::ids
-

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -173,4 +173,11 @@ enum class PipetteTipActionType {
     drop = 0x1,
 };
 
+/** Flags for motor position validity. */
+enum class MotorPositionFlags {
+    stepper_position_ok = 0x1,
+    encoder_position_ok = 0x2,
+};
+
 }  // namespace can::ids
+

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -357,10 +357,12 @@ struct MoveCompleted : BaseMessage<MessageId::move_completed> {
 struct EncoderPositionResponse
     : BaseMessage<MessageId::encoder_position_response> {
     int32_t encoder_position;
+    uint8_t position_flags;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter = bit_utils::int_to_bytes(encoder_position, body, limit);
+        iter = bit_utils::int_to_bytes(position_flags, iter, limit);
         return iter - body;
     }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -337,6 +337,7 @@ struct MoveCompleted : BaseMessage<MessageId::move_completed> {
     uint8_t seq_id;
     uint32_t current_position_um;
     int32_t encoder_position_um;
+    uint8_t position_flags;
     uint8_t ack_id;
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -345,6 +346,7 @@ struct MoveCompleted : BaseMessage<MessageId::move_completed> {
         iter = bit_utils::int_to_bytes(seq_id, iter, limit);
         iter = bit_utils::int_to_bytes(current_position_um, iter, limit);
         iter = bit_utils::int_to_bytes(encoder_position_um, iter, limit);
+        iter = bit_utils::int_to_bytes(position_flags, iter, limit);
         iter = bit_utils::int_to_bytes(ack_id, iter, limit);
         return iter - body;
     }

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -96,6 +96,10 @@ class MotionController {
                                     radix_offset_0{});
     }
 
+    [[nodiscard]] auto get_position_flags() const -> uint8_t {
+        return hardware.position_flags.get_flags();
+    }
+
   private:
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;
     BrushedMotorHardwareIface& hardware;

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -227,7 +227,7 @@ class BrushedMotorInterruptHandler {
         }
 
         if (buffered_move.group_id != NO_GROUP) {
-            auto ack = buffered_move.build_ack(hardware.get_encoder_pulses(),
+            auto ack = buffered_move.build_ack(hardware.get_encoder_pulses(), 0,
                                                ack_msg_id);
 
             static_cast<void>(

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -9,10 +9,10 @@ namespace motor_hardware {
 class MotorHardwareIface {
   public:
     MotorHardwareIface() = default;
-    MotorHardwareIface(const MotorHardwareIface&) = default;
-    MotorHardwareIface(MotorHardwareIface&&) = default;
-    auto operator=(MotorHardwareIface&&) -> MotorHardwareIface& = default;
-    auto operator=(const MotorHardwareIface&) -> MotorHardwareIface& = default;
+    MotorHardwareIface(const MotorHardwareIface&) = delete;
+    MotorHardwareIface(MotorHardwareIface&&) = delete;
+    auto operator=(MotorHardwareIface&&) -> MotorHardwareIface& = delete;
+    auto operator=(const MotorHardwareIface&) -> MotorHardwareIface& = delete;
     virtual ~MotorHardwareIface() = default;
     virtual void positive_direction() = 0;
     virtual void negative_direction() = 0;

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "motor-control/core/types.hpp"
+
 namespace motor_hardware {
 
 class MotorHardwareIface {
@@ -22,6 +24,10 @@ class MotorHardwareIface {
     virtual void reset_encoder_pulses() = 0;
     virtual void start_timer_interrupt() = 0;
     virtual void stop_timer_interrupt() = 0;
+
+    // This variable can remain public because the only public methods
+    // to it are thread-safe anyways.
+    MotorPositionStatus position_flags{};
 };
 
 class StepperMotorHardwareIface : virtual public MotorHardwareIface {

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -53,7 +53,8 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     uint8_t seq_id;
     MoveStopCondition stop_condition = MoveStopCondition::none;
 
-    auto build_ack(uint32_t position, int32_t pulses, uint8_t flags, AckMessageId _id) -> Ack {
+    auto build_ack(uint32_t position, int32_t pulses, uint8_t flags,
+                   AckMessageId _id) -> Ack {
         return Ack{
             .group_id = group_id,
             .seq_id = seq_id,
@@ -68,9 +69,10 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
 struct GearMotorMove : public Move {
     can::ids::PipetteTipActionType action;
 
-    auto build_ack(uint32_t position, int32_t pulses, uint8_t flags, AckMessageId _id)
-        -> GearMotorAck {
-        return GearMotorAck{group_id, seq_id, position, pulses, flags, _id, action};
+    auto build_ack(uint32_t position, int32_t pulses, uint8_t flags,
+                   AckMessageId _id) -> GearMotorAck {
+        return GearMotorAck{group_id, seq_id, position, pulses,
+                            flags,    _id,    action};
     }
 };
 

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -37,6 +37,7 @@ struct Ack {
     uint8_t seq_id;
     uint32_t current_position_steps;
     int32_t encoder_position;
+    uint8_t position_flags;
     AckMessageId ack_id;
 };
 
@@ -52,12 +53,13 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     uint8_t seq_id;
     MoveStopCondition stop_condition = MoveStopCondition::none;
 
-    auto build_ack(uint32_t position, int32_t pulses, AckMessageId _id) -> Ack {
+    auto build_ack(uint32_t position, int32_t pulses, uint8_t flags, AckMessageId _id) -> Ack {
         return Ack{
             .group_id = group_id,
             .seq_id = seq_id,
             .current_position_steps = position,
             .encoder_position = pulses,
+            .position_flags = flags,
             .ack_id = _id,
         };
     }
@@ -66,9 +68,9 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
 struct GearMotorMove : public Move {
     can::ids::PipetteTipActionType action;
 
-    auto build_ack(uint32_t position, int32_t pulses, AckMessageId _id)
+    auto build_ack(uint32_t position, int32_t pulses, uint8_t flags, AckMessageId _id)
         -> GearMotorAck {
-        return GearMotorAck{group_id, seq_id, position, pulses, _id, action};
+        return GearMotorAck{group_id, seq_id, position, pulses, flags, _id, action};
     }
 };
 
@@ -84,12 +86,13 @@ struct BrushedMove {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     int32_t encoder_position;
     MoveStopCondition stop_condition = MoveStopCondition::none;
 
-    auto build_ack(int32_t pulses, AckMessageId _id) -> Ack {
+    auto build_ack(int32_t pulses, uint8_t flags, AckMessageId _id) -> Ack {
         return Ack{
             .group_id = group_id,
             .seq_id = seq_id,
             .current_position_steps = 0,
             .encoder_position = pulses,
+            .position_flags = flags,
             .ack_id = _id,
         };
     }

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -119,6 +119,10 @@ class MotionController {
         return motion_constraints;
     }
 
+    [[nodiscard]] auto get_position_flags() const -> uint8_t {
+        return hardware.position_flags.get_flags();
+    }
+
   private:
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;
     StepperMotorHardwareIface& hardware;
@@ -218,6 +222,10 @@ class PipetteMotionController {
 
     [[nodiscard]] auto get_motion_constraints() -> MotionConstraints {
         return motion_constraints;
+    }
+
+    [[nodiscard]] auto get_position_flags() const -> uint8_t {
+        return hardware.position_flags.get_flags();
     }
 
   private:

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -141,9 +141,9 @@ class MotorInterruptHandler {
         if (limit_switch_triggered()) {
             position_tracker = 0;
             hardware.reset_encoder_pulses();
-            position_flags.set_flag(
+            hardware.position_flags.set_flag(
                 can::ids::MotorPositionFlags::stepper_position_ok);
-            position_flags.set_flag(
+            hardware.position_flags.set_flag(
                 can::ids::MotorPositionFlags::encoder_position_ok);
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
@@ -208,8 +208,8 @@ class MotorInterruptHandler {
         if (buffered_move.group_id != NO_GROUP) {
             auto ack = buffered_move.build_ack(
                 static_cast<uint32_t>(position_tracker >> 31),
-                hardware.get_encoder_pulses(), position_flags.get_flags(),
-                ack_msg_id);
+                hardware.get_encoder_pulses(),
+                hardware.position_flags.get_flags(), ack_msg_id);
 
             static_cast<void>(
                 status_queue_client.send_move_status_reporter_queue(ack));
@@ -260,8 +260,7 @@ class MotorInterruptHandler {
     uint64_t tick_count = 0x0;
     static constexpr const q31_31 tick_flag = 0x80000000;
     static constexpr const uint64_t overflow_flag = 0x8000000000000000;
-    q31_31 position_tracker = 0x0;         // in steps
-    MotorPositionStatus position_flags{};  // can/core/ids.hpp
+    q31_31 position_tracker = 0x0;  // in steps
     GenericQueue& queue;
     StatusClient& status_queue_client;
     motor_hardware::StepperMotorHardwareIface& hardware;

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -141,6 +141,10 @@ class MotorInterruptHandler {
         if (limit_switch_triggered()) {
             position_tracker = 0;
             hardware.reset_encoder_pulses();
+            position_flags.set_flag(
+                can::ids::MotorPositionFlags::stepper_position_ok);
+            position_flags.set_flag(
+                can::ids::MotorPositionFlags::encoder_position_ok);
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
         }
@@ -204,7 +208,8 @@ class MotorInterruptHandler {
         if (buffered_move.group_id != NO_GROUP) {
             auto ack = buffered_move.build_ack(
                 static_cast<uint32_t>(position_tracker >> 31),
-                hardware.get_encoder_pulses(), ack_msg_id);
+                hardware.get_encoder_pulses(), position_flags.get_flags(),
+                ack_msg_id);
 
             static_cast<void>(
                 status_queue_client.send_move_status_reporter_queue(ack));
@@ -255,8 +260,8 @@ class MotorInterruptHandler {
     uint64_t tick_count = 0x0;
     static constexpr const q31_31 tick_flag = 0x80000000;
     static constexpr const uint64_t overflow_flag = 0x8000000000000000;
-    q31_31 position_tracker = 0x0;  // in steps
-    uint8_t position_flags = 0x0; // can/core/ids.hpp
+    q31_31 position_tracker = 0x0;         // in steps
+    MotorPositionStatus position_flags{};  // can/core/ids.hpp
     GenericQueue& queue;
     StatusClient& status_queue_client;
     motor_hardware::StepperMotorHardwareIface& hardware;

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -256,6 +256,7 @@ class MotorInterruptHandler {
     static constexpr const q31_31 tick_flag = 0x80000000;
     static constexpr const uint64_t overflow_flag = 0x8000000000000000;
     q31_31 position_tracker = 0x0;  // in steps
+    uint8_t position_flags = 0x0; // can/core/ids.hpp
     GenericQueue& queue;
     StatusClient& status_queue_client;
     motor_hardware::StepperMotorHardwareIface& hardware;

--- a/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
@@ -83,8 +83,10 @@ class MotionControllerMessageHandler {
 
     void handle(const can::messages::EncoderPositionRequest&) {
         auto response = controller.read_encoder_pulses();
-        LOG("Received read encoder: encoder_pulses=%d", response);
-        can::messages::EncoderPositionResponse msg{{}, response};
+        auto flags = controller.get_position_flags();
+        LOG("Received read encoder: encoder_pulses=%d flags=0x%2X", response,
+            flags);
+        can::messages::EncoderPositionResponse msg{{}, response, flags};
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 

--- a/include/motor-control/core/tasks/motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/motion_controller_task.hpp
@@ -98,8 +98,10 @@ class MotionControllerMessageHandler {
 
     void handle(const can::messages::EncoderPositionRequest&) {
         auto response = controller.read_encoder_pulses();
-        LOG("Received read encoder: encoder_pulses=%d", response);
-        can::messages::EncoderPositionResponse msg{{}, response};
+        auto flags = controller.get_position_flags();
+        LOG("Received read encoder: encoder_pulses=%d flags=0x%2X", response,
+            flags);
+        can::messages::EncoderPositionResponse msg{{}, response, flags};
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 

--- a/include/motor-control/core/tasks/move_status_reporter_task.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task.hpp
@@ -48,6 +48,7 @@ class MoveStatusMessageHandler {
             .encoder_position_um = fixed_point_multiply(
                 um_per_encoder_pulse, message.encoder_position,
                 radix_offset_0{}),
+            .position_flags = message.position_flags,
             .ack_id = static_cast<uint8_t>(message.ack_id)};
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }

--- a/include/motor-control/core/types.hpp
+++ b/include/motor-control/core/types.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+
+#include "can/core/ids.hpp"
 
 using sq0_31 = int32_t;  // 0: signed bit,  1-31: fractional bits
 using sq15_16 =
@@ -14,3 +17,19 @@ using stepper_timer_ticks = uint64_t;
 using brushed_timer_ticks = uint64_t;
 using steps_per_tick = sq0_31;
 using steps_per_tick_sq = sq0_31;
+
+class MotorPositionStatus {
+  public:
+    using Flags = can::ids::MotorPositionFlags;
+
+    void set_flag(Flags flag);
+
+    void clear_flag(Flags flag);
+
+    bool check_flag(Flags flag);
+
+    uint8_t get_flags();
+
+  private:
+    std::atomic_uint8_t backing{0};
+};

--- a/include/motor-control/core/types.hpp
+++ b/include/motor-control/core/types.hpp
@@ -22,13 +22,13 @@ class MotorPositionStatus {
   public:
     using Flags = can::ids::MotorPositionFlags;
 
-    void set_flag(Flags flag);
+    auto set_flag(Flags flag) -> void;
 
-    void clear_flag(Flags flag);
+    auto clear_flag(Flags flag) -> void;
 
-    bool check_flag(Flags flag);
+    [[nodiscard]] auto check_flag(Flags flag) const -> bool;
 
-    uint8_t get_flags();
+    [[nodiscard]] auto get_flags() const -> uint8_t;
 
   private:
     std::atomic_uint8_t backing{0};

--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -23,10 +23,10 @@ class MotorHardware : public StepperMotorHardwareIface {
     MotorHardware(const HardwareConfig& config, void* timer_handle,
                   void* encoder_handle)
         : pins(config), tim_handle(timer_handle), enc_handle(encoder_handle) {}
-    MotorHardware(const MotorHardware&) = default;
-    auto operator=(const MotorHardware&) -> MotorHardware& = default;
-    MotorHardware(MotorHardware&&) = default;
-    auto operator=(MotorHardware&&) -> MotorHardware& = default;
+    MotorHardware(const MotorHardware&) = delete;
+    auto operator=(const MotorHardware&) -> MotorHardware& = delete;
+    MotorHardware(MotorHardware&&) = delete;
+    auto operator=(MotorHardware&&) -> MotorHardware& = delete;
     void step() final;
     void unstep() final;
     void positive_direction() final;

--- a/include/pipettes/firmware/pipette_motor_hardware.hpp
+++ b/include/pipettes/firmware/pipette_motor_hardware.hpp
@@ -24,10 +24,10 @@ class MotorHardware : public motor_hardware::PipetteStepperMotorHardwareIface {
     MotorHardware(const HardwareConfig& config, void* timer_handle,
                   void* encoder_handle)
         : pins(config), tim_handle(timer_handle), enc_handle(encoder_handle) {}
-    MotorHardware(const MotorHardware&) = default;
-    auto operator=(const MotorHardware&) -> MotorHardware& = default;
-    MotorHardware(MotorHardware&&) = default;
-    auto operator=(MotorHardware&&) -> MotorHardware& = default;
+    MotorHardware(const MotorHardware&) = delete;
+    auto operator=(const MotorHardware&) -> MotorHardware& = delete;
+    MotorHardware(MotorHardware&&) = delete;
+    auto operator=(MotorHardware&&) -> MotorHardware& = delete;
     void step() final;
     void unstep() final;
     void positive_direction() final;

--- a/motor-control/core/CMakeLists.txt
+++ b/motor-control/core/CMakeLists.txt
@@ -1,2 +1,5 @@
-add_library(motor-utils STATIC utils.cpp)
-target_include_directories(motor-utils PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../../include)
+add_library(motor-utils STATIC 
+    types.cpp    
+    utils.cpp)
+target_include_directories(motor-utils PUBLIC 
+    ${CMAKE_CURRENT_LIST_DIR}/../../include)

--- a/motor-control/core/types.cpp
+++ b/motor-control/core/types.cpp
@@ -1,0 +1,16 @@
+#include "motor-control/core/types.hpp"
+
+void MotorPositionStatus::set_flag(MotorPositionStatus::Flags flag) {
+    backing.fetch_or(static_cast<uint8_t>(flag));
+}
+
+void MotorPositionStatus::clear_flag(MotorPositionStatus::Flags flag) {
+    backing.fetch_and(~static_cast<uint8_t>(flag));
+}
+
+bool MotorPositionStatus::check_flag(MotorPositionStatus::Flags flag) {
+    return (backing.load() & static_cast<uint8_t>(flag)) ==
+           static_cast<uint8_t>(flag);
+}
+
+uint8_t MotorPositionStatus::get_flags() { return backing.load(); }

--- a/motor-control/core/types.cpp
+++ b/motor-control/core/types.cpp
@@ -1,16 +1,19 @@
 #include "motor-control/core/types.hpp"
 
-void MotorPositionStatus::set_flag(MotorPositionStatus::Flags flag) {
+auto MotorPositionStatus::set_flag(MotorPositionStatus::Flags flag) -> void {
     backing.fetch_or(static_cast<uint8_t>(flag));
 }
 
-void MotorPositionStatus::clear_flag(MotorPositionStatus::Flags flag) {
+auto MotorPositionStatus::clear_flag(MotorPositionStatus::Flags flag) -> void {
     backing.fetch_and(~static_cast<uint8_t>(flag));
 }
 
-bool MotorPositionStatus::check_flag(MotorPositionStatus::Flags flag) {
+[[nodiscard]] auto MotorPositionStatus::check_flag(
+    MotorPositionStatus::Flags flag) const -> bool {
     return (backing.load() & static_cast<uint8_t>(flag)) ==
            static_cast<uint8_t>(flag);
 }
 
-uint8_t MotorPositionStatus::get_flags() { return backing.load(); }
+[[nodiscard]] auto MotorPositionStatus::get_flags() const -> uint8_t {
+    return backing.load();
+}

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(motor-control
         test_move_status_handling.cpp
         test_sync_handling.cpp
         test_brushed_motor_interrupt_handler.cpp
+        test_motor_flags.cpp
         )
 
 target_ot_motor_control(motor-control)

--- a/motor-control/tests/test_motor_flags.cpp
+++ b/motor-control/tests/test_motor_flags.cpp
@@ -1,0 +1,39 @@
+#include <array>
+
+#include "can/core/ids.hpp"
+#include "catch2/catch.hpp"
+#include "motor-control/core/types.hpp"
+
+using Flags = MotorPositionStatus::Flags;
+
+TEST_CASE("motor status class functionality") {
+    MotorPositionStatus status;
+    GIVEN("motor flag object and a single flag") {
+        auto flag =
+            GENERATE(Flags::encoder_position_ok, Flags::stepper_position_ok);
+        THEN("the value is 0x00") { REQUIRE(status.get_flags() == 0x00); }
+        THEN("no flags are set") { REQUIRE(!status.check_flag(flag)); }
+        WHEN("a flag is set") {
+            status.set_flag(flag);
+            THEN("the flag can be checked") {
+                REQUIRE(status.check_flag(flag));
+            }
+            AND_THEN("the flag is cleared") {
+                status.clear_flag(flag);
+                THEN("the flag is no longer set") {
+                    REQUIRE(!status.check_flag(flag));
+                }
+            }
+        }
+    }
+
+    GIVEN("motor status object with multiple flags set") {
+        status.set_flag(Flags::encoder_position_ok);
+        status.set_flag(Flags::stepper_position_ok);
+        THEN("all of the flags are set") {
+            REQUIRE(status.get_flags() == 0x3);
+            REQUIRE(status.check_flag(Flags::encoder_position_ok));
+            REQUIRE(status.check_flag(Flags::stepper_position_ok));
+        }
+    }
+}

--- a/motor-control/tests/test_move_status_handling.cpp
+++ b/motor-control/tests/test_move_status_handling.cpp
@@ -38,6 +38,7 @@ SCENARIO("testing move status position translation") {
                                        .seq_id = 8,
                                        .current_position_steps = 0,
                                        .encoder_position = 0,
+                                       .position_flags = 0x3,
                                        .ack_id = AckMessageId::timeout});
             CHECK(mcc.queue.size() == 1);
 
@@ -47,6 +48,7 @@ SCENARIO("testing move status position translation") {
                 REQUIRE(resp_msg.group_id == 11);
                 REQUIRE(resp_msg.seq_id == 8);
                 REQUIRE(resp_msg.ack_id == 3);
+                REQUIRE(resp_msg.position_flags == 0x3);
             }
             THEN("the position value should still be 0") {
                 REQUIRE(resp_msg.current_position_um == 0);
@@ -60,6 +62,7 @@ SCENARIO("testing move status position translation") {
                                        .seq_id = 8,
                                        .current_position_steps = 0,
                                        .encoder_position = -1000,
+                                       .position_flags = 0x1,
                                        .ack_id = AckMessageId::timeout});
             CHECK(mcc.queue.size() == 1);
 
@@ -69,6 +72,7 @@ SCENARIO("testing move status position translation") {
                 REQUIRE(resp_msg.group_id == 11);
                 REQUIRE(resp_msg.seq_id == 8);
                 REQUIRE(resp_msg.ack_id == 3);
+                REQUIRE(resp_msg.position_flags == 0x1);
             }
             THEN("the position value should still be 0") {
                 REQUIRE(resp_msg.current_position_um == 0);


### PR DESCRIPTION

This PR adds flags tracking the validity of the stepper motor positions on the firmware boards. For now, these flags are set once the motor homes and they never get reset; in a future PR, they will be cleared by firmware to mark when a motor needs to be re-homed.

* The flags are stored in the Hardware Interface structure. This was done because the interface is shared by both the interrupt handler and the motor controller, which both need access to the flags.
* All operations on the flags are atomic in order to provide safety when accessed from interrupt vs task contexts.
* The flags are reported in two messages, the Encoder Position Response and the Move Completed message.

Tested on both a simulator and a physical OT-3 using `can-mon`:
* On startup, sending an Encoder Position request shows that the flags are at 0x00
* After a homing sequence on an axis is completed, the flags will indefinitely return 0x3 to indicate that both the step count and the encoder position are valid.

This PR should be merged at the same time as the matching Monorepo PR.