### PR TITLE
refactor(head): set dvt gearing

### DIFF
--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -212,7 +212,7 @@ static auto linear_config = lms::LinearMotionSystemConfig<lms::LeadScrewConfig>{
     .steps_per_rev = 200,
     .microstep = 16,
     .encoder_pulses_per_rev = 1024.0,
-    .gear_ratio = 4.0};
+    .gear_ratio = 3.2};
 
 static stall_check::StallCheck stallcheck_right(
     linear_config.get_encoder_pulses_per_mm() / 1000.0F,


### PR DESCRIPTION
On DVT, there are only three gears, and the net reduction ratio is now 3.2 instead of 4.

Closes RET-1315