### PR TITLE
feat(motor-control): read brushed motor driver config

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -60,6 +60,8 @@ typedef enum {
     can_messageid_gripper_grip_request = 0x42,
     can_messageid_gripper_home_request = 0x43,
     can_messageid_add_brushed_linear_move_request = 0x44,
+    can_messageid_brushed_motor_conf_request = 0x45,
+    can_messageid_brushed_motor_conf_response = 0x46,
     can_messageid_acknowledgement = 0x50,
     can_messageid_read_presence_sensing_voltage_request = 0x600,
     can_messageid_read_presence_sensing_voltage_response = 0x601,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -62,6 +62,8 @@ enum class MessageId {
     gripper_grip_request = 0x42,
     gripper_home_request = 0x43,
     add_brushed_linear_move_request = 0x44,
+    brushed_motor_conf_request = 0x45,
+    brushed_motor_conf_response = 0x46,
     acknowledgement = 0x50,
     read_presence_sensing_voltage_request = 0x600,
     read_presence_sensing_voltage_response = 0x601,

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -37,8 +37,9 @@ class MotorHandler {
 template <brushed_motor_driver_task::TaskClient BrushedMotorDriverTaskClient>
 class BrushedMotorHandler {
   public:
-    using MessageType = std::variant<std::monostate, SetBrushedMotorVrefRequest,
-                                     SetBrushedMotorPwmRequest, BrushedMotorConfRequest>;
+    using MessageType =
+        std::variant<std::monostate, SetBrushedMotorVrefRequest,
+                     SetBrushedMotorPwmRequest, BrushedMotorConfRequest>;
 
     BrushedMotorHandler(BrushedMotorDriverTaskClient &motor_client)
         : motor_client{motor_client} {}

--- a/include/can/core/message_handlers/motor.hpp
+++ b/include/can/core/message_handlers/motor.hpp
@@ -38,7 +38,7 @@ template <brushed_motor_driver_task::TaskClient BrushedMotorDriverTaskClient>
 class BrushedMotorHandler {
   public:
     using MessageType = std::variant<std::monostate, SetBrushedMotorVrefRequest,
-                                     SetBrushedMotorPwmRequest>;
+                                     SetBrushedMotorPwmRequest, BrushedMotorConfRequest>;
 
     BrushedMotorHandler(BrushedMotorDriverTaskClient &motor_client)
         : motor_client{motor_client} {}

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -867,7 +867,8 @@ struct SetBrushedMotorVrefRequest
 using BrushedMotorConfRequest = Empty<MessageId::brushed_motor_conf_request>;
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct BrushedMotorConfResponse : BaseMessage<MessageId::brushed_motor_conf_response> {
+struct BrushedMotorConfResponse
+    : BaseMessage<MessageId::brushed_motor_conf_response> {
     uint32_t message_index;
     uint32_t v_ref;
     uint32_t duty_cycle;
@@ -880,7 +881,8 @@ struct BrushedMotorConfResponse : BaseMessage<MessageId::brushed_motor_conf_resp
         return iter - body;
     }
 
-    auto operator==(const BrushedMotorConfResponse& other) const -> bool = default;
+    auto operator==(const BrushedMotorConfResponse& other) const
+        -> bool = default;
 };
 
 struct SetBrushedMotorPwmRequest

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1295,6 +1295,6 @@ using ResponseMessageType = std::variant<
     FirmwareUpdateStatusResponse, SensorThresholdResponse,
     SensorDiagnosticResponse, TaskInfoResponse, PipetteInfoResponse,
     BindSensorOutputResponse, GripperInfoResponse, TipActionResponse,
-    PeripheralStatusResponse>;
+    PeripheralStatusResponse, BrushedMotorConfResponse>;
 
 }  // namespace can::messages

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -864,6 +864,25 @@ struct SetBrushedMotorVrefRequest
         -> bool = default;
 };
 
+using BrushedMotorConfRequest = Empty<MessageId::brushed_motor_conf_request>;
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct BrushedMotorConfResponse : BaseMessage<MessageId::brushed_motor_conf_response> {
+    uint32_t message_index;
+    uint32_t v_ref;
+    uint32_t duty_cycle;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(message_index, body, limit);
+        iter = bit_utils::int_to_bytes(v_ref, iter, limit);
+        iter = bit_utils::int_to_bytes(duty_cycle, iter, limit);
+        return iter - body;
+    }
+
+    auto operator==(const BrushedMotorConfResponse& other) const -> bool = default;
+};
+
 struct SetBrushedMotorPwmRequest
     : BaseMessage<MessageId::set_brushed_motor_pwm_request> {
     uint32_t message_index;

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -39,7 +39,8 @@ using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
 using BrushedMotorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motor::BrushedMotorHandler<g_tasks::QueueClient>,
     can::messages::SetBrushedMotorVrefRequest,
-    can::messages::SetBrushedMotorPwmRequest>;
+    can::messages::SetBrushedMotorPwmRequest,
+    can::messages::BrushedMotorConfRequest>;
 using BrushedMotionDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motion::BrushedMotionHandler<g_tasks::QueueClient>,
     can::messages::DisableMotorRequest, can::messages::EnableMotorRequest,

--- a/include/motor-control/core/brushed_motor/driver_interface.hpp
+++ b/include/motor-control/core/brushed_motor/driver_interface.hpp
@@ -25,6 +25,8 @@ class BrushedMotorDriverIface {
     virtual void setup() = 0;
     virtual void update_pwm_settings(uint32_t duty_cycle) = 0;
     virtual auto pwm_active_duty_clamp(uint32_t duty_cycle) -> uint32_t = 0;
+    virtual auto get_current_vref() const -> float  = 0;
+    virtual auto get_current_duty_cycle() const -> uint32_t = 0;
 };
 
 }  // namespace brushed_motor_driver

--- a/include/motor-control/core/brushed_motor/driver_interface.hpp
+++ b/include/motor-control/core/brushed_motor/driver_interface.hpp
@@ -25,8 +25,8 @@ class BrushedMotorDriverIface {
     virtual void setup() = 0;
     virtual void update_pwm_settings(uint32_t duty_cycle) = 0;
     virtual auto pwm_active_duty_clamp(uint32_t duty_cycle) -> uint32_t = 0;
-    virtual auto get_current_vref() const -> float  = 0;
-    virtual auto get_current_duty_cycle() const -> uint32_t = 0;
+    [[nodiscard]] virtual auto get_current_vref() const -> float  = 0;
+    [[nodiscard]] virtual auto get_current_duty_cycle() const -> uint32_t = 0;
 };
 
 }  // namespace brushed_motor_driver

--- a/include/motor-control/core/brushed_motor/driver_interface.hpp
+++ b/include/motor-control/core/brushed_motor/driver_interface.hpp
@@ -25,7 +25,7 @@ class BrushedMotorDriverIface {
     virtual void setup() = 0;
     virtual void update_pwm_settings(uint32_t duty_cycle) = 0;
     virtual auto pwm_active_duty_clamp(uint32_t duty_cycle) -> uint32_t = 0;
-    [[nodiscard]] virtual auto get_current_vref() const -> float  = 0;
+    [[nodiscard]] virtual auto get_current_vref() const -> float = 0;
     [[nodiscard]] virtual auto get_current_duty_cycle() const -> uint32_t = 0;
 };
 

--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -58,6 +58,14 @@ class MotorDriverMessageHandler {
                                     can::messages::ack_from_request(m));
     }
 
