### PR TITLE
refactor: add revision to device info

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -277,7 +277,6 @@
         "pipettes-single-simulator",
         "pipettes-multi-simulator",
         "pipettes-96-simulator",
-        "pipettes-384-simulator",
         "gripper-simulator"
       ]
     },
@@ -296,7 +295,6 @@
         "pipettes-single-simulator",
         "pipettes-multi-simulator",
         "pipettes-96-simulator",
-        "pipettes-384-simulator",
         "gripper-simulator"
       ]
     }

--- a/bootloader/simulator/CMakeLists.txt
+++ b/bootloader/simulator/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(
         ${BOOTLOADER_SIMULATOR_SRC}
         )
 
+add_revision(TARGET bootloader-simulator REVISION a1)
+
 target_compile_options(
         bootloader-simulator
         PRIVATE

--- a/bootloader/tests/CMakeLists.txt
+++ b/bootloader/tests/CMakeLists.txt
@@ -40,6 +40,8 @@ target_compile_options(bootloader
 )
 target_link_libraries(bootloader Catch2::Catch2 bootloader-core)
 
+add_revision(TARGET bootloader REVISION a1)
+
 catch_discover_tests(bootloader)
 add_build_and_test_target(bootloader)
 

--- a/bootloader/tests/CMakeLists.txt
+++ b/bootloader/tests/CMakeLists.txt
@@ -31,12 +31,13 @@ target_compile_options(bootloader
         -Wextra
         -Wno-missing-field-initializers
         -Werror
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy
-        -fno-rtti)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 target_link_libraries(bootloader Catch2::Catch2 bootloader-core)
 
 catch_discover_tests(bootloader)

--- a/bootloader/tests/test_message_handler.cpp
+++ b/bootloader/tests/test_message_handler.cpp
@@ -68,7 +68,7 @@ SCENARIO("device info") {
                         can_messageid_device_info_response);
             }
             THEN("it populates response body") {
-                REQUIRE(response.size == 20);
+                REQUIRE(response.size == 24);
                 REQUIRE(response.data[0] == 0xD3);
                 REQUIRE(response.data[1] == 0x4D);
                 REQUIRE(response.data[2] == 0xB3);
@@ -89,6 +89,10 @@ SCENARIO("device info") {
                 REQUIRE(response.data[17] == 'f');
                 REQUIRE(response.data[18] == '0');
                 REQUIRE(response.data[19] == 0);
+                REQUIRE(response.data[20] == 'a');
+                REQUIRE(response.data[21] == '1');
+                REQUIRE(response.data[22] == 0);
+                REQUIRE(response.data[23] == 0);
             }
         }
     }

--- a/can/tests/CMakeLists.txt
+++ b/can/tests/CMakeLists.txt
@@ -28,13 +28,14 @@ target_compile_options(can
         -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy
-        -fno-rtti)
-target_link_libraries(can can-core Catch2::Catch2)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
+
 
 catch_discover_tests(can)
 add_build_and_test_target(can)

