### PR TITLE
feat(pipettes): add baseline sensor response

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -100,6 +100,7 @@ typedef enum {
     can_messageid_bind_sensor_output_response = 0x8b,
     can_messageid_peripheral_status_request = 0x8c,
     can_messageid_peripheral_status_response = 0x8d,
+    can_messageid_baseline_sensor_response = 0x8e,
 } CANMessageId;
 
 /** Can bus arbitration id node id. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -102,6 +102,7 @@ enum class MessageId {
     bind_sensor_output_response = 0x8b,
     peripheral_status_request = 0x8c,
     peripheral_status_response = 0x8d,
+    baseline_sensor_response = 0x8e,
 };
 
 /** Can bus arbitration id node id. */

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -800,6 +800,27 @@ struct BaselineSensorRequest : BaseMessage<MessageId::baseline_sensor_request> {
     auto operator==(const BaselineSensorRequest& other) const -> bool = default;
 };
 
+struct BaselineSensorResponse
+    : BaseMessage<MessageId::baseline_sensor_response> {
+    uint32_t message_index = 0;
+    can::ids::SensorType sensor{};
+    can::ids::SensorId sensor_id{};
+    int32_t offset_average = 0;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(message_index, body, limit);
+        iter =
+            bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
+                                       limit);
+        iter = bit_utils::int_to_bytes(offset_average, iter, limit);
+        return iter - body;
+    }
+    auto operator==(const BaselineSensorResponse& other) const
+        -> bool = default;
+};
+
 struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
     uint32_t message_index = 0;
     can::ids::SensorType sensor{};
@@ -1404,6 +1425,6 @@ using ResponseMessageType = std::variant<
     SensorDiagnosticResponse, TaskInfoResponse, PipetteInfoResponse,
     BindSensorOutputResponse, GripperInfoResponse, TipActionResponse,
     PeripheralStatusResponse, BrushedMotorConfResponse,
-    UpdateMotorPositionEstimationResponse>;
+    UpdateMotorPositionEstimationResponse, BaselineSensorResponse>;
 
 }  // namespace can::messages


### PR DESCRIPTION
This pr just adds a `BaselineSensorRespone` message. This is intended to replace the stream of `ReadFromSensorResponse` messages in the case of auto-zeroing. However, we do want to keep limited polling available for testing and dev purposes, so some additional firmware to differentiate between that and production auto-zeroing may be in order for the sensors.