+    void handle(const can::messages::BrushedMotorConfRequest& m) {
+        LOG("Received read motor config request");
+        can::messages::BrushedMotorConfResponse msg{
+                .message_index = m.message_index,
+                .v_ref =  static_cast<uint32_t>(convert_to_fixed_point(driver.get_current_vref(), 16)), .duty_cycle = driver.get_current_duty_cycle()};
+        can_client.send_can_message(can::ids::NodeId::host, msg);
+    }
+
     brushed_motor_driver::BrushedMotorDriverIface& driver;
     CanClient& can_client;
 };

--- a/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motor_driver_task.hpp
@@ -61,8 +61,10 @@ class MotorDriverMessageHandler {
     void handle(const can::messages::BrushedMotorConfRequest& m) {
         LOG("Received read motor config request");
         can::messages::BrushedMotorConfResponse msg{
-                .message_index = m.message_index,
-                .v_ref =  static_cast<uint32_t>(convert_to_fixed_point(driver.get_current_vref(), 16)), .duty_cycle = driver.get_current_duty_cycle()};
+            .message_index = m.message_index,
+            .v_ref = static_cast<uint32_t>(
+                convert_to_fixed_point(driver.get_current_vref(), 16)),
+            .duty_cycle = driver.get_current_duty_cycle()};
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -31,7 +31,8 @@ using MoveStatusReporterTaskMessage =
 
 using BrushedMotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,
-                 can::messages::SetBrushedMotorPwmRequest, can::messages::BrushedMotorConfRequest>;
+                 can::messages::SetBrushedMotorPwmRequest,
+                 can::messages::BrushedMotorConfRequest>;
 
 using BrushedMotionControllerTaskMessage = std::variant<
     std::monostate, can::messages::DisableMotorRequest,

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -31,7 +31,7 @@ using MoveStatusReporterTaskMessage =
 
 using BrushedMotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,
-                 can::messages::SetBrushedMotorPwmRequest>;
+                 can::messages::SetBrushedMotorPwmRequest, can::messages::BrushedMotorConfRequest>;
 
 using BrushedMotionControllerTaskMessage = std::variant<
     std::monostate, can::messages::DisableMotorRequest,

--- a/include/motor-control/firmware/brushed_motor/driver_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor/driver_hardware.hpp
@@ -38,16 +38,24 @@ class BrushedMotorDriver : public BrushedMotorDriverIface {
     auto set_reference_voltage(float val) -> bool final;
     void setup() final;
     void update_pwm_settings(uint32_t duty_cycle) final {
+        current_duty_cycle = duty_cycle;
         callback(duty_cycle);
     }
     auto pwm_active_duty_clamp(uint32_t duty_cycle) -> uint32_t final {
         return std::clamp(duty_cycle, conf.pwm_min, conf.pwm_max);
+    }
+    [[nodiscard]] auto get_current_vref() const -> float final {
+        return conf.vref;
+    }
+    [[nodiscard]] auto get_current_duty_cycle() const -> uint32_t final {
+        return current_duty_cycle;
     }
 
   private:
     DacConfig dac;
     DriverConfig conf;
     Callback callback;
+    uint32_t current_duty_cycle = 0;
 };
 
 };  // namespace brushed_motor_driver

