### PR TITLE
feat(pipettes): add tip sense check to the sensor hardware class

### DIFF
--- a/gripper/firmware/main_proto.cpp
+++ b/gripper/firmware/main_proto.cpp
@@ -77,18 +77,14 @@ static auto eeprom_hw_iface = EEPromHardwareInterface();
 
 auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
     .sync_in =
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_7,
-            .active_setting = GPIO_PIN_RESET},
-    .sync_out =
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_6,
-            .active_setting = GPIO_PIN_RESET}
-};
+        {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+         .port = GPIOB,
+         .pin = GPIO_PIN_7,
+         .active_setting = GPIO_PIN_RESET},
+    .sync_out = {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_6,
+                 .active_setting = GPIO_PIN_RESET}};
 
 auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins);
 

--- a/gripper/firmware/main_proto.cpp
+++ b/gripper/firmware/main_proto.cpp
@@ -75,7 +75,7 @@ class EEPromHardwareInterface
 };
 static auto eeprom_hw_iface = EEPromHardwareInterface();
 
-struct sensors::hardware::SensorHardwareConfiguration sensor_pins {
+auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
     .sync_in =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -87,8 +87,7 @@ struct sensors::hardware::SensorHardwareConfiguration sensor_pins {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             .port = GPIOB,
             .pin = GPIO_PIN_6,
-            .active_setting = GPIO_PIN_RESET},
-    .data_ready = {},
+            .active_setting = GPIO_PIN_RESET}
 };
 
 auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins);

--- a/gripper/firmware/main_rev1.cpp
+++ b/gripper/firmware/main_rev1.cpp
@@ -78,7 +78,7 @@ class EEPromHardwareInterface
 };
 static auto eeprom_hw_iface = EEPromHardwareInterface();
 
-struct sensors::hardware::SensorHardwareConfiguration sensor_pins {
+auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
     .sync_in =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -90,8 +90,7 @@ struct sensors::hardware::SensorHardwareConfiguration sensor_pins {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
             .port = GPIOB,
             .pin = GPIO_PIN_6,
-            .active_setting = GPIO_PIN_RESET},
-    .data_ready = {},
+            .active_setting = GPIO_PIN_RESET}
 };
 
 auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins);

--- a/gripper/firmware/main_rev1.cpp
+++ b/gripper/firmware/main_rev1.cpp
@@ -80,18 +80,14 @@ static auto eeprom_hw_iface = EEPromHardwareInterface();
 
 auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
     .sync_in =
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_7,
-            .active_setting = GPIO_PIN_RESET},
-    .sync_out =
-        {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_6,
-            .active_setting = GPIO_PIN_RESET}
-};
+        {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+         .port = GPIOB,
+         .pin = GPIO_PIN_7,
+         .active_setting = GPIO_PIN_RESET},
+    .sync_out = {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                 .port = GPIOB,
+                 .pin = GPIO_PIN_6,
+                 .active_setting = GPIO_PIN_RESET}};
 
 auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins);
 

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 
 #include "common/firmware/gpio.hpp"
 
@@ -11,6 +12,7 @@ struct SensorHardwareConfiguration {
     gpio::PinConfig sync_in;
     gpio::PinConfig sync_out;
     gpio::PinConfig data_ready;
+    std::optional<gpio::PinConfig> tip_sense = std::nullopt;
 };
 
 /** abstract sensor hardware device for a sync line */
