### PR TITLE
feature(motor-control): add error message to move response varient

### DIFF
--- a/generate_header.py
+++ b/generate_header.py
@@ -27,6 +27,7 @@ def generate_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
         write_enum_cpp(constants_mod.MessageId, output)
         write_enum_cpp(constants_mod.NodeId, output)
         write_enum_cpp(constants_mod.ErrorCode, output)
+        write_enum_cpp(constants_mod.ErrorSeverity, output)
         write_enum_cpp(constants_mod.ToolType, output)
         write_enum_cpp(constants_mod.SensorType, output)
         write_enum_cpp(constants_mod.SensorId, output)

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -123,6 +123,9 @@ typedef enum {
     can_errorcode_invalid_byte_count = 0x3,
     can_errorcode_invalid_input = 0x4,
     can_errorcode_hardware = 0x5,
+    can_errorcode_timeout = 0x6,
+    can_errorcode_estop_detected = 0x7,
+    can_errorcode_collision_detected = 0x8,
 } CANErrorCode;
 
 /** Tool types detected on Head. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -125,9 +125,12 @@ enum class ErrorCode {
     invalid_byte_count = 0x3,
     invalid_input = 0x4,
     hardware = 0x5,
+    timeout = 0x6,
+    estop_detected = 0x7,
+    collision_detected = 0x8,
 };
 
-/** Error Severity levels */
+/** Error Severity levels. */
 enum class ErrorSeverity {
     warning = 0x1,
     recoverable = 0x2,

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -75,14 +75,14 @@ static auto add_resp_ind(Resposne& resp, const Request& req) -> void {
 
 struct ErrorMessage : BaseMessage<MessageId::error_message> {
     uint32_t message_index;
-    uint16_t severity;
-    uint16_t error_code;
+    ErrorSeverity severity;
+    ErrorCode error_code;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter = bit_utils::int_to_bytes(message_index, body, limit);
-        iter = bit_utils::int_to_bytes(severity, iter, limit);
-        iter = bit_utils::int_to_bytes(error_code, iter, limit);
+        iter = bit_utils::int_to_bytes(uint16_t(severity), iter, limit);
+        iter = bit_utils::int_to_bytes(uint16_t(error_code), iter, limit);
         return iter - body;
     }
 
@@ -96,8 +96,8 @@ struct ErrorMessage : BaseMessage<MessageId::error_message> {
         body = bit_utils::bytes_to_int(body, limit, error_code);
 
         return ErrorMessage{.message_index = message_index,
-                            .severity = severity,
-                            .error_code = error_code};
+                            .severity = ErrorSeverity(severity),
+                            .error_code = ErrorCode(error_code)};
     }
 
     auto operator==(const ErrorMessage& other) const -> bool = default;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -81,8 +81,10 @@ struct ErrorMessage : BaseMessage<MessageId::error_message> {
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter = bit_utils::int_to_bytes(message_index, body, limit);
-        iter = bit_utils::int_to_bytes(uint16_t(severity), iter, limit);
-        iter = bit_utils::int_to_bytes(uint16_t(error_code), iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint16_t>(severity), iter,
+                                       limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint16_t>(error_code), iter,
+                                       limit);
         return iter - body;
     }
 

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <atomic>
 
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
 #include "common/core/logging.h"
 #include "common/core/message_queue.hpp"
 #include "motor-control/core/brushed_motor/driver_interface.hpp"

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -25,7 +25,9 @@ using MoveGroupTaskMessage =
                  can::messages::GetMoveGroupRequest,
                  can::messages::HomeRequest>;
 
-using MoveStatusReporterTaskMessage = motor_messages::Ack;
+using MoveStatusReporterTaskMessage =
+    std::variant<std::monostate, motor_messages::Ack,
+                 can::messages::ErrorMessage>;
 
 using BrushedMotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,

--- a/include/motor-control/core/tasks/move_status_reporter_task.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task.hpp
@@ -35,11 +35,21 @@ class MoveStatusMessageHandler {
     auto operator=(const MoveStatusMessageHandler&& c) = delete;
     ~MoveStatusMessageHandler() = default;
 
+    void handle_message(const TaskMessage& message) {
+        std::visit([this](auto m) { this->handle_message(m); }, message);
+    }
+
+    void handle_message(std::monostate&) {}
+
+    void handle_message(const can::messages::ErrorMessage& msg) {
+        can_client.send_can_message(can::ids::NodeId::host, msg);
+    }
+
     /**
      * Called upon arrival of new message
      * @param message
      */
-    void handle_message(const TaskMessage& message) {
+    void handle_message(const motor_messages::Ack& message) {
         can::messages::MoveCompleted msg = {
             .message_index = message.message_index,
             .group_id = message.group_id,

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -58,7 +58,8 @@ SCENARIO("Brushed motor interrupt handler handle move messages") {
                     THEN("Encoder value is reset and homed ack is sent") {
                         REQUIRE(test_objs.hw.get_encoder_pulses() == 0);
                         REQUIRE(test_objs.reporter.messages.size() >= 1);
-                        Ack read_ack = test_objs.reporter.messages.back();
+                        Ack read_ack =
+                            std::get<Ack>(test_objs.reporter.messages.back());
                         REQUIRE(read_ack.encoder_position == 0);
                         REQUIRE(read_ack.ack_id ==
                                 AckMessageId::stopped_by_condition);
@@ -107,7 +108,8 @@ SCENARIO("Brushed motor interrupt handler handle move messages") {
                             test_objs.handler.run_interrupt();
                             REQUIRE(test_objs.hw.get_encoder_pulses() == 30000);
                             REQUIRE(test_objs.reporter.messages.size() >= 1);
-                            Ack read_ack = test_objs.reporter.messages.back();
+                            Ack read_ack = std::get<Ack>(
+                                test_objs.reporter.messages.back());
                             REQUIRE(read_ack.encoder_position == 30000);
                             REQUIRE(read_ack.ack_id ==
                                     AckMessageId::complete_without_condition);
@@ -171,7 +173,8 @@ SCENARIO("Brushed motor interrupt handler handle move messages") {
                 test_objs.handler.run_interrupt();
                 REQUIRE(test_objs.driver.get_pwm_settings() == 0);
                 REQUIRE(test_objs.reporter.messages.size() >= 1);
-                Ack read_ack = test_objs.reporter.messages.back();
+                Ack read_ack =
+                    std::get<Ack>(test_objs.reporter.messages.back());
                 // check if position is withen acceptable parameters
                 REQUIRE(
                     std::abs(read_ack.encoder_position - msg.encoder_position) <

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -52,7 +52,8 @@ TEST_CASE("Move with stop condition == limit switch") {
                     "condition") {
                     REQUIRE(!test_objs.handler.pulse());
                     REQUIRE(test_objs.reporter.messages.size() >= 1);
-                    Ack read_ack = test_objs.reporter.messages.back();
+                    Ack read_ack =
+                        std::get<Ack>(test_objs.reporter.messages.back());
                     REQUIRE(read_ack.ack_id ==
                             AckMessageId::stopped_by_condition);
                     REQUIRE(read_ack.encoder_position == 0);
@@ -88,7 +89,8 @@ TEST_CASE("Move with stop condition == limit switch, case 2") {
                     REQUIRE(!test_objs.handler.pulse());
                     REQUIRE(!test_objs.handler.pulse());
                     REQUIRE(test_objs.reporter.messages.size() >= 1);
-                    Ack read_ack = test_objs.reporter.messages.back();
+                    Ack read_ack =
+                        std::get<Ack>(test_objs.reporter.messages.back());
                     REQUIRE(read_ack.ack_id ==
                             AckMessageId::complete_without_condition);
                 }
@@ -124,7 +126,8 @@ TEST_CASE("Move with stop condition != limit switch") {
                     "the move should have ack_id complete_without_condition, "
                     "and position = 4") {
                     REQUIRE(test_objs.reporter.messages.size() >= 1);
-                    Ack read_ack = test_objs.reporter.messages.back();
+                    Ack read_ack =
+                        std::get<Ack>(test_objs.reporter.messages.back());
                     REQUIRE(read_ack.ack_id ==
                             AckMessageId::complete_without_condition);
                 }

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -299,7 +299,7 @@ TEST_CASE("Finishing a move") {
             "the ack message should contain the correct information when the "
             "move finishes") {
             REQUIRE(test_objs.reporter.messages.size() == 1);
-            auto msg = test_objs.reporter.messages[0];
+            auto msg = std::get<Ack>(test_objs.reporter.messages[0]);
             REQUIRE(msg.group_id == move.group_id);
             REQUIRE(msg.seq_id == move.seq_id);
             REQUIRE(msg.current_position_steps == 100);
@@ -324,7 +324,7 @@ TEST_CASE("Finishing a move") {
             "the ack message should contain the correct information when the "
             "move finishes") {
             REQUIRE(test_objs.reporter.messages.size() == 1);
-            auto msg = test_objs.reporter.messages[0];
+            auto msg = std::get<Ack>(test_objs.reporter.messages[0]);
             REQUIRE(msg.group_id == move.group_id);
             REQUIRE(msg.seq_id == move.seq_id);
             REQUIRE(msg.current_position_steps == 0);
@@ -345,7 +345,7 @@ TEST_CASE("Finishing a move") {
                     "the ack message should contain the correct information "
                     "when the move finishes") {
                     REQUIRE(test_objs.reporter.messages.size() == 1);
-                    auto msg = test_objs.reporter.messages[0];
+                    auto msg = std::get<Ack>(test_objs.reporter.messages[0]);
                     REQUIRE(msg.group_id == move.group_id);
                     REQUIRE(msg.seq_id == move.seq_id);
                     REQUIRE(msg.current_position_steps == 100);

--- a/motor-control/tests/test_sync_handling.cpp
+++ b/motor-control/tests/test_sync_handling.cpp
@@ -51,7 +51,8 @@ TEST_CASE("Move with stop condition == cap sensor") {
                     "condition") {
                     REQUIRE(!test_objs.handler.pulse());
                     REQUIRE(test_objs.reporter.messages.size() >= 1);
-                    Ack read_ack = test_objs.reporter.messages.back();
+                    Ack read_ack =
+                        std::get<Ack>(test_objs.reporter.messages.back());
                     REQUIRE(read_ack.ack_id ==
                             AckMessageId::stopped_by_condition);
                 }
@@ -80,7 +81,8 @@ TEST_CASE("Move with stop condition == cap sensor, case 2") {
                     REQUIRE(!test_objs.handler.pulse());
                     REQUIRE(!test_objs.handler.pulse());
                     REQUIRE(test_objs.reporter.messages.size() >= 1);
-                    Ack read_ack = test_objs.reporter.messages.back();
+                    Ack read_ack =
+                        std::get<Ack>(test_objs.reporter.messages.back());
                     REQUIRE(read_ack.ack_id ==
                             AckMessageId::complete_without_condition);
                 }
@@ -113,7 +115,8 @@ TEST_CASE("Move with stop condition != cap sensor") {
                     "the move should have ack_id complete_without_condition, "
                     "and position = 4") {
                     REQUIRE(test_objs.reporter.messages.size() >= 1);
-                    Ack read_ack = test_objs.reporter.messages.back();
+                    Ack read_ack =
+                        std::get<Ack>(test_objs.reporter.messages.back());
                     REQUIRE(read_ack.ack_id ==
                             AckMessageId::complete_without_condition);
                 }


### PR DESCRIPTION
[RET-1250](https://opentrons.atlassian.net/browse/RET-1250) firmware side work
Allows the motor controller to respond to moves with an error message in addition to the ack