### PR TITLE
feat(motor-control): stall detection in stepper ISR

### DIFF
--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -189,11 +189,17 @@ static motor_class::Motor motor{
                                       .max_acceleration = 2},
     motor_queue};
 
+static stall_check::StallCheck stallcheck(
+    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0,
+    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0,
+    utils::STALL_THRESHOLD_UM);
+
 /**
  * Handler of motor interrupts.
  */
 static motor_handler::MotorInterruptHandler motor_interrupt(
-    motor_queue, gantry::queues::get_queues(), motor_hardware_iface);
+    motor_queue, gantry::queues::get_queues(), motor_hardware_iface,
+    stallcheck);
 
 /**
  * Timer callback.

--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -190,8 +190,8 @@ static motor_class::Motor motor{
     motor_queue};
 
 static stall_check::StallCheck stallcheck(
-    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0,
-    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0,
+    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
+    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
     utils::STALL_THRESHOLD_UM);
 
 /**

--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -192,7 +192,10 @@ static motor_class::Motor motor{
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
     utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
-    utils::STALL_THRESHOLD_UM);
+    static_cast<uint32_t>(
+        utils::STALL_THRESHOLD_FULLSTEPS* utils::linear_motion_system_config()
+            .get_um_per_step() *
+        utils::linear_motion_system_config().microstep));
 
 /**
  * Handler of motor interrupts.

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -214,11 +214,17 @@ static motor_class::Motor motor{
                                       .max_acceleration = 2},
     motor_queue};
 
+static stall_check::StallCheck stallcheck(
+    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0,
+    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0,
+    utils::STALL_THRESHOLD_UM);
+
 /**
  * Handler of motor interrupts.
  */
 static motor_handler::MotorInterruptHandler motor_interrupt(
-    motor_queue, gantry::queues::get_queues(), motor_hardware_iface);
+    motor_queue, gantry::queues::get_queues(), motor_hardware_iface,
+    stallcheck);
 
 /**
  * Timer callback.

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -217,7 +217,10 @@ static motor_class::Motor motor{
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
     utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
-    utils::STALL_THRESHOLD_UM);
+    static_cast<uint32_t>(
+        utils::linear_motion_system_config().get_um_per_step() *
+        utils::STALL_THRESHOLD_FULLSTEPS *
+        utils::linear_motion_system_config().microstep));
 
 /**
  * Handler of motor interrupts.

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -215,8 +215,8 @@ static motor_class::Motor motor{
     motor_queue};
 
 static stall_check::StallCheck stallcheck(
-    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0,
-    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0,
+    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
+    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
     utils::STALL_THRESHOLD_UM);
 
 /**

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -75,7 +75,8 @@ static motor_class::Motor motor{
 
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0,
-    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0, 500);
+    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0,
+    utils::STALL_THRESHOLD_UM);
 
 /**
  * Handler of motor interrupts.

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -74,8 +74,8 @@ static motor_class::Motor motor{
     motor_queue};
 
 static stall_check::StallCheck stallcheck(
-    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0,
-    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0,
+    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
+    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
     utils::STALL_THRESHOLD_UM);
 
 /**

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -76,7 +76,10 @@ static motor_class::Motor motor{
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
     utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
-    utils::STALL_THRESHOLD_UM);
+    static_cast<uint32_t>(
+        utils::linear_motion_system_config().get_um_per_step() *
+        utils::STALL_THRESHOLD_FULLSTEPS *
+        utils::linear_motion_system_config().microstep));
 
 /**
  * Handler of motor interrupts.

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -73,11 +73,15 @@ static motor_class::Motor motor{
                                       .max_acceleration = 2},
     motor_queue};
 
+static stall_check::StallCheck stallcheck(
+    utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0,
+    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0, 500);
+
 /**
  * Handler of motor interrupts.
  */
 static motor_handler::MotorInterruptHandler motor_interrupt(
-    motor_queue, gantry::queues::get_queues(), motor_interface);
+    motor_queue, gantry::queues::get_queues(), motor_interface, stallcheck);
 
 static motor_interrupt_driver::MotorInterruptDriver A(motor_queue,
                                                       motor_interrupt,

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -118,11 +118,15 @@ static motor_class::Motor z_motor{
                                       .max_acceleration = 2},
     motor_queue, true};
 
