### PR TITLE
feat(rear-panel):  add an enter bootloader message to the rear panel mcu

### DIFF
--- a/include/rear-panel/core/bin_msg_ids.hpp
+++ b/include/rear-panel/core/bin_msg_ids.hpp
@@ -10,6 +10,8 @@ enum class MessageType : uint16_t {
     ACK_FAILED = 0x02,
     DEVICE_INFO_REQ = 0x03,
     DEVICE_INFO_RESP = 0x04,
+    ENTER_BOOTLOADER = 0x05,
+    ENTER_BOOTLOADER_RESPONSE = 0x06,
 };
 
 };  // namespace messages

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -24,16 +24,15 @@ struct Echo : BinaryFormatMessage<MessageType::ECHO> {
     std::array<uint8_t, MAX_MESSAGE_SIZE> data;
 
     template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> Echo {
+    static auto parse(Input body, Limit limit)
+        -> std::variant<std::monostate, Echo> {
         uint16_t type = 0;
         uint16_t len = 0;
         std::array<uint8_t, MAX_MESSAGE_SIZE> data{};
         body = bit_utils::bytes_to_int(body, limit, type);
         body = bit_utils::bytes_to_int(body, limit, len);
         if (body + len > limit) {
-            // we got something wrong from this figure out what we want to
-            // do in this situation
-            len = uint16_t(limit - body);
+            return std::monostate{};
         }
         len = std::min(static_cast<size_t>(len), data.size());
         std::copy_n(body, len, data.begin());
@@ -78,15 +77,14 @@ struct DeviceInfoRequest : BinaryFormatMessage<MessageType::DEVICE_INFO_REQ> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> DeviceInfoRequest {
+    static auto parse(Input body, Limit limit)
+        -> std::variant<std::monostate, DeviceInfoRequest> {
         uint16_t type = 0;
         uint16_t len = 0;
         body = bit_utils::bytes_to_int(body, limit, type);
         body = bit_utils::bytes_to_int(body, limit, len);
         if (len > 0) {
-            // we got something wrong from this figure out what we want to
-            // do in this situation
-            len = 0;
+            return std::monostate{};
         }
         return DeviceInfoRequest{.length = len};
     }
@@ -139,15 +137,13 @@ struct EnterBootlader : BinaryFormatMessage<MessageType::ENTER_BOOTLOADER> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> EnterBootlader {
+    static auto parse(Input body, Limit limit) -> std::variant<std::monostate, EnterBootlader> {
         uint16_t type = 0;
         uint16_t len = 0;
         body = bit_utils::bytes_to_int(body, limit, type);
         body = bit_utils::bytes_to_int(body, limit, len);
         if (len > 0) {
-            // we got something wrong from this figure out what we want to
-            // do in this situation
-            len = 0;
+            return std::monostate{};
         }
         return EnterBootlader{.length = len};
     }

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -137,7 +137,8 @@ struct EnterBootlader : BinaryFormatMessage<MessageType::ENTER_BOOTLOADER> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> std::variant<std::monostate, EnterBootlader> {
+    static auto parse(Input body, Limit limit)
+        -> std::variant<std::monostate, EnterBootlader> {
         uint16_t type = 0;
         uint16_t len = 0;
         body = bit_utils::bytes_to_int(body, limit, type);

--- a/include/rear-panel/core/queues.hpp
+++ b/include/rear-panel/core/queues.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include "common/core/freertos_message_queue.hpp"
+#include "rear-panel/core/messages.hpp"
+
+namespace queue_client {
+
+/**
+ * Access to all the message queues in the system.
+ */
+struct QueueClient {
+    /*
+     //TODO(ryan): CORETASKS compile in and process the other basic tasks
+
+     void send_eeprom_queue(const eeprom::task::TaskMessage& m);
+
+     freertos_message_queue::FreeRTOSMessageQueue<i2c::writer::TaskMessage>*
+         i2c3_queue{nullptr};
+     freertos_message_queue::FreeRTOSMessageQueue<i2c::poller::TaskMessage>*
+         i2c3_poller_queue{nullptr};
+     freertos_message_queue::FreeRTOSMessageQueue<eeprom::task::TaskMessage>*
+         eeprom_queue{nullptr};
+     */
+    void send_system_queue(const rearpanel::messages::SystemTaskMessage& m);
+    freertos_message_queue::FreeRTOSMessageQueue<
+        rearpanel::messages::SystemTaskMessage>* system_queue{nullptr};
+
+    void send_host_comms_queue(
+        const rearpanel::messages::HostCommTaskMessage& m);
+    freertos_message_queue::FreeRTOSMessageQueue<
+        rearpanel::messages::HostCommTaskMessage>* host_comms_queue{nullptr};
+};
+
+/**
+ * Access to the queues singleton
+ * @return
+ */
+[[nodiscard]] auto get_main_queues() -> QueueClient&;
+
+}  // namespace queue_client

--- a/include/rear-panel/core/tasks.hpp
+++ b/include/rear-panel/core/tasks.hpp
@@ -2,7 +2,9 @@
 #include "common/core/freertos_message_queue.hpp"
 #include "common/core/message_queue.hpp"
 #include "rear-panel/core/messages.hpp"
+#include "rear-panel/core/queues.hpp"
 #include "rear-panel/core/tasks/host_comms_task.hpp"
+#include "rear-panel/core/tasks/system_task.hpp"
 
 // TODO(ryan): CORETASKS compile in and process the other basic tasks
 //#include "common/core/freertos_timer.hpp"
@@ -32,28 +34,6 @@ void start_tasks(
 );
 
 /**
- * Access to all the message queues in the system.
- */
-struct QueueClient {
-    /*
-     //TODO(ryan): CORETASKS compile in and process the other basic tasks
-
-     void send_eeprom_queue(const eeprom::task::TaskMessage& m);
-
-     freertos_message_queue::FreeRTOSMessageQueue<i2c::writer::TaskMessage>*
-         i2c3_queue{nullptr};
-     freertos_message_queue::FreeRTOSMessageQueue<i2c::poller::TaskMessage>*
-         i2c3_poller_queue{nullptr};
-     freertos_message_queue::FreeRTOSMessageQueue<eeprom::task::TaskMessage>*
-         eeprom_queue{nullptr};
-     */
-    void send_host_comms_queue(
-        const rearpanel::messages::HostCommTaskMessage& m);
-    freertos_message_queue::FreeRTOSMessageQueue<
-        rearpanel::messages::HostCommTaskMessage>* host_comms_queue{nullptr};
-};
-
-/**
  * Access to all tasks in the system.
  */
 struct AllTask {
@@ -70,6 +50,9 @@ struct AllTask {
     */
     host_comms_task::HostCommTask<freertos_message_queue::FreeRTOSMessageQueue>*
         host_comms_task{nullptr};
+
+    system_task::SystemTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        system_task{nullptr};
 };
 
 /**
@@ -77,11 +60,5 @@ struct AllTask {
  * @return
  */
 [[nodiscard]] auto get_all_tasks() -> AllTask&;
-
-/**
- * Access to the queues singleton
- * @return
- */
-[[nodiscard]] auto get_main_queues() -> QueueClient&;
 
 }  // namespace rear_panel_tasks

--- a/include/rear-panel/core/tasks/host_comms_task.hpp
+++ b/include/rear-panel/core/tasks/host_comms_task.hpp
@@ -181,7 +181,7 @@ class HostCommTask {
 
   private:
     QueueType &queue;
-    HostCommMessageHandler handler;
+    HostCommMessageHandler handler = HostCommMessageHandler{};
 };
 
 /**

--- a/include/rear-panel/core/tasks/host_comms_task.hpp
+++ b/include/rear-panel/core/tasks/host_comms_task.hpp
@@ -11,6 +11,7 @@
 #include "rear-panel/core/double_buffer.hpp"
 #include "rear-panel/core/messages.hpp"
 #include "rear-panel/core/queues.hpp"
+#include "rear-panel/firmware/system_hardware.h"
 
 namespace host_comms_task {
 
@@ -115,7 +116,7 @@ class HostCommMessageHandler {
                        InputIt tx_into, InputLimit tx_limit) -> InputIt {
         auto queue_client = queue_client::get_main_queues();
         queue_client.send_system_queue(msg);
-
+        may_connect_latch = false;
         auto resp = rearpanel::messages::Ack{};
         return visit_message(resp, tx_into, tx_limit);
     }
@@ -125,7 +126,6 @@ class HostCommMessageHandler {
         std::sized_sentinel_for<InputLimit, InputIt>
     auto visit_message(rearpanel::messages::EnterBootloaderResponse &msg,
                        InputIt tx_into, InputLimit tx_limit) -> InputIt {
-        may_connect_latch = !msg.success;
         return msg.serialize(tx_into, tx_limit);
     }
 

--- a/include/rear-panel/core/tasks/host_comms_task.hpp
+++ b/include/rear-panel/core/tasks/host_comms_task.hpp
@@ -17,7 +17,7 @@ namespace host_comms_task {
 
 class HostCommMessageHandler {
   public:
-    explicit HostCommMessageHandler() {}
+    explicit HostCommMessageHandler() = default;
     HostCommMessageHandler(const HostCommMessageHandler &) = delete;
     HostCommMessageHandler(const HostCommMessageHandler &&) = delete;
     auto operator=(const HostCommMessageHandler &)
@@ -45,7 +45,7 @@ class HostCommMessageHandler {
         return std::visit(visit_helper, m);
     }
 
-    auto may_connect() -> bool { return may_connect_latch; }
+    [[nodiscard]] auto may_connect() const -> bool { return may_connect_latch; }
 
   private:
     template <typename InputIt, typename InputLimit>
@@ -142,7 +142,7 @@ class HostCommTask {
   public:
     using Messages = rearpanel::messages::HostCommTaskMessage;
     using QueueType = QueueImpl<rearpanel::messages::HostCommTaskMessage>;
-    HostCommTask(QueueType &queue) : queue{queue}, handler{} {}
+    HostCommTask(QueueType &queue) : queue{queue} {}
     HostCommTask(const HostCommTask &c) = delete;
     HostCommTask(const HostCommTask &&c) = delete;
     auto operator=(const HostCommTask &c) = delete;

--- a/include/rear-panel/core/tasks/host_comms_task.hpp
+++ b/include/rear-panel/core/tasks/host_comms_task.hpp
@@ -10,14 +10,13 @@
 #include "rear-panel/core/binary_parse.hpp"
 #include "rear-panel/core/double_buffer.hpp"
 #include "rear-panel/core/messages.hpp"
+#include "rear-panel/core/queues.hpp"
 
 namespace host_comms_task {
 
-template <class ResponseQueue>
 class HostCommMessageHandler {
   public:
-    explicit HostCommMessageHandler(ResponseQueue &resp_queue)
-        : resp_queue{resp_queue} {}
+    explicit HostCommMessageHandler() {}
     HostCommMessageHandler(const HostCommMessageHandler &) = delete;
     HostCommMessageHandler(const HostCommMessageHandler &&) = delete;
     auto operator=(const HostCommMessageHandler &)
@@ -44,6 +43,8 @@ class HostCommMessageHandler {
         // return (aka how much data they wrote, if any) to the caller.
         return std::visit(visit_helper, m);
     }
+
+    auto may_connect() -> bool { return may_connect_latch; }
 
   private:
     template <typename InputIt, typename InputLimit>
@@ -105,7 +106,30 @@ class HostCommMessageHandler {
                        InputLimit tx_limit) -> InputIt {
         return msg.serialize(tx_into, tx_limit);
     }
-    ResponseQueue &resp_queue;
+
+    // Shutdown the hardware and enter the bootloader the ack_failed
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(rearpanel::messages::EnterBootlader &msg,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto queue_client = queue_client::get_main_queues();
+        queue_client.send_system_queue(msg);
+
+        auto resp = rearpanel::messages::Ack{};
+        return visit_message(resp, tx_into, tx_limit);
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(rearpanel::messages::EnterBootloaderResponse &msg,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        may_connect_latch = !msg.success;
+        return msg.serialize(tx_into, tx_limit);
+    }
+
+    bool may_connect_latch = true;
 };
 
 /**
@@ -118,7 +142,7 @@ class HostCommTask {
   public:
     using Messages = rearpanel::messages::HostCommTaskMessage;
     using QueueType = QueueImpl<rearpanel::messages::HostCommTaskMessage>;
-    HostCommTask(QueueType &queue) : queue{queue} {}
+    HostCommTask(QueueType &queue) : queue{queue}, handler{} {}
     HostCommTask(const HostCommTask &c) = delete;
     HostCommTask(const HostCommTask &&c) = delete;
     auto operator=(const HostCommTask &c) = delete;
@@ -145,7 +169,6 @@ class HostCommTask {
     requires std::forward_iterator<InputIt> &&
         std::sized_sentinel_for<InputLimit, InputIt>
     auto run_once(InputIt tx_into, InputLimit tx_limit) -> InputLimit {
-        auto handler = HostCommMessageHandler{get_queue()};
         rearpanel::messages::HostCommTaskMessage message{};
         queue.try_read(&message);
         // We should now be guaranteed to have a message, and can visit it to do
@@ -154,9 +177,11 @@ class HostCommTask {
     }
 
     [[nodiscard]] auto get_queue() const -> QueueType & { return queue; }
+    [[nodiscard]] auto may_connect() -> bool { return handler.may_connect(); }
 
   private:
     QueueType &queue;
+    HostCommMessageHandler handler;
 };
 
 /**

--- a/include/rear-panel/core/tasks/system_task.hpp
+++ b/include/rear-panel/core/tasks/system_task.hpp
@@ -1,0 +1,87 @@
+/*
+ * Interface for the firmware-specific system tasks
+ */
+#pragma once
+#include <tuple>
+
+#include "FreeRTOS.h"
+#include "common/core/message_queue.hpp"
+#include "common/core/version.h"
+#include "rear-panel/core/binary_parse.hpp"
+#include "rear-panel/core/double_buffer.hpp"
+#include "rear-panel/core/messages.hpp"
+#include "rear-panel/core/tasks.hpp"
+
+namespace system_task {
+
+using TaskMessage = rearpanel::messages::SystemTaskMessage;
+using ResponseMessage = rearpanel::messages::HostCommTaskMessage;
+
+template <class ResponseQueue>
+class SystemMessageHandler {
+  public:
+    explicit SystemMessageHandler(ResponseQueue* resp_queue)
+        : resp_queue{*resp_queue} {}
+    SystemMessageHandler(const SystemMessageHandler&) = delete;
+    SystemMessageHandler(const SystemMessageHandler&&) = delete;
+    auto operator=(const SystemMessageHandler&)
+        -> SystemMessageHandler& = delete;
+    auto operator=(const SystemMessageHandler&&)
+        -> SystemMessageHandler&& = delete;
+    ~SystemMessageHandler() = default;
+
+    void handle_message(const TaskMessage& message) {
+        std::visit([this](auto m) { this->handle(m); }, message);
+    }
+
+  private:
+    void handle(std::monostate m) { static_cast<void>(m); }
+
+    void handle(rearpanel::messages::EnterBootlader& m) {
+        std::ignore = m;
+        auto resp =
+            rearpanel::messages::EnterBootloaderResponse{.success = true};
+        resp_queue.try_write(resp);
+    }
+
+    ResponseQueue& resp_queue;
+};
+
+/**
+ * The task entry point.
+ */
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
+class SystemTask {
+  public:
+    using Messages = TaskMessage;
+    using QueueType = QueueImpl<TaskMessage>;
+    SystemTask(QueueType& queue) : queue{queue} {}
+    SystemTask(const SystemTask& c) = delete;
+    SystemTask(const SystemTask&& c) = delete;
+    auto operator=(const SystemTask& c) = delete;
+    auto operator=(const SystemTask&& c) = delete;
+    ~SystemTask() = default;
+
+    /**
+     * Task entry point.
+     */
+    template <template <class> class ReplyQueueImpl>
+    requires MessageQueue<ReplyQueueImpl<ResponseMessage>, ResponseMessage>
+    [[noreturn]] void operator()(ReplyQueueImpl<ResponseMessage>* resp_queue) {
+        auto handler = SystemMessageHandler{resp_queue};
+        TaskMessage message{};
+        for (;;) {
+            if (queue.try_read(&message, queue.max_delay)) {
+                handler.handle_message(message);
+            }
+        }
+    }
+
+    [[nodiscard]] auto get_queue() const -> QueueType& { return queue; }
+
+  private:
+    QueueType& queue;
+};
+
+}  // namespace system_task

--- a/include/rear-panel/core/tasks/system_task.hpp
+++ b/include/rear-panel/core/tasks/system_task.hpp
@@ -11,6 +11,7 @@
 #include "rear-panel/core/double_buffer.hpp"
 #include "rear-panel/core/messages.hpp"
 #include "rear-panel/core/tasks.hpp"
+#include "rear-panel/firmware/system_hardware.h"
 
 namespace system_task {
 
@@ -39,9 +40,8 @@ class SystemMessageHandler {
 
     void handle(rearpanel::messages::EnterBootlader& m) {
         std::ignore = m;
-        auto resp =
-            rearpanel::messages::EnterBootloaderResponse{.success = true};
-        resp_queue.try_write(resp);
+        system_hardware_enter_bootloader();
+        // above function does not return
     }
 
     ResponseQueue& resp_queue;

--- a/include/rear-panel/firmware/system_hardware.h
+++ b/include/rear-panel/firmware/system_hardware.h
@@ -1,0 +1,17 @@
+#ifndef SYSTEM_HARDWARE_H__
+#define SYSTEM_HARDWARE_H__
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#include <stdbool.h>
+
+/**
+ * @brief Enter the bootloader. This function never returns.
+ */
+void system_hardware_enter_bootloader(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // _SYSTEM_HARDWARE_H__

--- a/rear-panel/core/CMakeLists.txt
+++ b/rear-panel/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 function(target_rear_panel_core_rev1 TARGET)
     target_sources(${TARGET} PUBLIC
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tasks.cpp
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/queues.cpp
         )
     target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_FUNCTION_LIST_DIR})
     target_link_libraries(${TARGET} PUBLIC common-core)

--- a/rear-panel/core/queues.cpp
+++ b/rear-panel/core/queues.cpp
@@ -1,0 +1,27 @@
+#include "rear-panel/core/queues.hpp"
+
+static auto queues = queue_client::QueueClient{};
+
+// TODO(ryan): CORETASKS compile in and process the other basic tasks
+/*
+void queue_client::QueueClient::send_eeprom_queue(
+    const eeprom::task::TaskMessage& m) {
+    eeprom_queue->try_write(m);
+}
+*/
+
+void queue_client::QueueClient::send_host_comms_queue(
+    const rearpanel::messages::HostCommTaskMessage& m) {
+    host_comms_queue->try_write(m);
+}
+
+void queue_client::QueueClient::send_system_queue(
+    const rearpanel::messages::SystemTaskMessage& m) {
+    system_queue->try_write(m);
+}
+
+/**
+ * Access to the queues singleton
+ * @return
+ */
+auto queue_client::get_main_queues() -> QueueClient& { return queues; }

--- a/rear-panel/core/tasks.cpp
+++ b/rear-panel/core/tasks.cpp
@@ -35,7 +35,7 @@ void rear_panel_tasks::start_tasks(
     // i2c::hardware::I2CBase& i2c3,
     // eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface,
 ) {
-    auto queues = queue_client::get_main_queues();
+    auto& queues = queue_client::get_main_queues();
     // TODO(ryan): CORETASKS compile in and process the other basic tasks
     /*
     auto& i2c3_task = i2c3_task_builder.start(5, "i2c3", i2c3);
@@ -59,8 +59,7 @@ void rear_panel_tasks::start_tasks(
     // queues.i2c3_queue = &i2c3_task.get_queue();
     // queues.i2c3_poller_queue = &i2c3_poller_task.get_queue();
     // queues.eeprom_queue = &eeprom_task.get_queue();
-    auto& systemctl_task =
-        system_task_builder.start(5, "system", *queues.host_comms_queue);
+    auto& systemctl_task = system_task_builder.start(5, "system");
     tasks.system_task = &systemctl_task;
     queues.system_queue = &systemctl_task.get_queue();
 }

--- a/rear-panel/core/tasks.cpp
+++ b/rear-panel/core/tasks.cpp
@@ -6,8 +6,6 @@
 
 static auto tasks = rear_panel_tasks::AllTask{};
 
-static auto queues = rear_panel_tasks::QueueClient{};
-
 // TODO(ryan): CORETASKS compile in and process the other basic tasks
 /*
 static auto eeprom_task_builder =
@@ -28,6 +26,8 @@ static auto i2c3_poll_client =
     i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>{};
 */
 
+static auto system_task_builder =
+    freertos_task::TaskStarter<512, system_task::SystemTask>{};
 /**
  * Start rear tasks.
  */
@@ -35,6 +35,7 @@ void rear_panel_tasks::start_tasks(
     // i2c::hardware::I2CBase& i2c3,
     // eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface,
 ) {
+    auto queues = queue_client::get_main_queues();
     // TODO(ryan): CORETASKS compile in and process the other basic tasks
     /*
     auto& i2c3_task = i2c3_task_builder.start(5, "i2c3", i2c3);
@@ -48,28 +49,20 @@ void rear_panel_tasks::start_tasks(
                                                   eeprom_hw_iface);
     */
     auto comms = host_comms_control_task::start();
+    queues.host_comms_queue = &comms.task->get_queue();
+    tasks.host_comms_task = comms.task;
+
     // tasks.i2c3_task = &i2c3_task;
     // tasks.i2c3_poller_task = &i2c3_poller_task;
     // tasks.eeprom_task = &eeprom_task;
-    tasks.host_comms_task = comms.task;
 
     // queues.i2c3_queue = &i2c3_task.get_queue();
     // queues.i2c3_poller_queue = &i2c3_poller_task.get_queue();
     // queues.eeprom_queue = &eeprom_task.get_queue();
-    queues.host_comms_queue = &comms.task->get_queue();
-}
-
-// TODO(ryan): CORETASKS compile in and process the other basic tasks
-/*
-void rear_tasks::QueueClient::send_eeprom_queue(
-    const eeprom::task::TaskMessage& m) {
-    eeprom_queue->try_write(m);
-}
-*/
-
-void rear_panel_tasks::QueueClient::send_host_comms_queue(
-    const rearpanel::messages::HostCommTaskMessage& m) {
-    host_comms_queue->try_write(m);
+    auto& systemctl_task =
+        system_task_builder.start(5, "system", *queues.host_comms_queue);
+    tasks.system_task = &systemctl_task;
+    queues.system_queue = &systemctl_task.get_queue();
 }
 
 /**
@@ -77,9 +70,3 @@ void rear_panel_tasks::QueueClient::send_host_comms_queue(
  * @return
  */
 auto rear_panel_tasks::get_all_tasks() -> AllTask& { return tasks; }
-
-/**
- * Access to the queues singleton
- * @return
- */
-auto rear_panel_tasks::get_main_queues() -> QueueClient& { return queues; }

--- a/rear-panel/firmware/CMakeLists.txt
+++ b/rear-panel/firmware/CMakeLists.txt
@@ -40,6 +40,7 @@ set(REAR_PANEL_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
         ${CMAKE_CURRENT_SOURCE_DIR}/i2c_setup.c
         ${CMAKE_CURRENT_SOURCE_DIR}/led_hardware.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/system_hardware.c
         ${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task/usbd_conf.c
         ${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task/usb_hardware.c
         ${CMAKE_CURRENT_SOURCE_DIR}/host_comms_task/usbd_desc.c

--- a/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
@@ -69,13 +69,13 @@ void run(void *param) {  // NOLINT(misc-unused-parameters)
         auto *tx_end =
             top_task->run_once(local_task->tx_buf.accessible()->begin(),
                                local_task->tx_buf.accessible()->end());
-        // if (!top_task->may_connect()) {
-        //    usb_hw_stop();
-        //} else
         if (tx_end != local_task->tx_buf.accessible()->data()) {
             local_task->tx_buf.swap();
             usb_hw_send(local_task->tx_buf.committed()->data(),
                         tx_end - local_task->tx_buf.committed()->data());
+        }
+        if (!top_task->may_connect()) {
+            usb_hw_stop();
         }
     }
 }
@@ -85,7 +85,7 @@ auto start() -> rear_panel_tasks::Task<
     TaskHandle_t, host_comms_task::HostCommTask<
                       freertos_message_queue::FreeRTOSMessageQueue>> {
     auto *handle = xTaskCreateStatic(run, "HostCommsControl", stack.size(),
-                                     &_tasks, 1, stack.data(), &data);
+                                     &_tasks, 5, stack.data(), &data);
     return rear_panel_tasks::Task<TaskHandle_t, decltype(_top_task)>{
         .handle = handle, .task = &_top_task};
 }

--- a/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
@@ -162,7 +162,7 @@ static auto cdc_rx_handler(uint8_t *Buf, uint32_t *Len) -> uint8_t * {
         Buf + *Len);
     // if parse didn't return anything it means it was malformed so send an
     // ack_failed
-    if (message.index() == 0) {
+    if (std::get_if<std::monostate>(&message) != nullptr) {
         static_cast<void>(_top_task.get_queue().try_write_isr(
             rearpanel::messages::AckFailed{.length = 0}));
     } else {

--- a/rear-panel/firmware/system_hardware.c
+++ b/rear-panel/firmware/system_hardware.c
@@ -1,0 +1,61 @@
+#include "rear-panel/firmware/system_hardware.h"
+#include "rear-panel/firmware/usb_hardware.h"
+#include "stm32g4xx_hal.h"
+#include "stm32g4xx_hal_rcc.h"
+#include "stm32g4xx_hal_cortex.h"
+#include "stm32g4xx_hal_tim.h"
+
+/** Local defines */
+// This is the start of the sys memory region for the STM32G491 
+// from the reference manual and STM application note AN2606
+#define SYSMEM_START 0x1fff0000
+#define SYSMEM_BOOT (SYSMEM_START + 4)
+
+// address 4 in the bootable region is the address of the first instruction that
+// should run, aka the data that should be loaded into $pc.
+const uint32_t *const sysmem_boot_loc = (uint32_t*)SYSMEM_BOOT;
+
+/** PUBLIC FUNCTION IMPLEMENTATION */
+
+void system_hardware_enter_bootloader(void) {
+
+    // We have to uninitialize as many of the peripherals as possible, because the bootloader
+    // expects to start as the system comes up
+
+    // The HAL has ways to turn off all the core clocking and the clock security system
+    HAL_RCC_DisableLSECSS();
+    HAL_RCC_DeInit();
+
+    // systick should be off at boot
+    SysTick->CTRL = 0;
+    SysTick->LOAD = 0;
+    SysTick->VAL = 0;
+
+    /* Clear Interrupt Enable Register & Interrupt Pending Register */
+    for (int i=0;i<8;i++)
+    {
+        NVIC->ICER[i]=0xFFFFFFFF;
+        NVIC->ICPR[i]=0xFFFFFFFF;
+    }
+
+    // We have to make sure that the processor is mapping the system memory region to address 0,
+    // which the bootloader expects
+    __HAL_SYSCFG_REMAPMEMORY_SYSTEMFLASH();
+    // and now we're ready to set the system up to start executing system flash.
+    // arm cortex initialization means that
+    // address 0 in the bootable region is the address where the processor should start its stack
+    // which we have to do as late as possible because as soon as we do this the c and c++ runtime
+    // environment is no longer valid
+    __set_MSP(*((uint32_t*)SYSMEM_START));
+
+    // finally, jump to the bootloader. we do this in inline asm because we need
+    // this to be a naked call (no caller-side prep like stacking return addresses)
+    // and to have a naked function you need to define it as a function, not a
+    // function pointer, and we don't statically know the address here since it is
+    // whatever's contained in that second word of the bsystem memory region.
+    asm volatile (
+        "bx %0"
+        : // no outputs
+        : "r" (*sysmem_boot_loc)
+        : "memory"  );
+}

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -13,14 +13,18 @@ SCENARIO("message deserializing works") {
         auto arr = std::array<uint8_t, 4>{0x00, 0x03, 0x00, 0x00};
         WHEN("constructed") {
             auto r = DeviceInfoRequest::parse(arr.begin(), arr.end());
+            REQUIRE(r.index() != 0);
+            auto msg_ptr = std::get_if<DeviceInfoRequest>(&r);
+            REQUIRE(msg_ptr != 0);
+            auto msg = *msg_ptr;
             THEN("it is converted to a the correct structure") {
-                REQUIRE(r.length == 0x0000);
+                REQUIRE(msg.length == 0x0000);
             }
             THEN("it can be compared for equality") {
-                auto other = r;
-                REQUIRE(other == r);
+                auto other = msg;
+                REQUIRE(other == msg);
                 other.length = 10;
-                REQUIRE(other != r);
+                REQUIRE(other != msg);
             }
         }
     }
@@ -99,6 +103,51 @@ SCENARIO("message serializing works") {
             }
             THEN("size must be returned") {
                 REQUIRE(next_free == arr.begin() + 24);
+            }
+        }
+    }
+}
+
+SCENARIO("message parsing") {
+    GIVEN("a valid message id body") {
+        auto arr = std::array<uint8_t, 4>{0x00, 0x03, 0x00, 0x00};
+        WHEN("constructed") {
+            auto message = rearpanel::messages::rear_panel_parser.parse(
+                rearpanel::messages::MessageType(0x0003), arr.begin(),
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                arr.end());
+            THEN("monostate is not returned") { REQUIRE(message.index() != 0); }
+            THEN("DeviceInfoRequest is returned") {
+                auto typed = std::get_if<rearpanel::messages::DeviceInfoRequest>(&message);
+                REQUIRE(typed != 0);
+            }
+        }
+    }
+    GIVEN("a invalid message length") {
+        auto arr = std::array<uint8_t, 4>{0x00, 0x03, 0x00, 0x0A};
+        WHEN("constructed") {
+            auto message = rearpanel::messages::rear_panel_parser.parse(
+                rearpanel::messages::MessageType(0x0003), arr.begin(),
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                arr.end());
+            THEN("monostate is returned") { 
+                REQUIRE(message.index() == 0);
+                auto typed = std::get_if<std::monostate>(&message);
+                REQUIRE(typed != 0);
+            }
+        }
+    }
+    GIVEN("a invalid message id body") {
+        auto arr = std::array<uint8_t, 4>{0xAB, 0xCD, 0x00, 0x00};
+        WHEN("constructed") {
+            auto message = rearpanel::messages::rear_panel_parser.parse(
+                rearpanel::messages::MessageType(0xABCD), arr.begin(),
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                arr.end());
+            THEN("monostate is returned") { 
+                REQUIRE(message.index() == 0);
+                auto typed = std::get_if<std::monostate>(&message);
+                REQUIRE(typed != 0);
             }
         }
     }

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -118,7 +118,9 @@ SCENARIO("message parsing") {
                 arr.end());
             THEN("monostate is not returned") { REQUIRE(message.index() != 0); }
             THEN("DeviceInfoRequest is returned") {
-                auto typed = std::get_if<rearpanel::messages::DeviceInfoRequest>(&message);
+                auto typed =
+                    std::get_if<rearpanel::messages::DeviceInfoRequest>(
+                        &message);
                 REQUIRE(typed != 0);
             }
         }
@@ -130,7 +132,7 @@ SCENARIO("message parsing") {
                 rearpanel::messages::MessageType(0x0003), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
-            THEN("monostate is returned") { 
+            THEN("monostate is returned") {
                 REQUIRE(message.index() == 0);
                 auto typed = std::get_if<std::monostate>(&message);
                 REQUIRE(typed != 0);
@@ -144,7 +146,7 @@ SCENARIO("message parsing") {
                 rearpanel::messages::MessageType(0xABCD), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
-            THEN("monostate is returned") { 
+            THEN("monostate is returned") {
                 REQUIRE(message.index() == 0);
                 auto typed = std::get_if<std::monostate>(&message);
                 REQUIRE(typed != 0);


### PR DESCRIPTION
create a freertos task to handle system tasks and add a c file that disables peripherals and jumps to the bootloader

`
>>> import subprocess
>>> import time
>>> try:
...     ser = serial.Serial("/dev/ttyACM0",115200)
...     ser.write(bytes.fromhex("00050000"))
...     data = ser.read(size=5)
...     print(data)
...     ser.close() 
... except Exception as e:
...     print(e)
... 
4
[58096.797118] usb 1-1.1: USB disconnect, device number 22
read failed: device reports readiness to read but returned no data (device disconnected or multiple access on port?)
>>> time.sleep(0.5)
[58097.047217] usb 1-1.1: new full-speed USB device number 23 using ci_hdrc
>>> 
>>> output = subprocess.run(["lsusb"], capture_output=True)
>>> success =(output.stdout.find(b"DFU")) > 0 
>>> print("Device in dfu mode {success}".format(success=success))
Device in dfu mode True
>>> 
`