--- a/can/tests/CMakeLists.txt
+++ b/can/tests/CMakeLists.txt
@@ -36,6 +36,9 @@ target_compile_options(can
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
 
+add_revision(TARGET can REVISION a1)
+
+target_link_libraries(can PUBLIC can-core version-lib Catch2::Catch2)
 
 catch_discover_tests(can)
 add_build_and_test_target(can)

--- a/common/cmake/RevisionHandling.cmake
+++ b/common/cmake/RevisionHandling.cmake
@@ -221,17 +221,9 @@ foreach(_REVISION_MIXEDCASE IN LISTS _fer_REVISIONS)
   endif()
 
   if (NOT _fer_NO_SET_REVISION_DEFINES)
-    string(SUBSTRING ${REVISION} 0 1 PRIMARY_REVISION)
-    string(SUBSTRING ${REVISION} 1 1 SECONDARY_REVISION)
-    target_compile_definitions(${REVISION_TARGET} PUBLIC
-      PCBA_REVISION=${REVISION}
-      PCBA_PRIMARY_REVISION=${REVISION_PRIMARY}
-      PCBA_SECONDARY_REVISION=${REVISION_SECONDARY})
-    configure_file(
-      ${CMAKE_SOURCE_DIR}/common/core/revision.c.in
-      ${CMAKE_BINARY_DIR}/common/core/revision-${REVISION_TARGET}.c)
-    target_sources(${REVISION_TARGET} PRIVATE
-      ${CMAKE_BINARY_DIR}/common/core/revision-${REVISION_TARGET}.c)
+    add_revision(TARGET ${REVISION_TARGET} REVISION ${REVISION})
+    set(PRIMARY_REVISION ${_add_revision_PRIMARY_REVISION})
+    set(SECONDARY_REVISION ${_add_revision_SECONDARY_REVISION})
     message(VERBOSE "Added revision defines primary ${PRIMARY_REVISION} secondary ${SECONDARY_REVISION}")
   else()
     message(VERBOSE "Not adding revision defines (inhibited by NO_SET_REVISION_DEFINES)")

--- a/common/core/CMakeLists.txt
+++ b/common/core/CMakeLists.txt
@@ -44,3 +44,24 @@ target_compile_options(common-core
 )
 
 add_coverage(common-core)
+
+function(add_revision)
+  set(_ar_options)
+  set(_ar_onevalue TARGET REVISION)
+  set(_ar_multivalue)
+  cmake_parse_arguments(_ar "${_ar_options}" "${_ar_onevalue}" "${_ar_multivalue}" ${ARGN})
+  message(STATUS "add_revision has target ${_ar_TARGET} and revision ${_ar_REVISION}")
+  string(SUBSTRING ${_ar_REVISION} 0 1 PRIMARY_REVISION)
+  string(SUBSTRING ${_ar_REVISION} 1 1 SECONDARY_REVISION)
+
+  configure_file(${CMAKE_SOURCE_DIR}/common/core/revision.c.in ${CMAKE_CURRENT_BINARY_DIR}/revision.c)
+
+  target_sources(${_ar_TARGET} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/revision.c)
+
+  target_compile_definitions(${_ar_TARGET} PUBLIC
+      PCBA_REVISION=${_ar_REVISION}
+      PCBA_PRIMARY_REVISION=${PRIMARY_REVISION}
+      PCBA_SECONDARY_REVISION=${SECONDARY_REVISION})
+  set(_add_revision_PRIMARY_REVISION ${PRIMARY_REVISION} PARENT_SCOPE)
+  set(_add_revision_SECONDARY_REVISION ${SECONDARY_REVISION} PARENT_SCOPE)
+endfunction()

--- a/common/simulation/CMakeLists.txt
+++ b/common/simulation/CMakeLists.txt
@@ -24,13 +24,13 @@ target_include_directories(common-simulation PUBLIC
 target_compile_options(common-simulation
         PRIVATE
         -Wall
+        -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Werror
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy
-        -fno-rtti
-        )
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)

--- a/common/tests/CMakeLists.txt
+++ b/common/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ include(CTest)
 include(Catch)
 include(AddBuildAndTestTarget)
 
+
+
 add_executable(
         common
         test_main.cpp
@@ -13,6 +15,8 @@ add_executable(
         test_tool_detection.cpp
         test_voltage_conversion.cpp
 )
+
+add_revision(TARGET common REVISION "a1")
 
 target_include_directories(common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 set_target_properties(common
@@ -26,12 +30,13 @@ target_compile_options(common
   -Werror
   -Wextra
   -Wno-missing-field-initializers
-  -Weffc++
-  -Wreorder
-  -Wsign-promo
-  -Wextra-semi
-  -Wctor-dtor-privacy
-  -fno-rtti)
+  $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+  $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 target_link_libraries(common Catch2::Catch2 common-core)
 
 catch_discover_tests(common)

--- a/eeprom/tests/CMakeLists.txt
+++ b/eeprom/tests/CMakeLists.txt
@@ -36,6 +36,8 @@ target_compile_options(eeprom
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
 
+add_revision(TARGET eeprom REVISION a1)
+
 target_link_libraries(eeprom PUBLIC Catch2::Catch2 common-core)
 target_i2c_simlib(eeprom)
 

--- a/eeprom/tests/CMakeLists.txt
+++ b/eeprom/tests/CMakeLists.txt
@@ -28,11 +28,13 @@ target_compile_options(eeprom
         -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 
 target_link_libraries(eeprom PUBLIC Catch2::Catch2 common-core)
 target_i2c_simlib(eeprom)

--- a/gantry/core/can_task.cpp
+++ b/gantry/core/can_task.cpp
@@ -36,9 +36,13 @@ static auto can_motion_handler =
 /** Handler of system messages. */
 static auto system_message_handler =
     can::message_handlers::system::SystemMessageHandler{
-        queue_client, version_get()->version, version_get()->flags,
+        queue_client,
+        version_get()->version,
+        version_get()->flags,
         std::span(std::cbegin(version_get()->sha),
-                  std::cend(version_get()->sha))};
+                  std::cend(version_get()->sha)),
+        revision_get()->primary,
+        revision_get()->secondary};
 static auto system_dispatch_target =
     can_task::SystemDispatchTarget{system_message_handler};
 

--- a/gantry/simulator/CMakeLists.txt
+++ b/gantry/simulator/CMakeLists.txt
@@ -38,6 +38,7 @@ foreach(AXIS IN LISTS AXES)
           gantry-${AXIS}-simulator
           ${GANTRY_SIMULATOR_SRC}
   )
+  add_revision(TARGET gantry-${AXIS}-simulator REVISION a1)
 
   if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
       target_compile_definitions(gantry-${AXIS}-simulator PUBLIC USE_SOCKETCAN)

--- a/gantry/tests/CMakeLists.txt
+++ b/gantry/tests/CMakeLists.txt
@@ -23,12 +23,13 @@ target_compile_options(gantry
         -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy
-        -fno-rtti)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 target_link_libraries(gantry Catch2::Catch2)
 
 catch_discover_tests(gantry)

--- a/gantry/tests/CMakeLists.txt
+++ b/gantry/tests/CMakeLists.txt
@@ -32,6 +32,8 @@ target_compile_options(gantry
 )
 target_link_libraries(gantry Catch2::Catch2)
 
+add_revision(TARGET gantry REVISION a1)
+
 catch_discover_tests(gantry)
 add_build_and_test_target(gantry)
 

--- a/gripper/core/can_tasks.cpp
+++ b/gripper/core/can_tasks.cpp
@@ -32,9 +32,13 @@ static auto sensor_handler = sensors::handlers::SensorHandler{main_queues};
 /** Handler of system messages. */
 static auto system_message_handler =
     can::message_handlers::system::SystemMessageHandler{
-        main_queues, version_get()->version, version_get()->flags,
+        main_queues,
+        version_get()->version,
+        version_get()->flags,
         std::span(std::cbegin(version_get()->sha),
-                  std::cend(version_get()->sha))};
+                  std::cend(version_get()->sha)),
+        revision_get()->primary,
+        revision_get()->secondary};
 static auto system_dispatch_target =
     can_task::SystemDispatchTarget{system_message_handler};
 

--- a/gripper/simulator/CMakeLists.txt
+++ b/gripper/simulator/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(
         ${GRIPPER_SIMULATOR_SRC}
 )
 
+add_revision(TARGET gripper-simulator REVISION a1)
+
 
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
     target_compile_definitions(gripper-simulator PUBLIC USE_SOCKETCAN)

--- a/gripper/tests/CMakeLists.txt
+++ b/gripper/tests/CMakeLists.txt
@@ -23,12 +23,13 @@ target_compile_options(gripper
         -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy
-        -fno-rtti)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 target_link_libraries(gripper Catch2::Catch2)
 
 catch_discover_tests(gripper)

--- a/gripper/tests/CMakeLists.txt
+++ b/gripper/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ target_compile_options(gripper
         $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
+add_revision(TARGET gripper REVISION a1)
+
 target_link_libraries(gripper Catch2::Catch2)
 
 catch_discover_tests(gripper)

--- a/head/core/can_task.cpp
+++ b/head/core/can_task.cpp
@@ -77,7 +77,8 @@ static auto system_message_handler =
     can::message_handlers::system::SystemMessageHandler(
         common_queues, version_get()->version, version_get()->flags,
         std::span(std::cbegin(version_get()->sha),
-                  std::cend(version_get()->sha)));
+                  std::cend(version_get()->sha)),
+        revision_get()->primary, revision_get()->secondary);
 static auto system_dispatch_target =
     SystemDispatchTarget{system_message_handler};
 

