### PR TITLE
chore(.github): change cross compile builds to RelWithDebInfo

### DIFF
--- a/.github/workflows/eeprom.yaml
+++ b/.github/workflows/eeprom.yaml
@@ -60,7 +60,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: "Format"
         run: cmake --build ./build-cross --target eeprom-format-ci
   host-compile-test:

--- a/.github/workflows/gantry.yaml
+++ b/.github/workflows/gantry.yaml
@@ -58,7 +58,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: "Format"
         run: cmake --build ./build-cross --target gantry-format-ci
       - name: "Build"

--- a/.github/workflows/gripper.yaml
+++ b/.github/workflows/gripper.yaml
@@ -64,7 +64,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: "Format"
         run: cmake --build ./build-cross --target gripper-format-ci
       - name: "Build Proto"

--- a/.github/workflows/head.yaml
+++ b/.github/workflows/head.yaml
@@ -62,7 +62,7 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure"
-        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: "Format"
         run: cmake --build ./build-cross --target head-format-ci
       - name: "Build"

--- a/.github/workflows/pipettes.yaml
+++ b/.github/workflows/pipettes.yaml
@@ -64,9 +64,9 @@ jobs:
           path: "./stm32-tools"
           key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
       - name: "Configure proto"
-        run: cmake --preset=cross-pipettes . -DCMAKE_BUILD_TYPE=debug
+        run: cmake --preset=cross-pipettes . -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: "Configure rev1"
-        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: "Format"
         run: cmake --build --preset=pipettes --target pipettes-format-ci
       - name: "Build proto"


### PR DESCRIPTION
the Debug builds are too big for some proto boards so build as RelWithDebInfo instead