+// There is no encoder so the ratio doesn't matter
+static stall_check::StallCheck stallcheck(0, 0, 0);
+
 /**
  * Handler of motor interrupts.
  */
 static motor_handler::MotorInterruptHandler motor_interrupt(
-    motor_queue, gripper_tasks::z_tasks::get_queues(), motor_hardware_iface);
+    motor_queue, gripper_tasks::z_tasks::get_queues(), motor_hardware_iface,
+    stallcheck);
 
 /**
  * Timer callback.

--- a/gripper/simulator/interfaces.cpp
+++ b/gripper/simulator/interfaces.cpp
@@ -76,11 +76,15 @@ static motor_class::Motor motor{
                                       .max_acceleration = 2},
     motor_queue};
 
+// There is no encoder so the ratio doesn't matter
+static stall_check::StallCheck stallcheck(0, 0, 500);
+
 /**
  * Handler of motor interrupts.
  */
 static motor_handler::MotorInterruptHandler motor_interrupt(
-    motor_queue, gripper_tasks::z_tasks::get_queues(), motor_interface);
+    motor_queue, gripper_tasks::z_tasks::get_queues(), motor_interface,
+    stallcheck);
 
 static motor_interrupt_driver::MotorInterruptDriver A(motor_queue,
                                                       motor_interrupt,

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -202,7 +202,10 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_steps_per_mm() / 1000.0F,
+    static_cast<uint32_t>(linear_config.get_um_per_step() *
+                          utils::STALL_THRESHOLD_FULLSTEPS *
+                          linear_config.microstep));
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -226,7 +229,10 @@ static motor_class::Motor motor_right{
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_steps_per_mm() / 1000.0F,
+    static_cast<uint32_t>(linear_config.get_um_per_step() *
+                          utils::STALL_THRESHOLD_FULLSTEPS *
+                          linear_config.microstep));
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -201,8 +201,8 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
     .encoder_pulses_per_rev = 1024.0};
 
 static stall_check::StallCheck stallcheck_right(
-    linear_config.get_encoder_pulses_per_mm() / 1000.0,
-    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+    linear_config.get_encoder_pulses_per_mm() / 1000.0F,
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -225,8 +225,8 @@ static motor_class::Motor motor_right{
     motor_queue_right};
 
 static stall_check::StallCheck stallcheck_left(
-    linear_config.get_encoder_pulses_per_mm() / 1000.0,
-    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+    linear_config.get_encoder_pulses_per_mm() / 1000.0F,
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -27,6 +27,7 @@
 #include "head/core/presence_sensing_driver.hpp"
 #include "head/core/queues.hpp"
 #include "head/core/tasks_proto.hpp"
+#include "head/core/utils.hpp"
 #include "head/firmware/adc_comms.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/motor.hpp"
@@ -193,6 +194,16 @@ static tmc2130::configs::TMC2130DriverConfig motor_driver_configs_left{
         .GPIO_handle = GPIOA,
     }};
 
+static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
+    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
+    .steps_per_rev = 200.0,
+    .microstep = 32.0,
+    .encoder_pulses_per_rev = 1024.0};
+
+static stall_check::StallCheck stallcheck_right(
+    linear_config.get_encoder_pulses_per_mm() / 1000.0,
+    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+
 /**
  * TODO: This motor class is only used in motor handler and should be
  * instantiated inside of the MotorHandler class. However, some refactors
@@ -202,33 +213,29 @@ static tmc2130::configs::TMC2130DriverConfig motor_driver_configs_left{
 static motor_hardware::MotorHardware motor_hardware_right(
     pin_configurations_right, &htim7, &htim2);
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
-    motor_queue_right, head_tasks::get_right_queues(), motor_hardware_right);
+    motor_queue_right, head_tasks::get_right_queues(), motor_hardware_right,
+    stallcheck_right);
 
 static motor_class::Motor motor_right{
-    lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-        .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
-        .steps_per_rev = 200.0,
-        .microstep = 32.0,
-        .encoder_pulses_per_rev = 1024.0},
-    motor_hardware_right,
+    linear_config, motor_hardware_right,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,
                                       .min_acceleration = 1,
                                       .max_acceleration = 2},
     motor_queue_right};
 
+static stall_check::StallCheck stallcheck_left(
+    linear_config.get_encoder_pulses_per_mm() / 1000.0,
+    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);
 static motor_handler::MotorInterruptHandler motor_interrupt_left(
-    motor_queue_left, head_tasks::get_left_queues(), motor_hardware_left);
+    motor_queue_left, head_tasks::get_left_queues(), motor_hardware_left,
+    stallcheck_left);
 
 static motor_class::Motor motor_left{
-    lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-        .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
-        .steps_per_rev = 200.0,
-        .microstep = 32.0,
-        .encoder_pulses_per_rev = 1024.0},
-    motor_hardware_left,
+    linear_config, motor_hardware_left,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,
                                       .min_acceleration = 1,

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -197,8 +197,8 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
     .gear_ratio = 4.0};
 
 static stall_check::StallCheck stallcheck_right(
-    linear_config.get_encoder_pulses_per_mm() / 1000.0,
-    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+    linear_config.get_encoder_pulses_per_mm() / 1000.0F,
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -221,8 +221,8 @@ static motor_class::Motor motor_right{
     motor_queue_right};
 
 static stall_check::StallCheck stallcheck_left(
-    linear_config.get_encoder_pulses_per_mm() / 1000.0,
-    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+    linear_config.get_encoder_pulses_per_mm() / 1000.0F,
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -198,7 +198,10 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_steps_per_mm() / 1000.0F,
+    static_cast<uint32_t>(linear_config.get_um_per_step() *
+                          utils::STALL_THRESHOLD_FULLSTEPS *
+                          linear_config.microstep));
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -222,7 +225,10 @@ static motor_class::Motor motor_right{
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_steps_per_mm() / 1000.0F,
+    static_cast<uint32_t>(linear_config.get_um_per_step() *
+                          utils::STALL_THRESHOLD_FULLSTEPS *
+                          linear_config.microstep));
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -80,16 +80,16 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
     .encoder_pulses_per_rev = 1024.0};
 
 static stall_check::StallCheck stallcheck_right(
-    linear_config.get_encoder_pulses_per_mm() / 1000.0,
-    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+    linear_config.get_encoder_pulses_per_mm() / 1000.0F,
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_interface_right,
     stallcheck_right);
 
 static stall_check::StallCheck stallcheck_left(
-    linear_config.get_encoder_pulses_per_mm() / 1000.0,
-    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+    linear_config.get_encoder_pulses_per_mm() / 1000.0F,
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static auto motor_sys_config =
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -81,7 +81,10 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_steps_per_mm() / 1000.0F,
+    static_cast<uint32_t>(linear_config.get_um_per_step() *
+                          utils::STALL_THRESHOLD_FULLSTEPS *
+                          linear_config.microstep));
 
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_interface_right,
@@ -89,7 +92,10 @@ static motor_handler::MotorInterruptHandler motor_interrupt_right(
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_steps_per_mm() / 1000.0F,
+    static_cast<uint32_t>(linear_config.get_um_per_step() *
+                          utils::STALL_THRESHOLD_FULLSTEPS *
+                          linear_config.microstep));
 
 static auto motor_sys_config =
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -14,6 +14,7 @@
 #include "head/core/presence_sensing_driver.hpp"
 #include "head/core/queues.hpp"
 #include "head/core/tasks_proto.hpp"
+#include "head/core/utils.hpp"
 #include "head/simulation/adc.hpp"
 #include "motor-control/core/stepper_motor/motor.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
@@ -72,8 +73,23 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
         .GPIO_handle = 0,
     }};
 
+static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
+    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
+    .steps_per_rev = 200.0,
+    .microstep = 32.0,
+    .encoder_pulses_per_rev = 1024.0};
+
+static stall_check::StallCheck stallcheck_right(
+    linear_config.get_encoder_pulses_per_mm() / 1000.0,
+    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
+
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
-    motor_queue_right, head_tasks::get_right_queues(), motor_interface_right);
+    motor_queue_right, head_tasks::get_right_queues(), motor_interface_right,
+    stallcheck_right);
+
+static stall_check::StallCheck stallcheck_left(
+    linear_config.get_encoder_pulses_per_mm() / 1000.0,
+    linear_config.get_steps_per_mm() / 1000.0, utils::STALL_THRESHOLD_UM);
 
 static auto motor_sys_config =
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
@@ -91,7 +107,8 @@ static motor_class::Motor motor_right{
     motor_queue_right};
 
 static motor_handler::MotorInterruptHandler motor_interrupt_left(
-    motor_queue_left, head_tasks::get_left_queues(), motor_interface_left);
+    motor_queue_left, head_tasks::get_left_queues(), motor_interface_left,
+    stallcheck_left);
 
 static motor_class::Motor motor_left{
     motor_sys_config, motor_interface_left,

--- a/include/gantry/core/utils.hpp
+++ b/include/gantry/core/utils.hpp
@@ -7,7 +7,8 @@
 
 namespace utils {
 
-constexpr float STALL_THRESHOLD_UM = 500.0;
+// Number of full steps the stall threshold should equate to
+constexpr float STALL_THRESHOLD_FULLSTEPS = 2;
 
 auto get_node_id_by_axis(enum GantryAxisType which) -> can::ids::NodeId;
 

--- a/include/gantry/core/utils.hpp
+++ b/include/gantry/core/utils.hpp
@@ -7,6 +7,8 @@
 
 namespace utils {
 
+constexpr float STALL_THRESHOLD_UM = 500.0;
+
 auto get_node_id_by_axis(enum GantryAxisType which) -> can::ids::NodeId;
 
 auto get_node_id() -> can::ids::NodeId;

--- a/include/head/core/utils.hpp
+++ b/include/head/core/utils.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace utils {
+
+constexpr float STALL_THRESHOLD_UM = 500.0;
+
+}

--- a/include/head/core/utils.hpp
+++ b/include/head/core/utils.hpp
@@ -3,6 +3,6 @@
 namespace utils {
 
 // Number of full steps the stall threshold should equate to
-constexpr float STALL_THRESHOLD_FULLSTEPS = 2;;
+constexpr float STALL_THRESHOLD_FULLSTEPS = 2;
 
 }

--- a/include/head/core/utils.hpp
+++ b/include/head/core/utils.hpp
@@ -5,4 +5,4 @@ namespace utils {
 // Number of full steps the stall threshold should equate to
 constexpr float STALL_THRESHOLD_FULLSTEPS = 2;
 
-}
+}  // namespace utils

--- a/include/head/core/utils.hpp
+++ b/include/head/core/utils.hpp
@@ -2,6 +2,7 @@
 
 namespace utils {
 
-constexpr float STALL_THRESHOLD_UM = 500.0;
+// Number of full steps the stall threshold should equate to
+constexpr float STALL_THRESHOLD_FULLSTEPS = 2;;
 
 }

--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -16,8 +16,8 @@ class StallCheck {
     /**
      * @brief Construct a new Stall Check object
      *
-     * @param _encoder_tick_per_um Ratio of ticks : µm for encoder
-     * @param _stepper_tick_per_um Ratio of ticks : µm for microsteps
+     * @param encoder_tick_per_um Ratio of ticks : µm for encoder
+     * @param stepper_tick_per_um Ratio of ticks : µm for microsteps
      * @param um_threshold If encoder and stepper position differs by
      * more than this, consider the stepper stalled.
      */

--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -55,8 +55,9 @@ class StallCheck {
     [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) const -> bool
         __attribute__((optimize(3)));
 
-  private:
     [[nodiscard]] auto has_encoder() const -> bool;
+
+  private:
     [[nodiscard]] auto encoder_um_per_tick() const -> float;
     [[nodiscard]] auto stepper_um_per_tick() const -> float;
 

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -4,6 +4,7 @@
 #include "common/core/message_queue.hpp"
 #include "motor-control/core/motor_hardware_interface.hpp"
 #include "motor-control/core/motor_messages.hpp"
+#include "motor-control/core/stall_check.hpp"
 #include "motor-control/core/tasks/move_status_reporter_task.hpp"
 
 namespace motor_handler {
@@ -47,10 +48,12 @@ class MotorInterruptHandler {
     MotorInterruptHandler() = delete;
     MotorInterruptHandler(
         GenericQueue& incoming_queue, StatusClient& outgoing_queue,
-        motor_hardware::StepperMotorHardwareIface& hardware_iface)
+        motor_hardware::StepperMotorHardwareIface& hardware_iface,
+        stall_check::StallCheck& stall)
         : queue(incoming_queue),
           status_queue_client(outgoing_queue),
-          hardware(hardware_iface) {}
+          hardware(hardware_iface),
+          stall_checker{stall} {}
     ~MotorInterruptHandler() = default;
     auto operator=(MotorInterruptHandler&) -> MotorInterruptHandler& = delete;
     auto operator=(MotorInterruptHandler&&) -> MotorInterruptHandler&& = delete;
@@ -61,14 +64,23 @@ class MotorInterruptHandler {
     // It will run motion math, handle the immediate move buffer, and set or
     // clear step, direction, and sometimes enable pins
     void run_interrupt() {
+        bool dir = true;
         if (set_direction_pin()) {
             hardware.positive_direction();
         } else {
             hardware.negative_direction();
+            dir = false;
         }
         if (pulse()) {
             hardware.step();
             update_hardware_step_tracker();
+            if (stall_checker.step_itr(dir)) {
+                if (!stall_checker.check_stall_itr(
+                        hardware.get_encoder_pulses())) {
+                    hardware.position_flags.clear_flag(
+                        MotorPositionStatus::Flags::stepper_position_ok);
+                }
+            }
         }
         hardware.unstep();
     }
@@ -143,10 +155,13 @@ class MotorInterruptHandler {
             position_tracker = 0;
             hardware.reset_step_tracker();
             hardware.reset_encoder_pulses();
+            stall_checker.reset_itr_counts(0);
             hardware.position_flags.set_flag(
                 can::ids::MotorPositionFlags::stepper_position_ok);
-            hardware.position_flags.set_flag(
-                can::ids::MotorPositionFlags::encoder_position_ok);
+            if (stall_checker.has_encoder()) {
+                hardware.position_flags.set_flag(
+                    can::ids::MotorPositionFlags::encoder_position_ok);
+            }
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
         }
@@ -235,6 +250,7 @@ class MotorInterruptHandler {
         tick_count = 0x0;
         has_active_move = false;
         hardware.reset_encoder_pulses();
+        stall_checker.reset_itr_counts(0);
     }
 
     [[nodiscard]] static auto overflow(q31_31 current, q31_31 future) -> bool {
@@ -279,6 +295,7 @@ class MotorInterruptHandler {
     GenericQueue& queue;
     StatusClient& status_queue_client;
     motor_hardware::StepperMotorHardwareIface& hardware;
+    stall_check::StallCheck& stall_checker;
     MotorMoveMessage buffered_move = MotorMoveMessage{};
 };
 }  // namespace motor_handler

--- a/include/pipettes/core/configs.hpp
+++ b/include/pipettes/core/configs.hpp
@@ -5,6 +5,8 @@
 
 namespace configs {
 
+constexpr float STALL_THRESHOLD_UM = 500.0;
+
 auto linear_motion_sys_config_by_axis(PipetteType which)
     -> lms::LinearMotionSystemConfig<lms::LeadScrewConfig>;
 

--- a/include/pipettes/core/configs.hpp
+++ b/include/pipettes/core/configs.hpp
@@ -5,7 +5,9 @@
 
 namespace configs {
 
-constexpr float STALL_THRESHOLD_UM = 500.0;
+// Number of full steps the stall threshold should equate to
+constexpr float STALL_THRESHOLD_FULLSTEPS = 2;
+;
 
 auto linear_motion_sys_config_by_axis(PipetteType which)
     -> lms::LinearMotionSystemConfig<lms::LeadScrewConfig>;

--- a/include/pipettes/firmware/interfaces.hpp
+++ b/include/pipettes/firmware/interfaces.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "motor-control/core/motor_messages.hpp"
+#include "motor-control/core/stall_check.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "pipettes/core/gear_motor_tasks.hpp"
 #include "pipettes/core/interfaces.hpp"
@@ -64,10 +65,12 @@ auto get_interrupt_queues<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
 namespace linear_motor {
 
 auto get_interrupt(pipette_motor_hardware::MotorHardware& hw,
-                   LowThroughputInterruptQueues& queues)
+                   LowThroughputInterruptQueues& queues,
+                   stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient>;
 auto get_interrupt(pipette_motor_hardware::MotorHardware& hw,
-                   HighThroughputInterruptQueues& queues)
+                   HighThroughputInterruptQueues& queues,
+                   stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient>;
 auto get_motor_hardware(motor_configs::LowThroughputPipetteMotorHardware pins)
     -> pipette_motor_hardware::MotorHardware;
@@ -94,16 +97,21 @@ struct GearInterruptHandlers {
     GearMotorInterruptHandlerType<gear_motor_tasks::QueueClient> right;
 };
 
+struct GearStallCheck {
+    stall_check::StallCheck left;
+    stall_check::StallCheck right;
+};
+
 auto get_motor_hardware(motor_configs::LowThroughputPipetteMotorHardware)
     -> UnavailableGearHardware;
 auto get_motor_hardware(motor_configs::HighThroughputPipetteMotorHardware pins)
     -> GearHardware;
 
-auto get_interrupts(UnavailableGearHardware&, LowThroughputInterruptQueues&)
-    -> UnavailableGearInterrupts;
+auto get_interrupts(UnavailableGearHardware&, LowThroughputInterruptQueues&,
+                    GearStallCheck&) -> UnavailableGearInterrupts;
 
-auto get_interrupts(GearHardware& hw, HighThroughputInterruptQueues& queues)
-    -> GearInterruptHandlers;
+auto get_interrupts(GearHardware& hw, HighThroughputInterruptQueues& queues,
+                    GearStallCheck& stall) -> GearInterruptHandlers;
 
 auto get_motion_control(UnavailableGearHardware&,
                         LowThroughputInterruptQueues& queues)

--- a/include/pipettes/firmware/interfaces_g4.hpp
+++ b/include/pipettes/firmware/interfaces_g4.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "motor-control/core/motor_messages.hpp"
+#include "motor-control/core/stall_check.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/firmware/stepper_motor/motor_hardware.hpp"
 #include "pipettes/core/gear_motor_tasks.hpp"
@@ -73,10 +74,12 @@ auto get_interrupt_queues<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
 namespace linear_motor {
 
 auto get_interrupt(motor_hardware::MotorHardware& hw,
-                   LowThroughputInterruptQueues& queues)
+                   LowThroughputInterruptQueues& queues,
+                   stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient>;
 auto get_interrupt(motor_hardware::MotorHardware& hw,
-                   HighThroughputInterruptQueues& queues)
+                   HighThroughputInterruptQueues& queues,
+                   stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient>;
 auto get_motor_hardware(motor_hardware::HardwareConfig pins)
     -> motor_hardware::MotorHardware;
@@ -102,16 +105,21 @@ struct GearInterruptHandlers {
     GearMotorInterruptHandlerType<gear_motor_tasks::QueueClient> right;
 };
 
+struct GearStallCheck {
+    stall_check::StallCheck left;
+    stall_check::StallCheck right;
+};
+
 auto get_motor_hardware(motor_configs::LowThroughputPipetteMotorHardware)
     -> UnavailableGearHardware;
 auto get_motor_hardware(motor_configs::HighThroughputPipetteMotorHardware pins)
     -> GearHardware;
 
-auto get_interrupts(UnavailableGearHardware&, LowThroughputInterruptQueues&)
-    -> UnavailableGearInterrupts;
+auto get_interrupts(UnavailableGearHardware&, LowThroughputInterruptQueues&,
+                    GearStallCheck& stall) -> UnavailableGearInterrupts;
 
-auto get_interrupts(GearHardware& hw, HighThroughputInterruptQueues& queues)
-    -> GearInterruptHandlers;
+auto get_interrupts(GearHardware& hw, HighThroughputInterruptQueues& queues,
+                    GearStallCheck& stall) -> GearInterruptHandlers;
 
 auto get_motion_control(UnavailableGearHardware&,
                         LowThroughputInterruptQueues& queues)

--- a/include/pipettes/simulator/interfaces.hpp
+++ b/include/pipettes/simulator/interfaces.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "motor-control/core/stall_check.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/simulation/motor_interrupt_driver.hpp"
 #include "motor-control/simulation/sim_motor_hardware_iface.hpp"
@@ -58,7 +59,7 @@ auto get_interrupt_queues<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
 namespace linear_motor {
 
 auto get_interrupt(sim_motor_hardware_iface::SimMotorHardwareIface& hw,
-                   MoveQueue& queue)
+                   MoveQueue& queue, stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient>;
 
 auto get_interrupt_driver(
@@ -102,16 +103,21 @@ struct GearHardware {
     sim_motor_hardware_iface::SimGearMotorHardwareIface right;
 };
 
+struct GearStallCheck {
+    stall_check::StallCheck left;
+    stall_check::StallCheck right;
+};
+
 auto get_motor_hardware(motor_configs::LowThroughputPipetteMotorHardware)
     -> UnavailableGearHardware;
 auto get_motor_hardware(motor_configs::HighThroughputPipetteMotorHardware pins)
     -> GearHardware;
 
-auto get_interrupts(UnavailableGearHardware&, LowThroughputInterruptQueues&)
-    -> UnavailableGearInterrupts;
+auto get_interrupts(UnavailableGearHardware&, LowThroughputInterruptQueues&,
+                    GearStallCheck&) -> UnavailableGearInterrupts;
 
-auto get_interrupts(GearHardware& hw, HighThroughputInterruptQueues& queues)
-    -> GearInterruptHandlers;
+auto get_interrupts(GearHardware& hw, HighThroughputInterruptQueues& queues,
+                    GearStallCheck& stall) -> GearInterruptHandlers;
 
 auto get_interrupt_drivers(GearInterruptHandlers& interrupts,
                            HighThroughputInterruptQueues& queues,

--- a/motor-control/core/stall_check.cpp
+++ b/motor-control/core/stall_check.cpp
@@ -53,7 +53,7 @@ auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
     if (!has_encoder()) {
         return true;
     }
-    sq31_31 diff = std::labs(_encoder_ideal_counts -
+    sq31_31 diff = std::llabs(_encoder_ideal_counts -
                              (static_cast<sq31_31>(encoder_steps) << RADIX));
     return diff <= _encoder_step_threshold;
 }

--- a/motor-control/core/stall_check.cpp
+++ b/motor-control/core/stall_check.cpp
@@ -54,7 +54,7 @@ auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
         return true;
     }
     sq31_31 diff = std::llabs(_encoder_ideal_counts -
-                             (static_cast<sq31_31>(encoder_steps) << RADIX));
+                              (static_cast<sq31_31>(encoder_steps) << RADIX));
     return diff <= _encoder_step_threshold;
 }
 

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -13,9 +13,10 @@ struct HandlerContainer {
     test_mocks::MockMotorHardware hw{};
     test_mocks::MockMessageQueue<motor_messages::Move> queue{};
     test_mocks::MockMoveStatusReporterClient reporter{};
+    stall_check::StallCheck stall{10, 10, 10};
     MotorInterruptHandler<test_mocks::MockMessageQueue,
                           test_mocks::MockMoveStatusReporterClient, Move>
-        handler{queue, reporter, hw};
+        handler{queue, reporter, hw, stall};
 };
 
 static constexpr sq0_31 default_velocity =

--- a/motor-control/tests/test_motor_interrupt_queue.cpp
+++ b/motor-control/tests/test_motor_interrupt_queue.cpp
@@ -12,7 +12,8 @@ SCENARIO("queue multiple move messages") {
         test_mocks::MockMessageQueue<Move> queue;
         test_mocks::MockMoveStatusReporterClient reporter{};
         test_mocks::MockMotorHardware hardware;
-        auto handler = MotorInterruptHandler(queue, reporter, hardware);
+        stall_check::StallCheck stall(10, 10, 10);
+        auto handler = MotorInterruptHandler(queue, reporter, hardware, stall);
 
         WHEN("add multiple moves to the queue") {
             THEN("all the moves should exist in order") {

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -15,9 +15,10 @@ struct HandlerContainer {
     test_mocks::MockMotorHardware hw{};
     test_mocks::MockMessageQueue<Move> queue{};
     test_mocks::MockMoveStatusReporterClient reporter{};
+    stall_check::StallCheck stall{10, 10, 10};
     MotorInterruptHandler<test_mocks::MockMessageQueue,
                           test_mocks::MockMoveStatusReporterClient, Move>
-        handler{queue, reporter, hw};
+        handler{queue, reporter, hw, stall};
 };
 
 sq0_31 convert_velocity(float f) {

--- a/motor-control/tests/test_sync_handling.cpp
+++ b/motor-control/tests/test_sync_handling.cpp
@@ -13,9 +13,10 @@ struct HandlerContainer {
     test_mocks::MockMotorHardware hw{};
     test_mocks::MockMessageQueue<motor_messages::Move> queue{};
     test_mocks::MockMoveStatusReporterClient reporter{};
+    stall_check::StallCheck stall{10, 10, 10};
     MotorInterruptHandler<test_mocks::MockMessageQueue,
                           test_mocks::MockMoveStatusReporterClient, Move>
-        handler{queue, reporter, hw};
+        handler{queue, reporter, hw, stall};
 };
 
 static constexpr sq0_31 default_velocity =

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -43,17 +43,19 @@ void linear_motor::encoder_interrupt(motor_hardware::MotorHardware& hw,
 }
 
 auto linear_motor::get_interrupt(motor_hardware::MotorHardware& hw,
-                                 LowThroughputInterruptQueues& queues)
+                                 LowThroughputInterruptQueues& queues,
+                                 stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient> {
     return motor_handler::MotorInterruptHandler(
-        queues.plunger_queue, linear_motor_tasks::get_queues(), hw);
+        queues.plunger_queue, linear_motor_tasks::get_queues(), hw, stall);
 }
 
 auto linear_motor::get_interrupt(motor_hardware::MotorHardware& hw,
-                                 HighThroughputInterruptQueues& queues)
+                                 HighThroughputInterruptQueues& queues,
+                                 stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient> {
     return motor_handler::MotorInterruptHandler(
-        queues.plunger_queue, linear_motor_tasks::get_queues(), hw);
+        queues.plunger_queue, linear_motor_tasks::get_queues(), hw, stall);
 }
 
 auto linear_motor::get_motor_hardware(motor_hardware::HardwareConfig pins)
@@ -89,19 +91,20 @@ auto linear_motor::get_motion_control(motor_hardware::MotorHardware& hw,
 }
 
 auto gear_motor::get_interrupts(gear_motor::GearHardware& hw,
-                                HighThroughputInterruptQueues& queues)
+                                HighThroughputInterruptQueues& queues,
+                                GearStallCheck& stall)
     -> gear_motor::GearInterruptHandlers {
     return gear_motor::GearInterruptHandlers{
         .left = motor_handler::MotorInterruptHandler(
             queues.left_motor_queue, gear_motor_tasks::get_left_gear_queues(),
-            hw.left),
+            hw.left, stall.left),
         .right = motor_handler::MotorInterruptHandler(
             queues.right_motor_queue, gear_motor_tasks::get_right_gear_queues(),
-            hw.right)};
+            hw.right, stall.right)};
 }
 
 auto gear_motor::get_interrupts(gear_motor::UnavailableGearHardware&,
-                                LowThroughputInterruptQueues&)
+                                LowThroughputInterruptQueues&, GearStallCheck&)
     -> gear_motor::UnavailableGearInterrupts {
     return gear_motor::UnavailableGearInterrupts{};
 }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -92,7 +92,11 @@ static auto linear_stall_check = stall_check::StallCheck(
         1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
         1000.0F,
-    configs::STALL_THRESHOLD_UM);
+    static_cast<uint32_t>(
+        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
+            .get_um_per_step() *
+        configs::STALL_THRESHOLD_FULLSTEPS *
+        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).microstep));
 
 // Gear motors have no encoders
 static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -89,9 +89,9 @@ static auto eeprom_hardware_iface = PipetteEEPromHardwareIface{};
 static auto linear_stall_check = stall_check::StallCheck(
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
             .get_encoder_pulses_per_mm() /
-        1000.0,
+        1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
-        1000.0,
+        1000.0F,
     configs::STALL_THRESHOLD_UM);
 
 // Gear motors have no encoders

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -19,6 +19,7 @@
 #include "i2c/firmware/i2c_comms.hpp"
 #include "mount_detection.hpp"
 #include "pipettes/core/central_tasks.hpp"
+#include "pipettes/core/configs.hpp"
 #include "pipettes/core/gear_motor_tasks.hpp"
 #include "pipettes/core/linear_motor_tasks.hpp"
 #include "pipettes/core/motor_configurations.hpp"
@@ -85,6 +86,19 @@ auto convert_to_motor_hardware(
 
 static auto eeprom_hardware_iface = PipetteEEPromHardwareIface{};
 
+static auto linear_stall_check = stall_check::StallCheck(
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
+            .get_encoder_pulses_per_mm() /
+        1000.0,
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
+        1000.0,
+    configs::STALL_THRESHOLD_UM);
+
+// Gear motors have no encoders
+static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{
+    .left = stall_check::StallCheck(0, 0, 0),
+    .right = stall_check::StallCheck(0, 0, 0)};
+
 static auto motor_config = motor_configs::motor_configurations<PIPETTE_TYPE>();
 
 static auto interrupt_queues = interfaces::get_interrupt_queues<PIPETTE_TYPE>();
@@ -93,15 +107,15 @@ static auto linear_motor_hardware =
     interfaces::linear_motor::get_motor_hardware(
         convert_to_motor_hardware(motor_config.hardware_pins.linear_motor));
 static auto plunger_interrupt = interfaces::linear_motor::get_interrupt(
-    linear_motor_hardware, interrupt_queues);
+    linear_motor_hardware, interrupt_queues, linear_stall_check);
 static auto linear_motion_control =
     interfaces::linear_motor::get_motion_control(linear_motor_hardware,
                                                  interrupt_queues);
 
 static auto gear_hardware =
     interfaces::gear_motor::get_motor_hardware(motor_config.hardware_pins);
-static auto gear_interrupts =
-    interfaces::gear_motor::get_interrupts(gear_hardware, interrupt_queues);
+static auto gear_interrupts = interfaces::gear_motor::get_interrupts(
+    gear_hardware, interrupt_queues, gear_stall_check);
 static auto gear_motion_control =
     interfaces::gear_motor::get_motion_control(gear_hardware, interrupt_queues);
 

--- a/pipettes/firmware_l5/interfaces.cpp
+++ b/pipettes/firmware_l5/interfaces.cpp
@@ -39,19 +39,20 @@ auto interfaces::get_interrupt_queues<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
 }
 
 auto linear_motor::get_interrupt(pipette_motor_hardware::MotorHardware& hw,
-                                 LowThroughputInterruptQueues& queues)
+                                 LowThroughputInterruptQueues& queues,
+                                 stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient> {
     return motor_handler::MotorInterruptHandler(
-        queues.plunger_queue, linear_motor_tasks::get_queues(), hw);
+        queues.plunger_queue, linear_motor_tasks::get_queues(), hw, stall);
 }
 
 auto linear_motor::get_interrupt(pipette_motor_hardware::MotorHardware& hw,
-                                 HighThroughputInterruptQueues& queues)
+                                 HighThroughputInterruptQueues& queues,
+                                 stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient> {
     return motor_handler::MotorInterruptHandler(
-        queues.plunger_queue, linear_motor_tasks::get_queues(), hw);
+        queues.plunger_queue, linear_motor_tasks::get_queues(), hw, stall);
 }
