### PR TITLE
fix(pipettes): make pick up motor timer half the time of the plunger motor

### DIFF
--- a/pipettes/firmware/motor_timer_hardware.c
+++ b/pipettes/firmware/motor_timer_hardware.c
@@ -82,7 +82,7 @@ void MX_TIM6_Init(void) {
     TIM_MasterConfigTypeDef sMasterConfig = {0};
 
     htim6.Instance = TIM6;
-    htim6.Init.Prescaler = 499;
+    htim6.Init.Prescaler = 849;
     htim6.Init.CounterMode = TIM_COUNTERMODE_UP;
     htim6.Init.Period = 1;
     htim6.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;


### PR DESCRIPTION
## Overview

The 96 channel has two timer interrupts to control the 3 stepper motors in the system. The plunger motor timer frequency was bumped up to match the motor frequencies in the rest of the robot system, but the gear motor wasn't changed to accomodate this. As a result, the firmware application was getting overloaded and crashing when both timers were enabled. Hopefully in January we'll be able to do a full study of the system (including freertos tasks/interrupts etc) to figure out where we can better optimize our system.