--- a/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
@@ -10,17 +10,25 @@ class SimBrushedMotorDriverIface : public BrushedMotorDriverIface {
   public:
     bool start_digital_analog_converter() final { return true; }
     bool stop_digital_analog_converter() final { return true; }
-    bool set_reference_voltage(float) final { return true; }
+    bool set_reference_voltage(float v) final {
+        v_ref = v;
+        return true;
+    }
     void setup() final {}
     void update_pwm_settings(uint32_t) final {}
     auto pwm_active_duty_clamp(uint32_t duty_cycle) -> uint32_t final {
         return std::clamp(duty_cycle, uint32_t(7), uint32_t(100));
     }
     [[nodiscard]] auto get_current_vref() const -> float final {
-        return conf.vref;
-    };
+        return v_ref;
+    }
     [[nodiscard]] auto get_current_duty_cycle() const -> uint32_t final {
-        return current_duty_cycle;
+        return duty_cycle;
     }
 
-}  // namespace sim_brushed_motor_hardware_iface
+  private:
+    float v_ref = 0;
+    uint32_t duty_cycle = 0;
+
+
+};  // namespace sim_brushed_motor_hardware_iface

--- a/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
@@ -16,6 +16,11 @@ class SimBrushedMotorDriverIface : public BrushedMotorDriverIface {
     auto pwm_active_duty_clamp(uint32_t duty_cycle) -> uint32_t final {
         return std::clamp(duty_cycle, uint32_t(7), uint32_t(100));
     }
-};
+    [[nodiscard]] auto get_current_vref() const -> float final {
+        return conf.vref;
+    };
+    [[nodiscard]] auto get_current_duty_cycle() const -> uint32_t final {
+        return current_duty_cycle;
+    }
 
 }  // namespace sim_brushed_motor_hardware_iface