-
 auto linear_motor::get_motor_hardware(
     motor_configs::LowThroughputPipetteMotorHardware pins)
     -> pipette_motor_hardware::MotorHardware {
@@ -94,19 +95,20 @@ auto linear_motor::get_motion_control(pipette_motor_hardware::MotorHardware& hw,
 }
 
 auto gear_motor::get_interrupts(gear_motor::GearHardware& hw,
-                                HighThroughputInterruptQueues& queues)
+                                HighThroughputInterruptQueues& queues,
+                                GearStallCheck& stall)
     -> gear_motor::GearInterruptHandlers {
     return gear_motor::GearInterruptHandlers{
         .left = motor_handler::MotorInterruptHandler(
             queues.left_motor_queue, gear_motor_tasks::get_left_gear_queues(),
-            hw.left),
+            hw.left, stall.left),
         .right = motor_handler::MotorInterruptHandler(
             queues.right_motor_queue, gear_motor_tasks::get_right_gear_queues(),
-            hw.right)};
+            hw.right, stall.right)};
 }
 
 auto gear_motor::get_interrupts(gear_motor::UnavailableGearHardware&,
-                                LowThroughputInterruptQueues&)
+                                LowThroughputInterruptQueues&, GearStallCheck&)
     -> gear_motor::UnavailableGearInterrupts {
     return gear_motor::UnavailableGearInterrupts{};
 }

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -74,9 +74,9 @@ static auto eeprom_hardware_iface = EEPromHardwareIface();
 static auto linear_stall_check = stall_check::StallCheck(
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
             .get_encoder_pulses_per_mm() /
-        1000.0,
+        1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
-        1000.0,
+        1000.0F,
     configs::STALL_THRESHOLD_UM);
 
 // Gear motors have no encoders

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -77,7 +77,11 @@ static auto linear_stall_check = stall_check::StallCheck(
         1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
         1000.0F,
-    configs::STALL_THRESHOLD_UM);
+    static_cast<uint32_t>(
+        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
+            .get_um_per_step() *
+        configs::STALL_THRESHOLD_FULLSTEPS *
+        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).microstep));
 
 // Gear motors have no encoders
 static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{

--- a/pipettes/simulator/interfaces.cpp
+++ b/pipettes/simulator/interfaces.cpp
@@ -39,10 +39,11 @@ auto interfaces::get_interrupt_queues<PipetteType::THREE_EIGHTY_FOUR_CHANNEL>()
 }
 
 auto linear_motor::get_interrupt(
-    sim_motor_hardware_iface::SimMotorHardwareIface& hw, MoveQueue& queue)
+    sim_motor_hardware_iface::SimMotorHardwareIface& hw, MoveQueue& queue,
+    stall_check::StallCheck& stall)
     -> MotorInterruptHandlerType<linear_motor_tasks::QueueClient> {
     return motor_handler::MotorInterruptHandler(
-        queue, linear_motor_tasks::get_queues(), hw);
+        queue, linear_motor_tasks::get_queues(), hw, stall);
 }
 
 auto linear_motor::get_interrupt_driver(
@@ -88,15 +89,16 @@ auto linear_motor::get_motion_control(
 }
 
 auto gear_motor::get_interrupts(gear_motor::GearHardware& hw,
-                                HighThroughputInterruptQueues& queues)
+                                HighThroughputInterruptQueues& queues,
+                                GearStallCheck& stall)
     -> gear_motor::GearInterruptHandlers {
     return gear_motor::GearInterruptHandlers{
         .left = motor_handler::MotorInterruptHandler(
             queues.left_motor_queue, gear_motor_tasks::get_left_gear_queues(),
-            hw.left),
+            hw.left, stall.left),
         .right = motor_handler::MotorInterruptHandler(
             queues.right_motor_queue, gear_motor_tasks::get_right_gear_queues(),
-            hw.right),
+            hw.right, stall.right),
     };
 }
 
