### PR TITLE
feat(motor-control): add StallCheck class

### DIFF
--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -52,7 +52,7 @@ class StallCheck {
      * @return True if the motor position is OK, false if the encoder
      * indicates a stall occurred.
      */
-    [[nodiscard]] auto check_stall(int32_t encoder_steps) const -> bool
+    [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) const -> bool
         __attribute__((optimize(3)));
 
   private:

--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -56,7 +56,8 @@ class StallCheck {
 
     /**
      * @brief Given absolute step position of encoder and stepper, check
-     * whether a stall seems to have occurred.
+     * whether a stall seems to have occurred. As a byproduct, this resets
+     * the current position of the stepper motor within the object.
      * @note This function is NOT optimized for ISR use. It uses floating
      * point math and should only be called from a task context.
      *
@@ -65,8 +66,8 @@ class StallCheck {
      * @return true if the position is OK, false if the encoder indicates
      * a stall has occurred.
      */
-    [[nodiscard]] auto check_stall(int32_t encoder_steps,
-                                   int32_t stepper_steps) const -> bool;
+    [[nodiscard]] auto check_stall(int32_t encoder_steps, int32_t stepper_steps)
+        -> bool;
 
   private:
     [[nodiscard]] auto has_encoder() const -> bool;

--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -41,7 +41,8 @@ class StallCheck {
      * @param[in] direction true for a positive step, false for a negative
      * step. Only one step may be taken at a time.
      */
-    [[nodiscard]] auto step_itr(bool direction) -> bool;
+    [[nodiscard]] auto step_itr(bool direction) -> bool
+        __attribute__((optimize(3)));
 
     /**
      * @brief Check the stall status of the motor.
@@ -50,11 +51,14 @@ class StallCheck {
      * @return True if the motor position is OK, false if the encoder
      * indicates a stall occurred.
      */
-    [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) const -> bool;
+    [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) const -> bool
+        __attribute__((optimize(3)));
 
     /**
      * @brief Given absolute step position of encoder and stepper, check
      * whether a stall seems to have occurred.
+     * @note This function is NOT optimized for ISR use. It uses floating
+     * point math and should only be called from a task context.
      *
      * @param encoder_steps Encoder position in ticks
      * @param stepper_steps Stepper position in microsteps

--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -45,29 +45,15 @@ class StallCheck {
         __attribute__((optimize(3)));
 
     /**
-     * @brief Check the stall status of the motor.
+     * @brief Check the stall status of the motor. This function is optimized
+     * to be run in the high-frequency motor interrupt.
      *
      * @param encoder_steps Current microstep position of the encoder.
      * @return True if the motor position is OK, false if the encoder
      * indicates a stall occurred.
      */
-    [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) const -> bool
+    [[nodiscard]] auto check_stall(int32_t encoder_steps) const -> bool
         __attribute__((optimize(3)));
-
-    /**
-     * @brief Given absolute step position of encoder and stepper, check
-     * whether a stall seems to have occurred. As a byproduct, this resets
-     * the current position of the stepper motor within the object.
-     * @note This function is NOT optimized for ISR use. It uses floating
-     * point math and should only be called from a task context.
-     *
-     * @param encoder_steps Encoder position in ticks
-     * @param stepper_steps Stepper position in microsteps
-     * @return true if the position is OK, false if the encoder indicates
-     * a stall has occurred.
-     */
-    [[nodiscard]] auto check_stall(int32_t encoder_steps, int32_t stepper_steps)
-        -> bool;
 
   private:
     [[nodiscard]] auto has_encoder() const -> bool;

--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -1,0 +1,97 @@
+/**
+ * @file stall_check.hpp
+ * @brief Class interface for encoder stall detection
+ *
+ * @details
+ */
+
+#pragma once
+
+#include "motor-control/core/types.hpp"
+
+namespace stall_check {
+
+class StallCheck {
+  public:
+    /**
+     * @brief Construct a new Stall Check object
+     *
+     * @param _encoder_tick_per_um Ratio of ticks : µm for encoder
+     * @param _stepper_tick_per_um Ratio of ticks : µm for microsteps
+     * @param um_threshold If encoder and stepper position differs by
+     * more than this, consider the stepper stalled.
+     */
+    StallCheck(float encoder_tick_per_um, float stepper_tick_per_um,
+               uint32_t um_threshold);
+
+    /**
+     * @brief Reset the counters for the stall check to match the current
+     * stepper position.
+     * @note This function is NOT optimized for ISR use. It uses floating
+     * point math and should only be called from a task context.
+     *
+     * @param stepper_steps Current microsteps.
+     */
+    auto reset_itr_counts(int32_t stepper_steps) -> void;
+
+    /**
+     * Should be be called whenever the motor interrupt steps the motor.
+     * If this function returns true, `check_itr` should be called.
+     *
+     * @param[in] direction true for a positive step, false for a negative
+     * step. Only one step may be taken at a time.
+     */
+    [[nodiscard]] auto step_itr(bool direction) -> bool;
+
+    /**
+     * @brief Check the stall status of the motor.
+     *
+     * @param encoder_steps Current microstep position of the encoder.
+     * @return True if the motor position is OK, false if the encoder
+     * indicates a stall occurred.
+     */
+    [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) const -> bool;
+
+    /**
+     * @brief Given absolute step position of encoder and stepper, check
+     * whether a stall seems to have occurred.
+     *
+     * @param encoder_steps Encoder position in ticks
+     * @param stepper_steps Stepper position in microsteps
+     * @return true if the position is OK, false if the encoder indicates
+     * a stall has occurred.
+     */
+    [[nodiscard]] auto check_stall(int32_t encoder_steps,
+                                   int32_t stepper_steps) const -> bool;
+
+  private:
+    [[nodiscard]] auto has_encoder() const -> bool;
+    [[nodiscard]] auto encoder_um_per_tick() const -> float;
+    [[nodiscard]] auto stepper_um_per_tick() const -> float;
+
+    static constexpr uint64_t RADIX = 31;
+    static constexpr uint64_t RADIX_SHIFTED = static_cast<uint64_t>(1) << RADIX;
+
+    // Fixed point representations of the hardware limits
+    const float _encoder_tick_per_um;
+    const float _stepper_tick_per_um;
+
+    // Stall threshold
+    const uint32_t _um_threshold;
+
+    // Number of ticks within the stall thresholds
+    const sq31_31 _encoder_step_threshold;
+    const sq31_31 _stepper_step_threshold;
+
+    // This is an IDEAL position for the encoder, updated to match
+    // the stepper as it increments.
+    sq31_31 _encoder_ideal_counts = 0;
+    // Running counter for the stepper. This is a fixed point number
+    // to prevent error buildup as the magnitude increases over time.
+    sq31_31 _stepper_counts = 0;
+
+    sq31_31 _next_threshold_positive = 0;
+    sq31_31 _next_threshold_negative = 0;
+};
+
+}  // namespace stall_check

--- a/motor-control/core/CMakeLists.txt
+++ b/motor-control/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(motor-utils STATIC 
     motor_hardware_interface.cpp
+    stall_check.cpp
     types.cpp    
     utils.cpp)
 target_include_directories(motor-utils PUBLIC 

--- a/motor-control/core/stall_check.cpp
+++ b/motor-control/core/stall_check.cpp
@@ -59,16 +59,12 @@ auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
 }
 
 [[nodiscard]] auto StallCheck::check_stall(int32_t encoder_steps,
-                                           int32_t stepper_steps) const
-    -> bool {
+                                           int32_t stepper_steps) -> bool {
     if (!has_encoder()) {
         return true;
     }
-    float encoder_um = encoder_steps * encoder_um_per_tick();
-    float stepper_um = stepper_steps * stepper_um_per_tick();
-
-    return std::labs(encoder_um - stepper_um) <=
-           static_cast<float>(_um_threshold);
+    reset_itr_counts(stepper_steps);
+    return check_stall_itr(encoder_steps);
 }
 
 [[nodiscard]] auto StallCheck::has_encoder() const -> bool {

--- a/motor-control/core/stall_check.cpp
+++ b/motor-control/core/stall_check.cpp
@@ -1,0 +1,90 @@
+#include "motor-control/core/stall_check.hpp"
+
+#include <cstdlib>
+
+#include "motor-control/core/utils.hpp"
+
+using namespace stall_check;
+
+StallCheck::StallCheck(float encoder_tick_per_um, float stepper_tick_per_um,
+                       uint32_t um_threshold)
+    : _encoder_tick_per_um{encoder_tick_per_um},
+      _stepper_tick_per_um{stepper_tick_per_um},
+      _um_threshold{um_threshold},
+      _encoder_step_threshold{convert_to_fixed_point_64_bit(
+          encoder_tick_per_um * um_threshold, RADIX)},
+      _stepper_step_threshold{convert_to_fixed_point_64_bit(
+          stepper_tick_per_um * um_threshold, RADIX)} {
+    reset_itr_counts(0);
+}
+
+auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
+    _stepper_counts = stepper_steps * RADIX_SHIFTED;
+
+    _next_threshold_positive = _stepper_counts + _stepper_step_threshold;
+    _next_threshold_negative = _stepper_counts - _stepper_step_threshold;
+
+    _encoder_ideal_counts = convert_to_fixed_point_64_bit(
+        (_encoder_tick_per_um * stepper_steps) / _stepper_tick_per_um, RADIX);
+}
+
+[[nodiscard]] auto StallCheck::step_itr(bool direction) -> bool {
+    if (!has_encoder()) {
+        return false;
+    }
+    _stepper_counts += direction ? RADIX_SHIFTED : -RADIX_SHIFTED;
+    if (_stepper_counts > _next_threshold_positive) {
+        _next_threshold_positive += _stepper_step_threshold;
+        _next_threshold_negative += _stepper_step_threshold;
+        _encoder_ideal_counts += _encoder_step_threshold;
+        return true;
+    }
+    if (_stepper_counts < _next_threshold_negative) {
+        _next_threshold_positive -= _stepper_step_threshold;
+        _next_threshold_negative -= _stepper_step_threshold;
+        _encoder_ideal_counts -= _encoder_step_threshold;
+        return true;
+    }
+    return false;
+}
+
+[[nodiscard]] auto StallCheck::check_stall_itr(int32_t encoder_steps) const
+    -> bool {
+    if (!has_encoder()) {
+        return true;
+    }
+    sq31_31 diff = std::labs(_encoder_ideal_counts -
+                             (static_cast<sq31_31>(encoder_steps) << RADIX));
+    return diff <= _encoder_step_threshold;
+}
+
+[[nodiscard]] auto StallCheck::check_stall(int32_t encoder_steps,
+                                           int32_t stepper_steps) const
+    -> bool {
+    if (!has_encoder()) {
+        return true;
+    }
+    float encoder_um = encoder_steps * encoder_um_per_tick();
+    float stepper_um = stepper_steps * stepper_um_per_tick();
+
+    return std::labs(encoder_um - stepper_um) <=
+           static_cast<float>(_um_threshold);
+}
+
+[[nodiscard]] auto StallCheck::has_encoder() const -> bool {
+    return _encoder_tick_per_um != 0.0F;
+}
+
+[[nodiscard]] auto StallCheck::encoder_um_per_tick() const -> float {
+    if (_encoder_tick_per_um == 0) {
+        return 0;
+    }
+    return 1.0F / _encoder_tick_per_um;
+}
+
+[[nodiscard]] auto StallCheck::stepper_um_per_tick() const -> float {
+    if (_stepper_tick_per_um == 0) {
+        return 0;
+    }
+    return 1.0F / _stepper_tick_per_um;
+}

--- a/motor-control/core/stall_check.cpp
+++ b/motor-control/core/stall_check.cpp
@@ -48,7 +48,7 @@ auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
     return false;
 }
 
-[[nodiscard]] auto StallCheck::check_stall_itr(int32_t encoder_steps) const
+[[nodiscard]] auto StallCheck::check_stall(int32_t encoder_steps) const
     -> bool {
     if (!has_encoder()) {
         return true;
@@ -56,15 +56,6 @@ auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
     sq31_31 diff = std::labs(_encoder_ideal_counts -
                              (static_cast<sq31_31>(encoder_steps) << RADIX));
     return diff <= _encoder_step_threshold;
-}
-
-[[nodiscard]] auto StallCheck::check_stall(int32_t encoder_steps,
-                                           int32_t stepper_steps) -> bool {
-    if (!has_encoder()) {
-        return true;
-    }
-    reset_itr_counts(stepper_steps);
-    return check_stall_itr(encoder_steps);
 }
 
 [[nodiscard]] auto StallCheck::has_encoder() const -> bool {

--- a/motor-control/core/stall_check.cpp
+++ b/motor-control/core/stall_check.cpp
@@ -48,7 +48,7 @@ auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
     return false;
 }
 
-[[nodiscard]] auto StallCheck::check_stall(int32_t encoder_steps) const
+[[nodiscard]] auto StallCheck::check_stall_itr(int32_t encoder_steps) const
     -> bool {
     if (!has_encoder()) {
         return true;

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(motor-control
         test_brushed_motor_interrupt_handler.cpp
         test_motor_flags.cpp
         test_motor_position_tracker.cpp
+        test_stall_check.cpp
         )
 
 target_ot_motor_control(motor-control)

--- a/motor-control/tests/test_stall_check.cpp
+++ b/motor-control/tests/test_stall_check.cpp
@@ -8,22 +8,22 @@ TEST_CASE("stall itr check functionality") {
             subject.reset_itr_counts(0);
             THEN("acceptable encoder positions are not stalls") {
                 int32_t encoder_ticks = GENERATE(0, -10, 10);
-                REQUIRE(subject.check_stall(encoder_ticks));
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(11, -11);
-                REQUIRE(!subject.check_stall(encoder_ticks));
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
         WHEN("stepper count is set to 123") {
             subject.reset_itr_counts(123);
             THEN("acceptable encoder positions are not stalls") {
                 int32_t encoder_ticks = GENERATE(123, 113, 133);
-                REQUIRE(subject.check_stall(encoder_ticks));
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(112, 134);
-                REQUIRE(!subject.check_stall(encoder_ticks));
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
     }
@@ -33,22 +33,22 @@ TEST_CASE("stall itr check functionality") {
             subject.reset_itr_counts(123);
             THEN("acceptable encoder positions are not stalls") {
                 int32_t encoder_ticks = GENERATE(12, 3, 21);
-                REQUIRE(subject.check_stall(encoder_ticks));
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(1, 23);
-                REQUIRE(!subject.check_stall(encoder_ticks));
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
         WHEN("stepper count is set to 1230") {
             subject.reset_itr_counts(1230);
             THEN("acceptable encoder positions are not stalls") {
                 int32_t encoder_ticks = GENERATE(123, 113, 133);
-                REQUIRE(subject.check_stall(encoder_ticks));
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(112, 134);
-                REQUIRE(!subject.check_stall(encoder_ticks));
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
     }
@@ -58,11 +58,11 @@ TEST_CASE("stall itr check functionality") {
             subject.reset_itr_counts(123);
             THEN("acceptable encoder positions are not stalls") {
                 int32_t encoder_ticks = GENERATE(1230, 1130, 1330);
-                REQUIRE(subject.check_stall(encoder_ticks));
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(1129, 1331);
-                REQUIRE(!subject.check_stall(encoder_ticks));
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
     }
@@ -105,12 +105,12 @@ TEST_CASE("stall check isr step handling") {
                 float encoder_position = stepper_begin_um + stall_threshold_um;
                 THEN("valid encoder position returns true: "
                      << encoder_position) {
-                    REQUIRE(subject.check_stall(static_cast<int32_t>(
+                    REQUIRE(subject.check_stall_itr(static_cast<int32_t>(
                         encoder_position * encoder_tick_per_um)));
                 }
                 THEN("invalid encoder position returns false") {
                     encoder_position += stall_threshold_um + 10;
-                    REQUIRE(!subject.check_stall(static_cast<int32_t>(
+                    REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
                         encoder_position * encoder_tick_per_um)));
                 }
             }
@@ -130,12 +130,12 @@ TEST_CASE("stall check isr step handling") {
                 float encoder_position = stepper_begin_um - stall_threshold_um;
                 THEN("valid encoder position returns true: "
                      << encoder_position) {
-                    REQUIRE(subject.check_stall(static_cast<int32_t>(
+                    REQUIRE(subject.check_stall_itr(static_cast<int32_t>(
                         encoder_position * encoder_tick_per_um)));
                 }
                 THEN("invalid encoder position returns false") {
                     encoder_position -= stall_threshold_um + 10;
-                    REQUIRE(!subject.check_stall(static_cast<int32_t>(
+                    REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
                         encoder_position * encoder_tick_per_um)));
                 }
             }
@@ -160,7 +160,7 @@ TEST_CASE("stall check handling with no encoder") {
         }
         THEN("the interrupt stall check always returns true") {
             int32_t encoder = GENERATE(0, 100, 10000, 1000000);
-            REQUIRE(subject.check_stall(encoder));
+            REQUIRE(subject.check_stall_itr(encoder));
         }
     }
 }

--- a/motor-control/tests/test_stall_check.cpp
+++ b/motor-control/tests/test_stall_check.cpp
@@ -1,0 +1,200 @@
+#include "catch2/catch.hpp"
+#include "motor-control/core/stall_check.hpp"
+
+TEST_CASE("stall itr check functionality") {
+    GIVEN("1 step per µm for encoder and stepper, 10 µm stall threshold") {
+        auto subject = stall_check::StallCheck(1, 1, 10);
+        WHEN("stepper count is zero") {
+            subject.reset_itr_counts(0);
+            THEN("acceptable encoder positions are not stalls") {
+                int32_t encoder_ticks = GENERATE(0, -10, 10);
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
+            }
+            THEN("unacceptable encoder positions are stalls") {
+                int32_t encoder_ticks = GENERATE(11, -11);
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
+            }
+        }
+        WHEN("stepper count is set to 123") {
+            subject.reset_itr_counts(123);
+            THEN("acceptable encoder positions are not stalls") {
+                int32_t encoder_ticks = GENERATE(123, 113, 133);
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
+            }
+            THEN("unacceptable encoder positions are stalls") {
+                int32_t encoder_ticks = GENERATE(112, 134);
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
+            }
+        }
+    }
+    GIVEN("10 step/µm stepper, 1 step/µm encoder, 10 µm stall threshold") {
+        auto subject = stall_check::StallCheck(1, 10, 10);
+        WHEN("stepper count is set to 123") {
+            subject.reset_itr_counts(123);
+            THEN("acceptable encoder positions are not stalls") {
+                int32_t encoder_ticks = GENERATE(12, 3, 21);
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
+            }
+            THEN("unacceptable encoder positions are stalls") {
+                int32_t encoder_ticks = GENERATE(1, 23);
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
+            }
+        }
+        WHEN("stepper count is set to 1230") {
+            subject.reset_itr_counts(1230);
+            THEN("acceptable encoder positions are not stalls") {
+                int32_t encoder_ticks = GENERATE(123, 113, 133);
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
+            }
+            THEN("unacceptable encoder positions are stalls") {
+                int32_t encoder_ticks = GENERATE(112, 134);
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
+            }
+        }
+    }
+    GIVEN("1 step/µm stepper, 10 step/µm encoder, 10 µm stall threshold") {
+        auto subject = stall_check::StallCheck(10, 1, 10);
+        WHEN("stepper count is set to 123") {
+            subject.reset_itr_counts(123);
+            THEN("acceptable encoder positions are not stalls") {
+                int32_t encoder_ticks = GENERATE(1230, 1130, 1330);
+                REQUIRE(subject.check_stall_itr(encoder_ticks));
+            }
+            THEN("unacceptable encoder positions are stalls") {
+                int32_t encoder_ticks = GENERATE(1129, 1331);
+                REQUIRE(!subject.check_stall_itr(encoder_ticks));
+            }
+        }
+    }
+}
+
+TEST_CASE("stall check isr step handling") {
+    float stepper_begin_um = GENERATE(0.0, 100.0, 10000.0, 123456.0);
+    float stepper_tick_per_um = GENERATE(50, 100, 200);
+    float encoder_tick_per_um = 100;
+    float stall_threshold_um = 50;
+    int32_t stepper_begin_steps =
+        static_cast<int32_t>(stepper_begin_um * stepper_tick_per_um);
+    GIVEN("a stall check initialized to " << stepper_begin_um
+                                          << " micrometers") {
+        auto subject = stall_check::StallCheck(
+            encoder_tick_per_um, stepper_tick_per_um, stall_threshold_um);
+        subject.reset_itr_counts(stepper_begin_steps);
+        WHEN("stepping the motor less than the stall threshold") {
+            bool got_a_true = false;
+            for (int i = 0; i < (stall_threshold_um * stepper_tick_per_um) - 1;
+                 ++i) {
+                if (subject.step_itr(true)) {
+                    got_a_true = true;
+                }
+            }
+            THEN("no stallcheck was flagged") { REQUIRE(!got_a_true); }
+        }
+        WHEN("stepping the motor positively until the stall threshold") {
+            int steps = 0;
+            int expected =
+                static_cast<int>(stepper_tick_per_um * stall_threshold_um);
+            while (steps < (expected * 2)) {
+                if (subject.step_itr(true)) {
+                    break;
+                }
+                steps++;
+            }
+            REQUIRE(steps == expected);
+            AND_WHEN("checking stall status") {
+                float encoder_position = stepper_begin_um + stall_threshold_um;
+                THEN("valid encoder position returns true: "
+                     << encoder_position) {
+                    REQUIRE(subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um)));
+                }
+                THEN("invalid encoder position returns false") {
+                    encoder_position += stall_threshold_um + 10;
+                    REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um)));
+                }
+            }
+        }
+        WHEN("stepping the motor negatively until the stall threshold") {
+            int steps = 0;
+            int expected =
+                static_cast<int>(stepper_tick_per_um * stall_threshold_um);
+            while (steps < (expected * 2)) {
+                if (subject.step_itr(false)) {
+                    break;
+                }
+                steps++;
+            }
+            REQUIRE(steps == expected);
+            AND_WHEN("checking stall status") {
+                float encoder_position = stepper_begin_um - stall_threshold_um;
+                THEN("valid encoder position returns true: "
+                     << encoder_position) {
+                    REQUIRE(subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um)));
+                }
+                THEN("invalid encoder position returns false") {
+                    encoder_position -= stall_threshold_um + 10;
+                    REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um)));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("stall check handling with no encoder") {
+    GIVEN("a stall check with no encoder") {
+        auto subject = stall_check::StallCheck(0, 1, 10);
+        THEN("the step function always returns false") {
+            bool got_a_true = false;
+            for (int i = 0; i < 100; ++i) {
+                if (subject.step_itr(true)) {
+                    got_a_true = true;
+                }
+                if (subject.step_itr(false)) {
+                    got_a_true = true;
+                }
+            }
+            REQUIRE(!got_a_true);
+        }
+        THEN("the interrupt stall check always returns true") {
+            int32_t encoder = GENERATE(0, 100, 10000, 1000000);
+            REQUIRE(subject.check_stall_itr(encoder));
+        }
+        THEN("the non-interrupt stall check returns true on any combination") {
+            int32_t encoder = GENERATE(0, 100, 10000, 1000000);
+            int32_t microsteps = GENERATE(0, 1000, 100000);
+            REQUIRE(subject.check_stall(encoder, microsteps));
+        }
+    }
+}
+
+TEST_CASE("stall check non-interrupt stall checks") {
+    float stepper_tick_per_um = GENERATE(1, 10, 15);
+    float encoder_tick_per_um = GENERATE(10, 20);
+    GIVEN("stall threshold of 10 µm") {
+        auto subject = stall_check::StallCheck(encoder_tick_per_um,
+                                               stepper_tick_per_um, 10);
+        GIVEN("valid combination of positions") {
+            float position_um = GENERATE(1000, 10000, 1000000);
+            auto stepper_ticks =
+                static_cast<int32_t>(position_um * stepper_tick_per_um);
+            auto encoder_ticks =
+                static_cast<int32_t>(position_um * encoder_tick_per_um);
+            THEN("there is no stall") {
+                REQUIRE(subject.check_stall(encoder_ticks, stepper_ticks));
+            }
+        }
+        GIVEN("invalid combination of positions") {
+            float position_um = GENERATE(1000, 10000, 1000000);
+            auto stepper_ticks =
+                static_cast<int32_t>(position_um * stepper_tick_per_um);
+            auto encoder_ticks =
+                static_cast<int32_t>((position_um + 12) * encoder_tick_per_um);
+            THEN("there is a stall") {
+                REQUIRE(!subject.check_stall(encoder_ticks, stepper_ticks));
+            }
+        }
+    }
+}

--- a/motor-control/tests/test_stall_check.cpp
+++ b/motor-control/tests/test_stall_check.cpp
@@ -140,6 +140,34 @@ TEST_CASE("stall check isr step handling") {
                 }
             }
         }
+        WHEN("hitting the stall-check threshold 1000 times") {
+            int stallchecks = 0;
+            while (stallchecks < 1000) {
+                if (subject.step_itr(true)) {
+                    stallchecks++;
+                }
+            }
+            AND_WHEN("checking valid encoder positions") {
+                float error = GENERATE(-50, 50, 0);
+                float encoder_position = stepper_begin_um +
+                                         (stall_threshold_um * stallchecks) +
+                                         error;
+                THEN("the position is valid") {
+                    REQUIRE(subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um)));
+                }
+            }
+            AND_WHEN("checking invalid encoder positions") {
+                float error = GENERATE(-51, 51, 1000);
+                float encoder_position = stepper_begin_um +
+                                         (stall_threshold_um * stallchecks) +
+                                         error;
+                THEN("the position is not valid") {
+                    REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um)));
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a class for checking the stall status of a stepper motor. The class is not integrated into the motor interrupt in this PR, it is just tested with CI.

Given the ratio of steps : µm for both the encoder and the stepper (using any microstepping ratio), the class keeps a running count of the position of the stepper motor vs the expected position of the encoder. The functions that are expected to be called from interrupts specifically avoid using any floating-point math or any multiplication in an effort to keep their overhead low.

The StallCheck object is set to be able to work with axes without encoders by just never indicating a bad status.