### PR TITLE
fix(pipettes): add position flags and action type to TipActionResponse

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -338,4 +338,48 @@ SCENARIO("message serializing works") {
             }
         }
     }
+
+    GIVEN("a tip action response") {
+        constexpr uint8_t MESSAGE_SIZE = 18;
+        auto message =
+            TipActionResponse{.message_index = 0x1234,
+                              .group_id = 1,
+                              .seq_id = 2,
+                              .current_position_um = 0x3456789a,
+                              .encoder_position_um = 0x05803931,
+                              .ack_id = 0x1,
+                              .success = 0x1,
+                              .action = can::ids::PipetteTipActionType::pick_up,
+                              .position_flags = 0x0};
+        auto arr = std::array<uint8_t, MESSAGE_SIZE + 5>{0, 0, 0, 0, 0, 0, 0, 0,
+                                                         0, 0, 0, 0, 0, 0, 0, 0,
+                                                         0, 0, 0, 0, 0, 0, 0};
+        auto body = std::span{arr};
+        WHEN("serialized into a buffer exactly the size needed") {
+            auto size = message.serialize(arr.begin(), arr.end());
+            THEN("it is fully written into the buffer") {
+                REQUIRE(body.data()[0] == 0x0);
+                REQUIRE(body.data()[1] == 0x0);
+                REQUIRE(body.data()[2] == 0x12);
+                REQUIRE(body.data()[3] == 0x34);
+                REQUIRE(body.data()[4] == 0x01);
+                REQUIRE(body.data()[5] == 0x02);
+                REQUIRE(body.data()[6] == 0x34);
+                REQUIRE(body.data()[7] == 0x56);
+                REQUIRE(body.data()[8] == 0x78);
+                REQUIRE(body.data()[9] == 0x9a);
+                REQUIRE(body.data()[10] == 0x05);
+                REQUIRE(body.data()[11] == 0x80);
+                REQUIRE(body.data()[12] == 0x39);
+                REQUIRE(body.data()[13] == 0x31);
+                REQUIRE(body.data()[14] == 0x1);
+                REQUIRE(body.data()[15] == 0x1);
+                REQUIRE(body.data()[16] == 0x0);
+                REQUIRE(body.data()[17] == 0x0);
+            }
+            THEN("the total message size is the expected value") {
+                REQUIRE(size == MESSAGE_SIZE);
+            }
+        }
+    }
 }

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1216,12 +1216,11 @@ struct TipActionResponse
     uint8_t group_id;
     uint8_t seq_id;
     uint32_t current_position_um;
-    int32_t encoder_position;
+    int32_t encoder_position_um;
     uint8_t ack_id;
     uint8_t success;
     can::ids::PipetteTipActionType action;
     uint8_t position_flags;
-
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
@@ -1229,10 +1228,11 @@ struct TipActionResponse
         iter = bit_utils::int_to_bytes(group_id, iter, limit);
         iter = bit_utils::int_to_bytes(seq_id, iter, limit);
         iter = bit_utils::int_to_bytes(current_position_um, iter, limit);
-        iter = bit_utils::int_to_bytes(encoder_position, iter, limit);
+        iter = bit_utils::int_to_bytes(encoder_position_um, iter, limit);
         iter = bit_utils::int_to_bytes(ack_id, iter, limit);
         iter = bit_utils::int_to_bytes(success, iter, limit);
-        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(action), iter, limit);
+        iter =
+            bit_utils::int_to_bytes(static_cast<uint8_t>(action), iter, limit);
         iter = bit_utils::int_to_bytes(position_flags, iter, limit);
         return iter - body;
     }

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1220,6 +1220,8 @@ struct TipActionResponse
     uint8_t ack_id;
     uint8_t success;
     can::ids::PipetteTipActionType action;
+    uint8_t position_flags;
+
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
@@ -1230,6 +1232,8 @@ struct TipActionResponse
         iter = bit_utils::int_to_bytes(encoder_position, iter, limit);
         iter = bit_utils::int_to_bytes(ack_id, iter, limit);
         iter = bit_utils::int_to_bytes(success, iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(action), iter, limit);
+        iter = bit_utils::int_to_bytes(position_flags, iter, limit);
         return iter - body;
     }
 

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -43,7 +43,9 @@ class MoveStatusMessageHandler {
             .message_index = message.message_index,
             .group_id = message.group_id,
             .seq_id = message.seq_id,
-            .encoder_position = message.encoder_position,
+            .current_position_um = fixed_point_multiply(
+                um_per_step, message.current_position_steps),
+            .encoder_position_um = 0,
             .ack_id = static_cast<uint8_t>(message.ack_id),
             // TODO: In a follow-up PR, tip sense reporting will
             // actually update this value to true or false.

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -48,7 +48,8 @@ class MoveStatusMessageHandler {
             // TODO: In a follow-up PR, tip sense reporting will
             // actually update this value to true or false.
             .success = static_cast<uint8_t>(true),
-            .action = message.action};
+            .action = message.action,
+            .position_flags = 0};
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 


### PR DESCRIPTION
# Overview
The TipActionResponse was missing a few attributes in the message which caused it to fail unpacking the response on the python side.