@@ -112,7 +114,7 @@ auto gear_motor::get_interrupt_drivers(
 }
 
 auto gear_motor::get_interrupts(gear_motor::UnavailableGearHardware&,
-                                LowThroughputInterruptQueues&)
+                                LowThroughputInterruptQueues&, GearStallCheck&)
     -> gear_motor::UnavailableGearInterrupts {
     return gear_motor::UnavailableGearInterrupts{};
 }

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -45,9 +45,9 @@ static auto interrupt_queues = interfaces::get_interrupt_queues<PIPETTE_TYPE>();
 static auto linear_stall_check = stall_check::StallCheck(
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
             .get_encoder_pulses_per_mm() /
-        1000.0,
+        1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
-        1000.0,
+        1000.0F,
     configs::STALL_THRESHOLD_UM);
 
 // Gear motors have no encoders

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -48,7 +48,9 @@ static auto linear_stall_check = stall_check::StallCheck(
         1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
         1000.0F,
-    configs::STALL_THRESHOLD_UM);
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_um_per_step() *
+        configs::STALL_THRESHOLD_FULLSTEPS *
+        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).microstep);
 
 // Gear motors have no encoders
 static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -42,10 +42,23 @@ static auto motor_config = motor_configs::motor_configurations<PIPETTE_TYPE>();
 
 static auto interrupt_queues = interfaces::get_interrupt_queues<PIPETTE_TYPE>();
 
