### PR TITLE
fix(bootloader) account for the fact that the bootloader is unable to read messages of size 60

### DIFF
--- a/bootloader/tests/test_message_handler.cpp
+++ b/bootloader/tests/test_message_handler.cpp
@@ -112,7 +112,7 @@ SCENARIO("update data bad checksum error") {
         request.data[6] = 0xEE;
         request.data[7] = 0x00;
 
-        request.size = 60;
+        request.size = 64;
 
         WHEN("received") {
             Message response;

--- a/bootloader/tests/test_messages.cpp
+++ b/bootloader/tests/test_messages.cpp
@@ -54,7 +54,7 @@ SCENARIO("empty message errors") {
 
 SCENARIO("update data") {
     GIVEN("a message with a data byte count of 0") {
-        auto arr = std::array<uint8_t, 60>{
+        auto arr = std::array<uint8_t, 64>{
             // Message Index
             0xde, 0xad, 0xbe, 0xef,
             // Address
@@ -86,7 +86,7 @@ SCENARIO("update data") {
     }
 
     GIVEN("a message with full data byte count") {
-        auto arr = std::array<uint8_t, 60>{
+        auto arr = std::array<uint8_t, 64>{
             // Message Index
             0xde, 0xad, 0xbe, 0xef,
             // Address
@@ -152,7 +152,7 @@ SCENARIO("update data errors") {
     }
 
     GIVEN("a message with invalid data byte count") {
-        auto arr = std::array<uint8_t, 60>{
+        auto arr = std::array<uint8_t, 64>{
             // Message Index
             0xde, 0xad, 0xbe, 0xef,
             // Address
@@ -177,7 +177,7 @@ SCENARIO("update data errors") {
     }
 
     GIVEN("a message with incorrect checksum") {
-        auto arr = std::array<uint8_t, 60>{
+        auto arr = std::array<uint8_t, 64>{
             // Message Index
             0xde, 0xad, 0xbe, 0xef,
             // Address

--- a/include/bootloader/core/messages.h
+++ b/include/bootloader/core/messages.h
@@ -20,7 +20,7 @@ typedef struct {
     uint16_t checksum;
 } UpdateData;
 
-#define UPDATE_DATA_MESSAGE_SIZE    60
+#define UPDATE_DATA_MESSAGE_SIZE    64
 // can't be (UPDATE_DATA_MESSAGE_SIZE - sizeof(UpdateData) - sizeof(uint8_t))
 // since c adds padding to align all struct members to 32bit addresses
 


### PR DESCRIPTION
the HAl code skips sizes from 48 to 64. and defaults to size=64 when its not one of the defined values in length_from_hal in bootloader/core/utils.c

so this sets the size back to 64 and adjusts the tests accordingly