### PR TITLE
refactor(pipettes): Only monitor for a TipActionRequest in the move motor task and add a motor id

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -426,7 +426,7 @@ SCENARIO("message serializing works") {
     }
 
     GIVEN("a tip action response") {
-        constexpr uint8_t MESSAGE_SIZE = 18;
+        constexpr uint8_t MESSAGE_SIZE = 19;
         auto message =
             TipActionResponse{.message_index = 0x1234,
                               .group_id = 1,
@@ -436,7 +436,8 @@ SCENARIO("message serializing works") {
                               .ack_id = 0x1,
                               .success = 0x1,
                               .action = can::ids::PipetteTipActionType::pick_up,
-                              .position_flags = 0x0};
+                              .position_flags = 0x0,
+                              .gear_motor_id = can::ids::GearMotorId::left};
         auto arr = std::array<uint8_t, MESSAGE_SIZE + 5>{0, 0, 0, 0, 0, 0, 0, 0,
                                                          0, 0, 0, 0, 0, 0, 0, 0,
                                                          0, 0, 0, 0, 0, 0, 0};

--- a/generate_header.py
+++ b/generate_header.py
@@ -34,6 +34,7 @@ def generate_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
         write_enum_cpp(constants_mod.SensorOutputBinding, output)
         write_enum_cpp(constants_mod.SensorThresholdMode, output)
         write_enum_cpp(constants_mod.PipetteTipActionType, output)
+        write_enum_cpp(constants_mod.GearMotorId, output)
         write_enum_cpp(constants_mod.MotorPositionFlags, output)
         write_enum_cpp(constants_mod.MoveStopCondition, output)
 
@@ -51,6 +52,7 @@ def generate_c(output: io.StringIO, constants_mod: ModuleType, arbitration_id: M
     write_enum_c(constants_mod.SensorOutputBinding, output, can)
     write_enum_c(constants_mod.SensorThresholdMode, output, can)
     write_enum_c(constants_mod.PipetteTipActionType, output, can)
+    write_enum_c(constants_mod.GearMotorId, output, can)
     write_enum_c(constants_mod.MotorPositionFlags, output, can)
     write_enum_c(constants_mod.MoveStopCondition, output, can)
     write_arbitration_id_c(output, can, arbitration_id)

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -83,6 +83,11 @@ typedef enum {
     can_messageid_limit_sw_response = 0x9,
     can_messageid_do_self_contained_tip_action_request = 0x501,
     can_messageid_do_self_contained_tip_action_response = 0x502,
+    can_messageid_gear_enable_motor_request = 0x503,
+    can_messageid_gear_disable_motor_request = 0x504,
+    can_messageid_gear_set_current_request = 0x505,
+    can_messageid_gear_write_motor_driver_request = 0x506,
+    can_messageid_gear_read_motor_driver_request = 0x507,
     can_messageid_read_sensor_request = 0x82,
     can_messageid_write_sensor_request = 0x83,
     can_messageid_baseline_sensor_request = 0x84,
@@ -182,6 +187,12 @@ typedef enum {
     can_pipettetipactiontype_pick_up = 0x0,
     can_pipettetipactiontype_drop = 0x1,
 } CANPipetteTipActionType;
+
+/** Tip action types. */
+typedef enum {
+    can_gearmotorid_left = 0x0,
+    can_gearmotorid_right = 0x1,
+} CANGearMotorId;
 
 /** Flags for motor position validity. */
 typedef enum {

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -220,4 +220,3 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
-

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -102,7 +102,6 @@ enum class MessageId {
     bind_sensor_output_response = 0x8b,
     peripheral_status_request = 0x8c,
     peripheral_status_response = 0x8d,
-
 };
 
 /** Can bus arbitration id node id. */
@@ -198,6 +197,12 @@ enum class PipetteTipActionType {
     drop = 0x1,
 };
 
+/** Tip action types. */
+enum class GearMotorId {
+    left = 0x0,
+    right = 0x1,
+};
+
 /** Flags for motor position validity. */
 enum class MotorPositionFlags {
     stepper_position_ok = 0x1,
@@ -215,3 +220,4 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
+

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1263,7 +1263,8 @@ struct TipActionResponse
         iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(action), iter, limit);
         iter = bit_utils::int_to_bytes(position_flags, iter, limit);
-        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(gear_motor_id), iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(gear_motor_id),
+                                       iter, limit);
         return iter - body;
     }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1249,6 +1249,7 @@ struct TipActionResponse
     uint8_t success;
     can::ids::PipetteTipActionType action;
     uint8_t position_flags;
+    can::ids::GearMotorId gear_motor_id;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
@@ -1262,6 +1263,7 @@ struct TipActionResponse
         iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(action), iter, limit);
         iter = bit_utils::int_to_bytes(position_flags, iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(gear_motor_id), iter, limit);
         return iter - body;
     }
 

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -27,6 +27,7 @@ enum class AckMessageId : uint8_t {
     position_error = 0x4
 };
 
