### PR TITLE
refactor(pipettes): disable the pressure sensor interrupt for the 96 channel

### DIFF
--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -141,7 +141,7 @@ auto sensor_hardware =
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin &&
-        PIPETTE_TYPE == NINETY_SIX_CHANNEL) {
+        PIPETTE_TYPE != NINETY_SIX_CHANNEL) {
         sensor_hardware.data_ready();
     }
 }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -140,7 +140,8 @@ auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin && PIPETTE_TYPE == NINETY_SIX_CHANNEL) {
+    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin &&
+        PIPETTE_TYPE == NINETY_SIX_CHANNEL) {
         sensor_hardware.data_ready();
     }
 }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -140,7 +140,7 @@ auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
+    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin && PIPETTE_TYPE == NINETY_SIX_CHANNEL) {
         sensor_hardware.data_ready();
     }
 }


### PR DESCRIPTION
## Overview

We will not have a fix for the noise on the data ready line of the 96 channel until DVT. To make testing easier, we should just disable this in main until then.