### PR TITLE
fix(bootloader): update move stop condition enum name

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -204,7 +204,7 @@ typedef enum {
 typedef enum {
     can_movestopcondition_none = 0x0,
     can_movestopcondition_limit_switch = 0x1,
-    can_movestopcondition_cap_sensor = 0x2,
+    can_movestopcondition_sync_line = 0x2,
     can_movestopcondition_encoder_position = 0x4,
     can_movestopcondition_gripper_force = 0x8,
     can_movestopcondition_stall = 0x10,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -220,3 +220,4 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
+

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -220,4 +220,3 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
-


### PR DESCRIPTION
Changes are created by the header generator — seems like we forgot to edit the enum in bootloader after updating the `can/core/ids.hpp`.