### PR TITLE
refactor(pipettes): rename tip actions to align with their purposes

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -435,7 +435,7 @@ SCENARIO("message serializing works") {
                               .encoder_position_um = 0x05803931,
                               .ack_id = 0x1,
                               .success = 0x1,
-                              .action = can::ids::PipetteTipActionType::pick_up,
+                              .action = can::ids::PipetteTipActionType::clamp,
                               .position_flags = 0x0,
                               .gear_motor_id = can::ids::GearMotorId::left};
         auto arr = std::array<uint8_t, MESSAGE_SIZE + 5>{0, 0, 0, 0, 0, 0, 0, 0,

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -184,8 +184,8 @@ typedef enum {
 
 /** Tip action types. */
 typedef enum {
-    can_pipettetipactiontype_pick_up = 0x0,
-    can_pipettetipactiontype_drop = 0x1,
+    can_pipettetipactiontype_clamp = 0x0,
+    can_pipettetipactiontype_home = 0x1,
 } CANPipetteTipActionType;
 
 /** Tip action types. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -193,8 +193,8 @@ enum class SensorThresholdMode {
 
 /** Tip action types. */
 enum class PipetteTipActionType {
-    pick_up = 0x0,
-    drop = 0x1,
+    clamp = 0x0,
+    home = 0x1,
 };
 
 /** Tip action types. */
@@ -220,3 +220,4 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
+

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -220,4 +220,3 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
-

--- a/pipettes/tests/test_gear_move_status_handling.cpp
+++ b/pipettes/tests/test_gear_move_status_handling.cpp
@@ -38,7 +38,7 @@ SCENARIO("testing gear move status response handling") {
                                      100,
                                      0x1,
                                      AckMessageId::complete_without_condition,
-                                     can::ids::PipetteTipActionType::pick_up,
+                                     can::ids::PipetteTipActionType::clamp,
                                      can::ids::GearMotorId::left};
 
         auto mcc = MockCanClient();


### PR DESCRIPTION
## Overview

I had a slight misunderstanding with how the clamp motors + adapters were supposed to interact with each other. Decided to rename the tip actions to be more in line with the actions that will actually happen on the robot.