### PR TITLE
fix(can): fix motor-position-response serialization

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -229,26 +229,32 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("an encoder position response") {
-        auto message = MotorPositionResponse{.current_position = 0xBA12CD,
+        auto message = MotorPositionResponse{.message_index = 0x1234,
+                                             .current_position = 0xBA12CD,
                                              .encoder_position = 0xABEF,
                                              .position_flags = 0x2};
-        auto arr = std::array<uint8_t, 10>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        auto arr =
+            std::array<uint8_t, 14>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         auto body = std::span{arr};
         WHEN("serialized into a buffer larger than needed") {
             auto size = message.serialize(arr.begin(), arr.end());
             THEN("it is fully written into the buffer") {
                 REQUIRE(body.data()[0] == 0x00);
-                REQUIRE(body.data()[1] == 0xBA);
+                REQUIRE(body.data()[1] == 0x00);
                 REQUIRE(body.data()[2] == 0x12);
-                REQUIRE(body.data()[3] == 0xCD);
+                REQUIRE(body.data()[3] == 0x34);
                 REQUIRE(body.data()[4] == 0x00);
-                REQUIRE(body.data()[5] == 0x00);
-                REQUIRE(body.data()[6] == 0xAB);
-                REQUIRE(body.data()[7] == 0xEF);
-                REQUIRE(body.data()[8] == 0x02);
+                REQUIRE(body.data()[5] == 0xBA);
+                REQUIRE(body.data()[6] == 0x12);
+                REQUIRE(body.data()[7] == 0xCD);
+                REQUIRE(body.data()[8] == 0x00);
                 REQUIRE(body.data()[9] == 0x00);
+                REQUIRE(body.data()[10] == 0xAB);
+                REQUIRE(body.data()[11] == 0xEF);
+                REQUIRE(body.data()[12] == 0x02);
+                REQUIRE(body.data()[13] == 0x00);
             }
-            THEN("size must be returned") { REQUIRE(size == 9); }
+            THEN("size must be returned") { REQUIRE(size == 13); }
         }
     }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -456,7 +456,7 @@ struct MotorPositionResponse : BaseMessage<MessageId::motor_position_response> {
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
         auto iter = bit_utils::int_to_bytes(message_index, body, limit);
-        iter = bit_utils::int_to_bytes(current_position, body, limit);
+        iter = bit_utils::int_to_bytes(current_position, iter, limit);
         iter = bit_utils::int_to_bytes(encoder_position, iter, limit);
         iter = bit_utils::int_to_bytes(position_flags, iter, limit);
         return iter - body;


### PR DESCRIPTION
When #507 added the message index to the MotorPositionResponse message, the serialization was not updated correctly and therefore the hardware controller can never get the response.

Tested that this change lets the can_comm and can_mon scripts receive the MotorPositionResponse