### PR TITLE
refactor: build manifest and hook in install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ add_custom_target(update-headers
         COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/bootloader/core/ids.h --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c")
 
 set(_install_cmd "execute_process(\
-        COMMAND ${SHELL_FOR_PYTHON} -c \"python ${CMAKE_SOURCE_DIR}/scripts/subsystem_versions.py\
+        COMMAND ${SHELL_FOR_PYTHON} -c \"python3 ${CMAKE_SOURCE_DIR}/scripts/subsystem_versions.py\
                                                --prefix=${FIRMWARE_DESTINATION_PREFIX}\
                                                --hex-dir=${CMAKE_INSTALL_PREFIX}/applications\
                                                ${CMAKE_INSTALL_PREFIX}/applications/opentrons-firmware.json\"\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,10 +197,28 @@ else ()
             "${OPENTRONS_HARDWARE_PATH}. Update CANbus headers by running cmake --build --preset=<any> --target update-headers")
 endif ()
 
+# this code builds in generating a firmware manifest to running cmake --install. it needs to stay last,
+# or at least later than all the other install commands, because it depends on their presence to find the
+# files to build the manifest for.
+#
+# however, if you run a build and then run cmake --install, you will get a dist/applications that has a
+# manifest and is suited to scp'ing in its entirety to a robot's /usr/lib/firmware/ dir.
 add_custom_target(update-headers
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         VERBATIM
         COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/can/core/ids.hpp --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c++"
         COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/bootloader/core/ids.h --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c")
+
+set(_install_cmd "execute_process(\
+        COMMAND ${SHELL_FOR_PYTHON} -c \"python ${CMAKE_SOURCE_DIR}/scripts/subsystem_versions.py\
+                                               --prefix=${FIRMWARE_DESTINATION_PREFIX}\
+                                               --hex-dir=${CMAKE_INSTALL_PREFIX}/applications\
+                                               ${CMAKE_INSTALL_PREFIX}/applications/opentrons-firmware.json\"\
+        COMMAND_ECHO STDOUT\
+        )")
+message(VERBOSE "built manifest command: ${_install_cmd}")
+install(
+    CODE ${_install_cmd}
+    COMPONENT Applications)
 
 coverage_evaluate()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,8 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "CMAKE_MODULE_PATH": "${sourceDir}/cmake;${sourceDir}/common/cmake",
         "CMAKE_FIND_APPBUNDLE": "NEVER",
-        "ARM_ARCH_TYPE": "cortex-m4"
+        "ARM_ARCH_TYPE": "cortex-m4",
+        "FIRMWARE_DESTINATION_PREFIX": "/usr/lib/firmware/"
       },
       "inherits": "configuration-ok"
     },
@@ -46,7 +47,8 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": true,
         "CMAKE_MODULE_PATH": "${sourceDir}/cmake;${sourceDir}/common/cmake",
         "CMAKE_FIND_APPBUNDLE": "NEVER",
-        "ARM_ARCH_TYPE": "cortex-m33"
+        "ARM_ARCH_TYPE": "cortex-m33",
+        "FIRMWARE_DESTINATION_PREFIX": "/usr/lib/firmware/"
       },
       "inherits": "configuration-ok"
     },

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Application binaries are generated with different names for each revision and ca
 
 This can end up being quite a lot of hex files scattered in various subdirectories, so if you run `cmake --install` cmake will helpfully copy them all to the `dist/` subdirectory for you. You can change where it installs by changing `CMAKE_INSTALL_PREFIX`.
 
+The `--install` command will now helpfully build the manifest required for firmware update. That means that you can do `cmake --build --preset=firmware-g4 --target firmware-applications`, then `cmake --install ./build-cross --component Applications` and then you'll have everything you need in `dist/applications` to do firmware update, so you can do `scp ./dist/applications/* robotip:/usr/lib/firmware/` and get things restarted. This is not currently integrated into cmake because the robot ip is a runtime argument which is hard to get cmake to want to do.
+
 ## Working with CMake
 
 This project uses cmake as a build and configuration system. It uses [cmake presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) to ease remembering commands. It requires at least CMake 3.20 (to support build presets) to run.

--- a/scripts/subsystem_versions.py
+++ b/scripts/subsystem_versions.py
@@ -47,7 +47,7 @@ def main(args):
     files = {k: {} for k in SUBSYSTEMS}
 
     for subsystem, revision, name in find_files(hexdir):
-        files[subsystem][revision] = name
+        files[subsystem][revision] = os.path.join(args.prefix, name)
 
     for subsystem in subsystems:
         if subsystem not in SUBSYSTEMS:
@@ -62,7 +62,9 @@ def main(args):
             "branch": branch,
         }
 
-    json.dump(version_info, args.output)
+
+    manifest = {'manifest_version': 1, 'subsystems': version_info}
+    json.dump(manifest, args.output)
 
     return version_info
 
@@ -84,6 +86,12 @@ if __name__ == "__main__":
         type=argparse.FileType('w'),
         default=sys.stdout,
         help="saves json output to given output path or stdout."
+    )
+    parser.add_argument(
+        '--prefix', '-p',
+        type=str,
+        default='',
+        help='Define a prefix for the hex file paths on the target'
     )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
This builds a manifest.json locally in the script instead of relying on openembedded to do it. It also builds it into cmake --install, so instead of having to run the script separately it will just get run when you run that.

We should merge https://github.com/Opentrons/oe-core/pull/55 before/around when we merge this

- [x] test image upload here: https://ot3-development.builds.opentrons.com/ot3-oe/4175342073/ot3-system.zip with automated fw update with new manifest
