### PR TITLE
refactor(pipettes): modify direction pin for 96 channel plunger

### DIFF
--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -195,7 +195,7 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOA,
                      .pin = GPIO_PIN_6,
-                     .active_setting = GPIO_PIN_SET},
+                     .active_setting = GPIO_PIN_RESET},
                 .step =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOA,


### PR DESCRIPTION
The active setting of the direction pin is flipped for the 96 channel