### PR TITLE
motor-control: errors for moves during estop

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -153,6 +153,7 @@ class MotorInterruptHandler {
     void run_interrupt() {
         // handle error state
         if (in_estop) {
+            handle_update_position_queue();
             in_estop = estop_update();
         } else if (estop_triggered()) {
             cancel_and_clear_moves(can::ids::ErrorCode::estop_detected);


### PR DESCRIPTION
The motor controller would send an error if it was executing a move and an estop happened; but if it estop was asserted and it got new moves, it just wouldn't ever execute them. That means that anything that was waiting on those moves would have to wait for some timeout, which in the problematic case of the robot server starting while estop is asserted would be forever for home moves.

This commit extends the behavior of "nak the first move and blackhole the rest" to moves that come in while estop is asserted, which should raise an error in the host side. The host side will have to be fixed to handle such errors and still start up instead of exploding.

Ideally this would happen on the execute command, but then it wouldn't be the same as how it works for moves during estop assertion and would need new host code; and also there would be a time-of-check/time-of-use problem, where if estop asserted after the check in the move group controller and before the move got to the motor interrupt handler, you'd get the same behavior.

Plus it would really be a pain to get this information back to the move group control task.

# Test Plan
- Flash to a robot
- [x] Enable estop during a move and check that just one error is sent back 
- [x] While estop is enabled, send moves and check that one error is sent back
- [x] Disable estop and check that everything works again

# Todo
- [x] tests