### PR TITLE
refactor(all): Modify calculation for usteps per mm and update microstepping to 1/16th for tip motors

### DIFF
--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -207,7 +207,7 @@ static motor_class::Motor motor{
 
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
-    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
+    utils::linear_motion_system_config().get_usteps_per_mm() / 1000.0F,
     utils::STALL_THRESHOLD_UM);
 
 /**

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -232,7 +232,7 @@ static motor_class::Motor motor{
 
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
-    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
+    utils::linear_motion_system_config().get_usteps_per_mm() / 1000.0F,
     utils::STALL_THRESHOLD_UM);
 
 /**

--- a/gantry/simulator/interfaces.cpp
+++ b/gantry/simulator/interfaces.cpp
@@ -79,7 +79,7 @@ static motor_class::Motor motor{
 
 static stall_check::StallCheck stallcheck(
     utils::linear_motion_system_config().get_encoder_pulses_per_mm() / 1000.0F,
-    utils::linear_motion_system_config().get_steps_per_mm() / 1000.0F,
+    utils::linear_motion_system_config().get_usteps_per_mm() / 1000.0F,
     utils::STALL_THRESHOLD_UM);
 
 /**

--- a/gantry/tests/test_linear_motion_config.cpp
+++ b/gantry/tests/test_linear_motion_config.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Linear motion system using a belt") {
             .steps_per_rev = 200, .microstep = 32,
             .encoder_pulses_per_rev = 1000,
         };
-        REQUIRE(linearConfig.get_steps_per_mm() == 160.40813f);
+        REQUIRE(linearConfig.get_usteps_per_mm() == 160.40813f);
         REQUIRE(linearConfig.get_encoder_pulses_per_mm() == 100.25508f);
     }
 }

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -108,11 +108,11 @@ static brushed_motor_driver::BrushedMotorDriver brushed_motor_driver_iface(
     update_pwm);
 
 static lms::LinearMotionSystemConfig<lms::GearBoxConfig> gear_config{
-    .mech_config = lms::GearBoxConfig{.gear_diameter = 9},
+    .mech_config =
+        lms::GearBoxConfig{.gear_diameter = 9, .gear_reduction_ratio = 103.81},
     .steps_per_rev = 0,
     .microstep = 0,
-    .encoder_pulses_per_rev = 512,
-    .gear_ratio = 103.81};
+    .encoder_pulses_per_rev = 512};
 
 static brushed_motor::BrushedMotor grip_motor(gear_config,
                                               brushed_motor_hardware_iface,

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -122,11 +122,11 @@ static freertos_message_queue::FreeRTOSMessageQueue<
  */
 static motor_class::Motor z_motor{
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-        .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12},
+        .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12,
+                                            .gear_reduction_ratio = 1.8},
         .steps_per_rev = 200,
         .microstep = 32,
-        .encoder_pulses_per_rev = 0,
-        .gear_ratio = 1.8},
+        .encoder_pulses_per_rev = 0},
     motor_hardware_iface,
     motor_messages::MotionConstraints{.min_velocity = 1,
                                       .max_velocity = 2,

--- a/gripper/simulator/interfaces.cpp
+++ b/gripper/simulator/interfaces.cpp
@@ -110,11 +110,11 @@ static auto brushed_motor_hardware_iface =
         MoveMessageHardware::g);
 
 static auto gear_conf = lms::LinearMotionSystemConfig<lms::GearBoxConfig>{
-    .mech_config = lms::GearBoxConfig{.gear_diameter = 9},
+    .mech_config =
+        lms::GearBoxConfig{.gear_diameter = 9, .gear_reduction_ratio = 84.29},
     .steps_per_rev = 0,
     .microstep = 0,
-    .encoder_pulses_per_rev = 512,
-    .gear_ratio = 84.29};
+    .encoder_pulses_per_rev = 512};
 
 static auto grip_motor = brushed_motor::BrushedMotor(
     gear_conf, brushed_motor_hardware_iface, brushed_motor_driver_iface,

--- a/gripper/simulator/interfaces.cpp
+++ b/gripper/simulator/interfaces.cpp
@@ -65,7 +65,8 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
 
 static auto z_motor_sys_config =
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-        .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 4},
+        .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 4,
+                                            .gear_reduction_ratio = 1.0},
         .steps_per_rev = 200,
         .microstep = 16,
         .encoder_pulses_per_rev = 0};

