### PR TITLE
refactor(head): enable motors on boot

### DIFF
--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -232,13 +232,14 @@ static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_hardware_right,
     stallcheck_right, update_position_queue_right);
 
+// engaging motors on boot
 static motor_class::Motor motor_right{
     linear_config, motor_hardware_right,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,
                                       .min_acceleration = 1,
                                       .max_acceleration = 2},
-    motor_queue_right, update_position_queue_right};
+    motor_queue_right, update_position_queue_right, true};
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
@@ -250,13 +251,14 @@ static motor_handler::MotorInterruptHandler motor_interrupt_left(
     motor_queue_left, head_tasks::get_left_queues(), motor_hardware_left,
     stallcheck_left, update_position_queue_left);
 
+// engaging motors on boot
 static motor_class::Motor motor_left{
     linear_config, motor_hardware_left,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,
                                       .min_acceleration = 1,
                                       .max_acceleration = 2},
-    motor_queue_left, update_position_queue_left};
+    motor_queue_left, update_position_queue_left, true};
 
 extern "C" void motor_callback_glue() {
     motor_interrupt_left.run_interrupt();

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -234,12 +234,15 @@ static motor_handler::MotorInterruptHandler motor_interrupt_right(
 
 // engaging motors on boot
 static motor_class::Motor motor_right{
-    linear_config, motor_hardware_right,
+    linear_config,
+    motor_hardware_right,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,
                                       .min_acceleration = 1,
                                       .max_acceleration = 2},
-    motor_queue_right, update_position_queue_right, true};
+    motor_queue_right,
+    update_position_queue_right,
+    true};
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
@@ -253,12 +256,15 @@ static motor_handler::MotorInterruptHandler motor_interrupt_left(
 
 // engaging motors on boot
 static motor_class::Motor motor_left{
-    linear_config, motor_hardware_left,
+    linear_config,
+    motor_hardware_left,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,
                                       .min_acceleration = 1,
                                       .max_acceleration = 2},
-    motor_queue_left, update_position_queue_left, true};
+    motor_queue_left,
+    update_position_queue_left,
+    true};
 
 extern "C" void motor_callback_glue() {
     motor_interrupt_left.run_interrupt();


### PR DESCRIPTION
## Overview

The 96 channel is extremely heavy. We have the ebrake to prevent the pipette from falling when the robot is off, however immediately on boot of the system the pipette starts falling. This means that we will need to enable the Z motor on boot. I decided to just enable both motors to make the behavior the same, but I am fine with only doing the mount that matters as well.