### PR TITLE
feat(motor-control): update all stall thresholds to 0.5mm

### DIFF
--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -208,10 +208,7 @@ static motor_class::Motor motor{
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
     utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(
-        utils::STALL_THRESHOLD_FULLSTEPS* utils::linear_motion_system_config()
-            .get_um_per_step() *
-        utils::linear_motion_system_config().microstep));
+    utils::STALL_THRESHOLD_UM);
 
 /**
  * Handler of motor interrupts.

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -233,10 +233,7 @@ static motor_class::Motor motor{
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
     utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(
-        utils::linear_motion_system_config().get_um_per_step() *
-        utils::STALL_THRESHOLD_FULLSTEPS *
-        utils::linear_motion_system_config().microstep));
+    utils::STALL_THRESHOLD_UM);
 
 /**
  * Handler of motor interrupts.

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -80,10 +80,7 @@ static motor_class::Motor motor{
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
     utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(
-        utils::linear_motion_system_config().get_um_per_step() *
-        utils::STALL_THRESHOLD_FULLSTEPS *
-        utils::linear_motion_system_config().microstep));
+    utils::STALL_THRESHOLD_UM);
 
 /**
  * Handler of motor interrupts.

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -222,10 +222,7 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(linear_config.get_um_per_step() *
-                          utils::STALL_THRESHOLD_FULLSTEPS *
-                          linear_config.microstep));
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -249,10 +246,7 @@ static motor_class::Motor motor_right{
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(linear_config.get_um_per_step() *
-                          utils::STALL_THRESHOLD_FULLSTEPS *
-                          linear_config.microstep));
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -218,10 +218,7 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(linear_config.get_um_per_step() *
-                          utils::STALL_THRESHOLD_FULLSTEPS *
-                          linear_config.microstep));
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -245,10 +242,7 @@ static motor_class::Motor motor_right{
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(linear_config.get_um_per_step() *
-                          utils::STALL_THRESHOLD_FULLSTEPS *
-                          linear_config.microstep));
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -89,10 +89,7 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(linear_config.get_um_per_step() *
-                          utils::STALL_THRESHOLD_FULLSTEPS *
-                          linear_config.microstep));
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_interface_right,
@@ -100,10 +97,7 @@ static motor_handler::MotorInterruptHandler motor_interrupt_right(
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F,
-    static_cast<uint32_t>(linear_config.get_um_per_step() *
-                          utils::STALL_THRESHOLD_FULLSTEPS *
-                          linear_config.microstep));
+    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static auto motor_sys_config =
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{

--- a/include/gantry/core/utils.hpp
+++ b/include/gantry/core/utils.hpp
@@ -8,7 +8,7 @@
 namespace utils {
 
 // Number of full steps the stall threshold should equate to
-constexpr float STALL_THRESHOLD_FULLSTEPS = 2;
+constexpr float STALL_THRESHOLD_UM = 500;
 
 auto get_node_id_by_axis(enum GantryAxisType which) -> can::ids::NodeId;
 

--- a/include/head/core/utils.hpp
+++ b/include/head/core/utils.hpp
@@ -3,6 +3,6 @@
 namespace utils {
 
 // Number of full steps the stall threshold should equate to
-constexpr float STALL_THRESHOLD_FULLSTEPS = 2;
+constexpr float STALL_THRESHOLD_UM = 500;
 
 }  // namespace utils

--- a/include/pipettes/core/configs.hpp
+++ b/include/pipettes/core/configs.hpp
@@ -6,7 +6,7 @@
 namespace configs {
 
 // Number of full steps the stall threshold should equate to
-constexpr float STALL_THRESHOLD_FULLSTEPS = 2;
+constexpr float STALL_THRESHOLD_UM = 500;
 ;
 
 auto linear_motion_sys_config_by_axis(PipetteType which)

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -94,11 +94,7 @@ static auto linear_stall_check = stall_check::StallCheck(
         1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
         1000.0F,
-    static_cast<uint32_t>(
-        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
-            .get_um_per_step() *
-        configs::STALL_THRESHOLD_FULLSTEPS *
-        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).microstep));
+    configs::STALL_THRESHOLD_UM);
 
 // Gear motors have no encoders
 static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -77,11 +77,7 @@ static auto linear_stall_check = stall_check::StallCheck(
         1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
         1000.0F,
-    static_cast<uint32_t>(
-        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
-            .get_um_per_step() *
-        configs::STALL_THRESHOLD_FULLSTEPS *
-        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).microstep));
+    configs::STALL_THRESHOLD_UM);
 
 // Gear motors have no encoders
 static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -48,9 +48,7 @@ static auto linear_stall_check = stall_check::StallCheck(
         1000.0F,
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
         1000.0F,
-    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_um_per_step() *
-        configs::STALL_THRESHOLD_FULLSTEPS *
-        configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).microstep);
+    configs::STALL_THRESHOLD_UM);
 
 // Gear motors have no encoders
 static auto gear_stall_check = interfaces::gear_motor::GearStallCheck{


### PR DESCRIPTION
Per discussions with hardware, we want the default stall threshold for the motors to always be 0.5mm. This has the nice side effect of making the initialization code look really clean and simple.