### PR TITLE
fix(gantry): initialize estop GPIO pin correctly

### DIFF
--- a/gantry/firmware/utility_gpio.c
+++ b/gantry/firmware/utility_gpio.c
@@ -72,7 +72,7 @@ void limit_switch_gpio_init(void) {
 
 void estop_input_gpio_init() {
        /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
 
     /*Configure GPIO pin EStopin : PA10 */
     GPIO_InitTypeDef GPIO_InitStruct = {0};


### PR DESCRIPTION
![kill me now](https://media3.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif)
