### PR TITLE
fix(gripper): update vref & cap max PWM to 60

### DIFF
--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -13,7 +13,7 @@
 
 #pragma GCC diagnostic pop
 
-constexpr uint32_t PWM_MAX = 100;
+constexpr uint32_t PWM_MAX = 60;
 constexpr uint32_t PWM_MIN = 7;
 
 /**
@@ -98,7 +98,7 @@ static motor_hardware::BrushedMotorHardware brushed_motor_hardware_iface(
 static brushed_motor_driver::BrushedMotorDriver brushed_motor_driver_iface(
     dac_config,
     brushed_motor_driver::DriverConfig{
-        .vref = 1, .pwm_min = PWM_MIN, .pwm_max = PWM_MAX},
+        .vref = 2.0, .pwm_min = PWM_MIN, .pwm_max = PWM_MAX},
     update_pwm);
 
 static lms::LinearMotionSystemConfig<lms::GearBoxConfig> gear_config{


### PR DESCRIPTION
Update gripper jaw motor reference voltage and max duty cycle based on [gripper tuning results](https://docs.google.com/presentation/d/1Kuc0oXqTgO0FE_G5YqW_9KY8MkJ1SdFq3aVmZUNStyQ/edit#slide=id.g1c51a215cf4_0_133).