+static auto linear_stall_check = stall_check::StallCheck(
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
+            .get_encoder_pulses_per_mm() /
+        1000.0,
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
+        1000.0,
+    configs::STALL_THRESHOLD_UM);
+
+// Gear motors have no encoders
+static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{
+    .left = stall_check::StallCheck(0, 0, 0),
+    .right = stall_check::StallCheck(0, 0, 0)};
+
 static auto linear_motor_hardware =
     interfaces::linear_motor::get_motor_hardware();
 static auto plunger_interrupt = interfaces::linear_motor::get_interrupt(
-    linear_motor_hardware, interrupt_queues.plunger_queue);
+    linear_motor_hardware, interrupt_queues.plunger_queue, linear_stall_check);
 static auto plunger_interrupt_driver =
     interfaces::linear_motor::get_interrupt_driver(
         linear_motor_hardware, interrupt_queues.plunger_queue,
@@ -56,8 +69,8 @@ static auto linear_motion_control =
 
 static auto gear_hardware =
     interfaces::gear_motor::get_motor_hardware(motor_config.hardware_pins);
-static auto gear_interrupts =
-    interfaces::gear_motor::get_interrupts(gear_hardware, interrupt_queues);
+static auto gear_interrupts = interfaces::gear_motor::get_interrupts(
+    gear_hardware, interrupt_queues, gear_stall_check);
 static auto gear_motion_control =
     interfaces::gear_motor::get_motion_control(gear_hardware, interrupt_queues);
 


### PR DESCRIPTION
This PR adds support for stall detection in the ISR for stepper motors. The stall threshold is set to 500µm on every axis for now, which seems to work from basic testing. The stall check is only run when the stepper motor travels the distance of the stall threshold (i.e. 500µm on any encoder-enabled axes), and is never executed for an axis with no encoder.

Tested on the X, Y, and Z-L axes of an OT-3 by verifying that, if an axis stalls out at its end of travel, the flag for `stepper_position_ok` gets cleared. It is only reenabled if the axis is homed.