### PR TITLE
fix(coverage): run coverage on pushes to main

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - 'edge'
+      - 'main'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Coverage wasn't being generated on the main branch because the codecov action was configured to run on pushes to `edge`, but this repository uses `main`.