### PR TITLE
feat(gripper): make gripper jaw error tolerance adjustable

### DIFF
--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -114,14 +114,13 @@ static lms::LinearMotionSystemConfig<lms::GearBoxConfig> gear_config{
     .microstep = 0,
     .encoder_pulses_per_rev = 512};
 
-
-static error_tolerance_config::BrushedMotorErrorTolerance error_conf(gear_config);
+static error_tolerance_config::BrushedMotorErrorTolerance error_conf(
+    gear_config);
 
 static brushed_motor::BrushedMotor grip_motor(gear_config,
                                               brushed_motor_hardware_iface,
                                               brushed_motor_driver_iface,
-                                              motor_queue,
-                                              error_conf);
+                                              motor_queue, error_conf);
 
 /**
  * Handler of brushed motor interrupts.

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -2,6 +2,7 @@
 #include "gripper/core/interfaces.hpp"
 #include "motor-control/core/brushed_motor/brushed_motor.hpp"
 #include "motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp"
+#include "motor-control/core/brushed_motor/error_tolerance_config.hpp"
 #include "motor-control/core/tasks/motor_hardware_task.hpp"
 #include "motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp"
 #include "motor-control/firmware/brushed_motor/driver_hardware.hpp"
@@ -113,10 +114,14 @@ static lms::LinearMotionSystemConfig<lms::GearBoxConfig> gear_config{
     .microstep = 0,
     .encoder_pulses_per_rev = 512};
 
+
+static error_tolerance_config::BrushedMotorErrorTolerance error_conf(gear_config);
+
 static brushed_motor::BrushedMotor grip_motor(gear_config,
                                               brushed_motor_hardware_iface,
                                               brushed_motor_driver_iface,
-                                              motor_queue);
+                                              motor_queue,
+                                              error_conf);
 
 /**
  * Handler of brushed motor interrupts.
@@ -124,7 +129,7 @@ static brushed_motor::BrushedMotor grip_motor(gear_config,
 static brushed_motor_handler::BrushedMotorInterruptHandler
     brushed_motor_interrupt(motor_queue, gripper_tasks::g_tasks::get_queues(),
                             brushed_motor_hardware_iface,
-                            brushed_motor_driver_iface, gear_config);
+                            brushed_motor_driver_iface, error_conf);
 
 extern "C" void call_brushed_motor_handler(void) {
     brushed_motor_interrupt.run_interrupt();

--- a/gripper/simulator/interfaces.cpp
+++ b/gripper/simulator/interfaces.cpp
@@ -4,6 +4,7 @@
 #include "gripper/core/tasks.hpp"
 #include "gripper/simulation/sim_interfaces.hpp"
 #include "motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp"
+#include "motor-control/core/brushed_motor/error_tolerance_config.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
 #include "motor-control/simulation/brushed_motor_interrupt_driver.hpp"
@@ -118,15 +119,17 @@ static auto gear_conf = lms::LinearMotionSystemConfig<lms::GearBoxConfig>{
     .microstep = 0,
     .encoder_pulses_per_rev = 512};
 
+static error_tolerance_config::BrushedMotorErrorTolerance error_conf(gear_conf);
+
 static auto grip_motor = brushed_motor::BrushedMotor(
     gear_conf, brushed_motor_hardware_iface, brushed_motor_driver_iface,
-    brushed_motor_queue);
+    brushed_motor_queue, error_conf);
 
 static brushed_motor_handler::BrushedMotorInterruptHandler
     brushed_motor_interrupt(brushed_motor_queue,
                             gripper_tasks::g_tasks::get_queues(),
                             brushed_motor_hardware_iface,
-                            brushed_motor_driver_iface, gear_conf);
+                            brushed_motor_driver_iface, error_conf);
 
 static brushed_motor_interrupt_driver::BrushedMotorInterruptDriver G(
     brushed_motor_queue, brushed_motor_interrupt, brushed_motor_hardware_iface);

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -64,6 +64,7 @@ typedef enum {
     can_messageid_add_brushed_linear_move_request = 0x44,
     can_messageid_brushed_motor_conf_request = 0x45,
     can_messageid_brushed_motor_conf_response = 0x46,
+    can_messageid_set_gripper_error_tolerance = 0x47,
     can_messageid_acknowledgement = 0x50,
     can_messageid_read_presence_sensing_voltage_request = 0x600,
     can_messageid_read_presence_sensing_voltage_response = 0x601,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -221,4 +221,3 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
-

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -66,6 +66,7 @@ enum class MessageId {
     add_brushed_linear_move_request = 0x44,
     brushed_motor_conf_request = 0x45,
     brushed_motor_conf_response = 0x46,
+    set_gripper_error_tolerance = 0x47,
     acknowledgement = 0x50,
     read_presence_sensing_voltage_request = 0x600,
     read_presence_sensing_voltage_response = 0x601,
@@ -220,3 +221,4 @@ enum class MoveStopCondition {
 };
 
 }  // namespace can::ids
+

--- a/include/can/core/message_handlers/motion.hpp
+++ b/include/can/core/message_handlers/motion.hpp
@@ -46,7 +46,8 @@ class BrushedMotionHandler {
   public:
     using MessageType =
         std::variant<std::monostate, DisableMotorRequest, EnableMotorRequest,
-                     ReadLimitSwitchRequest, MotorPositionRequest, SetGripperErrorToleranceRequest>;
+                     ReadLimitSwitchRequest, MotorPositionRequest,
+                     SetGripperErrorToleranceRequest>;
 
     BrushedMotionHandler(BrushedMotionTaskClient &motion_client)
         : motion_client{motion_client} {}

--- a/include/can/core/message_handlers/motion.hpp
+++ b/include/can/core/message_handlers/motion.hpp
@@ -46,7 +46,7 @@ class BrushedMotionHandler {
   public:
     using MessageType =
         std::variant<std::monostate, DisableMotorRequest, EnableMotorRequest,
-                     ReadLimitSwitchRequest, MotorPositionRequest>;
+                     ReadLimitSwitchRequest, MotorPositionRequest, SetGripperErrorToleranceRequest>;
 
     BrushedMotionHandler(BrushedMotionTaskClient &motion_client)
         : motion_client{motion_client} {}

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1390,6 +1390,30 @@ struct PeripheralStatusResponse
 
 using InstrumentInfoRequest = Empty<MessageId::instrument_info_request>;
 
+struct SetGripperErrorToleranceRequest
+        : BaseMessage<MessageId::set_gripper_error_tolerance> {
+    uint32_t message_index;
+    uint32_t max_pos_error_mm;
+    uint32_t max_unwanted_movement_mm;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> SetGripperErrorToleranceRequest {
+        uint32_t pos_error = 0;
+        uint32_t unwanted_movement = 0;
+        uint32_t msg_ind = 0;
+
+        body = bit_utils::bytes_to_int(body, limit, msg_ind);
+        body = bit_utils::bytes_to_int(body, limit, pos_error);
+        body = bit_utils::bytes_to_int(body, limit, unwanted_movement);
+        return SetGripperErrorToleranceRequest{
+                .message_index = msg_ind,
+                .max_pos_error_mm = pos_error,
+                .max_unwanted_movement_mm = unwanted_movement};
+    }
+    auto operator==(const SetGripperErrorToleranceRequest& other) const
+    -> bool = default;
+};
+
 /**
  * A variant of all message types we might send..
  */

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1391,13 +1391,14 @@ struct PeripheralStatusResponse
 using InstrumentInfoRequest = Empty<MessageId::instrument_info_request>;
 
 struct SetGripperErrorToleranceRequest
