### PR TITLE
fix(motor-control): motor position estimation when encoder is below zero

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -360,6 +360,7 @@ class MotorInterruptHandler {
             if (!has_active_move &&
                 hardware.position_flags.check_flag(
                     MotorPositionStatus::Flags::encoder_position_ok)) {
+                encoder_pulses = address_negative_encoder();
                 auto stepper_tick_estimate =
                     stall_checker.encoder_ticks_to_stepper_ticks(
                         encoder_pulses);
@@ -401,6 +402,15 @@ class MotorInterruptHandler {
             static_cast<void>(
                 status_queue_client.send_move_status_reporter_queue(response));
         }
+    }
+
+    auto address_negative_encoder() -> int32_t {
+        auto pulses = hardware.get_encoder_pulses();
+        if (pulses < 0) {
+            hardware.reset_encoder_pulses();
+            return 0;
+        }
+        return pulses;
     }
 
   private:

--- a/motor-control/tests/test_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_motor_interrupt_handler.cpp
@@ -51,3 +51,29 @@ SCENARIO("estop pressed during motor interrupt handler") {
         }
     }
 }
+
+SCENARIO("negative position reset") {
+    MotorContainer test_objs{};
+
+    GIVEN("current encoder position is negative") {
+        test_objs.hw.sim_set_encoder_pulses(-1);
+        WHEN("correcting negative encoder value") {
+            auto ret = test_objs.handler.address_negative_encoder();
+            THEN("the encoder count is raised to 0") {
+                REQUIRE(ret == 0);
+                REQUIRE(test_objs.hw.get_encoder_pulses() == 0);
+            }
+        }
+    }
+    GIVEN("current encoder position is positive") {
+        int32_t val = GENERATE(0, 100);
+        test_objs.hw.sim_set_encoder_pulses(val);
+        WHEN("correcting negative encoder value") {
+            auto ret = test_objs.handler.address_negative_encoder();
+            THEN("the encoder count is not changed") {
+                REQUIRE(ret == val);
+                REQUIRE(test_objs.hw.get_encoder_pulses() == val);
+            }
+        }
+    }
+}


### PR DESCRIPTION
When an `UpdateMotorPositionEstimationRequest` command is handled, it approximates the _unsigned_ stepper motor position from the _signed_ encoder position. This means a negative encoder value will result in an underflow of the motor position, which is Very Incorrect. This PR just adds handling to reset the encoder value back to 0 if such a situation arises.

In all of the testing I've done, the encoder value never goes very significantly below 0 - usually 1 or 2 steps. Since the motor controller will never explicitly try to go below the 0 point (as defined by the home switch), in practice the encoder does not go significantly under 0. Therefore, the approach in this PR is just to reset the encoder to 0 if it's below that level, and then estimate the stepper from there (in effect setting the stepper to 0 as well).