+
 struct Ack {
     uint32_t message_index;
     uint8_t group_id;
@@ -39,6 +40,7 @@ struct Ack {
 
 struct GearMotorAck : public Ack {
     can::ids::PipetteTipActionType action;
+    can::ids::GearMotorId gear_motor_id;
 };
 
 struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
@@ -66,11 +68,12 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 struct GearMotorMove : public Move {
     can::ids::PipetteTipActionType action;
+    can::ids::GearMotorId gear_motor_id;
 
     auto build_ack(uint32_t position, int32_t pulses, uint8_t flags,
                    AckMessageId _id, uint32_t message_index) -> GearMotorAck {
         return GearMotorAck{message_index, group_id, seq_id, position,
-                            pulses,        flags,    _id,    action};
+                            pulses,        flags,    _id,    action, gear_motor_id};
     }
 };
 

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -27,7 +27,6 @@ enum class AckMessageId : uint8_t {
     position_error = 0x4
 };
 
-
 struct Ack {
     uint32_t message_index;
     uint8_t group_id;
@@ -72,8 +71,9 @@ struct GearMotorMove : public Move {
 
     auto build_ack(uint32_t position, int32_t pulses, uint8_t flags,
                    AckMessageId _id, uint32_t message_index) -> GearMotorAck {
-        return GearMotorAck{message_index, group_id, seq_id, position,
-                            pulses,        flags,    _id,    action, gear_motor_id};
+        return GearMotorAck{message_index, group_id, seq_id,
+                            position,      pulses,   flags,
+                            _id,           action,   gear_motor_id};
     }
 };
 

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -181,7 +181,8 @@ class PipetteMotionController {
         freertos_message_queue::FreeRTOSMessageQueue<GearMotorMove>;
     PipetteMotionController(lms::LinearMotionSystemConfig<MEConfig> lms_config,
                             PipetteStepperMotorHardwareIface& hardware_iface,
-                            MotionConstraints constraints, GenericQueue& queue)
+                            MotionConstraints constraints, GenericQueue& queue,
+                            can::ids::GearMotorId gear_motor_id)
         : linear_motion_sys_config(lms_config),
           hardware(hardware_iface),
           motion_constraints(constraints),
@@ -189,7 +190,8 @@ class PipetteMotionController {
           steps_per_mm(convert_to_fixed_point_64_bit(
               linear_motion_sys_config.get_steps_per_mm(), 31)),
           um_per_step(convert_to_fixed_point_64_bit(
-              linear_motion_sys_config.get_um_per_step(), 31)) {}
+              linear_motion_sys_config.get_um_per_step(), 31)),
+          gear_motor_id(gear_motor_id) {}
 
     auto operator=(const PipetteMotionController&)
         -> PipetteMotionController& = delete;
@@ -216,7 +218,8 @@ class PipetteMotionController {
             can_msg.group_id,
             can_msg.seq_id,
             static_cast<MoveStopCondition>(can_msg.request_stop_condition),
-            can_msg.action};
+            can_msg.action,
+            gear_motor_id};
         if (!enabled) {
             enable_motor();
         }
@@ -282,6 +285,7 @@ class PipetteMotionController {
     sq31_31 steps_per_mm{0};
     sq31_31 um_per_step{0};
     bool enabled = false;
+    can::ids::GearMotorId gear_motor_id;
 };
 
 }  // namespace pipette_motion_controller

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -68,8 +68,8 @@ using GearMotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::GearDisableMotorRequest,
     can::messages::GearEnableMotorRequest,
     can::messages::GetMotionConstraintsRequest,