--- a/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
@@ -7,7 +7,7 @@ namespace sim_brushed_motor_hardware_iface {
 using namespace brushed_motor_driver;
 
 class SimBrushedMotorDriverIface : public BrushedMotorDriverIface {
-public:
+  public:
     bool start_digital_analog_converter() final { return true; }
 
     bool stop_digital_analog_converter() final { return true; }
@@ -25,9 +25,7 @@ public:
         return std::clamp(duty_cycle, uint32_t(7), uint32_t(100));
     }
 
-    [[nodiscard]] auto get_current_vref() const -> float final {
-        return v_ref;
-    }
+    [[nodiscard]] auto get_current_vref() const -> float final { return v_ref; }
 
     [[nodiscard]] auto get_current_duty_cycle() const -> uint32_t final {
         return duty_cycle;
@@ -36,6 +34,6 @@ public:
   private:
     float v_ref = 0;
     uint32_t duty_cycle = 0;
-    };
+};
 
 }  // namespace sim_brushed_motor_hardware_iface

--- a/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_driver_hardware_iface.hpp
@@ -7,21 +7,28 @@ namespace sim_brushed_motor_hardware_iface {
 using namespace brushed_motor_driver;
 
 class SimBrushedMotorDriverIface : public BrushedMotorDriverIface {
-  public:
+public:
     bool start_digital_analog_converter() final { return true; }
+
     bool stop_digital_analog_converter() final { return true; }
+
     bool set_reference_voltage(float v) final {
         v_ref = v;
         return true;
     }
+
     void setup() final {}
+
     void update_pwm_settings(uint32_t) final {}
+
     auto pwm_active_duty_clamp(uint32_t duty_cycle) -> uint32_t final {
         return std::clamp(duty_cycle, uint32_t(7), uint32_t(100));
     }
+
     [[nodiscard]] auto get_current_vref() const -> float final {
         return v_ref;
     }
+
     [[nodiscard]] auto get_current_duty_cycle() const -> uint32_t final {
         return duty_cycle;
     }
@@ -29,6 +36,6 @@ class SimBrushedMotorDriverIface : public BrushedMotorDriverIface {
   private:
     float v_ref = 0;
     uint32_t duty_cycle = 0;
+    };
 
-
-};  // namespace sim_brushed_motor_hardware_iface
+}  // namespace sim_brushed_motor_hardware_iface

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -77,15 +77,25 @@ class MockBrushedMotorDriverIface : public BrushedMotorDriverIface {
   public:
     bool start_digital_analog_converter() final { return true; }
     bool stop_digital_analog_converter() final { return true; }
-    bool set_reference_voltage(float) final { return true; }
+    bool set_reference_voltage(float v) final {
+        v_ref = v;
+        return true;
+    }
     void setup() final {}
     void update_pwm_settings(uint32_t pwm_set) { pwm_val = pwm_set; }
     uint32_t get_pwm_settings() { return pwm_val; }
     uint32_t pwm_active_duty_clamp(uint32_t duty_cycle) {
         return std::clamp(duty_cycle, uint32_t(7), uint32_t(100));
     }
+    [[nodiscard]] auto get_current_vref() const -> float final {
+        return v_ref;
+    }
+    [[nodiscard]] auto get_current_duty_cycle() const -> uint32_t final {
+        return pwm_val;
+    }
 
   private:
+    float v_ref = 0;
     uint32_t pwm_val = 0;
 };
 

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -87,9 +87,7 @@ class MockBrushedMotorDriverIface : public BrushedMotorDriverIface {
     uint32_t pwm_active_duty_clamp(uint32_t duty_cycle) {
         return std::clamp(duty_cycle, uint32_t(7), uint32_t(100));
     }
-    [[nodiscard]] auto get_current_vref() const -> float final {
-        return v_ref;
-    }
+    [[nodiscard]] auto get_current_vref() const -> float final { return v_ref; }
     [[nodiscard]] auto get_current_duty_cycle() const -> uint32_t final {
         return pwm_val;
     }


### PR DESCRIPTION
This PR allows us to read the current duty cycle and the vref of the brushed motor via CAN. 