@@ -25,6 +27,7 @@ class SensorHardwareBase {
 
     virtual auto set_sync() -> void = 0;
     virtual auto reset_sync() -> void = 0;
+    virtual auto check_tip_presence() -> bool = 0;
     virtual auto add_data_ready_callback(std::function<void()> callback)
         -> bool = 0;
 };

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -9,9 +9,9 @@ namespace sensors {
 namespace hardware {
 
 struct SensorHardwareConfiguration {
-    gpio::PinConfig sync_in;
-    gpio::PinConfig sync_out;
-    gpio::PinConfig data_ready;
+    gpio::PinConfig sync_in{};
+    gpio::PinConfig sync_out{};
+    std::optional<gpio::PinConfig> data_ready = std::nullopt;
     std::optional<gpio::PinConfig> tip_sense = std::nullopt;
 };
 

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -13,6 +13,12 @@ class SensorHardware : public SensorHardwareBase {
         : hardware(hardware) {}
     auto set_sync() -> void override { gpio::set(hardware.sync_out); }
     auto reset_sync() -> void override { gpio::reset(hardware.sync_out); }
+    auto check_tip_presence() -> bool override {
+        if (hardware.tip_sense.has_value()) {
+            return gpio::is_set(hardware.tip_sense.value());
+        }
+        return 0;
+    }
     // TODO: change data_ready's input parameter to an std::map object, so that
     //  the function being called is definitely the callback corresponding to
     //  the correct GPIO interrupt

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -17,7 +17,7 @@ class SensorHardware : public SensorHardwareBase {
         if (hardware.tip_sense.has_value()) {
             return gpio::is_set(hardware.tip_sense.value());
         }
-        return 0;
+        return false;
     }
     // TODO: change data_ready's input parameter to an std::map object, so that
     //  the function being called is definitely the callback corresponding to

--- a/include/sensors/simulation/mock_hardware.hpp
+++ b/include/sensors/simulation/mock_hardware.hpp
@@ -21,6 +21,7 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
             _state_manager->send_sync_msg(SyncPinState::LOW);
         }
     }
+    auto check_tip_presence() -> bool override { return false; }
     std::array<std::function<void()>, 5> data_ready_callbacks = {};
     auto add_data_ready_callback(std::function<void()> callback)
         -> bool override {

--- a/include/sensors/tests/mock_hardware.hpp
+++ b/include/sensors/tests/mock_hardware.hpp
@@ -12,6 +12,7 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
         sync_state = false;
         sync_reset_calls++;
     }
+    auto check_tip_presence() -> bool override { return false; }
     std::array<std::function<void()>, 5> data_ready_callbacks = {};
     auto add_data_ready_callback(std::function<void()> callback)
         -> bool override {

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -128,9 +128,7 @@ auto sensor_hardware =
 auto data_ready_gpio = pins_for_sensor.primary.data_ready.value();
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-
-    if (GPIO_Pin == data_ready_gpio.pin &&
-        PIPETTE_TYPE != NINETY_SIX_CHANNEL) {
+    if (GPIO_Pin == data_ready_gpio.pin && PIPETTE_TYPE != NINETY_SIX_CHANNEL) {
         sensor_hardware.data_ready();
     }
 }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -125,9 +125,11 @@ static auto pins_for_sensor =
 
 auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
+auto data_ready_gpio = pins_for_sensor.primary.data_ready.value();
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin &&
+
+    if (GPIO_Pin == data_ready_gpio.pin &&
         PIPETTE_TYPE != NINETY_SIX_CHANNEL) {
         sensor_hardware.data_ready();
     }

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -314,7 +314,8 @@ auto motor_configs::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
                  .pin = GPIO_PIN_6,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{
+                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
                  .pin = GPIO_PIN_3,
                  .active_setting = GPIO_PIN_RESET},
@@ -339,7 +340,8 @@ auto motor_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
                  .pin = GPIO_PIN_6,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{
+                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
                  .pin = GPIO_PIN_3,
                  .active_setting = GPIO_PIN_RESET},
@@ -363,7 +365,8 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                      .pin = GPIO_PIN_9,
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    gpio::PinConfig{
+                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
                      .pin = GPIO_PIN_11,
                      .active_setting = GPIO_PIN_RESET},
@@ -380,7 +383,8 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                  .pin = GPIO_PIN_9,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{
+                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
                  .pin = GPIO_PIN_6,
                  .active_setting = GPIO_PIN_RESET},
@@ -405,7 +409,8 @@ auto motor_configs::sensor_configurations<
                      .pin = GPIO_PIN_9,
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    gpio::PinConfig{
+                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
                      .pin = GPIO_PIN_11,
                      .active_setting = GPIO_PIN_RESET},
@@ -422,7 +427,8 @@ auto motor_configs::sensor_configurations<
                  .pin = GPIO_PIN_9,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{
+                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
                  .pin = GPIO_PIN_6,
                  .active_setting = GPIO_PIN_RESET},

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -318,7 +318,11 @@ auto motor_configs::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
                  .port = GPIOC,
                  .pin = GPIO_PIN_3,
                  .active_setting = GPIO_PIN_RESET},
-        }};
+            .tip_sense = gpio::PinConfig{
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                .port = GPIOC,
+                .pin = GPIO_PIN_2,
+                .active_setting = GPIO_PIN_RESET}}};
     return pins;
 }
 
@@ -339,7 +343,11 @@ auto motor_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
                  .port = GPIOC,
                  .pin = GPIO_PIN_3,
                  .active_setting = GPIO_PIN_RESET},
-        }};
+            .tip_sense = gpio::PinConfig{
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                .port = GPIOC,
+                .pin = GPIO_PIN_2,
+                .active_setting = GPIO_PIN_RESET}}};
     return pins;
 }
 
@@ -359,7 +367,12 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                      .port = GPIOC,
                      .pin = GPIO_PIN_11,
                      .active_setting = GPIO_PIN_RESET},
