### PR TITLE
refactor: deliver all firmware revisions to OE

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 2,
+  "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 20,
+    "minor": 21,
     "patch": 0
   },
   "configurePresets": [
@@ -13,21 +13,26 @@
         "PRESET_IN_USE": "1"
       }
     },
-    {
-      "name": "cross",
-      "displayName": "STM32 G4 OT-3 cross-compilation",
-      "description": "Build application firmware for OT-3 systems that use STM32, for flashing onto boards",
+    {"name": "cross-no-directory-reqs",
+      "displayName": "STM32 G4 OT-3 cross-compilation with no directory specifications",
+      "description": "Build application firmware for OT-3 systems that use STM32",
       "generator": "Unix Makefiles",
-      "binaryDir": "${sourceDir}/build-cross",
+      "toolchainFile": "${sourceDir}/cmake/STM32CortexM4GCCCrossToolchain.cmake",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "CMAKE_MODULE_PATH": "${sourceDir}/cmake;${sourceDir}/common/cmake",
         "CMAKE_FIND_APPBUNDLE": "NEVER",
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/STM32CortexM4GCCCrossToolchain.cmake",
-        "ARM_ARCH_TYPE": "cortex-m4",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist"
+        "ARM_ARCH_TYPE": "cortex-m4"
       },
       "inherits": "configuration-ok"
+    },
+    {
+      "name": "cross",
+      "displayName": "STM32 G4 OT-3 cross-compilation",
+      "description": "Build application firmware for OT-3 systems that use STM32, for flashing onto boards",
+      "installDir": "${sourceDir}/dist",
+      "binaryDir": "${sourceDir}/build-cross",
+      "inherits": "cross-no-directory-reqs"
     },
     {
       "name": "cross-pipettes",
@@ -35,13 +40,13 @@
       "description": "Build application firmware for OT-3 systems that use STM32, for flashing onto boards",
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build-cross-pipettes",
+      "installDir": "${sourceDir}/dist",
+      "toolchainFile": "${sourceDir}/cmake/STM32CortexM33GCCCrossToolchain.cmake",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "CMAKE_MODULE_PATH": "${sourceDir}/cmake;${sourceDir}/common/cmake",
         "CMAKE_FIND_APPBUNDLE": "NEVER",
-        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/STM32CortexM33GCCCrossToolchain.cmake",
-        "ARM_ARCH_TYPE": "cortex-m33",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist"
+        "ARM_ARCH_TYPE": "cortex-m33"
       },
       "inherits": "configuration-ok"
     },
@@ -83,7 +88,7 @@
       "name": "all-application-firmware",
       "displayName": "all application hex binaries",
       "description": "Build all the hex binaries that will go on the OT3 filesystem.",
-      "configurePreset": "cross",
+      "configurePreset": "cross-no-directory-reqs",
       "jobs": 4,
       "targets": ["firmware-applications"]
     },


### PR DESCRIPTION
Now that we have the capability to build all the electrical revisions, we need to deliver them to the built system images. This PR does that and a couple other little refactors:

- Alter `subsystem_versions.py` to look for hex files in the `dist/applications` directory that `cmake --install` will populate, which means we don't have to worry about image.hex files getting in there; also dynamically pick up subsystems
- Make some changes to make OE's job a little easier, such as: bump the minimum required version, to bump the preset version, to allow configure presets without binary dirs, to let OE specify a build directory in _OE's_ build directory, and do some other nice little changes

## Testing
- [ ] Look at the outcome of https://github.com/Opentrons/oe-core/pull/53 and make sure that hex files are properly included