### PR TITLE
refactor(motor-control): parameterize motor hardware in stepper interrupt

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -39,8 +39,9 @@ using namespace motor_messages;
  */
 
 template <template <class> class QueueImpl, class StatusClient,
-          typename MotorMoveMessage>
-requires MessageQueue<QueueImpl<MotorMoveMessage>, MotorMoveMessage>
+          typename MotorMoveMessage, typename MotorHardware>
+requires MessageQueue<QueueImpl<MotorMoveMessage>, MotorMoveMessage> &&
+    std::is_base_of_v<motor_hardware::MotorHardwareIface, MotorHardware>
 class MotorInterruptHandler {
   public:
     using MoveQueue = QueueImpl<MotorMoveMessage>;
@@ -48,11 +49,11 @@ class MotorInterruptHandler {
         QueueImpl<can::messages::UpdateMotorPositionEstimationRequest>;
 
     MotorInterruptHandler() = delete;
-    MotorInterruptHandler(
-        MoveQueue& incoming_move_queue, StatusClient& outgoing_queue,
-        motor_hardware::StepperMotorHardwareIface& hardware_iface,
-        stall_check::StallCheck& stall,
-        UpdatePositionQueue& incoming_update_position_queue)
+    MotorInterruptHandler(MoveQueue& incoming_move_queue,
+                          StatusClient& outgoing_queue,
+                          MotorHardware& hardware_iface,
+                          stall_check::StallCheck& stall,
+                          UpdatePositionQueue& incoming_update_position_queue)
         : move_queue(incoming_move_queue),
           status_queue_client(outgoing_queue),
           hardware(hardware_iface),
@@ -416,7 +417,7 @@ class MotorInterruptHandler {
     q31_31 position_tracker{0};
     MoveQueue& move_queue;
     StatusClient& status_queue_client;
-    motor_hardware::StepperMotorHardwareIface& hardware;
+    MotorHardware& hardware;
     stall_check::StallCheck& stall_checker;
     UpdatePositionQueue& update_position_queue;
     MotorMoveMessage buffered_move = MotorMoveMessage{};

--- a/include/motor-control/simulation/motor_interrupt_driver.hpp
+++ b/include/motor-control/simulation/motor_interrupt_driver.hpp
@@ -18,7 +18,7 @@ class MotorInterruptDriver {
             can::messages::UpdateMotorPositionEstimationRequest>;
     using InterruptHandler = motor_handler::MotorInterruptHandler<
         freertos_message_queue::FreeRTOSMessageQueue, StatusClient,
-        MotorMoveMessage>;
+        MotorMoveMessage, MotorHardware>;
 
   public:
     MotorInterruptDriver(InterruptQueue& q, InterruptHandler& h,

--- a/include/pipettes/firmware/interfaces.hpp
+++ b/include/pipettes/firmware/interfaces.hpp
@@ -21,11 +21,12 @@ namespace interfaces {
 
 template <typename Client>
 using MotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
-    freertos_message_queue::FreeRTOSMessageQueue, Client, motor_messages::Move>;
+    freertos_message_queue::FreeRTOSMessageQueue, Client, motor_messages::Move,
+    motor_hardware::MotorHardware>;
 template <typename Client>
 using GearMotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
     freertos_message_queue::FreeRTOSMessageQueue, Client,
-    motor_messages::GearMotorMove>;
+    motor_messages::GearMotorMove, pipette_motor_hardware::MotorHardware>;
 
 template <PipetteType P>
 auto get_interrupt_queues()

--- a/include/pipettes/firmware/interfaces.hpp
+++ b/include/pipettes/firmware/interfaces.hpp
@@ -22,7 +22,7 @@ namespace interfaces {
 template <typename Client>
 using MotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
     freertos_message_queue::FreeRTOSMessageQueue, Client, motor_messages::Move,
-    motor_hardware::MotorHardware>;
+    pipette_motor_hardware::MotorHardware>;
 template <typename Client>
 using GearMotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
     freertos_message_queue::FreeRTOSMessageQueue, Client,

--- a/include/pipettes/firmware/interfaces_g4.hpp
+++ b/include/pipettes/firmware/interfaces_g4.hpp
@@ -30,11 +30,12 @@ namespace interfaces {
 
 template <typename Client>
 using MotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
-    freertos_message_queue::FreeRTOSMessageQueue, Client, motor_messages::Move>;
+    freertos_message_queue::FreeRTOSMessageQueue, Client, motor_messages::Move,
+    motor_hardware::MotorHardware>;
 template <typename Client>
 using GearMotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
     freertos_message_queue::FreeRTOSMessageQueue, Client,
-    motor_messages::GearMotorMove>;
+    motor_messages::GearMotorMove, pipette_motor_hardware::MotorHardware>;
 
 template <PipetteType P>
 auto get_interrupt_queues()

--- a/include/pipettes/simulator/interfaces.hpp
+++ b/include/pipettes/simulator/interfaces.hpp
@@ -14,12 +14,14 @@ namespace interfaces {
 
 template <typename Client>
 using MotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
-    freertos_message_queue::FreeRTOSMessageQueue, Client, motor_messages::Move>;
+    freertos_message_queue::FreeRTOSMessageQueue, Client, motor_messages::Move,
+    sim_motor_hardware_iface::SimMotorHardwareIface>;
 
 template <typename Client>
 using GearMotorInterruptHandlerType = motor_handler::MotorInterruptHandler<
     freertos_message_queue::FreeRTOSMessageQueue, Client,
-    motor_messages::GearMotorMove>;
+    motor_messages::GearMotorMove,
+    sim_motor_hardware_iface::SimGearMotorHardwareIface>;
 
 template <PipetteType P>
 auto get_interrupt_queues()

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -18,7 +18,8 @@ struct HandlerContainer {
     test_mocks::MockMoveStatusReporterClient reporter{};
     stall_check::StallCheck stall{10, 10, 10};
     MotorInterruptHandler<test_mocks::MockMessageQueue,
-                          test_mocks::MockMoveStatusReporterClient, Move>
+                          test_mocks::MockMoveStatusReporterClient, Move,
+                          test_mocks::MockMotorHardware>
         handler{queue, reporter, hw, stall, update_position_queue};
 };
 

--- a/motor-control/tests/test_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_motor_interrupt_handler.cpp
@@ -18,7 +18,7 @@ struct MotorContainer {
     stall_check::StallCheck st{1, 1, 10};
     MotorInterruptHandler<test_mocks::MockMessageQueue,
                           test_mocks::MockMoveStatusReporterClient,
-                          motor_messages::Move>
+                          motor_messages::Move, test_mocks::MockMotorHardware>
         handler{queue, reporter, hw, st, update_position_queue};
 };
 

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -23,7 +23,8 @@ struct HandlerContainer {
     test_mocks::MockMoveStatusReporterClient reporter{};
     stall_check::StallCheck stall{tick_per_um, tick_per_um, stall_threshold_um};
     MotorInterruptHandler<test_mocks::MockMessageQueue,
-                          test_mocks::MockMoveStatusReporterClient, Move>
+                          test_mocks::MockMoveStatusReporterClient, Move,
+                          test_mocks::MockMotorHardware>
         handler{queue, reporter, hw, stall, update_position_queue};
 };
 

--- a/motor-control/tests/test_sync_handling.cpp
+++ b/motor-control/tests/test_sync_handling.cpp
@@ -18,7 +18,8 @@ struct HandlerContainer {
     test_mocks::MockMoveStatusReporterClient reporter{};
     stall_check::StallCheck stall{10, 10, 10};
     MotorInterruptHandler<test_mocks::MockMessageQueue,
-                          test_mocks::MockMoveStatusReporterClient, Move>
+                          test_mocks::MockMoveStatusReporterClient, Move,
+                          test_mocks::MockMotorHardware>
         handler{queue, reporter, hw, stall, update_position_queue};
 };
 


### PR DESCRIPTION
In our ongoing quest to reduce the overhead of the motor interrupts, virtual calls seems like a good target. By adding a template parameter for the type used for the motor hardware in the stepper interrupt, the compiler is now able to optimize out some virtual hardware calls.

I tested that this at least doesn't slow down the interrupts by running it on a Head unit, but I didn't quantify the difference. However, I checked the disassembly with `objdump` and gcc is definitely calling the hardware functions directly (and was using virtual calls before), so I'm 99% confident that this is an improvement (even if it's only marginal).

There are other places we could do the same thing with a bit more work, but this was pretty low-hanging fruit.