### PR TITLE
fix(head, pipettes): use the correct gpio clock for estop pin

### DIFF
--- a/head/firmware/utility_hardware.c
+++ b/head/firmware/utility_hardware.c
@@ -57,7 +57,7 @@ void sync_drive_gpio_init() {
 
 void estop_input_gpio_init() {
        /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOB_CLK_ENABLE();
 
     /*Configure GPIO pin EStopin : PB4 */
     GPIO_InitTypeDef GPIO_InitStruct = {0};

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -187,10 +187,9 @@ void data_ready_gpio_init() {
 
 void estop_input_gpio_init() {
     PipetteType pipette_type = get_pipette_type();
-       /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     if (pipette_type == NINETY_SIX_CHANNEL) {
+        __HAL_RCC_GPIOB_CLK_ENABLE();
         /*Configure GPIO pin EStopin : PB9 */
         GPIO_InitStruct.Pin = GPIO_PIN_9;
         GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
@@ -198,6 +197,7 @@ void estop_input_gpio_init() {
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
     }
     else {
+        __HAL_RCC_GPIOC_CLK_ENABLE();
         /*Configure GPIO pin EStopin : PC12*/
         GPIO_InitStruct.Pin = GPIO_PIN_12;
         GPIO_InitStruct.Mode = GPIO_MODE_INPUT;

--- a/pipettes/firmware_l5/utility_gpio.c
+++ b/pipettes/firmware_l5/utility_gpio.c
@@ -175,7 +175,7 @@ int tip_present() {
 
 void estop_input_gpio_init() {
        /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     /*Configure GPIO pin EStopin : PA9 */
     GPIO_InitStruct.Pin = GPIO_PIN_9;


### PR DESCRIPTION
Missed changing the clock when I corrected the Pins for some boards in the other PR