### PR TITLE
build: fix version generation in OE

### DIFF
--- a/common/core/CMakeLists.txt
+++ b/common/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_custom_target(generate_version
         ${CMAKE_COMMAND} -DGENERATE_VERSION_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/generate_version.cmake
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/version.c)
 
 add_library(version-lib STATIC ${CMAKE_CURRENT_BINARY_DIR}/version.c)


### PR DESCRIPTION
Openembedded puts the build directories outside the git repo. The source directories should still be in there, so let's make sure we run generate_version in the source directory - this will still work fine for output because we give explicit output directories.

## testing
- [x] do a normal build locally and check that the sha gets found
- [x] do a `cmake --preset=cross-no-directory-reqs` with a `-B` somewhere outside the ot3-firmware directory, build that, and check that the sha is found
- [ ] do an OE build and check that the sha is found