### PR TITLE
feat(pipettes): add auto-zeroing for pressure sensor

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -778,23 +778,23 @@ struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
     uint32_t message_index = 0;
     uint8_t sensor = 0;
     uint8_t sensor_id = 0;
-    uint16_t sample_rate = 1;
+    uint16_t number_of_reads = 1;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> BaselineSensorRequest {
         uint8_t sensor = 0;
         uint8_t sensor_id = 0;
-        uint16_t sample_rate = 0;
+        uint16_t number_of_reads = 0;
         uint32_t msg_ind = 0;
 
         body = bit_utils::bytes_to_int(body, limit, msg_ind);
         body = bit_utils::bytes_to_int(body, limit, sensor);
         body = bit_utils::bytes_to_int(body, limit, sensor_id);
-        body = bit_utils::bytes_to_int(body, limit, sample_rate);
+        body = bit_utils::bytes_to_int(body, limit, number_of_reads);
         return BaselineSensorRequest{.message_index = msg_ind,
                                      .sensor = sensor,
                                      .sensor_id = sensor_id,
-                                     .sample_rate = sample_rate};
+                                     .number_of_reads = number_of_reads};
     }
 
     auto operator==(const BaselineSensorRequest& other) const -> bool = default;

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -113,12 +113,12 @@ class CapacitiveMessageHandler {
     void visit(can::messages::BaselineSensorRequest &m) {
         LOG("Received request to baseline %d sensor", m.sensor);
         capacitance_handler.reset_limited();
-        capacitance_handler.set_number_of_reads(m.sample_rate);
+        capacitance_handler.set_number_of_reads(m.number_of_reads);
         std::array tags{utils::ResponseTag::IS_PART_OF_POLL,
                         utils::ResponseTag::IS_BASELINE};
         poller.multi_register_poll(
-            ADDRESS, MSB_MEASUREMENT_1, 2, LSB_MEASUREMENT_1, 2, m.sample_rate,
-            DELAY, own_queue,
+            ADDRESS, MSB_MEASUREMENT_1, 2, LSB_MEASUREMENT_1, 2,
+            m.number_of_reads, DELAY, own_queue,
             utils::build_id(ADDRESS, MSB_MEASUREMENT_1,
                             utils::byte_from_tags(tags)));
         can_client.send_can_message(can::ids::NodeId::host,

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -55,7 +55,7 @@ class EnvironmentSensorMessageHandler {
     }
 
     void visit(const can::messages::BaselineSensorRequest &m) {
-        driver.trigger_on_demand(m.sample_rate);
+        driver.trigger_on_demand(m.number_of_reads);
         driver.get_can_client().send_can_message(
             can::ids::NodeId::host, can::messages::ack_from_request(m));
     }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -272,11 +272,12 @@ class MMR920C04 {
         set_stop_polling(binding);
     }
 
-    void set_baseline_values(uint16_t number_of_reads) {
+    void set_number_of_reads(uint16_t number_of_reads) {
         this->total_baseline_reads = number_of_reads;
         this->readings_taken = 0;
         this->running_total = 0;
         this->offset_average = 0;
+        this->stop_polling = false;
     }
 
     void set_limited_poll(bool _limited) { limited_poll = _limited; }
@@ -310,7 +311,7 @@ class MMR920C04 {
                     if (readings_taken == total_baseline_reads) {
                         offset_average = running_total / total_baseline_reads;
                         send_baseline_response(tm.message_index);
-                        set_baseline_values(0);
+                        set_number_of_reads(0);
                     }
                 }
                 break;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -302,7 +302,7 @@ class MMR920C04 {
                         hardware.reset_sync();
                     }
                 }
-                if (report && !limited_poll) {
+                if (report) {
                     send_pressure(tm.message_index);
                 }
                 if (limited_poll) {

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -307,9 +307,8 @@ class MMR920C04 {
                 }
                 if (limited_poll) {
                     running_total += pressure_pascals;
-                    offset_average =
-                        running_total / static_cast<float>(readings_taken);
                     if (readings_taken == total_baseline_reads) {
+                        offset_average = running_total / total_baseline_reads;
                         send_baseline_response(tm.message_index);
                         set_baseline_values(0);
                     }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
@@ -173,7 +175,7 @@ class MMR920C04 {
     }
 
     auto send_pressure(uint32_t message_index) -> void {
-        // Pressure is sent via CAN in pascals
+        // Pressure is sent via CAN in pascals as a fixed point value
         auto pressure_pascals =
             mmr920C04::Pressure::to_pressure(_registers.pressure.reading);
         auto pressure_fixed_point =
@@ -183,6 +185,17 @@ class MMR920C04 {
             .sensor = get_sensor_type(),
             .sensor_data = pressure_fixed_point};
         can_client.send_can_message(get_host_id(), message);
+    }
+
+    auto send_baseline_response(uint32_t message_index) -> void {
+        auto offset_fixed_point =
+            convert_to_fixed_point(offset_average, S15Q16_RADIX);
+        auto message = can::messages::BaselineSensorResponse{
+            .message_index = message_index,
+            .sensor = get_sensor_type(),
+            .offset_average = offset_fixed_point};
+        auto host_id = get_host_id();
+        can_client.send_can_message(host_id, message);
     }
 
     auto send_pressure_low_pass(uint32_t message_index) -> void {
@@ -241,8 +254,8 @@ class MMR920C04 {
                             static_cast<std::size_t>(3), own_queue,
                             static_cast<uint8_t>(read_register));
         if (limited_poll && !stop_polling) {
-            number_of_reads--;
-            if (number_of_reads < 1) {
+            number_of_reads++;
+            if (number_of_reads >= total_baseline_reads) {
                 stop_polling = true;
             }
         }
@@ -259,8 +272,11 @@ class MMR920C04 {
         set_stop_polling(binding);
     }
 
-    void set_number_of_reads(uint16_t number_of_reads) {
-        this->number_of_reads = number_of_reads;
+    void set_baseline_values(uint16_t number_of_reads) {
+        this->total_baseline_reads = number_of_reads;
+        this->number_of_reads = 0;
+        this->running_total = 0;
+        this->offset_average = 0;
     }
 
     void set_limited_poll(bool _limited) { limited_poll = _limited; }
@@ -277,15 +293,26 @@ class MMR920C04 {
             case mmr920C04::Registers::PRESSURE_READ:
                 read_pressure(data);
                 if (sync) {
-                    if (pressure_pascals > threshold_pascals) {
+                    if (std::fabs(pressure_pascals) -
+                            std::fabs(offset_average) >
+                        threshold_pascals) {
                         hardware.set_sync();
                         stop_polling = true;
                     } else {
                         hardware.reset_sync();
                     }
                 }
-                if (report) {
+                if (report && !limited_poll) {
                     send_pressure(tm.message_index);
+                }
+                if (limited_poll) {
+                    running_total += pressure_pascals;
+                    offset_average =
+                        running_total / static_cast<float>(number_of_reads);
+                    if (number_of_reads == total_baseline_reads) {
+                        send_baseline_response(tm.message_index);
+                        set_baseline_values(0);
+                    }
                 }
                 break;
             case mmr920C04::Registers::LOW_PASS_PRESSURE_READ:
@@ -321,9 +348,12 @@ class MMR920C04 {
     bool report = true;
     bool limited_poll = true;
     uint16_t number_of_reads = 0x1;
+    float running_total = 0;
+    uint16_t total_baseline_reads = 0x8;
     // TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
     // sure this is an arbitrarily large number to enable continuous reads.
     float threshold_pascals = 100.0F;
+    float offset_average = 0;
     const uint16_t DELAY = 20;
     mmr920C04::Registers read_register = mmr920C04::Registers::PRESSURE_READ;
     I2CQueueWriter &writer;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -254,8 +254,8 @@ class MMR920C04 {
                             static_cast<std::size_t>(3), own_queue,
                             static_cast<uint8_t>(read_register));
         if (limited_poll && !stop_polling) {
-            number_of_reads++;
-            if (number_of_reads >= total_baseline_reads) {
+            readings_taken++;
+            if (readings_taken >= total_baseline_reads) {
                 stop_polling = true;
             }
         }
@@ -274,7 +274,7 @@ class MMR920C04 {
 
     void set_baseline_values(uint16_t number_of_reads) {
         this->total_baseline_reads = number_of_reads;
-        this->number_of_reads = 0;
+        this->readings_taken = 0;
         this->running_total = 0;
         this->offset_average = 0;
     }
@@ -308,8 +308,8 @@ class MMR920C04 {
                 if (limited_poll) {
                     running_total += pressure_pascals;
                     offset_average =
-                        running_total / static_cast<float>(number_of_reads);
-                    if (number_of_reads == total_baseline_reads) {
+                        running_total / static_cast<float>(readings_taken);
+                    if (readings_taken == total_baseline_reads) {
                         send_baseline_response(tm.message_index);
                         set_baseline_values(0);
                     }
@@ -347,7 +347,7 @@ class MMR920C04 {
     bool sync = false;
     bool report = true;
     bool limited_poll = true;
-    uint16_t number_of_reads = 0x1;
+    uint16_t readings_taken = 0x1;
     float running_total = 0;
     uint16_t total_baseline_reads = 0x8;
     // TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -106,9 +106,14 @@ class PressureMessageHandler {
         LOG("received baseline request");
         static_cast<void>(m);
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.set_sync_bind(can::ids::SensorOutputBinding::report);
+            if (m.report) {
+                driver.set_sync_bind(can::ids::SensorOutputBinding::report);
+            }
+            else {
+                driver.set_sync_bind(can::ids::SensorOutputBinding::none);
+            }
             driver.set_limited_poll(true);
-            driver.set_baseline_values(m.sample_rate);
+            driver.set_number_of_reads(m.sample_rate);
             driver.get_pressure();
         }
     }

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -108,8 +108,7 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             if (m.report) {
                 driver.set_sync_bind(can::ids::SensorOutputBinding::report);
-            }
-            else {
+            } else {
                 driver.set_sync_bind(can::ids::SensorOutputBinding::none);
             }
             driver.set_limited_poll(true);

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -105,11 +105,14 @@ class PressureMessageHandler {
     void visit(const can::messages::BaselineSensorRequest &m) {
         LOG("received baseline request");
         static_cast<void>(m);
+        driver.set_sync_bind(can::ids::SensorOutputBinding::none);
+        driver.set_limited_poll(true);
+        driver.set_number_of_reads(m.number_of_reads);
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.set_sync_bind(can::ids::SensorOutputBinding::none);
-            driver.set_limited_poll(true);
-            driver.set_number_of_reads(m.number_of_reads);
             driver.get_pressure();
+        } else if (can::ids::SensorType(m.sensor) ==
+                   can::ids::SensorType::temperature) {
+            driver.get_temperature();
         }
         driver.get_can_client().send_can_message(
             can::ids::NodeId::host, can::messages::ack_from_request(m));

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -56,7 +56,7 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
             driver.set_limited_poll(true);
-            driver.set_baseline_values(1);
+            driver.set_number_of_reads(1);
             if (!driver.get_pressure()) {
                 LOG("Could not send read pressure command");
             }
@@ -106,10 +106,13 @@ class PressureMessageHandler {
         LOG("received baseline request");
         static_cast<void>(m);
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
+            driver.set_sync_bind(can::ids::SensorOutputBinding::none);
             driver.set_limited_poll(true);
-            driver.set_baseline_values(m.number_of_reads);
+            driver.set_number_of_reads(m.number_of_reads);
             driver.get_pressure();
         }
+        driver.get_can_client().send_can_message(
+            can::ids::NodeId::host, can::messages::ack_from_request(m));
     }
 
     void visit(const can::messages::PeripheralStatusRequest &m) {

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -56,7 +56,7 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
             driver.set_limited_poll(true);
-            driver.set_number_of_reads(1);
+            driver.set_baseline_values(1);
             if (!driver.get_pressure()) {
                 LOG("Could not send read pressure command");
             }
@@ -106,13 +106,8 @@ class PressureMessageHandler {
         LOG("received baseline request");
         static_cast<void>(m);
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            if (m.report) {
-                driver.set_sync_bind(can::ids::SensorOutputBinding::report);
-            } else {
-                driver.set_sync_bind(can::ids::SensorOutputBinding::none);
-            }
             driver.set_limited_poll(true);
-            driver.set_number_of_reads(m.sample_rate);
+            driver.set_baseline_values(m.number_of_reads);
             driver.get_pressure();
         }
     }

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -56,7 +56,7 @@ class PressureMessageHandler {
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
             driver.set_limited_poll(true);
-            driver.set_baseline_values(1);
+            driver.set_number_of_reads(1);
             if (!driver.get_pressure()) {
                 LOG("Could not send read pressure command");
             }

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -159,7 +159,7 @@ SCENARIO("Read pressure sensor values") {
         driver.set_sync_bind(can::ids::SensorOutputBinding::report);
         WHEN("a limited poll for 3 reads is set") {
             i2c_queue.reset();
-            driver.set_number_of_reads(4);
+            driver.set_baseline_values(4);
             driver.set_limited_poll(true);
             driver.get_pressure();
             THEN("the i2c queue receives a MEASURE_MODE_4 command") {
@@ -193,7 +193,7 @@ SCENARIO("Read pressure sensor values") {
         }
         WHEN("A single read command is sent") {
             driver.set_limited_poll(true);
-            driver.set_number_of_reads(1);
+            driver.set_baseline_values(1);
             driver.get_pressure();
             THEN("the i2c queue receives a MEASURE_MODE_4 command") {
                 REQUIRE(i2c_queue.get_size() == 1);
@@ -258,7 +258,7 @@ SCENARIO("Read pressure sensor values") {
             "executed") {
             driver.set_sync_bind(can::ids::SensorOutputBinding::report);
             driver.set_limited_poll(true);
-            driver.set_number_of_reads(1);
+            driver.set_baseline_values(1);
             driver.get_pressure();
             driver.sensor_callback();
             THEN(
@@ -338,7 +338,7 @@ SCENARIO("Read pressure sensor values") {
                 auto sensor_response = i2c::messages::TransactionResponse{
                     .id = id,
                     .bytes_read = 3,
-                    .read_buffer = {0x20, 0x0, 0x0, 0x0 0x0, 0x0, 0x0, 0x0,
+                    .read_buffer = {0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                     0x0}};
                 driver.handle_response(sensor_response);
             }

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -330,26 +330,27 @@ SCENARIO("Read pressure sensor values") {
                 auto sensor_response = i2c::messages::TransactionResponse{
                     .id = id,
                     .bytes_read = 3,
-                    .read_buffer = {0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                                    0x0, 0x0}};
+                    .read_buffer = {0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                    0x0}};
                 driver.handle_response(sensor_response);
             }
             for (int i = 0; i < 5; i++) {
                 auto sensor_response = i2c::messages::TransactionResponse{
                     .id = id,
                     .bytes_read = 3,
-                    .read_buffer = {0x20, 0x0, 0x0, 0x0 0x0, 0x0, 0x0,
-                                    0x0, 0x0}};
+                    .read_buffer = {0x20, 0x0, 0x0, 0x0 0x0, 0x0, 0x0, 0x0,
+                                    0x0}};
                 driver.handle_response(sensor_response);
             }
         }
-        THEN("a BaselineSensorResponse is sent with the correct calculated average") {
+        THEN(
+            "a BaselineSensorResponse is sent with the correct calculated "
+            "average") {
             can::message_writer_task::TaskMessage can_msg{};
 
             can_queue.try_read(&can_msg);
-            auto response_msg =
-                std::get<can::messages::BaselineSensorResponse>(
-                    can_msg.message);
+            auto response_msg = std::get<can::messages::BaselineSensorResponse>(
+                can_msg.message);
             float check_data =
                 fixed_point_to_float(response_msg.offset_average, 16);
             float expected = 30.0;

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -2,7 +2,6 @@
 
 #include "can/core/messages.hpp"
 #include "catch2/catch.hpp"
-#include "common/core/logging.h"
 #include "common/tests/mock_message_queue.hpp"
 #include "common/tests/mock_queue_client.hpp"
 #include "i2c/core/poller.hpp"

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -314,4 +314,46 @@ SCENARIO("Read pressure sensor values") {
             }
         }
     }
+    GIVEN("a baseline sensor request with 10 reads is processed") {
+        int num_reads = 10;
+        driver.set_sync_bind(can::ids::SensorOutputBinding::none);
+        driver.set_limited_poll(true);
+        driver.set_baseline_values(num_reads);
+        driver.get_pressure();
+        WHEN("pressure driver receives the requested sensor readings") {
+            auto id = i2c::messages::TransactionIdentifier{
+                .token = static_cast<uint32_t>(
+                    sensors::mmr920C04::Registers::PRESSURE_READ),
+                .is_completed_poll = false,
+                .transaction_index = static_cast<uint8_t>(0)};
+            for (int i = 0; i < 5; i++) {
+                auto sensor_response = i2c::messages::TransactionResponse{
+                    .id = id,
+                    .bytes_read = 3,
+                    .read_buffer = {0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                    0x0, 0x0}};
+                driver.handle_response(sensor_response);
+            }
+            for (int i = 0; i < 5; i++) {
+                auto sensor_response = i2c::messages::TransactionResponse{
+                    .id = id,
+                    .bytes_read = 3,
+                    .read_buffer = {0x20, 0x0, 0x0, 0x0 0x0, 0x0, 0x0,
+                                    0x0, 0x0}};
+                driver.handle_response(sensor_response);
+            }
+        }
+        THEN("a BaselineSensorResponse is sent with the correct calculated average") {
+            can::message_writer_task::TaskMessage can_msg{};
+
+            can_queue.try_read(&can_msg);
+            auto response_msg =
+                std::get<can::messages::BaselineSensorResponse>(
+                    can_msg.message);
+            float check_data =
+                fixed_point_to_float(response_msg.offset_average, 16);
+            float expected = 30.0;
+            REQUIRE(check_data == Approx(expected));
+        }
+    }
 }


### PR DESCRIPTION
Unlike the capacitive sensor, the pressure sensor does not have built-in auto-zeroing functionality. This pr allows `pressure_driver.hpp` to take a baseline reading of the ambient pressure by averaging together a number of samples specified in a `BaselineSensorRequest`. 

The threshold value will still act as an absolute threshold, but will now be compared to the difference between a given pressure reading and the averaged baseline pressure. 

In addition, after finishing calculating a baseline pressure, the pressure driver will send a `BaselineSensorResponse` with the average offset it's found.  