### PR TITLE
fix(state-manager): add shared data to the state manager

### DIFF
--- a/state_manager/pyproject.toml
+++ b/state_manager/pyproject.toml
@@ -27,7 +27,7 @@ mdformat_footnote = "^0.1.1"
 
 # Expects the monorepo (opentrons) to be a sibling of this repo
 opentrons = { path = "../../opentrons/api", develop = true}
-opentrons-shared-data = { develop = true, path = "../../opentrons/shared-data/python" }
+opentrons-shared-data = { path = "../../opentrons/shared-data/python", develop = true }
 header_generation_utils = { path = "../header_generation_utils", develop = true}
 
 [tool.poetry.scripts]

--- a/state_manager/pyproject.toml
+++ b/state_manager/pyproject.toml
@@ -27,6 +27,7 @@ mdformat_footnote = "^0.1.1"
 
 # Expects the monorepo (opentrons) to be a sibling of this repo
 opentrons = { path = "../../opentrons/api", develop = true}
+opentrons-shared-data = { develop = true, path = "../../opentrons/shared-data/python" }
 header_generation_utils = { path = "../header_generation_utils", develop = true}
 
 [tool.poetry.scripts]


### PR DESCRIPTION
There are certain files the state manager accesses which is now dependent on shared-data so it needs to be added to the toml file.