-            },
+                .tip_sense =
+                    gpio::PinConfig{
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                        .port = GPIOC,
+                        .pin = GPIO_PIN_12,
+                        .active_setting = GPIO_PIN_RESET}},
         .secondary = sensors::hardware::SensorHardwareConfiguration{
             .sync_out =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -371,7 +384,11 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                  .port = GPIOC,
                  .pin = GPIO_PIN_6,
                  .active_setting = GPIO_PIN_RESET},
-        }};
+            .tip_sense = gpio::PinConfig{
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                .port = GPIOC,
+                .pin = GPIO_PIN_7,
+                .active_setting = GPIO_PIN_RESET}}};
     return pins;
 }
 
@@ -392,7 +409,12 @@ auto motor_configs::sensor_configurations<
                      .port = GPIOC,
                      .pin = GPIO_PIN_11,
                      .active_setting = GPIO_PIN_RESET},
-            },
+                .tip_sense =
+                    gpio::PinConfig{
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                        .port = GPIOC,
+                        .pin = GPIO_PIN_12,
+                        .active_setting = GPIO_PIN_RESET}},
         .secondary = sensors::hardware::SensorHardwareConfiguration{
             .sync_out =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -404,6 +426,10 @@ auto motor_configs::sensor_configurations<
                  .port = GPIOC,
                  .pin = GPIO_PIN_6,
                  .active_setting = GPIO_PIN_RESET},
-        }};
+            .tip_sense = gpio::PinConfig{
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                .port = GPIOC,
+                .pin = GPIO_PIN_7,
+                .active_setting = GPIO_PIN_RESET}}};
     return pins;
 }

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -315,10 +315,10 @@ auto motor_configs::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 gpio::PinConfig{
-                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOC,
-                 .pin = GPIO_PIN_3,
-                 .active_setting = GPIO_PIN_RESET},
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOC,
+                    .pin = GPIO_PIN_3,
+                    .active_setting = GPIO_PIN_RESET},
             .tip_sense = gpio::PinConfig{
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .port = GPIOC,
@@ -341,10 +341,10 @@ auto motor_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 gpio::PinConfig{
-                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOC,
-                 .pin = GPIO_PIN_3,
-                 .active_setting = GPIO_PIN_RESET},
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOC,
+                    .pin = GPIO_PIN_3,
+                    .active_setting = GPIO_PIN_RESET},
             .tip_sense = gpio::PinConfig{
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .port = GPIOC,
@@ -366,10 +366,10 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
                     gpio::PinConfig{
-                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_11,
-                     .active_setting = GPIO_PIN_RESET},
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                        .port = GPIOC,
+                        .pin = GPIO_PIN_11,
+                        .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     gpio::PinConfig{
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -384,10 +384,10 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 gpio::PinConfig{
-                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOC,
-                 .pin = GPIO_PIN_6,
-                 .active_setting = GPIO_PIN_RESET},
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOC,
+                    .pin = GPIO_PIN_6,
+                    .active_setting = GPIO_PIN_RESET},
             .tip_sense = gpio::PinConfig{
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .port = GPIOC,
@@ -410,10 +410,10 @@ auto motor_configs::sensor_configurations<
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
                     gpio::PinConfig{
-                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_11,
-                     .active_setting = GPIO_PIN_RESET},
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                        .port = GPIOC,
+                        .pin = GPIO_PIN_11,
+                        .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     gpio::PinConfig{
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -428,10 +428,10 @@ auto motor_configs::sensor_configurations<
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 gpio::PinConfig{
-                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOC,
-                 .pin = GPIO_PIN_6,
-                 .active_setting = GPIO_PIN_RESET},
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOC,
+                    .pin = GPIO_PIN_6,
+                    .active_setting = GPIO_PIN_RESET},
             .tip_sense = gpio::PinConfig{
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .port = GPIOC,

--- a/pipettes/firmware_l5/main.cpp
+++ b/pipettes/firmware_l5/main.cpp
@@ -117,8 +117,10 @@ static auto pins_for_sensor =
 auto sensor_hardware =
     sensors::hardware::SensorHardware(pins_for_sensor.primary);
 
+auto data_ready_gpio = pins_for_sensor.primary.data_ready.value();
+
 extern "C" void HAL_GPIO_EXTI_Falling_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == pins_for_sensor.primary.data_ready.pin) {
+    if (GPIO_Pin == data_ready_gpio.pin) {
         sensor_hardware.data_ready();
     }
 }

--- a/pipettes/firmware_l5/motor_configurations.cpp
+++ b/pipettes/firmware_l5/motor_configurations.cpp
@@ -303,10 +303,11 @@ auto motor_configs::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
                  .pin = GPIO_PIN_4,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOC,
-                 .pin = GPIO_PIN_9,
-                 .active_setting = GPIO_PIN_RESET},
+                gpio::PinConfig{
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOC,
+                    .pin = GPIO_PIN_9,
+                    .active_setting = GPIO_PIN_RESET},
         }};
     return pins;
 }
