### PR TITLE
fix(motor-control): update stall checker when updating position estimation

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -373,6 +373,7 @@ class MotorInterruptHandler {
                         encoder_pulses);
                 set_current_position(static_cast<q31_31>(stepper_tick_estimate)
                                      << 31);
+                stall_checker.reset_itr_counts(stepper_tick_estimate);
                 hardware.position_flags.set_flag(
                     MotorPositionStatus::Flags::stepper_position_ok);
             }


### PR DESCRIPTION
When updating the position estimation, we weren't updating the stall checker. This was fine if the position of the encoder and motor accumulator were already within the stall threshold, but if an actual stall happened then the next movement would immediately cause a stall. Oops!