### PR TITLE
fix(motor-control): clear move group after stall

### DIFF
--- a/motor-control/tests/test_motor_interrupt_queue.cpp
+++ b/motor-control/tests/test_motor_interrupt_queue.cpp
@@ -35,15 +35,15 @@ TEST_CASE("motor interrupt handler queue functionality") {
                 queue.try_write(msg4);
                 REQUIRE(queue.get_size() == 4);
                 REQUIRE(handler.has_move_messages() == true);
-            }
-        }
 
-        WHEN("moves have been issued") {
-            THEN("the step motor command should execute all of them") {
-                while (handler.has_move_messages()) {
-                    static_cast<void>(handler.run_interrupt());
+                WHEN("moves have been issued") {
+                    THEN("the step motor command should execute all of them") {
+                        while (handler.has_move_messages()) {
+                            static_cast<void>(handler.run_interrupt());
+                        }
+                        REQUIRE(handler.has_move_messages() == false);
+                    }
                 }
-                REQUIRE(handler.has_move_messages() == false);
             }
         }
 

--- a/motor-control/tests/test_motor_interrupt_queue.cpp
+++ b/motor-control/tests/test_motor_interrupt_queue.cpp
@@ -1,3 +1,4 @@
+#include "can/core/ids.hpp"
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
@@ -42,6 +43,30 @@ TEST_CASE("motor interrupt handler queue functionality") {
                             static_cast<void>(handler.run_interrupt());
                         }
                         REQUIRE(handler.has_move_messages() == false);
+                    }
+                }
+                WHEN("a movement stalls") {
+                    handler.run_interrupt();
+                    handler.cancel_and_clear_moves(
+                        can::ids::ErrorCode::hardware,
+                        can::ids::ErrorSeverity::warning, false);
+                    THEN("the other pending movements are cancelled") {
+                        REQUIRE(handler.has_move_messages());
+                        // There are 3 more messages to clear
+                        for (auto i = 0; i < 3; ++i) {
+                            handler.run_interrupt();
+                        }
+                        REQUIRE(!handler.has_move_messages());
+                        AND_WHEN("more moves are enqueued") {
+                            queue.try_write(msg1);
+                            queue.try_write(msg2);
+                            THEN("the move is executed normallly") {
+                                for (auto i = 0; i < 3; ++i) {
+                                    handler.run_interrupt();
+                                }
+                                REQUIRE(handler.has_move_messages());
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
During stall repeatability testing, we noticed that motor axes would sometimes continue to drive into the endstop after stalling. The culprit appears to be that, when the Stop message was removed in #542, there was no replacement for clearing out the interrupt's queue.

This PR adds functionality to the interrupt handler to clear out its queue when a stall occurs. We've previously had trouble using the actual `clear` function for FreeRTOS queues in interrupts, so instead we set a flag to "drain" the queue (one message per interrupt) until it's empty.

Tested by:
* Move an axis very close to its endstop
* Command the axis to move through the endstop with the `_check_stalls` flag enabled. Make the distance at least twice that of the distance to the endstop, to ensure it will collide during the acceleration phase.
* Send an "update position" request, and then move the axis back away from the endstop to make sure the interrupt is behaving normally

Tested on head to ensure the queue-draining functionality doesn't cause timing issues, and tested on the Gantry-X with a slow motion video to verify that the axis doesn't overdrive into the spring-loaded endstop.