--- a/gripper/tests/test_linear_motion_config.cpp
+++ b/gripper/tests/test_linear_motion_config.cpp
@@ -6,11 +6,11 @@ using namespace lms;
 TEST_CASE("Linear motion system using a leadscrew and gears") {
     GIVEN("Gripper Z config") {
         struct LinearMotionSystemConfig<LeadScrewConfig> linearConfig {
-            .mech_config = LeadScrewConfig{.lead_screw_pitch = 4},
+            .mech_config = LeadScrewConfig{.lead_screw_pitch = 12,
+                                           .gear_reduction_ratio = 1.8},
             .steps_per_rev = 200, .microstep = 16, .encoder_pulses_per_rev = 0,
-            .gear_ratio = 1.8,
         };
-        REQUIRE(linearConfig.get_usteps_per_mm() == 1440);
+        REQUIRE(linearConfig.get_usteps_per_mm() == 479.99997f);
         REQUIRE(linearConfig.get_encoder_pulses_per_mm() == 0.0);
     }
 }
@@ -18,9 +18,9 @@ TEST_CASE("Linear motion system using a leadscrew and gears") {
 TEST_CASE("Linear motion system using a brushed motor and gears") {
     GIVEN("Gripper G config") {
         struct LinearMotionSystemConfig<GearBoxConfig> linearConfig {
-            .mech_config = GearBoxConfig{.gear_diameter = 9},
+            .mech_config = GearBoxConfig{.gear_diameter = 9,
+                                         .gear_reduction_ratio = 84.29},
             .steps_per_rev = 0, .microstep = 0, .encoder_pulses_per_rev = 512,
-            .gear_ratio = 84.29,
         };
         REQUIRE(linearConfig.get_usteps_per_mm() == 0);
         REQUIRE(linearConfig.get_encoder_pulses_per_mm() == 6105.39307f);

--- a/gripper/tests/test_linear_motion_config.cpp
+++ b/gripper/tests/test_linear_motion_config.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Linear motion system using a leadscrew and gears") {
             .steps_per_rev = 200, .microstep = 16, .encoder_pulses_per_rev = 0,
             .gear_ratio = 1.8,
         };
-        REQUIRE(linearConfig.get_steps_per_mm() == 1440);
+        REQUIRE(linearConfig.get_usteps_per_mm() == 1440);
         REQUIRE(linearConfig.get_encoder_pulses_per_mm() == 0.0);
     }
 }
@@ -22,7 +22,7 @@ TEST_CASE("Linear motion system using a brushed motor and gears") {
             .steps_per_rev = 0, .microstep = 0, .encoder_pulses_per_rev = 512,
             .gear_ratio = 84.29,
         };
-        REQUIRE(linearConfig.get_steps_per_mm() == 0);
+        REQUIRE(linearConfig.get_usteps_per_mm() == 0);
         REQUIRE(linearConfig.get_encoder_pulses_per_mm() == 6105.39307f);
     }
 }

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -215,14 +215,15 @@ static tmc2130::configs::TMC2130DriverConfig motor_driver_configs_left{
     }};
 
 static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
+    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0,
+                                        .gear_reduction_ratio = 1.0},
     .steps_per_rev = 200.0,
     .microstep = 32.0,
     .encoder_pulses_per_rev = 1024.0};
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_usteps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -246,7 +247,7 @@ static motor_class::Motor motor_right{
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_usteps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -210,15 +210,15 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_configs_left{
     }};
 
 static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
+    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0,
+                                        .gear_reduction_ratio = 4.0},
     .steps_per_rev = 200,
     .microstep = 16,