-    can::messages::SetMotionConstraints, can::messages::StopRequest,
-    can::messages::ReadLimitSwitchRequest, can::messages::TipActionRequest,
+    can::messages::SetMotionConstraints,
+    can::messages::ReadLimitSwitchRequest,
     can::messages::UpdateMotorPositionEstimationRequest>;
 
 using SystemDispatchTarget = can::dispatch::DispatchParseTarget<

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -68,8 +68,7 @@ using GearMotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::GearDisableMotorRequest,
     can::messages::GearEnableMotorRequest,
     can::messages::GetMotionConstraintsRequest,
-    can::messages::SetMotionConstraints,
-    can::messages::ReadLimitSwitchRequest,
+    can::messages::SetMotionConstraints, can::messages::ReadLimitSwitchRequest,
     can::messages::UpdateMotorPositionEstimationRequest>;
 
 using SystemDispatchTarget = can::dispatch::DispatchParseTarget<

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -24,9 +24,11 @@ class MoveStatusMessageHandler {
   public:
     MoveStatusMessageHandler(
         CanClient& can_client,
-        const lms::LinearMotionSystemConfig<LmsConfig>& lms_config)
+        const lms::LinearMotionSystemConfig<LmsConfig>& lms_config,
+        can::ids::GearMotorId gear_motor_id)
         : can_client{can_client},
           lms_config(lms_config),
+          gear_motor_id(gear_motor_id),
           um_per_step(convert_to_fixed_point_64_bit(
               lms_config.get_um_per_step(), 31)) {}
     MoveStatusMessageHandler(const MoveStatusMessageHandler& c) = delete;
