### PR TITLE
build: add workflow for ot3 builds

### DIFF
--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - *
+      - '*'
   pull_request:
     types:
       - opened

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -38,7 +38,7 @@ jobs:
 
   handle-pr:
     runs-on: 'ubuntu-latest'
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/ot3-firmware' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
     name: "Start an OT-3 build for a requested PR"
     steps:
       - name: 'start build'

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -1,0 +1,60 @@
+name: 'Start OT-3 build'
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - *
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+
+jobs:
+  handle-push:
+    runs-on: 'ubuntu-latest'
+    if: github.event_name == 'push'
+    name: "Start an OT-3 build for a branch/tag push"
+    steps:
+      - name: 'start build'
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: main
+          inputs: |
+            {
+              "oe-core-ref": "-",
+              "monorepo-ref": "-",
+              "ot3-firmware-ref": "${{ github.ref }}",
+              "infra-stage": "stage-prod"
+            }
+
+
+  handle-pr:
+    runs-on: 'ubuntu-latest'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'Opentrons/opentrons' && contains(github.event.pull_request.labels.*.name, 'ot3-build')
+    name: "Start an OT-3 build for a requested PR"
+    steps:
+      - name: 'start build'
+        uses: octokit/request-action@v2.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.OT3_BUILD_CROSSREPO_ACCESS }}
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow-id}/dispatches
+          owner: opentrons
+          repo: oe-core
+          workflow-id: build-ot3-actions.yml
+          ref: main
+          inputs: |
+            {
+              "oe-core-ref": "-",
+              "monorepo-ref": "-",
+              "ot3-firmware-ref": "refs/heads/${{ github.head_ref }}",
+              "infra-stage": "stage-prod"
+            }


### PR DESCRIPTION
This workflow should hook into the same mechanics that do builds for the monorepo and cause ot3 builds on pushes to main and pull requests that are labeled with 'ot3-build'.