### PR TITLE
refactor(motor-control): rename cap_sensor stop condition to sync_line

### DIFF
--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -213,7 +213,7 @@ enum class MotorPositionFlags {
 enum class MoveStopCondition {
     none = 0x0,
     limit_switch = 0x1,
-    cap_sensor = 0x2,
+    sync_line = 0x2,
     encoder_position = 0x4,
     gripper_force = 0x8,
     stall = 0x10,

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -142,7 +142,7 @@ class BrushedMotorInterruptHandler {
                         AckMessageId::complete_without_condition);
                 }
                 break;
-            case MoveStopCondition::cap_sensor:
+            case MoveStopCondition::sync_line:
                 // TODO write cap sensor move code
                 break;
         }
@@ -249,7 +249,7 @@ class BrushedMotorInterruptHandler {
                 tick = 0;
                 hardware.grip();
                 break;
-            case MoveStopCondition::cap_sensor:
+            case MoveStopCondition::sync_line:
                 // this is an unused move stop condition for the brushed motor
                 // just return with no condition
                 // TODO creat can bus error messages and send that instead
@@ -314,7 +314,7 @@ class BrushedMotorInterruptHandler {
             // the cap sensor move isn't valid here, so make sure if we got that
             // type of message that we just pass through and return the ack
         } else if (buffered_move.stop_condition !=
-                   MoveStopCondition::cap_sensor) {
+                   MoveStopCondition::sync_line) {
             hold_encoder_position = hardware.get_encoder_pulses();
             motor_state =
                 buffered_move.stop_condition == MoveStopCondition::limit_switch

--- a/motor-control/tests/test_sync_handling.cpp
+++ b/motor-control/tests/test_sync_handling.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Move with stop condition == cap sensor") {
                       .acceleration = 0,
                       .group_id = 1,
                       .seq_id = 0,
-                      .stop_condition = MoveStopCondition::cap_sensor};
+                      .stop_condition = MoveStopCondition::sync_line};
 
     GIVEN("the move is in progress") {
         test_objs.queue.try_write_isr(msg10);
@@ -73,7 +73,7 @@ TEST_CASE("Move with stop condition == cap sensor, case 2") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = MoveStopCondition::cap_sensor};
+                     .stop_condition = MoveStopCondition::sync_line};
     GIVEN("the sync line has not been set") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_sync_line(false);


### PR DESCRIPTION
# Overview
Before this, the moves created in the liquid sensing code used `MoveStopCondition.cap_sensor` to check the sync line during motion. Since there's no reason to differentiate between the two sensors for the purpose of the `MoveStopCondition` enum, both sensors will use the same condition, which will now be called `sync_line`.

# Changelog

- changed `MoveStopCondition.cap_sensor` to `MoveStopCondition.sync_line`
- combined `sync_triggered()` and `calibration_stopped()` to make naming a little less redundant
- moved sync line check out of nested `if` to appease the linter