### PR TITLE
fix(pipettes): add sync_in to pipette motor configs

### DIFF
--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -81,6 +81,7 @@ auto convert_to_motor_hardware(
         .enable = motor_config.enable,
         .limit_switch = motor_config.limit_switch,
         .led = motor_config.led,
+        .sync_in = motor_config.sync_in,
     };
 }
 

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -114,6 +114,11 @@ auto motor_configs::hardware_config_by_axis(TMC2130PipetteAxis which)
                      .active_setting = GPIO_PIN_SET},
                 // LED PIN B11, active setting low
                 .led = {},
+                .sync_in =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_7,
+                     .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
@@ -150,6 +155,11 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                      .active_setting = GPIO_PIN_SET},
                 // LED PIN C11, active setting low
                 .led = {},
+                .sync_in =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_7,
+                     .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     {// Located on the back sensor board
                      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -181,6 +191,11 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                      .active_setting = GPIO_PIN_SET},
                 // LED PIN C11, active setting low
                 .led = {},
+                .sync_in =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_7,
+                     .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     {// Located on the front sensor board
                      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -213,6 +228,11 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                      .active_setting = GPIO_PIN_SET},
                 // LED PIN C11, active setting low
                 .led = {},
+                .sync_in =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_7,
+                     .active_setting = GPIO_PIN_RESET},
                 // tip sense will be checked on the two pipette
                 // tip pick up motors.
                 // TODO need to think further about force pick up of tips
@@ -297,16 +317,6 @@ auto motor_configs::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
     -> motor_configs::LowThroughputSensorHardware {
     auto pins = motor_configs::LowThroughputSensorHardware{
         .primary = sensors::hardware::SensorHardwareConfiguration{
-            .sync_in =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOB,
-                 .pin = GPIO_PIN_7,
-                 .active_setting = GPIO_PIN_RESET},
-            .sync_out =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOB,
-                 .pin = GPIO_PIN_6,
-                 .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
@@ -323,16 +333,6 @@ auto motor_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
     -> motor_configs::LowThroughputSensorHardware {
     auto pins = motor_configs::LowThroughputSensorHardware{
         .primary = sensors::hardware::SensorHardwareConfiguration{
-            .sync_in =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOB,
-                 .pin = GPIO_PIN_7,
-                 .active_setting = GPIO_PIN_RESET},
-            .sync_out =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOB,
-                 .pin = GPIO_PIN_6,
-                 .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
@@ -348,16 +348,6 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
     auto pins = motor_configs::HighThroughputSensorHardware{
         .primary =
             sensors::hardware::SensorHardwareConfiguration{
-                .sync_in =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOD,
-                     .pin = GPIO_PIN_2,
-                     .active_setting = GPIO_PIN_RESET},
-                .sync_out =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOA,
-                     .pin = GPIO_PIN_9,
-                     .active_setting = GPIO_PIN_RESET},
                 .data_ready =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
@@ -365,16 +355,6 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                      .active_setting = GPIO_PIN_RESET},
             },
         .secondary = sensors::hardware::SensorHardwareConfiguration{
-            .sync_in =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOD,
-                 .pin = GPIO_PIN_2,
-                 .active_setting = GPIO_PIN_RESET},
-            .sync_out =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOA,
-                 .pin = GPIO_PIN_9,
-                 .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
@@ -391,16 +371,6 @@ auto motor_configs::sensor_configurations<
     auto pins = motor_configs::HighThroughputSensorHardware{
         .primary =
             sensors::hardware::SensorHardwareConfiguration{
-                .sync_in =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOD,
-                     .pin = GPIO_PIN_2,
-                     .active_setting = GPIO_PIN_RESET},
-                .sync_out =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOA,
-                     .pin = GPIO_PIN_9,
-                     .active_setting = GPIO_PIN_RESET},
                 .data_ready =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
@@ -408,16 +378,6 @@ auto motor_configs::sensor_configurations<
                      .active_setting = GPIO_PIN_RESET},
             },
         .secondary = sensors::hardware::SensorHardwareConfiguration{
-            .sync_in =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOD,
-                 .pin = GPIO_PIN_2,
-                 .active_setting = GPIO_PIN_RESET},
-            .sync_out =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOA,
-                 .pin = GPIO_PIN_9,
-                 .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -155,11 +155,6 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                      .active_setting = GPIO_PIN_SET},
                 // LED PIN C11, active setting low
                 .led = {},
-                .sync_in =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOD,
-                     .pin = GPIO_PIN_2,
-                     .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     {// Located on the back sensor board
                      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -191,11 +186,6 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                      .active_setting = GPIO_PIN_SET},
                 // LED PIN C11, active setting low
                 .led = {},
-                .sync_in =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOD,
-                     .pin = GPIO_PIN_2,
-                     .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     {// Located on the front sensor board
                      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -157,8 +157,8 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                 .led = {},
                 .sync_in =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_7,
+                     .port = GPIOD,
+                     .pin = GPIO_PIN_2,
                      .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     {// Located on the back sensor board
@@ -193,8 +193,8 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                 .led = {},
                 .sync_in =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_7,
+                     .port = GPIOD,
+                     .pin = GPIO_PIN_2,
                      .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     {// Located on the front sensor board
@@ -230,8 +230,8 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                 .led = {},
                 .sync_in =
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOB,
-                     .pin = GPIO_PIN_7,
+                     .port = GPIOD,
+                     .pin = GPIO_PIN_2,
                      .active_setting = GPIO_PIN_RESET},
                 // tip sense will be checked on the two pipette
                 // tip pick up motors.


### PR DESCRIPTION
Previously the `sync_in` pin assignment was under `SensorHardwareConfiguration`. Moving it to `HardwareConfig` lets the firmware read the correct pin and therefore move with the sync line as a stop condition. 