@@ -329,10 +330,11 @@ auto motor_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
                  .pin = GPIO_PIN_4,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOC,
-                 .pin = GPIO_PIN_9,
-                 .active_setting = GPIO_PIN_RESET},
+                gpio::PinConfig{
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOC,
+                    .pin = GPIO_PIN_9,
+                    .active_setting = GPIO_PIN_RESET},
         }};
     return pins;
 }
@@ -354,10 +356,11 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                      .pin = GPIO_PIN_5,
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
-                    gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_15,
-                     .active_setting = GPIO_PIN_RESET},
+                    gpio::PinConfig{
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                        .port = GPIOC,
+                        .pin = GPIO_PIN_15,
+                        .active_setting = GPIO_PIN_RESET},
             },
         .secondary = sensors::hardware::SensorHardwareConfiguration{
             .sync_in =
@@ -371,10 +374,11 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                  .pin = GPIO_PIN_5,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOA,
-                 .pin = GPIO_PIN_8,
-                 .active_setting = GPIO_PIN_RESET},
+                gpio::PinConfig{
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOA,
+                    .pin = GPIO_PIN_8,
+                    .active_setting = GPIO_PIN_RESET},
         }};
     return pins;
 }
@@ -398,10 +402,10 @@ auto motor_configs::sensor_configurations<
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
                     gpio::PinConfig{
-                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                     .port = GPIOC,
-                     .pin = GPIO_PIN_15,
-                     .active_setting = GPIO_PIN_RESET},
+                        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                        .port = GPIOC,
+                        .pin = GPIO_PIN_15,
+                        .active_setting = GPIO_PIN_RESET},
             },
         .secondary = sensors::hardware::SensorHardwareConfiguration{
             .sync_in =
@@ -416,10 +420,10 @@ auto motor_configs::sensor_configurations<
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
                 gpio::PinConfig{
-                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOA,
-                 .pin = GPIO_PIN_8,
-                 .active_setting = GPIO_PIN_RESET},
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    .port = GPIOA,
+                    .pin = GPIO_PIN_8,
+                    .active_setting = GPIO_PIN_RESET},
         }};
     return pins;
 }

--- a/pipettes/firmware_l5/motor_configurations.cpp
+++ b/pipettes/firmware_l5/motor_configurations.cpp
@@ -303,7 +303,7 @@ auto motor_configs::sensor_configurations<PipetteType::SINGLE_CHANNEL>()
                  .pin = GPIO_PIN_4,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
                  .pin = GPIO_PIN_9,
                  .active_setting = GPIO_PIN_RESET},
@@ -329,7 +329,7 @@ auto motor_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
                  .pin = GPIO_PIN_4,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOC,
                  .pin = GPIO_PIN_9,
                  .active_setting = GPIO_PIN_RESET},
@@ -354,7 +354,7 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                      .pin = GPIO_PIN_5,
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
                      .pin = GPIO_PIN_15,
                      .active_setting = GPIO_PIN_RESET},
@@ -371,7 +371,7 @@ auto motor_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                  .pin = GPIO_PIN_5,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOA,
                  .pin = GPIO_PIN_8,
                  .active_setting = GPIO_PIN_RESET},
@@ -397,7 +397,8 @@ auto motor_configs::sensor_configurations<
                      .pin = GPIO_PIN_5,
                      .active_setting = GPIO_PIN_RESET},
                 .data_ready =
-                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                    gpio::PinConfig{
+                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOC,
                      .pin = GPIO_PIN_15,
                      .active_setting = GPIO_PIN_RESET},
@@ -414,7 +415,8 @@ auto motor_configs::sensor_configurations<
                  .pin = GPIO_PIN_5,
                  .active_setting = GPIO_PIN_RESET},
             .data_ready =
-                {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                gpio::PinConfig{
+                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                  .port = GPIOA,
                  .pin = GPIO_PIN_8,
                  .active_setting = GPIO_PIN_RESET},


### PR DESCRIPTION
## Overview

Tip sensing falls more under the category of general sensor hardware. The pin configurations are also more conducive to having "multiples" of the tip sense. The next bit of work will involve setting up a task that can fire off tip presence data once a state change has been detected.

Some notes for next steps. For single/eight channel the ejector stage flag is active when in 'resting' position. For ninety-six the ejector stage flag is inactive when in 'resting' position.

The ninety six channel tip presence routine will be much more involved than the single/eight because it involves moving the pick up motors slightly 😞 