-        : BaseMessage<MessageId::set_gripper_error_tolerance> {
+    : BaseMessage<MessageId::set_gripper_error_tolerance> {
     uint32_t message_index;
     uint32_t max_pos_error_mm;
     uint32_t max_unwanted_movement_mm;
 
     template <bit_utils::ByteIterator Input, typename Limit>
-    static auto parse(Input body, Limit limit) -> SetGripperErrorToleranceRequest {
+    static auto parse(Input body, Limit limit)
+        -> SetGripperErrorToleranceRequest {
         uint32_t pos_error = 0;
         uint32_t unwanted_movement = 0;
         uint32_t msg_ind = 0;
@@ -1406,12 +1407,12 @@ struct SetGripperErrorToleranceRequest
         body = bit_utils::bytes_to_int(body, limit, pos_error);
         body = bit_utils::bytes_to_int(body, limit, unwanted_movement);
         return SetGripperErrorToleranceRequest{
-                .message_index = msg_ind,
-                .max_pos_error_mm = pos_error,
-                .max_unwanted_movement_mm = unwanted_movement};
+            .message_index = msg_ind,
+            .max_pos_error_mm = pos_error,
+            .max_unwanted_movement_mm = unwanted_movement};
     }
     auto operator==(const SetGripperErrorToleranceRequest& other) const
-    -> bool = default;
+        -> bool = default;
 };
 
 /**

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -45,7 +45,8 @@ using BrushedMotorDispatchTarget = can::dispatch::DispatchParseTarget<
 using BrushedMotionDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::motion::BrushedMotionHandler<g_tasks::QueueClient>,
     can::messages::DisableMotorRequest, can::messages::EnableMotorRequest,
-    can::messages::ReadLimitSwitchRequest, can::messages::MotorPositionRequest>;
+    can::messages::ReadLimitSwitchRequest, can::messages::MotorPositionRequest,
+    can::messages::SetGripperErrorToleranceRequest>;
 using BrushedMoveGroupDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::move_group::BrushedMoveGroupHandler<
         g_tasks::QueueClient>,

--- a/include/motor-control/core/brushed_motor/brushed_motor.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor.hpp
@@ -3,6 +3,7 @@
 #include "common/core/freertos_message_queue.hpp"
 #include "driver_interface.hpp"
 #include "motor-control/core/brushed_motor/brushed_motion_controller.hpp"
+#include "motor-control/core/brushed_motor/error_tolerance_config.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/motor_messages.hpp"
 
@@ -23,9 +24,10 @@ struct BrushedMotor {
     BrushedMotor(lms::LinearMotionSystemConfig<MEConfig> lms_config,
                  motor_hardware::BrushedMotorHardwareIface& hardware_iface,
                  brushed_motor_driver::BrushedMotorDriverIface& driver_iface,
-                 GenericQueue& queue)
+                 GenericQueue& queue,
+                 error_tolerance_config::BrushedMotorErrorTolerance& error_conf)
         : driver(driver_iface),
-          motion_controller{lms_config, hardware_iface, queue} {}
+          motion_controller{lms_config, hardware_iface, queue, error_conf} {}
 
     brushed_motor_driver::BrushedMotorDriverIface& driver;
     brushed_motion_controller::MotionController<MEConfig> motion_controller;

--- a/include/motor-control/core/brushed_motor/error_tolerance_config.hpp
+++ b/include/motor-control/core/brushed_motor/error_tolerance_config.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "motor-control/core/linear_motion_system.hpp"
+
+namespace error_tolerance_config {
+
+// upon advice from hardware, 0.01mm is a good limit for precision
+static constexpr double ACCEPTABLE_DISTANCE_TOLERANCE_MM = 0.01;
+static constexpr double UNWANTED_MOVEMENT_DISTANCE_MM = 0.02;
+
+class BrushedMotorErrorTolerance {
+public:
+    BrushedMotorErrorTolerance(
+            lms::LinearMotionSystemConfig<lms::GearBoxConfig>& gearbox_config
+    ): gear_conf(gearbox_config) {
+        acceptable_position_error =
+                int32_t(gear_conf.get_encoder_pulses_per_mm() *
+                        ACCEPTABLE_DISTANCE_TOLERANCE_MM);
+        unwanted_movement_threshold =
+                int32_t(gear_conf.get_encoder_pulses_per_mm() *
+                        UNWANTED_MOVEMENT_DISTANCE_MM);
+    }
+
+    void update_tolerance(double pos_error, double unwanted_movement) {
+        acceptable_position_error = int32_t(gear_conf.get_encoder_pulses_per_mm() * pos_error);
+        unwanted_movement_threshold = int32_t(gear_conf.get_encoder_pulses_per_mm() * unwanted_movement);
+    }
+    lms::LinearMotionSystemConfig<lms::GearBoxConfig>& gear_conf;
+    int32_t acceptable_position_error = 0;
+    int32_t unwanted_movement_threshold = 0;
+};
+
+}
+

--- a/include/motor-control/core/brushed_motor/error_tolerance_config.hpp
+++ b/include/motor-control/core/brushed_motor/error_tolerance_config.hpp
@@ -9,26 +9,27 @@ static constexpr double ACCEPTABLE_DISTANCE_TOLERANCE_MM = 0.01;
 static constexpr double UNWANTED_MOVEMENT_DISTANCE_MM = 0.02;
 
 class BrushedMotorErrorTolerance {
-public:
+  public:
     BrushedMotorErrorTolerance(
-            lms::LinearMotionSystemConfig<lms::GearBoxConfig>& gearbox_config
-    ): gear_conf(gearbox_config) {
+        lms::LinearMotionSystemConfig<lms::GearBoxConfig>& gearbox_config)
+        : gear_conf(gearbox_config) {
         acceptable_position_error =
-                int32_t(gear_conf.get_encoder_pulses_per_mm() *
-                        ACCEPTABLE_DISTANCE_TOLERANCE_MM);
+            int32_t(gear_conf.get_encoder_pulses_per_mm() *
+                    ACCEPTABLE_DISTANCE_TOLERANCE_MM);
         unwanted_movement_threshold =
-                int32_t(gear_conf.get_encoder_pulses_per_mm() *
-                        UNWANTED_MOVEMENT_DISTANCE_MM);
+            int32_t(gear_conf.get_encoder_pulses_per_mm() *
+                    UNWANTED_MOVEMENT_DISTANCE_MM);
     }
 
     void update_tolerance(double pos_error, double unwanted_movement) {
-        acceptable_position_error = int32_t(gear_conf.get_encoder_pulses_per_mm() * pos_error);
-        unwanted_movement_threshold = int32_t(gear_conf.get_encoder_pulses_per_mm() * unwanted_movement);
+        acceptable_position_error =
+            int32_t(gear_conf.get_encoder_pulses_per_mm() * pos_error);
+        unwanted_movement_threshold =
+            int32_t(gear_conf.get_encoder_pulses_per_mm() * unwanted_movement);
     }
     lms::LinearMotionSystemConfig<lms::GearBoxConfig>& gear_conf;
     int32_t acceptable_position_error = 0;
     int32_t unwanted_movement_threshold = 0;
 };
 
-}
-
+}  // namespace error_tolerance_config

--- a/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
@@ -101,6 +101,12 @@ class MotionControllerMessageHandler {
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 
+    void handle(const can::messages::SetGripperErrorToleranceRequest& m) {
+        controller.set_error_tolerance(m);
+        can_client.send_can_message(can::ids::NodeId::host,
+                                    can::messages::ack_from_request(m));
+    }
+
     brushed_motion_controller::MotionController<MEConfig>& controller;
     CanClient& can_client;
 };

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -41,7 +41,8 @@ using BrushedMotionControllerTaskMessage = std::variant<
     can::messages::EnableMotorRequest, can::messages::GripperGripRequest,
     can::messages::GripperHomeRequest,
     can::messages::AddBrushedLinearMoveRequest, can::messages::StopRequest,
-    can::messages::ReadLimitSwitchRequest, can::messages::MotorPositionRequest>;
+    can::messages::ReadLimitSwitchRequest, can::messages::MotorPositionRequest,
+    can::messages::SetGripperErrorToleranceRequest>;
 
 using BrushedMoveGroupTaskMessage = std::variant<
     std::monostate, can::messages::ClearAllMoveGroupsRequest,

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "motor-control/core/brushed_motor/driver_interface.hpp"
+#include "motor-control/core/brushed_motor/error_tolerance_config.hpp"
 #include "motor-control/core/motor_hardware_interface.hpp"
 #include "motor-control/core/tasks/move_status_reporter_task.hpp"
 #include "ot_utils/core/pid.hpp"
@@ -8,6 +9,7 @@ namespace test_mocks {
 
 using namespace brushed_motor_driver;
 using namespace motor_hardware;
+using namespace error_tolerance_config;
 
 enum class PWM_DIRECTION { positive, negative, unset };
 
@@ -115,6 +117,17 @@ struct MockBrushedMoveStatusReporterClient {
     }
 
     std::vector<move_status_reporter_task::TaskMessage> messages{};
+};
+
+struct MockBrushedMotionController {
+    void set_error_tolerance(
+        const can::messages::SetGripperErrorToleranceRequest& can_msg) {
+        error_config.update_tolerance(
+            fixed_point_to_float(can_msg.max_pos_error_mm, S15Q16_RADIX),
+            fixed_point_to_float(can_msg.max_unwanted_movement_mm,
+                                 S15Q16_RADIX));
+    }
+    BrushedMotorErrorTolerance& error_config;
 };
 
 };  // namespace test_mocks

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(motor-control
         test_motor_flags.cpp
         test_motor_position_tracker.cpp
         test_stall_check.cpp
+        test_brushed_motor_error_tolerance_handling.cpp
         )
 
 target_ot_motor_control(motor-control)

--- a/motor-control/tests/test_brushed_motor_error_tolerance_handling.cpp
+++ b/motor-control/tests/test_brushed_motor_error_tolerance_handling.cpp
@@ -1,0 +1,48 @@
+#include "can/core/messages.hpp"
+#include "catch2/catch.hpp"
+#include "common/tests/mock_message_queue.hpp"
+#include "motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp"
+#include "motor-control/core/brushed_motor/error_tolerance_config.hpp"
+#include "motor-control/core/motor_messages.hpp"
+#include "motor-control/tests/mock_brushed_motor_components.hpp"
+#include "motor-control/tests/mock_move_status_reporter_client.hpp"
+
+using namespace brushed_motor_handler;
+
+auto _gear_config = lms::LinearMotionSystemConfig<lms::GearBoxConfig>{
+    .mech_config =
+        lms::GearBoxConfig{.gear_diameter = 9, .gear_reduction_ratio = 84.29},
+    .steps_per_rev = 0,
+    .microstep = 0,
+    .encoder_pulses_per_rev = 512};
+auto _error_config =
+    error_tolerance_config::BrushedMotorErrorTolerance{_gear_config};
+
+SCENARIO("testing error tolerance handling") {
+    GIVEN("a motion controller and motor interrupt handler") {
+        test_mocks::MockBrushedMotionController controller(_error_config);
+        auto pos_error_before = _error_config.acceptable_position_error;
+        auto unwanted_movement_before =
+            _error_config.unwanted_movement_threshold;
+        WHEN(
+            "a set gripper error tolerance request is handled by the motion "
+            "controller") {
+            auto msg = can::messages::SetGripperErrorToleranceRequest{
+                .message_index = 0,
+                .max_pos_error_mm = 98304,
+                .max_unwanted_movement_mm = 98304,
+            };
+            controller.set_error_tolerance(msg);
+            THEN("error config values should be updated") {
+                CHECK(pos_error_before !=
+                      _error_config.acceptable_position_error);
+                CHECK(unwanted_movement_before !=
+                      _error_config.unwanted_movement_threshold);
+                CHECK(_error_config.acceptable_position_error ==
+                      int(_gear_config.get_encoder_pulses_per_mm() * 1.5));
+                CHECK(_error_config.unwanted_movement_threshold ==
+                      int(_gear_config.get_encoder_pulses_per_mm() * 1.5));
+            }
+        }
+    }
+}

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -2,6 +2,7 @@
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
 #include "motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp"
+#include "motor-control/core/brushed_motor/error_tolerance_config.hpp"
 #include "motor-control/core/motor_messages.hpp"
 #include "motor-control/tests/mock_brushed_motor_components.hpp"
 #include "motor-control/tests/mock_move_status_reporter_client.hpp"
@@ -14,6 +15,8 @@ auto gear_config = lms::LinearMotionSystemConfig<lms::GearBoxConfig>{
     .steps_per_rev = 0,
     .microstep = 0,
     .encoder_pulses_per_rev = 512};
+auto error_config =
+    error_tolerance_config::BrushedMotorErrorTolerance{gear_config};
 
 struct BrushedMotorContainer {
     test_mocks::MockBrushedMotorHardware hw{};
@@ -23,7 +26,7 @@ struct BrushedMotorContainer {
     BrushedMotorInterruptHandler<
         test_mocks::MockMessageQueue,
         test_mocks::MockBrushedMoveStatusReporterClient>
-        handler{queue, reporter, hw, driver, gear_config};
+        handler{queue, reporter, hw, driver, error_config};
 };
 
 SCENARIO("Brushed motor interrupt handler handle move messages") {


### PR DESCRIPTION
**Changes:**
* New CAN message to change the gripper jaw error tolerance. 
* Added a new class `BrushedMotorErrorTolerance` to keep the tolerance values.
* The message is handled by the motion controller task which modifies the tolerance values in `BrushedMotorErrorTolerance`.