-    .encoder_pulses_per_rev = 1024.0,
-    .gear_ratio = 4.0};
+    .encoder_pulses_per_rev = 1024.0};
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_usteps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 /**
  * TODO: This motor class is only used in motor handler and should be
@@ -246,7 +246,7 @@ static motor_class::Motor motor_right{
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_usteps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_hardware::MotorHardware motor_hardware_left(
     pin_configurations_left, &htim7, &htim3);

--- a/head/simulator/main.cpp
+++ b/head/simulator/main.cpp
@@ -82,14 +82,15 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
     }};
 
 static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0},
+    .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 12.0,
+                                        .gear_reduction_ratio = 4.0},
     .steps_per_rev = 200.0,
     .microstep = 32.0,
     .encoder_pulses_per_rev = 1024.0};
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_usteps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_interface_right,
@@ -97,7 +98,7 @@ static motor_handler::MotorInterruptHandler motor_interrupt_right(
 
 static stall_check::StallCheck stallcheck_left(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,
-    linear_config.get_steps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
+    linear_config.get_usteps_per_mm() / 1000.0F, utils::STALL_THRESHOLD_UM);
 
 static auto motor_sys_config =
     lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{

--- a/include/motor-control/core/linear_motion_system.hpp
+++ b/include/motor-control/core/linear_motion_system.hpp
@@ -13,16 +13,19 @@ struct BeltConfig {
 };
 
 struct LeadScrewConfig {
-    float lead_screw_pitch;  // mm/rev
+    float lead_screw_pitch;      // mm/rev
+    float gear_reduction_ratio;  // large teeth / small teeth
     [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
-        return lead_screw_pitch;
+        return lead_screw_pitch * (1.0 / gear_reduction_ratio);
     }
 };
 
 struct GearBoxConfig {
-    float gear_diameter;  // mm
+    float gear_diameter;         // mm
+    float gear_reduction_ratio;  // large teeth / small teeth
     [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
-        return static_cast<float>(gear_diameter * std::numbers::pi);
+        return static_cast<float>(gear_diameter * std::numbers::pi *
+                                  (1.0 / gear_reduction_ratio));
     }
 };
 
@@ -38,22 +41,19 @@ struct LinearMotionSystemConfig {
     float steps_per_rev{};
     float microstep{};
     float encoder_pulses_per_rev{0.0};
-    float gear_ratio{1.0};
-    [[nodiscard]] constexpr auto get_steps_per_mm() const -> float {
-        return (steps_per_rev * microstep * gear_ratio) /
-               (mech_config.get_mm_per_rev());
+    [[nodiscard]] constexpr auto get_usteps_per_mm() const -> float {
+        return (steps_per_rev * microstep) / (mech_config.get_mm_per_rev());
     }
     [[nodiscard]] constexpr auto get_um_per_step() const -> float {
-        return (mech_config.get_mm_per_rev()) /
-               (steps_per_rev * microstep * gear_ratio) * 1000;
+        return (mech_config.get_mm_per_rev()) / (steps_per_rev * microstep) *
+               1000;
     }
     [[nodiscard]] constexpr auto get_encoder_pulses_per_mm() const -> float {
-        return (encoder_pulses_per_rev * 4.0 * gear_ratio) /
-               (mech_config.get_mm_per_rev());
+        return (encoder_pulses_per_rev * 4.0) / (mech_config.get_mm_per_rev());
     }
     [[nodiscard]] constexpr auto get_encoder_um_per_pulse() const -> float {
-        return (mech_config.get_mm_per_rev()) /
-               (encoder_pulses_per_rev * 4.0 * gear_ratio) * 1000.0;
+        return (mech_config.get_mm_per_rev()) / (encoder_pulses_per_rev * 4.0) *
+               1000.0;
     }
 };
 

--- a/include/motor-control/core/linear_motion_system.hpp
+++ b/include/motor-control/core/linear_motion_system.hpp
@@ -16,7 +16,7 @@ struct LeadScrewConfig {
     float lead_screw_pitch;      // mm/rev
     float gear_reduction_ratio;  // large teeth / small teeth
     [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
-        return lead_screw_pitch * (1.0 / gear_reduction_ratio);
+        return lead_screw_pitch / gear_reduction_ratio;
     }
 };
 
@@ -24,8 +24,8 @@ struct GearBoxConfig {
     float gear_diameter;         // mm
     float gear_reduction_ratio;  // large teeth / small teeth
     [[nodiscard]] constexpr auto get_mm_per_rev() const -> float {
-        return static_cast<float>(gear_diameter * std::numbers::pi *
-                                  (1.0 / gear_reduction_ratio));
+        return static_cast<float>((gear_diameter * std::numbers::pi) /
+                                  gear_reduction_ratio);
     }
 };
 

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -37,7 +37,7 @@ class MotionController {
           queue(queue),
           update_queue(update_queue),
           steps_per_mm(convert_to_fixed_point_64_bit(
-              linear_motion_sys_config.get_steps_per_mm(), 31)),
+              linear_motion_sys_config.get_usteps_per_mm(), 31)),
           um_per_step(convert_to_fixed_point_64_bit(
               linear_motion_sys_config.get_um_per_step(), 31)),
           um_per_encoder_pulse(convert_to_fixed_point_64_bit(
@@ -188,7 +188,7 @@ class PipetteMotionController {
           motion_constraints(constraints),
           queue(queue),
           steps_per_mm(convert_to_fixed_point_64_bit(
-              linear_motion_sys_config.get_steps_per_mm(), 31)),
+              linear_motion_sys_config.get_usteps_per_mm(), 31)),
           um_per_step(convert_to_fixed_point_64_bit(
               linear_motion_sys_config.get_um_per_step(), 31)),
           gear_motor_id(gear_motor_id) {}

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -9,11 +9,11 @@
 using namespace brushed_motor_handler;
 
 auto gear_config = lms::LinearMotionSystemConfig<lms::GearBoxConfig>{
-    .mech_config = lms::GearBoxConfig{.gear_diameter = 9},
+    .mech_config =
+        lms::GearBoxConfig{.gear_diameter = 9, .gear_reduction_ratio = 84.29},
     .steps_per_rev = 0,
     .microstep = 0,
-    .encoder_pulses_per_rev = 512,
-    .gear_ratio = 84.29};
+    .encoder_pulses_per_rev = 512};
 
 struct BrushedMotorContainer {
     test_mocks::MockBrushedMotorHardware hw{};

--- a/motor-control/tests/test_linear_motion_config.cpp
+++ b/motor-control/tests/test_linear_motion_config.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Linear motion system using a leadscrew") {
             .encoder_pulses_per_rev = 1000,
         };
         THEN("the steps/mm calculation should match the known value") {
-            REQUIRE(linearConfig.get_steps_per_mm() == 3200);
+            REQUIRE(linearConfig.get_usteps_per_mm() == 3200);
         }
         THEN("the pulses/mm calculation should match the known value") {
             REQUIRE(linearConfig.get_encoder_pulses_per_mm() == 2000.0);

--- a/motor-control/tests/test_linear_motion_config.cpp
+++ b/motor-control/tests/test_linear_motion_config.cpp
@@ -6,7 +6,8 @@ using namespace lms;
 TEST_CASE("Linear motion system using a leadscrew") {
     GIVEN("OT2 GEN2 pipette config") {
         struct LinearMotionSystemConfig<LeadScrewConfig> linearConfig {
-            .mech_config = LeadScrewConfig{.lead_screw_pitch = 2},
+            .mech_config = LeadScrewConfig{.lead_screw_pitch = 2,
+                                           .gear_reduction_ratio = 1.0},
             .steps_per_rev = 200, .microstep = 32,
             .encoder_pulses_per_rev = 1000,
         };

--- a/motor-control/tests/test_move_status_handling.cpp
+++ b/motor-control/tests/test_move_status_handling.cpp
@@ -27,7 +27,8 @@ struct MockCanClient {
 SCENARIO("testing move status position translation") {
     GIVEN("a status handler with known LMS config") {
         struct LinearMotionSystemConfig<LeadScrewConfig> linearConfig {
-            .mech_config = LeadScrewConfig{.lead_screw_pitch = 2},
+            .mech_config = LeadScrewConfig{.lead_screw_pitch = 2,
+                                           .gear_reduction_ratio = 1.0},
             .steps_per_rev = 200, .microstep = 32,
             .encoder_pulses_per_rev = 1000,
         };

--- a/pipettes/core/configs.cpp
+++ b/pipettes/core/configs.cpp
@@ -6,7 +6,9 @@ auto configs::linear_motion_sys_config_by_axis(PipetteType which)
         case PipetteType::NINETY_SIX_CHANNEL:
         case PipetteType::THREE_EIGHTY_FOUR_CHANNEL:
             return lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-                .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 2},
+                .mech_config =
+                    lms::LeadScrewConfig{.lead_screw_pitch = 2,
+                                         .gear_reduction_ratio = 1.0},
                 .steps_per_rev = 200,
                 .microstep = 64,
                 .encoder_pulses_per_rev = 1000};
@@ -14,7 +16,9 @@ auto configs::linear_motion_sys_config_by_axis(PipetteType which)
         case PipetteType::SINGLE_CHANNEL:
         default:
             return lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-                .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 3},
+                .mech_config =
+                    lms::LeadScrewConfig{.lead_screw_pitch = 3,
+                                         .gear_reduction_ratio = 1.0},
                 .steps_per_rev = 200,
                 .microstep = 32,
                 .encoder_pulses_per_rev = 1000};
@@ -24,8 +28,9 @@ auto configs::linear_motion_sys_config_by_axis(PipetteType which)
 auto configs::gear_motion_sys_config()
     -> lms::LinearMotionSystemConfig<lms::LeadScrewConfig> {
     return lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
-        .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 2},
+        .mech_config =
+            lms::LeadScrewConfig{.lead_screw_pitch = 2,
+                                 .gear_reduction_ratio = 25.0 / 12.0},
         .steps_per_rev = 200,
-        .microstep = 16,
-        .gear_ratio = 0.48};
+        .microstep = 16};
 }

--- a/pipettes/core/configs.cpp
+++ b/pipettes/core/configs.cpp
@@ -26,6 +26,6 @@ auto configs::gear_motion_sys_config()
     return lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
         .mech_config = lms::LeadScrewConfig{.lead_screw_pitch = 2},
         .steps_per_rev = 200,
-        .microstep = 32,
-        .gear_ratio = 2};
+        .microstep = 16,
+        .gear_ratio = 0.48};
 }

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -152,16 +152,14 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
     return gear_motor::GearMotionControl{
         .left =
             pipette_motion_controller::PipetteMotionController{
-                configs::gear_motion_sys_config(),
-                hw.left,
+                configs::gear_motion_sys_config(), hw.left,
                 motor_messages::MotionConstraints{.min_velocity = 1,
                                                   .max_velocity = 2,
                                                   .min_acceleration = 1,
                                                   .max_acceleration = 2},
                 queues.left_motor_queue, can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
-            configs::gear_motion_sys_config(),
-            hw.right,
+            configs::gear_motion_sys_config(), hw.right,
             motor_messages::MotionConstraints{.min_velocity = 1,
                                               .max_velocity = 2,
                                               .min_acceleration = 1,

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -152,8 +152,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
     return gear_motor::GearMotionControl{
         .left =
             pipette_motion_controller::PipetteMotionController{
-                configs::linear_motion_sys_config_by_axis(
-                    PipetteType::NINETY_SIX_CHANNEL),
+                configs::gear_motion_sys_config(),
                 hw.left,
                 motor_messages::MotionConstraints{.min_velocity = 1,
                                                   .max_velocity = 2,
@@ -161,8 +160,7 @@ auto gear_motor::get_motion_control(gear_motor::GearHardware& hw,
                                                   .max_acceleration = 2},
                 queues.left_motor_queue, can::ids::GearMotorId::left},
         .right = pipette_motion_controller::PipetteMotionController{
-            configs::linear_motion_sys_config_by_axis(
-                PipetteType::NINETY_SIX_CHANNEL),
+            configs::gear_motion_sys_config(),
             hw.right,
             motor_messages::MotionConstraints{.min_velocity = 1,
                                               .max_velocity = 2,

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -92,7 +92,8 @@ static auto linear_stall_check = stall_check::StallCheck(
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
             .get_encoder_pulses_per_mm() /
         1000.0F,
-    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
+            .get_usteps_per_mm() /
         1000.0F,
     configs::STALL_THRESHOLD_UM);
 
@@ -138,10 +139,10 @@ static auto pins_for_sensor =
 auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
-extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
-        sensor_hardware.data_ready();
-    }
+extern "C" void HAL_GPIO_EXTI_Callback(uint16_t) {
+    // if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
+    //     sensor_hardware.data_ready() ;
+    // }
 }
 
 // Unfortunately, these numbers need to be literals or defines

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -139,10 +139,10 @@ static auto pins_for_sensor =
 auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
-extern "C" void HAL_GPIO_EXTI_Callback(uint16_t) {
-    // if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
-    //     sensor_hardware.data_ready() ;
-    // }
+extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
+    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
+        sensor_hardware.data_ready() ;
+    }
 }
 
 // Unfortunately, these numbers need to be literals or defines

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -141,7 +141,7 @@ auto sensor_hardware =
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
-        sensor_hardware.data_ready() ;
+        sensor_hardware.data_ready();
     }
 }
 

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -40,7 +40,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .GPIO_handle = GPIOB,
             };
-            tmc2160_conf.registers.chopconf.mres = 0x3;
+            tmc2160_conf.registers.chopconf.mres = 0x4;
             return tmc2160_conf;
         case TMC2160PipetteAxis::right_gear_motor:
             tmc2160_conf.chip_select = {
@@ -48,7 +48,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .GPIO_handle = GPIOC,
             };
-            tmc2160_conf.registers.chopconf.mres = 0x3;
+            tmc2160_conf.registers.chopconf.mres = 0x4;
             return tmc2160_conf;
         case TMC2160PipetteAxis::linear_motor:
         default:

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -40,6 +40,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .GPIO_handle = GPIOB,
             };
+            tmc2160_conf.registers.chopconf.mres = 0x3;
             return tmc2160_conf;
         case TMC2160PipetteAxis::right_gear_motor:
             tmc2160_conf.chip_select = {
@@ -47,6 +48,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .GPIO_handle = GPIOC,
             };
+            tmc2160_conf.registers.chopconf.mres = 0x3;
             return tmc2160_conf;
         case TMC2160PipetteAxis::linear_motor:
         default:

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -75,7 +75,8 @@ static auto linear_stall_check = stall_check::StallCheck(
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
             .get_encoder_pulses_per_mm() /
         1000.0F,
-    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
+            .get_usteps_per_mm() /
         1000.0F,
     configs::STALL_THRESHOLD_UM);
 

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -46,7 +46,8 @@ static auto linear_stall_check = stall_check::StallCheck(
     configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
             .get_encoder_pulses_per_mm() /
         1000.0F,
-    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE).get_steps_per_mm() /
+    configs::linear_motion_sys_config_by_axis(PIPETTE_TYPE)
+            .get_usteps_per_mm() /
         1000.0F,
     configs::STALL_THRESHOLD_UM);
 


### PR DESCRIPTION
## Overview

The steps per mm calculation was slightly off for the tip motors. This is because we have been using two different types of gear ratios -- the gear reduction ratio and the regular gear ratio. The regular gear ratio is `driving gear teeth / driven gear teeth` whereas the reduction ratio is `larger teeth / smaller teeth`.

The current way we do the calculations worked out OK for the gripper motor because the reduction ratio is the inverse of the regular gear ratio (since the larger gear motor is the driven gear). However, logically, it makes a bit more sense to multiple these gear ratios by the leadscrew pitch (which represents mm per rev) because gear trains affect the mm per rev. 

In addition, when we changed the motor drivers for the tip motors to use tmc2160s, we did not change the microstepping to 1/16th. The issue hadn't been found thus far because the tip motors were also executing moves twice so it would appear to be moving mostly to the correct position.