--- a/head/simulator/CMakeLists.txt
+++ b/head/simulator/CMakeLists.txt
@@ -33,6 +33,8 @@ add_executable(
         ${HEAD-CORE-SRC}
 )
 
+add_revision(TARGET head-simulator REVISION a1)
+
 if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND DEFINED ENV{USE_SOCKETCAN})
     target_compile_definitions(head-simulator PUBLIC USE_SOCKETCAN)
 endif()

--- a/head/tests/CMakeLists.txt
+++ b/head/tests/CMakeLists.txt
@@ -23,14 +23,14 @@ target_compile_options(head
         PUBLIC
         -Wall
         -Werror
-        -Weffc++
-        -Wextra
         -Wno-missing-field-initializers
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy
-        -fno-rtti)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 
 target_link_libraries(head PUBLIC Catch2::Catch2 common-core)
 

--- a/head/tests/CMakeLists.txt
+++ b/head/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
         test_voltage_conversion.cpp       
 )
 
+add_revision(TARGET head REVISION a1)
 
 target_include_directories(head PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 set_target_properties(head

--- a/i2c/simulation/CMakeLists.txt
+++ b/i2c/simulation/CMakeLists.txt
@@ -11,11 +11,13 @@ target_compile_options(i2c-simlib
         -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 
 target_include_directories(i2c-simlib PUBLIC ${CMAKE_SOURCE_DIR}/include)
 

--- a/i2c/tests/CMakeLists.txt
+++ b/i2c/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_options(i2c
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
 
+add_revision(TARGET i2c REVISION a1)
 
 target_i2c_simlib(i2c)
 target_link_libraries(i2c PUBLIC Catch2::Catch2 common-core)

--- a/i2c/tests/CMakeLists.txt
+++ b/i2c/tests/CMakeLists.txt
@@ -25,13 +25,16 @@ target_compile_options(i2c
         PUBLIC
         -Wall
         -Werror
-        -Weffc++
         -Wextra
         -Wno-missing-field-initializers
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
+
 
 target_i2c_simlib(i2c)
 target_link_libraries(i2c PUBLIC Catch2::Catch2 common-core)

--- a/include/can/core/message_handlers/system.hpp
+++ b/include/can/core/message_handlers/system.hpp
@@ -27,8 +27,13 @@ class SystemMessageHandler {
      * @param version The firmware version on this device
      */
     SystemMessageHandler(CanClient &writer, uint32_t version, uint32_t flags,
-                         std::span<const char> version_sha)
-        : writer(writer), response{.version = version, .flags = flags} {
+                         std::span<const char> version_sha,
+                         char primary_revision, char secondary_revision)
+        : writer(writer),
+          response{.version = version,
+                   .flags = flags,
+                   .primary_revision = primary_revision,
+                   .secondary_revision = secondary_revision} {
         std::copy_n(version_sha.begin(),
                     std::min(version_sha.size(), response.shortsha.size()),
                     response.shortsha.begin());

--- a/include/common/core/version.h
+++ b/include/common/core/version.h
@@ -38,9 +38,7 @@ struct revision {
     char secondary;
 };
 
-#if defined(PCBA_REVISION)
 const struct revision* revision_get();
-#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -42,6 +42,9 @@ target_compile_options(motor-control
         $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
+
+add_revision(TARGET motor-control REVISION a1)
+
 target_link_libraries(motor-control PUBLIC Catch2::Catch2 motor-utils)
 
 catch_discover_tests(motor-control)

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -33,13 +33,15 @@ target_compile_options(motor-control
         PUBLIC
         -Wall
         -Werror
-        -Weffc++
         -Wextra
         -Wno-missing-field-initializers
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 target_link_libraries(motor-control PUBLIC Catch2::Catch2 motor-utils)
 
 catch_discover_tests(motor-control)

--- a/pipettes/core/can_task_high_throughput.cpp
+++ b/pipettes/core/can_task_high_throughput.cpp
@@ -47,9 +47,13 @@ static auto eeprom_handler = eeprom::message_handler::EEPromHandler{
 
 static auto system_message_handler =
     can::message_handlers::system::SystemMessageHandler{
-        central_queue_client, version_get()->version, version_get()->flags,
+        central_queue_client,
+        version_get()->version,
+        version_get()->flags,
         std::span(std::cbegin(version_get()->sha),
-                  std::cend(version_get()->sha))};
+                  std::cend(version_get()->sha)),
+        revision_get()->primary,
+        revision_get()->secondary};
 
 static auto sensor_handler =
     sensors::handlers::SensorHandler{sensor_queue_client};

--- a/pipettes/core/can_task_low_throughput.cpp
+++ b/pipettes/core/can_task_low_throughput.cpp
@@ -29,9 +29,13 @@ static auto eeprom_handler = eeprom::message_handler::EEPromHandler{
 
 static auto system_message_handler =
     can::message_handlers::system::SystemMessageHandler{
-        central_queue_client, version_get()->version, version_get()->flags,
+        central_queue_client,
+        version_get()->version,
+        version_get()->flags,
         std::span(std::cbegin(version_get()->sha),
-                  std::cend(version_get()->sha))};
+                  std::cend(version_get()->sha)),
+        revision_get()->primary,
+        revision_get()->secondary};
 
 static auto sensor_handler =
     sensors::handlers::SensorHandler{sensor_queue_client};

--- a/pipettes/simulator/CMakeLists.txt
+++ b/pipettes/simulator/CMakeLists.txt
@@ -35,6 +35,7 @@ function(add_simulator_executable TARGET)
             ${CMAKE_CURRENT_SOURCE_DIR}/motor_configurations.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
             )
+    add_revision(TARGET ${TARGET} REVISION b1)
     target_include_directories(${TARGET} PUBLIC ${PIPETTE_SIM_INCLUDE})
     target_i2c_simlib(${TARGET})
 
@@ -77,4 +78,3 @@ endfunction()
 add_simulator_executable(pipettes-single-simulator)
 add_simulator_executable(pipettes-multi-simulator)
 add_simulator_executable(pipettes-96-simulator)
-add_simulator_executable(pipettes-384-simulator)

--- a/pipettes/tests/CMakeLists.txt
+++ b/pipettes/tests/CMakeLists.txt
@@ -31,6 +31,8 @@ target_compile_options(pipettes
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
 
+add_revision(TARGET pipettes REVISION b1)
+
 target_link_libraries(pipettes PUBLIC Catch2::Catch2 common-core motor-utils)
 target_i2c_simlib(pipettes)
 

--- a/pipettes/tests/CMakeLists.txt
+++ b/pipettes/tests/CMakeLists.txt
@@ -23,11 +23,13 @@ target_compile_options(pipettes
         -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 
 target_link_libraries(pipettes PUBLIC Catch2::Catch2 common-core motor-utils)
 target_i2c_simlib(pipettes)

--- a/sensors/tests/CMakeLists.txt
+++ b/sensors/tests/CMakeLists.txt
@@ -25,13 +25,15 @@ target_compile_options(sensors
         PUBLIC
         -Wall
         -Werror
-        -Weffc++
         -Wextra
         -Wno-missing-field-initializers
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 
 target_link_libraries(sensors PUBLIC Catch2::Catch2 common-core motor-utils)
 target_i2c_simlib(sensors)

--- a/spi/simulation/CMakeLists.txt
+++ b/spi/simulation/CMakeLists.txt
@@ -11,11 +11,13 @@ target_compile_options(spi-simlib
         -Werror
         -Wextra
         -Wno-missing-field-initializers
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 
 target_include_directories(spi-simlib PUBLIC ${CMAKE_SOURCE_DIR}/include)
 

--- a/spi/tests/CMakeLists.txt
+++ b/spi/tests/CMakeLists.txt
@@ -23,11 +23,13 @@ target_compile_options(spi
         -Wextra
         -Wno-missing-field-initializers
         -Werror
-        -Weffc++
-        -Wreorder
-        -Wsign-promo
-        -Wextra-semi
-        -Wctor-dtor-privacy)
+        $<$<COMPILE_LANGUAGE:CXX>:-Weffc++>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wreorder>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wsign-promo>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
+        $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
+)
 
 target_spi_simlib(spi)
 target_link_libraries(spi PUBLIC Catch2::Catch2 common-core)

--- a/spi/tests/CMakeLists.txt
+++ b/spi/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set_target_properties(spi
 
 target_compile_options(spi
         PUBLIC
+
         -Wall
         -Wextra
         -Wno-missing-field-initializers
@@ -30,6 +31,8 @@ target_compile_options(spi
         $<$<COMPILE_LANGUAGE:CXX>:-Wctor-dtor-privacy>
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
+
+add_revision(TARGET spi REVISION a1)
 
 target_spi_simlib(spi)
 target_link_libraries(spi PUBLIC Catch2::Catch2 common-core)


### PR DESCRIPTION
The revision of the PCBA that is currently running the firmware is part
of the firmware image. This seems circular, but it is established by the
firmware image that is programmed at the factory when the PCBA is
integrated into its subassembly - at that time, we'll program using an
image that has a bootloader with the appropriate revision compiled in.
From there, we'll only update micros with application firmware for the
revision that matches the bootloader. That means we don't need to store
the firmware revision in the eeprom, and compiling it in is enough.

The revision needs to be communicated from a microcontroller to the host
for this to work. That happens by adding it to the device info
message (with tests) for all the bootloaders and all the application
firmwares (all the ones that currently handle device info, anyway - it's
not implemented yet in rear-panel).

There will still be some bootloaders in the wild that don't and will
never have this change because it's impractical to reflash the boards,
but they are all DVT boards of various varieties and can be defaulted as
such in the python side of the update process.

This is a PR that touched a lot of files because of further CMake concerns; I've 
split it into commits by what the point of the changes were, so that's a good
way to review it.

This PR can be merged in any order relative to https://github.com/Opentrons/opentrons/pull/12111 
because the python side will ignore extra data in CAN messages, but that PR will 
be necessary to test that this PR sends the right data.

## Test plan
- [ ] Run on some boards and check that the revision is sent appropriately

Closes RET-1321
