### PR TITLE
feat(all): support new eeprom chip for gripper and 96 channel

### DIFF
--- a/eeprom/tests/test_dev_data.cpp
+++ b/eeprom/tests/test_dev_data.cpp
@@ -131,7 +131,7 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
     auto writer = i2c::writer::Writer<test_mocks::MockMessageQueue>{};
     writer.set_queue(&i2c_queue);
     auto hardware_iface =
-        MockHardwareIface{hardware_iface::EEPromChipType::ST_M24128};
+        MockHardwareIface{hardware_iface::EEPromChipType::ST_M24128_BF};
 
     auto eeprom =
         task::EEPromMessageHandler{writer, response_queue, hardware_iface};
@@ -295,7 +295,7 @@ SCENARIO("writing large data to partition") {
     auto writer = i2c::writer::Writer<test_mocks::MockMessageQueue>{};
     writer.set_queue(&i2c_queue);
     auto hardware_iface =
-        MockHardwareIface{hardware_iface::EEPromChipType::ST_M24128};
+        MockHardwareIface{hardware_iface::EEPromChipType::ST_M24128_BF};
 
     auto eeprom =
         task::EEPromMessageHandler{writer, response_queue, hardware_iface};
@@ -490,7 +490,7 @@ SCENARIO("reading large data from partition") {
     auto writer = i2c::writer::Writer<test_mocks::MockMessageQueue>{};
     writer.set_queue(&i2c_queue);
     auto hardware_iface =
-        MockHardwareIface{hardware_iface::EEPromChipType::ST_M24128};
+        MockHardwareIface{hardware_iface::EEPromChipType::ST_M24128_BF};
 
     auto eeprom =
         task::EEPromMessageHandler{writer, response_queue, hardware_iface};

--- a/eeprom/tests/test_eeprom_task.cpp
+++ b/eeprom/tests/test_eeprom_task.cpp
@@ -120,7 +120,7 @@ SCENARIO("Sending messages to 16 bit address Eeprom task") {
     writer.set_queue(&i2c_queue);
 
     auto hardware_iface_16 =
-        MockHardwareIface(hardware_iface::EEPromChipType::ST_M24128);
+        MockHardwareIface(hardware_iface::EEPromChipType::ST_M24128_BF);
 
     auto eeprom_16 =
         task::EEPromMessageHandler{writer, response_queue, hardware_iface_16};

--- a/eeprom/tests/test_hardware_iface.cpp
+++ b/eeprom/tests/test_hardware_iface.cpp
@@ -35,7 +35,7 @@ SCENARIO("Configuring EEProm Address Length") {
         }
         WHEN("Explicit 16 bit contructor used") {
             auto hw_16_bit_explicit =
-                MockEepromHardwareIface(EEPromChipType::ST_M24128);
+                MockEepromHardwareIface(EEPromChipType::ST_M24128_BF);
             THEN("address setting is 16 bit") {
                 REQUIRE(
                     hw_16_bit_explicit.get_eeprom_addr_bytes() ==
@@ -96,6 +96,27 @@ SCENARIO("WriteProtector class") {
             THEN("write protect is enabled then disabled") {
                 REQUIRE(hw.set_calls == std::vector<bool>{true, false});
             }
+        }
+    }
+}
+SCENARIO("looking up i2c address by chip type") {
+    WHEN("we have a MICROCHIP_24AA02T") {
+        THEN("the address should be 0x50 shifted left (0xA0)") {
+            REQUIRE(hardware_iface::get_i2c_device_address(
+                        hardware_iface::EEPromChipType::MICROCHIP_24AA02T) ==
+                    0xA0);
+        }
+    }
+    WHEN("we have a ST_M24128_BF") {
+        THEN("the address should be 0x50 shifted left (0xA0)") {
+            REQUIRE(hardware_iface::get_i2c_device_address(
+                        hardware_iface::EEPromChipType::ST_M24128_BF) == 0xA0);
+        }
+    }
+    WHEN("we have a ST_M24128_DF") {
+        THEN("the address should be 0x51 shifted left (0xA2)") {
+            REQUIRE(hardware_iface::get_i2c_device_address(
+                        hardware_iface::EEPromChipType::ST_M24128_DF) == 0xA2);
         }
     }
 }

--- a/gripper/firmware/main_rev1.cpp
+++ b/gripper/firmware/main_rev1.cpp
@@ -67,7 +67,7 @@ class EEPromHardwareInterface
   public:
     EEPromHardwareInterface()
         : eeprom::hardware_iface::EEPromHardwareIface(
-              eeprom::hardware_iface::EEPromChipType::ST_M24128) {}
+              eeprom::hardware_iface::EEPromChipType::ST_M24128_DF) {}
     void set_write_protect(bool enable) final {
         if (enable) {
             disable_eeprom_write();

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -18,13 +18,10 @@ enum class EEpromMemorySize { MICROCHIP_256_BYTE = 256, ST_16_KBYTE = 16384 };
 
 inline auto get_i2c_device_address(
     EEPromChipType chip = EEPromChipType::ST_M24128_BF) -> uint16_t {
-    uint16_t chip_address = 0x50;
     if (chip == EEPromChipType::ST_M24128_DF) {
-        chip_address = 0x51;
-        return chip_address;
-    } else {
-        return chip_address;
+        return 0x51 << 1;
     }
+    return 0x50 << 1;
 }
 /**
  * Interface to eeprom. Must be implemented in FW and Simulation

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -4,7 +4,7 @@
 namespace eeprom {
 namespace hardware_iface {
 
-enum class EEPromChipType { MICROCHIP_24AA02T, ST_M24128 };
+enum class EEPromChipType { MICROCHIP_24AA02T, ST_M24128_BF, ST_M24128_DF };
 
 enum class EEPromAddressType {
     EEPROM_ADDR_8_BIT = sizeof(uint8_t),
@@ -15,6 +15,17 @@ constexpr uint8_t ADDR_BITS_DIFFERENCE =
     8 * (sizeof(uint16_t) - sizeof(uint8_t));
 
 enum class EEpromMemorySize { MICROCHIP_256_BYTE = 256, ST_16_KBYTE = 16384 };
+
+inline auto get_i2c_device_address(
+    EEPromChipType chip = EEPromChipType::ST_M24128_BF) -> uint16_t {
+    uint16_t chip_address = 0x50;
+    if (chip == EEPromChipType::ST_M24128_DF) {
+        chip_address = 0x51;
+        return chip_address;
+    } else {
+        return chip_address;
+    }
+}
 /**
  * Interface to eeprom. Must be implemented in FW and Simulation
  *
@@ -33,7 +44,13 @@ class EEPromHardwareIface {
                 eeprom_mem_size =
                     static_cast<size_t>(EEpromMemorySize::MICROCHIP_256_BYTE);
                 break;
-            case EEPromChipType::ST_M24128:
+            case EEPromChipType::ST_M24128_BF:
+                eeprom_addr_bytes =
+                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_16_BIT);
+                eeprom_mem_size =
+                    static_cast<size_t>(EEpromMemorySize::ST_16_KBYTE);
+                break;
+            case EEPromChipType::ST_M24128_DF:
                 eeprom_addr_bytes =
                     static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_16_BIT);
                 eeprom_mem_size =

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -128,7 +128,8 @@ class EEPromMessageHandler {
             iter);
         // A write transaction.
         auto transaction = i2c::messages::Transaction{
-            .address = types::DEVICE_ADDRESS,
+            .address = hardware_iface::get_i2c_device_address(
+                hw_iface.get_eeprom_chip_type()),
             .bytes_to_read = 0,
             .bytes_to_write = static_cast<std::size_t>(iter - buffer.begin()),
             .write_buffer = buffer};
@@ -187,7 +188,8 @@ class EEPromMessageHandler {
             m.memory_address, iter, (iter + hw_iface.get_eeprom_addr_bytes()));
 
         auto transaction = i2c::messages::Transaction{
-            .address = types::DEVICE_ADDRESS,
+            .address = hardware_iface::get_i2c_device_address(
+                hw_iface.get_eeprom_chip_type()),
             .bytes_to_read = m.length,
             .bytes_to_write =
                 static_cast<std::size_t>(iter - write_buffer.begin()),

--- a/include/eeprom/core/types.hpp
+++ b/include/eeprom/core/types.hpp
@@ -13,7 +13,5 @@ constexpr data_length max_data_length = 8;
 
 using EepromData = std::array<uint8_t, max_data_length>;
 
-constexpr uint16_t DEVICE_ADDRESS = 0xA0;
-
 }  // namespace types
 }  // namespace eeprom

--- a/include/eeprom/simulation/eeprom.hpp
+++ b/include/eeprom/simulation/eeprom.hpp
@@ -30,11 +30,11 @@ class EEProm : public I2CDeviceBase,
         return BackingStore::add_options(cmdline_desc, env_desc);
     }
     explicit EEProm(po::variables_map& options, const uint32_t backing_data = 0)
-        : I2CDeviceBase(types::DEVICE_ADDRESS),
+        : I2CDeviceBase(hardware_iface::get_i2c_device_address()),
           backing(options, backing_data) {}
     EEProm(hardware_iface::EEPromChipType chip, po::variables_map& options,
            const uint32_t backing_data = 0)
-        : I2CDeviceBase(types::DEVICE_ADDRESS),
+        : I2CDeviceBase(hardware_iface::get_i2c_device_address(chip)),
           hardware_iface::EEPromHardwareIface(chip),
           backing(options, backing_data) {}
 

--- a/pipettes/core/sensor_tasks_g4.cpp
+++ b/pipettes/core/sensor_tasks_g4.cpp
@@ -40,8 +40,12 @@ void sensor_tasks::start_tasks(
                                     ? i2c2_poller_client
                                     : i2c3_poller_client;
 
-    auto& eeprom_task = eeprom_task_builder.start(5, "eeprom", i2c2_task_client,
-                                                  eeprom_hardware);
+    auto& eeprom_i2c_client = get_pipette_type() == NINETY_SIX_CHANNEL
+                                  ? i2c3_task_client
+                                  : i2c2_task_client;
+
+    auto& eeprom_task = eeprom_task_builder.start(
+        5, "eeprom", eeprom_i2c_client, eeprom_hardware);
     auto& environment_sensor_task = environment_sensor_task_builder.start(
         5, "enviro sensor", i2c3_task_client, i2c3_poller_client, queues);
     auto& pressure_sensor_task = pressure_sensor_task_builder.start(

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -52,12 +52,16 @@ static auto i2c_comms3 = i2c::hardware::I2C();
 static auto i2c_comms2 = i2c::hardware::I2C();
 static I2CHandlerStruct i2chandler_struct{};
 
+static auto eeprom_chip =
+    PIPETTE_TYPE == NINETY_SIX_CHANNEL
+        ? eeprom::hardware_iface::EEPromChipType::ST_M24128_DF
+        : eeprom::hardware_iface::EEPromChipType::ST_M24128_BF;
+
 class PipetteEEPromHardwareIface
     : public eeprom::hardware_iface::EEPromHardwareIface {
   public:
     PipetteEEPromHardwareIface()
-        : eeprom::hardware_iface::EEPromHardwareIface(
-              eeprom::hardware_iface::EEPromChipType::ST_M24128) {}
+        : eeprom::hardware_iface::EEPromHardwareIface(eeprom_chip) {}
     void set_write_protect(bool enable) final {
         if (enable) {
             disable_eeprom_write();


### PR DESCRIPTION
Both the gripper and 96 channel require a different eeprom chip due to i2c address collisions. See #RET-1284.