@@ -50,20 +52,22 @@ class MoveStatusMessageHandler {
      * Handle Ack message
      */
     void handle_message(const motor_messages::GearMotorAck& message) {
-        can::messages::TipActionResponse msg = {
-            .message_index = message.message_index,
-            .group_id = message.group_id,
-            .seq_id = message.seq_id,
-            .current_position_um = fixed_point_multiply(
-                um_per_step, message.current_position_steps),
-            .encoder_position_um = 0,
-            .ack_id = static_cast<uint8_t>(message.ack_id),
-            // TODO: In a follow-up PR, tip sense reporting will
-            // actually update this value to true or false.
-            .success = static_cast<uint8_t>(true),
-            .action = message.action,
-            .position_flags = 0};
-        can_client.send_can_message(can::ids::NodeId::host, msg);
+        if (message.gear_motor_id == gear_motor_id) {
+            can::messages::TipActionResponse msg = {
+                .message_index = message.message_index,
+                .group_id = message.group_id,
+                .seq_id = message.seq_id,
+                .current_position_um = fixed_point_multiply(
+                    um_per_step, message.current_position_steps),
+                .encoder_position_um = 0,
+                .ack_id = static_cast<uint8_t>(message.ack_id),
+                // TODO: In a follow-up PR, tip sense reporting will
+                // actually update this value to true or false.
+                .success = static_cast<uint8_t>(true),
+                .action = message.action,
+                .position_flags = 0};
+            can_client.send_can_message(can::ids::NodeId::host, msg);
+        }
     }
 
     void handle_message(const motor_messages::UpdatePositionResponse& message) {
@@ -83,7 +87,9 @@ class MoveStatusMessageHandler {
   private:
     CanClient& can_client;
     const lms::LinearMotionSystemConfig<LmsConfig>& lms_config;
+    can::ids::GearMotorId gear_motor_id;
     sq31_31 um_per_step;
+
 };
 
 /**
@@ -95,7 +101,7 @@ class MoveStatusReporterTask {
   public:
     using Messages = TaskMessage;
     using QueueType = QueueImpl<TaskMessage>;
-    MoveStatusReporterTask(QueueType& queue) : queue{queue} {}
+    MoveStatusReporterTask(QueueType& queue, can::ids::GearMotorId gear_motor_id) : queue{queue}, gear_motor_id{gear_motor_id} {}
     MoveStatusReporterTask(const MoveStatusReporterTask& c) = delete;
     MoveStatusReporterTask(const MoveStatusReporterTask&& c) = delete;
     auto operator=(const MoveStatusReporterTask& c) = delete;
@@ -110,7 +116,7 @@ class MoveStatusReporterTask {
     [[noreturn]] void operator()(
         CanClient* can_client,
         const lms::LinearMotionSystemConfig<LmsConfig>* config) {
-        auto handler = MoveStatusMessageHandler{*can_client, *config};
+        auto handler = MoveStatusMessageHandler{*can_client, *config, gear_motor_id};
         TaskMessage message{};
         for (;;) {
             if (queue.try_read(&message, queue.max_delay)) {
@@ -123,6 +129,7 @@ class MoveStatusReporterTask {
 
   private:
     QueueType& queue;
+    can::ids::GearMotorId gear_motor_id;
 };
 
 /**

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -24,11 +24,9 @@ class MoveStatusMessageHandler {
   public:
     MoveStatusMessageHandler(
         CanClient& can_client,
-        const lms::LinearMotionSystemConfig<LmsConfig>& lms_config,
-        can::ids::GearMotorId gear_motor_id)
+        const lms::LinearMotionSystemConfig<LmsConfig>& lms_config)
         : can_client{can_client},
           lms_config(lms_config),
-          gear_motor_id(gear_motor_id),
           um_per_step(convert_to_fixed_point_64_bit(
               lms_config.get_um_per_step(), 31)) {}
     MoveStatusMessageHandler(const MoveStatusMessageHandler& c) = delete;
@@ -52,23 +50,21 @@ class MoveStatusMessageHandler {
      * Handle Ack message
      */
     void handle_message(const motor_messages::GearMotorAck& message) {
-        if (message.gear_motor_id == gear_motor_id) {
-            can::messages::TipActionResponse msg = {
-                .message_index = message.message_index,
-                .group_id = message.group_id,
-                .seq_id = message.seq_id,
-                .current_position_um = fixed_point_multiply(
-                    um_per_step, message.current_position_steps),
-                .encoder_position_um = 0,
-                .ack_id = static_cast<uint8_t>(message.ack_id),
-                // TODO: In a follow-up PR, tip sense reporting will
-                // actually update this value to true or false.
-                .success = static_cast<uint8_t>(true),
-                .action = message.action,
-                .position_flags = 0,
-                .gear_motor_id = gear_motor_id};
-            can_client.send_can_message(can::ids::NodeId::host, msg);
-        }
+        can::messages::TipActionResponse msg = {
+            .message_index = message.message_index,
+            .group_id = message.group_id,
+            .seq_id = message.seq_id,
+            .current_position_um = fixed_point_multiply(
+                um_per_step, message.current_position_steps),
+            .encoder_position_um = 0,
+            .ack_id = static_cast<uint8_t>(message.ack_id),
+            // TODO: In a follow-up PR, tip sense reporting will
+            // actually update this value to true or false.
+            .success = static_cast<uint8_t>(true),
+            .action = message.action,
+            .position_flags = 0,
+            .gear_motor_id = message.gear_motor_id};
+        can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 
     void handle_message(const motor_messages::UpdatePositionResponse& message) {
@@ -88,7 +84,6 @@ class MoveStatusMessageHandler {
   private:
     CanClient& can_client;
     const lms::LinearMotionSystemConfig<LmsConfig>& lms_config;
-    can::ids::GearMotorId gear_motor_id;
     sq31_31 um_per_step;
 };
 
@@ -101,9 +96,7 @@ class MoveStatusReporterTask {
   public:
     using Messages = TaskMessage;
     using QueueType = QueueImpl<TaskMessage>;
-    MoveStatusReporterTask(QueueType& queue,
-                           can::ids::GearMotorId gear_motor_id)
-        : queue{queue}, gear_motor_id{gear_motor_id} {}
+    MoveStatusReporterTask(QueueType& queue) : queue{queue} {}
     MoveStatusReporterTask(const MoveStatusReporterTask& c) = delete;
     MoveStatusReporterTask(const MoveStatusReporterTask&& c) = delete;
     auto operator=(const MoveStatusReporterTask& c) = delete;
@@ -118,8 +111,7 @@ class MoveStatusReporterTask {
     [[noreturn]] void operator()(
         CanClient* can_client,
         const lms::LinearMotionSystemConfig<LmsConfig>* config) {
-        auto handler =
-            MoveStatusMessageHandler{*can_client, *config, gear_motor_id};
+        auto handler = MoveStatusMessageHandler{*can_client, *config};
         TaskMessage message{};
         for (;;) {
             if (queue.try_read(&message, queue.max_delay)) {
@@ -132,7 +124,6 @@ class MoveStatusReporterTask {
 
   private:
     QueueType& queue;
-    can::ids::GearMotorId gear_motor_id;
 };
 
 /**

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -65,7 +65,8 @@ class MoveStatusMessageHandler {
                 // actually update this value to true or false.
                 .success = static_cast<uint8_t>(true),
                 .action = message.action,
-                .position_flags = 0};
+                .position_flags = 0,
+                .gear_motor_id = gear_motor_id};
             can_client.send_can_message(can::ids::NodeId::host, msg);
         }
     }
@@ -89,7 +90,6 @@ class MoveStatusMessageHandler {
     const lms::LinearMotionSystemConfig<LmsConfig>& lms_config;
     can::ids::GearMotorId gear_motor_id;
     sq31_31 um_per_step;
-
 };
 
 /**
@@ -101,7 +101,9 @@ class MoveStatusReporterTask {
   public:
     using Messages = TaskMessage;
     using QueueType = QueueImpl<TaskMessage>;
-    MoveStatusReporterTask(QueueType& queue, can::ids::GearMotorId gear_motor_id) : queue{queue}, gear_motor_id{gear_motor_id} {}
+    MoveStatusReporterTask(QueueType& queue,
+                           can::ids::GearMotorId gear_motor_id)
+        : queue{queue}, gear_motor_id{gear_motor_id} {}
     MoveStatusReporterTask(const MoveStatusReporterTask& c) = delete;
     MoveStatusReporterTask(const MoveStatusReporterTask&& c) = delete;
     auto operator=(const MoveStatusReporterTask& c) = delete;
@@ -116,7 +118,8 @@ class MoveStatusReporterTask {
     [[noreturn]] void operator()(
         CanClient* can_client,
         const lms::LinearMotionSystemConfig<LmsConfig>* config) {
-        auto handler = MoveStatusMessageHandler{*can_client, *config, gear_motor_id};
+        auto handler =
+            MoveStatusMessageHandler{*can_client, *config, gear_motor_id};
         TaskMessage message{};
         for (;;) {
             if (queue.try_read(&message, queue.max_delay)) {

--- a/include/pipettes/core/tasks/message_handlers/motion.hpp
+++ b/include/pipettes/core/tasks/message_handlers/motion.hpp
@@ -17,8 +17,8 @@ class GearMotorMotionHandler {
     using MessageType =
         std::variant<std::monostate, GearDisableMotorRequest,
                      GearEnableMotorRequest, GetMotionConstraintsRequest,
-                     SetMotionConstraints, StopRequest, ReadLimitSwitchRequest,
-                     TipActionRequest, UpdateMotorPositionEstimationRequest>;
+                     SetMotionConstraints, ReadLimitSwitchRequest,
+                     UpdateMotorPositionEstimationRequest>;
 
     GearMotorMotionHandler(GearMotionTaskClient &motion_client)
         : motion_client{motion_client} {}

--- a/include/pipettes/core/tasks/messages.hpp
+++ b/include/pipettes/core/tasks/messages.hpp
@@ -9,13 +9,15 @@ namespace task_messages {
 
 namespace motor_control_task_messages {
 
-using MotionControlTaskMessage = std::variant<
-    std::monostate, can::messages::TipActionRequest, can::messages::GearDisableMotorRequest,
-    can::messages::GearEnableMotorRequest,
-    can::messages::GetMotionConstraintsRequest,
-    can::messages::SetMotionConstraints, can::messages::StopRequest,
-    can::messages::ReadLimitSwitchRequest, 
-    can::messages::UpdateMotorPositionEstimationRequest>;
+using MotionControlTaskMessage =
+    std::variant<std::monostate, can::messages::TipActionRequest,
+                 can::messages::GearDisableMotorRequest,
+                 can::messages::GearEnableMotorRequest,
+                 can::messages::GetMotionConstraintsRequest,
+                 can::messages::SetMotionConstraints,
+                 can::messages::StopRequest,
+                 can::messages::ReadLimitSwitchRequest,
+                 can::messages::UpdateMotorPositionEstimationRequest>;
 
 using MoveStatusReporterTaskMessage =
     std::variant<std::monostate, motor_messages::GearMotorAck,

--- a/include/pipettes/core/tasks/messages.hpp
+++ b/include/pipettes/core/tasks/messages.hpp
@@ -10,11 +10,11 @@ namespace task_messages {
 namespace motor_control_task_messages {
 
 using MotionControlTaskMessage = std::variant<
-    std::monostate, can::messages::GearDisableMotorRequest,
+    std::monostate, can::messages::TipActionRequest, can::messages::GearDisableMotorRequest,
     can::messages::GearEnableMotorRequest,
     can::messages::GetMotionConstraintsRequest,
     can::messages::SetMotionConstraints, can::messages::StopRequest,
-    can::messages::ReadLimitSwitchRequest, can::messages::TipActionRequest,
+    can::messages::ReadLimitSwitchRequest, 
     can::messages::UpdateMotorPositionEstimationRequest>;
 
 using MoveStatusReporterTaskMessage =

--- a/pipettes/core/gear_motor_tasks.cpp
+++ b/pipettes/core/gear_motor_tasks.cpp
@@ -19,8 +19,7 @@ static auto tmc2160_driver_task_builder_left =
 static auto move_group_task_builder_left = freertos_task::TaskStarter<
     512, pipettes::tasks::move_group_task::MoveGroupTask>{};
 static auto move_status_task_builder_left = freertos_task::TaskStarter<
-    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask,
-    can::ids::GearMotorId>(can::ids::GearMotorId::left);
+    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
 
 // right gear motor tasks
 static auto mc_task_builder_right = freertos_task::TaskStarter<
@@ -31,8 +30,7 @@ static auto tmc2160_driver_task_builder_right =
 static auto move_group_task_builder_right = freertos_task::TaskStarter<
     512, pipettes::tasks::move_group_task::MoveGroupTask>{};
 static auto move_status_task_builder_right = freertos_task::TaskStarter<
-    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask,
-    can::ids::GearMotorId>(can::ids::GearMotorId::right);
+    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
 
 void gear_motor_tasks::start_tasks(
     gear_motor_tasks::CanWriterTask& can_writer,
@@ -85,10 +83,10 @@ void gear_motor_tasks::start_tasks(
         5, "move status", right_queues,
         motion_controllers.right.get_mechanical_config());
 
-    right_tasks.driver = &tmc2160_driver_left;
-    right_tasks.motion_controller = &motion_left;
-    right_tasks.move_group = &move_group_left;
-    right_tasks.move_status_reporter = &move_status_reporter_left;
+    right_tasks.driver = &tmc2160_driver_right;
+    right_tasks.motion_controller = &motion_right;
+    right_tasks.move_group = &move_group_right;
+    right_tasks.move_status_reporter = &move_status_reporter_right;
 
     right_queues.set_queue(&can_writer.get_queue());
     right_queues.driver_queue = &tmc2160_driver_right.get_queue();

--- a/pipettes/core/gear_motor_tasks.cpp
+++ b/pipettes/core/gear_motor_tasks.cpp
@@ -19,7 +19,8 @@ static auto tmc2160_driver_task_builder_left =
 static auto move_group_task_builder_left = freertos_task::TaskStarter<
     512, pipettes::tasks::move_group_task::MoveGroupTask>{};
 static auto move_status_task_builder_left = freertos_task::TaskStarter<
-    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
+    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask,
+    can::ids::GearMotorId>(can::ids::GearMotorId::left);
 
 // right gear motor tasks
 static auto mc_task_builder_right = freertos_task::TaskStarter<
@@ -30,7 +31,8 @@ static auto tmc2160_driver_task_builder_right =
 static auto move_group_task_builder_right = freertos_task::TaskStarter<
     512, pipettes::tasks::move_group_task::MoveGroupTask>{};
 static auto move_status_task_builder_right = freertos_task::TaskStarter<
-    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
+    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask,
+    can::ids::GearMotorId>(can::ids::GearMotorId::right);
 
 void gear_motor_tasks::start_tasks(
     gear_motor_tasks::CanWriterTask& can_writer,

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -159,7 +159,8 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                                   .max_velocity = 2,
                                                   .min_acceleration = 1,
                                                   .max_acceleration = 2},
-                queues.left_motor_queue},
+                queues.left_motor_queue,
+                can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
             configs::linear_motion_sys_config_by_axis(
                 PipetteType::NINETY_SIX_CHANNEL),
@@ -168,7 +169,8 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                               .max_velocity = 2,
                                               .min_acceleration = 1,
                                               .max_acceleration = 2},
-            queues.right_motor_queue}};
+            queues.right_motor_queue,
+            can::ids::GearMotorId::right}};
 }
 
 auto gear_motor::get_motion_control(gear_motor::UnavailableGearHardware&,

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -159,8 +159,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                                   .max_velocity = 2,
                                                   .min_acceleration = 1,
                                                   .max_acceleration = 2},
-                queues.left_motor_queue,
-                can::ids::GearMotorId::left},
+                queues.left_motor_queue, can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
             configs::linear_motion_sys_config_by_axis(
                 PipetteType::NINETY_SIX_CHANNEL),
@@ -169,8 +168,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                               .max_velocity = 2,
                                               .min_acceleration = 1,
                                               .max_acceleration = 2},
-            queues.right_motor_queue,
-            can::ids::GearMotorId::right}};
+            queues.right_motor_queue, can::ids::GearMotorId::right}};
 }
 
 auto gear_motor::get_motion_control(gear_motor::UnavailableGearHardware&,

--- a/pipettes/firmware_l5/interfaces.cpp
+++ b/pipettes/firmware_l5/interfaces.cpp
@@ -163,8 +163,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                                   .max_velocity = 2,
                                                   .min_acceleration = 1,
                                                   .max_acceleration = 2},
-                queues.left_motor_queue,
-                can::ids::GearMotorId::left},
+                queues.left_motor_queue, can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
             configs::linear_motion_sys_config_by_axis(
                 PipetteType::NINETY_SIX_CHANNEL),
@@ -173,8 +172,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                               .max_velocity = 2,
                                               .min_acceleration = 1,
                                               .max_acceleration = 2},
-            queues.right_motor_queue,
-            can::ids::GearMotorId::right}};
+            queues.right_motor_queue, can::ids::GearMotorId::right}};
 }
 
 auto gear_motor::get_motion_control(gear_motor::UnavailableGearHardware&,

--- a/pipettes/firmware_l5/interfaces.cpp
+++ b/pipettes/firmware_l5/interfaces.cpp
@@ -163,7 +163,8 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                                   .max_velocity = 2,
                                                   .min_acceleration = 1,
                                                   .max_acceleration = 2},
-                queues.left_motor_queue},
+                queues.left_motor_queue,
+                can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
             configs::linear_motion_sys_config_by_axis(
                 PipetteType::NINETY_SIX_CHANNEL),
@@ -172,7 +173,8 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                               .max_velocity = 2,
                                               .min_acceleration = 1,
                                               .max_acceleration = 2},
-            queues.right_motor_queue}};
+            queues.right_motor_queue,
+            can::ids::GearMotorId::right}};
 }
 
 auto gear_motor::get_motion_control(gear_motor::UnavailableGearHardware&,

--- a/pipettes/simulator/interfaces.cpp
+++ b/pipettes/simulator/interfaces.cpp
@@ -163,8 +163,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                                   .max_velocity = 2,
                                                   .min_acceleration = 1,
                                                   .max_acceleration = 2},
-                queues.left_motor_queue,
-                can::ids::GearMotorId::left},
+                queues.left_motor_queue, can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
             configs::linear_motion_sys_config_by_axis(
                 PipetteType::NINETY_SIX_CHANNEL),
@@ -173,8 +172,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                               .max_velocity = 2,
                                               .min_acceleration = 1,
                                               .max_acceleration = 2},
-            queues.right_motor_queue,
-            can::ids::GearMotorId::right}};
+            queues.right_motor_queue, can::ids::GearMotorId::right}};
 }
 
 auto gear_motor::get_motion_control(gear_motor::UnavailableGearHardware&,

--- a/pipettes/simulator/interfaces.cpp
+++ b/pipettes/simulator/interfaces.cpp
@@ -163,7 +163,8 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                                   .max_velocity = 2,
                                                   .min_acceleration = 1,
                                                   .max_acceleration = 2},
-                queues.left_motor_queue},
+                queues.left_motor_queue,
+                can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
             configs::linear_motion_sys_config_by_axis(
                 PipetteType::NINETY_SIX_CHANNEL),
@@ -172,7 +173,8 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                               .max_velocity = 2,
                                               .min_acceleration = 1,
                                               .max_acceleration = 2},
-            queues.right_motor_queue}};
+            queues.right_motor_queue,
+            can::ids::GearMotorId::right}};
 }
 
 auto gear_motor::get_motion_control(gear_motor::UnavailableGearHardware&,

--- a/pipettes/tests/CMakeLists.txt
+++ b/pipettes/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
         pipettes
         test_main.cpp
         test_mount_detection.cpp
+        test_gear_move_status_handling.cpp
 )
 
 target_include_directories(pipettes PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/pipettes/tests/test_gear_move_status_handling.cpp
+++ b/pipettes/tests/test_gear_move_status_handling.cpp
@@ -1,0 +1,88 @@
+#include <climits>
+#include <cstdint>
+#include <deque>
+#include <utility>
+#include <variant>
+
+#include "can/core/ids.hpp"
+#include "can/core/messages.hpp"
+#include "catch2/catch.hpp"
+#include "motor-control/core/linear_motion_system.hpp"
+#include "motor-control/core/motor_messages.hpp"
+#include "pipettes/core/tasks/gear_move_status_reporter_task.hpp"
+
+using namespace motor_messages;
+using namespace pipettes::tasks::gear_move_status;
+using namespace lms;
+
+struct MockCanClient {
+    std::deque<std::pair<can::ids::NodeId, can::messages::ResponseMessageType>>
+        queue{};
+    auto send_can_message(can::ids::NodeId node_id,
+                          const can::messages::ResponseMessageType& m) -> void {
+        queue.push_back(std::make_pair(node_id, m));
+    }
+};
+
+SCENARIO("testing gear move status response handling") {
+    GIVEN("a left and right status handler with known LMS config") {
+        struct LinearMotionSystemConfig<LeadScrewConfig> linearConfig {
+            .mech_config = LeadScrewConfig{.lead_screw_pitch = 2},
+            .steps_per_rev = 200, .microstep = 32,
+            .encoder_pulses_per_rev = 1000,
+        };
+		auto left_ack = GearMotorAck{
+			1,
+			11,
+			8,
+			100,
+			100,
+			0x1,
+			AckMessageId::complete_without_condition,
+			can::ids::PipetteTipActionType::pick_up,
+			can::ids::GearMotorId::left
+		};
+
+		auto right_ack = GearMotorAck{
+			1,
+			11,
+			8,
+			100,
+			100,
+			0x1,
+			AckMessageId::complete_without_condition,
+			can::ids::PipetteTipActionType::pick_up,
+			can::ids::GearMotorId::right
+		};
+        auto mcc = MockCanClient();
+        auto left_handler = MoveStatusMessageHandler(mcc, linearConfig, can::ids::GearMotorId::left);
+		auto right_handler = MoveStatusMessageHandler(mcc, linearConfig, can::ids::GearMotorId::right);
+        WHEN("Each handler is given the correct gear id") {
+            left_handler.handle_message(left_ack);
+			right_handler.handle_message(right_ack);
+            CHECK(mcc.queue.size() == 2);
+
+            auto left_resp = mcc.queue.front();
+			auto right_resp = mcc.queue.back();
+            auto left_resp_msg = std::get<can::messages::TipActionResponse>(left_resp.second);
+			auto right_resp_msg = std::get<can::messages::TipActionResponse>(right_resp.second);
+            THEN("there should be a TipActionResponse and the id should match the handlers id") {
+                REQUIRE(left_resp_msg.group_id == 11);
+                REQUIRE(left_resp_msg.seq_id == 8);
+				REQUIRE(left_resp_msg.gear_motor_id == can::ids::GearMotorId::left);
+				
+				REQUIRE(right_resp_msg.group_id == 11);
+                REQUIRE(right_resp_msg.seq_id == 8);
+				REQUIRE(right_resp_msg.gear_motor_id == can::ids::GearMotorId::right);
+            }
+        }
+		WHEN("Each handler is given the incorrect gear id") {
+            left_handler.handle_message(right_ack);
+			right_handler.handle_message(left_ack);
+            CHECK(mcc.queue.size() == 0);
+            THEN("there should be no responses in the can queue") {
+				CHECK(mcc.queue.size() == 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Previously, the gear move and motion tasks were both looking for TipActionRequests on the CAN dispatcher. This meant that any time you sent a tip action request, it would send back four responses rather than two responses.

In addition, I added a "GearMotorId" to help determine which motor is sending back the response. Required changes on the python side can be found [here](https://github.com/Opentrons/opentrons/pull/12018).

See RLIQ-295 for more information.

# Test Plan

- [x] Test 96 channel tip motor movement with the diagnostic script
- [x] Check that this fixes tip pick up behavior in LPC where the 96 channel starts homing before pick up tip is completed.