### PR TITLE
feat(pipettes): add GPIO EXTI interrupt support for the tip sense GPIOs

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1466,6 +1466,7 @@ using ResponseMessageType = std::variant<
     SensorDiagnosticResponse, TaskInfoResponse, PipetteInfoResponse,
     BindSensorOutputResponse, GripperInfoResponse, TipActionResponse,
     PeripheralStatusResponse, BrushedMotorConfResponse,
-    UpdateMotorPositionEstimationResponse, BaselineSensorResponse>;
+    UpdateMotorPositionEstimationResponse, BaselineSensorResponse,
+    PushTipPresenceNotification>;
 
 }  // namespace can::messages

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -11,6 +11,7 @@
 #include "sensors/core/tasks/capacitive_sensor_task.hpp"
 #include "sensors/core/tasks/environmental_sensor_task.hpp"
 #include "sensors/core/tasks/pressure_sensor_task.hpp"
+#include "sensors/core/tasks/tip_presence_notification_task.hpp"
 
 /**
  * Sensor Tasks
@@ -57,6 +58,9 @@ struct Tasks {
     sensors::tasks::PressureSensorTask<
         freertos_message_queue::FreeRTOSMessageQueue>* pressure_sensor_task{
         nullptr};
+    sensors::tasks::TipPresenceNotificationTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* tip_notification_task{
+        nullptr};
 };
 
 /**
@@ -86,6 +90,8 @@ struct QueueClient : can::message_writer::MessageWriter {
         capacitive_sensor_queue_front{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<sensors::utils::TaskMessage>*
         pressure_sensor_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<
+        sensors::tip_presence::TaskMessage>* tip_notification_queue{nullptr};
 };
 
 /**

--- a/include/sensors/core/tasks/tip_presence_notification_task.hpp
+++ b/include/sensors/core/tasks/tip_presence_notification_task.hpp
@@ -1,0 +1,80 @@
+namespace sensors {
+namespace tasks {
+
+template <can::message_writer_task::TaskClient CanClient>
+class TipPresenceNotificationHandler {
+  public:
+    explicit TipPresenceNotificationHandler(
+        CanClient &can_client, sensors::hardware::SensorHardwareBase &hardware)
+        : can_client{can_client}, hardware{hardware} {}
+    TipPresenceNotificationHandler(const TipPresenceNotificationHandler &) =
+        delete;
+    TipPresenceNotificationHandler(const TipPresenceNotificationHandler &&) =
+        delete;
+    auto operator=(const TipPresenceNotificationHandler &)
+        -> TipPresenceNotificationHandler & = delete;
+    auto operator=(const TipPresenceNotificationHandler &&)
+        -> TipPresenceNotificationHandler && = delete;
+    ~TipPresenceNotificationHandler() = default;
+
+    void handle_message(const tip_presence::TaskMessage &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+    void visit(const std::monostate &) {}
+
+    void visit(const tip_presence::TipStatusChangeDetected &) {
+        can_client.send_can_message(
+            can::ids::NodeId::host,
+            can::messages::PushTipPresenceNotification{
+                .message_index = 0,
+                .ejector_flag_status =
+                    static_cast<uint8_t>(hardware.check_tip_presence())});
+    }
+
+  private:
+    CanClient &can_client;
+    sensors::hardware::SensorHardwareBase &hardware;
+};
+
+/**
+ * The task type.
+ */
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<tip_presence::TaskMessage>,
+                      tip_presence::TaskMessage>
+class TipPresenceNotificationTask {
+  public:
+    using Messages = tip_presence::TaskMessage;
+    using QueueType = QueueImpl<Messages>;
+    TipPresenceNotificationTask(QueueType &queue) : queue{queue} {}
+    TipPresenceNotificationTask(const TipPresenceNotificationTask &c) = delete;
+    TipPresenceNotificationTask(const TipPresenceNotificationTask &&c) = delete;
+    auto operator=(const TipPresenceNotificationTask &c) = delete;
+    auto operator=(const TipPresenceNotificationTask &&c) = delete;
+    ~TipPresenceNotificationTask() = default;
+
+    /**
+     * Task entry point.
+     */
+    template <can::message_writer_task::TaskClient CanClient>
+    [[noreturn]] void operator()(
+        CanClient *can_client,
+        sensors::hardware::SensorHardwareBase *hardware) {
+        auto handler = TipPresenceNotificationHandler{*can_client, *hardware};
+        Messages message{};
+        for (;;) {
+            if (queue.try_read(&message, queue.max_delay)) {
+                handler.handle_message(message);
+            }
+        }
+    }
+
+    [[nodiscard]] auto get_queue() const -> QueueType & { return queue; }
+
+  private:
+    QueueType &queue;
+};
+
+}  // namespace tasks
+}  // namespace sensors

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -7,6 +7,14 @@
 #include "i2c/core/messages.hpp"
 
 namespace sensors {
+
+namespace tip_presence {
+struct TipStatusChangeDetected {};
+
+using TaskMessage = std::variant<std::monostate, TipStatusChangeDetected>;
+
+}  // namespace tip_presence
+
 namespace utils {
 
 using CanMessageTuple = std::tuple<can::messages::ReadFromSensorRequest,

--- a/pipettes/core/sensor_tasks_g4.cpp
+++ b/pipettes/core/sensor_tasks_g4.cpp
@@ -21,6 +21,10 @@ static auto pressure_sensor_task_builder =
     freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
+static auto tip_notification_task_builder_front =
+    freertos_task::TaskStarter<512,
+                               sensors::tasks::TipPresenceNotificationTask>{};
+
 void sensor_tasks::start_tasks(
     sensor_tasks::CanWriterTask& can_writer,
     sensor_tasks::I2CClient& i2c3_task_client,
@@ -55,11 +59,14 @@ void sensor_tasks::start_tasks(
         capacitive_sensor_task_builder_front.start(
             5, "capacitive sensor s0", i2c3_task_client, i2c3_poller_client,
             sensor_hardware, queues);
+    auto& tip_notification_task = tip_notification_task_builder_front.start(
+        5, "tip notification", queues, sensor_hardware);
 
     tasks.eeprom_task = &eeprom_task;
     tasks.environment_sensor_task = &environment_sensor_task;
     tasks.capacitive_sensor_task_front = &capacitive_sensor_task_front;
     tasks.pressure_sensor_task = &pressure_sensor_task;
+    tasks.tip_notification_task = &tip_notification_task;
 
     queues.set_queue(&can_writer.get_queue());
     queues.eeprom_queue = &eeprom_task.get_queue();
@@ -67,6 +74,7 @@ void sensor_tasks::start_tasks(
     queues.capacitive_sensor_queue_front =
         &capacitive_sensor_task_front.get_queue();
     queues.pressure_sensor_queue = &pressure_sensor_task.get_queue();
+    queues.tip_notification_queue = &tip_notification_task.get_queue();
 }
 
 sensor_tasks::QueueClient::QueueClient()

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -33,10 +33,21 @@ static PipetteHardwarePin get_gpio_ht(PipetteHardwareDevice device) {
     }
 }
 
-IRQn_Type get_interrupt_line(const PipetteType pipette_type) {
-    switch (pipette_type) {
-        case NINETY_SIX_CHANNEL:
-        case THREE_EIGHTY_FOUR_CHANNEL:
+
+static IRQn_Type get_interrupt_line_lt(PipetteGPIOInterrupt gpio_pin_type) {
+    switch (gpio_pin_type) {
+        case pipette_gpio_data_ready:
+            return EXTI3_IRQn;
+        case pipette_gpio_tip_sense:
+        default:
+            // External interrupt line 3
+            return EXTI3_IRQn;
+    }
+}
+
+static IRQn_Type get_interrupt_line_ht(PipetteGPIOInterrupt gpio_pin_type) {
+    switch (gpio_pin_type) {
+        case pipette_gpio_data_ready:
             // External interrupt lines 15:10
             // TODO(lc: 10-20-2022) This will only
             // return the front sensor board data ready line
@@ -44,12 +55,24 @@ IRQn_Type get_interrupt_line(const PipetteType pipette_type) {
             // for the 96-chan and 8-chan
             // PC6 -> GPIO_EXTI6 (EXTI9_5_IRQn)
             // PC11 -> GPIO_EXTI11 (EXTI15_10_IRQn)
-            return EXTI15_10_IRQn;
-        case SINGLE_CHANNEL:
-        case EIGHT_CHANNEL:
+            return EXTI15_10_IRQn | EXTI9_5_IRQn;
+        case pipette_gpio_tip_sense:
         default:
             // External interrupt line 3
             return EXTI3_IRQn;
+    }
+}
+
+
+IRQn_Type get_interrupt_line(const PipetteType pipette_type, PipetteGPIOInterrupt gpio_pin_type) {
+    switch (pipette_type) {
+        case NINETY_SIX_CHANNEL:
+        case THREE_EIGHTY_FOUR_CHANNEL:
+            return get_interrupt_line_ht(gpio_pin_type);
+        case SINGLE_CHANNEL:
+        case EIGHT_CHANNEL:
+        default:
+            return get_interrupt_line_lt(gpio_pin_type);
     }
 }
 

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -34,44 +34,31 @@ static PipetteHardwarePin get_gpio_ht(PipetteHardwareDevice device) {
 }
 
 
-static IRQn_Type get_interrupt_line_lt(PipetteGPIOInterrupt gpio_pin_type) {
+IRQn_Type get_interrupt_line(GPIOInterruptBlock gpio_pin_type) {
     switch (gpio_pin_type) {
-        case pipette_gpio_data_ready:
-            // Tip sense External interrupt line 3
-            return EXTI3_IRQn;
-        case pipette_gpio_tip_sense:
-        default:
-            // Tip sense External interrupt line 2
-            return EXTI2_IRQn;
-    }
-}
-
-static IRQn_Type get_interrupt_line_ht(PipetteGPIOInterrupt gpio_pin_type) {
-    switch (gpio_pin_type) {
-        case pipette_gpio_data_ready:
-            // External interrupt lines 15:10
+        case gpio_block_9_5:
+            // Data ready line for 96 channel (rear)
             // PC6 -> GPIO_EXTI6 (EXTI9_5_IRQn)
-            // PC11 -> GPIO_EXTI11 (EXTI15_10_IRQn)
-            return EXTI15_10_IRQn | EXTI9_5_IRQn;
-        case pipette_gpio_tip_sense:
-        default:
-            // tip sense
+
+            // Tip sense line for the 96 channel (rear)
             // PC7 -> GPIO_EXTI6 (EXTI9_5_IRQn)
+            return EXTI9_5_IRQn;
+        case gpio_block_15_10:
+            // Data ready line for 96 channel (front)
+            // PC11 -> GPIO_EXTI11 (EXTI15_10_IRQn)
+
+            // Tip sense line for the 96 channel (front)
             // PC12 -> GPIO_EXTI11 (EXTI15_10_IRQn)
-            return EXTI15_10_IRQn | EXTI9_5_IRQn;
-    }
-}
-
-
-IRQn_Type get_interrupt_line(const PipetteType pipette_type, PipetteGPIOInterrupt gpio_pin_type) {
-    switch (pipette_type) {
-        case NINETY_SIX_CHANNEL:
-        case THREE_EIGHTY_FOUR_CHANNEL:
-            return get_interrupt_line_ht(gpio_pin_type);
-        case SINGLE_CHANNEL:
-        case EIGHT_CHANNEL:
+            return EXTI15_10_IRQn;
+        case gpio_block_3:
+            // Single channel data ready line
+            // PC3 -> GPIO_EXTI3 (EXTI3_IRQn)
+            return EXTI3_IRQn;
+        case gpio_block_2:
+            // tip sense single and eight channel
+            // PC2 -> GPIO_EXTI2 (EXTI2_IRQn)
         default:
-            return get_interrupt_line_lt(gpio_pin_type);
+            return EXTI2_IRQn;
     }
 }
 

--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -37,11 +37,12 @@ static PipetteHardwarePin get_gpio_ht(PipetteHardwareDevice device) {
 static IRQn_Type get_interrupt_line_lt(PipetteGPIOInterrupt gpio_pin_type) {
     switch (gpio_pin_type) {
         case pipette_gpio_data_ready:
+            // Tip sense External interrupt line 3
             return EXTI3_IRQn;
         case pipette_gpio_tip_sense:
         default:
-            // External interrupt line 3
-            return EXTI3_IRQn;
+            // Tip sense External interrupt line 2
+            return EXTI2_IRQn;
     }
 }
 
@@ -49,17 +50,15 @@ static IRQn_Type get_interrupt_line_ht(PipetteGPIOInterrupt gpio_pin_type) {
     switch (gpio_pin_type) {
         case pipette_gpio_data_ready:
             // External interrupt lines 15:10
-            // TODO(lc: 10-20-2022) This will only
-            // return the front sensor board data ready line
-            // for now. We need to support and set-up both
-            // for the 96-chan and 8-chan
             // PC6 -> GPIO_EXTI6 (EXTI9_5_IRQn)
             // PC11 -> GPIO_EXTI11 (EXTI15_10_IRQn)
             return EXTI15_10_IRQn | EXTI9_5_IRQn;
         case pipette_gpio_tip_sense:
         default:
-            // External interrupt line 3
-            return EXTI3_IRQn;
+            // tip sense
+            // PC7 -> GPIO_EXTI6 (EXTI9_5_IRQn)
+            // PC12 -> GPIO_EXTI11 (EXTI15_10_IRQn)
+            return EXTI15_10_IRQn | EXTI9_5_IRQn;
     }
 }
 

--- a/pipettes/firmware/hardware_config.h
+++ b/pipettes/firmware/hardware_config.h
@@ -16,11 +16,13 @@ typedef enum {
 }PipetteHardwareDevice;
 
 typedef enum {
-    pipette_gpio_data_ready,
-    pipette_gpio_tip_sense
-}PipetteGPIOInterrupt;
+    gpio_block_9_5,
+    gpio_block_15_10,
+    gpio_block_2,
+    gpio_block_3
+}GPIOInterruptBlock;
 
 uint16_t pipette_hardware_spi_pins(const PipetteType pipette_type, GPIO_TypeDef* which_handle);
 uint16_t pipette_hardware_motor_driver_pins(const PipetteType pipette_type, GPIO_TypeDef* for_handle);
 PipetteHardwarePin pipette_hardware_get_gpio(const PipetteType pipette_type, PipetteHardwareDevice device);
-IRQn_Type get_interrupt_line(const PipetteType pipette_type, PipetteGPIOInterrupt gpio_pin_type);
+IRQn_Type get_interrupt_line(GPIOInterruptBlock gpio_pin_type);

--- a/pipettes/firmware/hardware_config.h
+++ b/pipettes/firmware/hardware_config.h
@@ -15,6 +15,11 @@ typedef enum {
     pipette_hardware_device_data_ready_rear
 }PipetteHardwareDevice;
 
+typedef enum {
+    pipette_gpio_data_ready,
+    pipette_gpio_tip_sense
+}PipetteGPIOInterrupt;
+
 uint16_t pipette_hardware_spi_pins(const PipetteType pipette_type, GPIO_TypeDef* which_handle);
 uint16_t pipette_hardware_motor_driver_pins(const PipetteType pipette_type, GPIO_TypeDef* for_handle);
 PipetteHardwarePin pipette_hardware_get_gpio(const PipetteType pipette_type, PipetteHardwareDevice device);

--- a/pipettes/firmware/hardware_config.h
+++ b/pipettes/firmware/hardware_config.h
@@ -23,4 +23,4 @@ typedef enum {
 uint16_t pipette_hardware_spi_pins(const PipetteType pipette_type, GPIO_TypeDef* which_handle);
 uint16_t pipette_hardware_motor_driver_pins(const PipetteType pipette_type, GPIO_TypeDef* for_handle);
 PipetteHardwarePin pipette_hardware_get_gpio(const PipetteType pipette_type, PipetteHardwareDevice device);
-IRQn_Type get_interrupt_line(const PipetteType pipette_type);
+IRQn_Type get_interrupt_line(const PipetteType pipette_type, PipetteGPIOInterrupt gpio_pin_type);

--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -118,12 +118,37 @@ void DebugMon_Handler(void) {}
 /*  file (startup_stm32g4xxxx.s).                                             */
 /******************************************************************************/
 
+void EXTI2_IRQHandler(void) {
+    EXTI->PR1 = EXTI_LINE_2;
+    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
+}
+
 void EXTI3_IRQHandler(void) {
+    EXTI->PR1 = EXTI_LINE_3;
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
 }
 
+void EXTI9_5_IRQHandler(void) {
+    if (EXTI->PR1 & (1 << 6)) {
+        // clear pending
+        EXTI->PR1 = EXTI_LINE_6;
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_6);
+    } else if (EXTI->PR1 & (1 << 2)) {
+        // clear pending
+        EXTI->PR1 = EXTI_LINE_7;
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7); 
+    }
+}
+
+
 void EXTI15_10_IRQHandler(void) {
-    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_11);
+    if (EXTI->PR1 & (1 << 12)) {
+        EXTI->PR1 = EXTI_LINE_12;
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
+    } else if (EXTI->PR1 & (1 << 11)) {
+        EXTI->PR1 = EXTI_LINE_11;
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_11);
+    }
 }
 
 // TODO refer to schematic to check and see that the data ready

--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -119,34 +119,34 @@ void DebugMon_Handler(void) {}
 /******************************************************************************/
 
 void EXTI2_IRQHandler(void) {
-    EXTI->PR1 = EXTI_LINE_2;
+    __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_2);
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
 }
 
 void EXTI3_IRQHandler(void) {
-    EXTI->PR1 = EXTI_LINE_3;
+    __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_3);
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
 }
 
 void EXTI9_5_IRQHandler(void) {
-    if (EXTI->PR1 & (1 << 6)) {
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_6)) {
         // clear pending
-        EXTI->PR1 = EXTI_LINE_6;
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_6);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_6);
-    } else if (EXTI->PR1 & (1 << 2)) {
+    } else if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_7)) {
         // clear pending
-        EXTI->PR1 = EXTI_LINE_7;
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_7);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7); 
     }
 }
 
 
 void EXTI15_10_IRQHandler(void) {
-    if (EXTI->PR1 & (1 << 12)) {
-        EXTI->PR1 = EXTI_LINE_12;
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_12)) {
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_12);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
-    } else if (EXTI->PR1 & (1 << 11)) {
-        EXTI->PR1 = EXTI_LINE_11;
+    } else if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_11)) {
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_11);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_11);
     }
 }

--- a/pipettes/firmware/stm32g4xx_it.h
+++ b/pipettes/firmware/stm32g4xx_it.h
@@ -47,6 +47,8 @@ void TIM7_IRQHandler(void);
 void TIM6_DAC_IRQHandler(void);
 void EXTI3_IRQHandler(void);
 void EXTI15_10_IRQHandler(void);
+void EXTI9_5_IRQHandler(void);
+void EXTI2_IRQHandler(void);
 
 #ifdef __cplusplus
 }

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -31,7 +31,6 @@ static void tip_sense_gpio_init() {
          * */
         GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_7;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-
     } else {
         /*Configure GPIO pin : C2 */
         GPIO_InitStruct.Pin = GPIO_PIN_2;

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -20,6 +20,7 @@ static void enable_gpio_port(void* port) {
  */
 static void tip_sense_gpio_init() {
     PipetteType pipette_type = get_pipette_type();
+    IRQn_Type exti_line = get_interrupt_line(pipette_type, pipette_gpio_tip_sense);
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
@@ -36,6 +37,9 @@ static void tip_sense_gpio_init() {
         GPIO_InitStruct.Pin = GPIO_PIN_2;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     }
+    /* EXTI interrupt init*/
+    HAL_NVIC_SetPriority(exti_line, 10, 0);
+    HAL_NVIC_EnableIRQ(exti_line);
 }
 
 
@@ -152,7 +156,7 @@ static void data_ready_gpio_init() {
             pipette_hardware_get_gpio(
                 pipette_type, pipette_hardware_device_data_ready_front);
     enable_gpio_port(hardware.port);
-    IRQn_Type exti_line = get_interrupt_line(pipette_type);
+    IRQn_Type exti_line = get_interrupt_line(pipette_type, pipette_gpio_data_ready);
     if (pipette_type != SINGLE_CHANNEL && pipette_type != EIGHT_CHANNEL) {
         PipetteHardwarePin hardware_rear = pipette_hardware_get_gpio(
             pipette_type, pipette_hardware_device_data_ready_rear);
@@ -165,9 +169,9 @@ static void data_ready_gpio_init() {
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         HAL_GPIO_Init(hardware.port, &GPIO_InitStruct);
 
-        /* EXTI interrupt init*/
-        HAL_NVIC_SetPriority(exti_line, 10, 0);
-        HAL_NVIC_EnableIRQ(exti_line);
+        // /* EXTI interrupt init*/
+        // HAL_NVIC_SetPriority(exti_line, 10, 0);
+        // HAL_NVIC_EnableIRQ(exti_line);
     }
 
     /*Configure GPIO pin*/

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -20,9 +20,9 @@ static void enable_gpio_port(void* port) {
  */
 static void tip_sense_gpio_init() {
     PipetteType pipette_type = get_pipette_type();
-    IRQn_Type exti_line = get_interrupt_line(pipette_type, pipette_gpio_tip_sense);
+    
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     enable_gpio_port(GPIOC);
     if (pipette_type == NINETY_SIX_CHANNEL) {
@@ -37,11 +37,41 @@ static void tip_sense_gpio_init() {
         GPIO_InitStruct.Pin = GPIO_PIN_2;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     }
-    /* EXTI interrupt init*/
-    HAL_NVIC_SetPriority(exti_line, 10, 0);
-    HAL_NVIC_EnableIRQ(exti_line);
+
 }
 
+
+/**
+ * @brief NVIC EXTI interrupt priority Initialization
+ * @param None
+ * @retval None
+ */
+static void nvic_priority_enable_init() {
+    PipetteType pipette_type = get_pipette_type();
+
+    if (pipette_type == NINETY_SIX_CHANNEL) {
+        IRQn_Type block_9_5 = get_interrupt_line(gpio_block_9_5);
+        IRQn_Type block_15_10 = get_interrupt_line(gpio_block_15_10);
+        /* EXTI interrupt init data ready/tip sense rear*/
+        HAL_NVIC_SetPriority(block_9_5, 10, 0);
+        HAL_NVIC_EnableIRQ(block_9_5);
+
+        /* EXTI interrupt init data ready/tip sense front*/
+        HAL_NVIC_SetPriority(block_15_10, 10, 0);
+        HAL_NVIC_EnableIRQ(block_15_10);
+    } else {
+        IRQn_Type block_3 = get_interrupt_line(gpio_block_3);
+        IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
+        /* EXTI interrupt init block tip sense*/
+        HAL_NVIC_SetPriority(block_2, 10, 0);
+        HAL_NVIC_EnableIRQ(block_2);
+
+        /* EXTI interrupt init data ready*/
+        HAL_NVIC_SetPriority(block_3, 10, 0);
+        HAL_NVIC_EnableIRQ(block_3);
+    }
+
+}
 
 /**
  * @brief Limit Switch GPIO Initialization Function
@@ -156,7 +186,6 @@ static void data_ready_gpio_init() {
             pipette_hardware_get_gpio(
                 pipette_type, pipette_hardware_device_data_ready_front);
     enable_gpio_port(hardware.port);
-    IRQn_Type exti_line = get_interrupt_line(pipette_type, pipette_gpio_data_ready);
     if (pipette_type != SINGLE_CHANNEL && pipette_type != EIGHT_CHANNEL) {
         PipetteHardwarePin hardware_rear = pipette_hardware_get_gpio(
             pipette_type, pipette_hardware_device_data_ready_rear);
@@ -169,9 +198,6 @@ static void data_ready_gpio_init() {
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         HAL_GPIO_Init(hardware.port, &GPIO_InitStruct);
 
-        // /* EXTI interrupt init*/
-        // HAL_NVIC_SetPriority(exti_line, 10, 0);
-        // HAL_NVIC_EnableIRQ(exti_line);
     }
 
     /*Configure GPIO pin*/
@@ -182,9 +208,6 @@ static void data_ready_gpio_init() {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(hardware.port, &GPIO_InitStruct);
 
-    /* EXTI interrupt init*/
-    HAL_NVIC_SetPriority(exti_line, 10, 0);
-    HAL_NVIC_EnableIRQ(exti_line);
 }
 
 
@@ -231,6 +254,7 @@ static void mount_id_init() {
 
 void utility_gpio_init() {
     mount_id_init();
+    nvic_priority_enable_init();
     limit_switch_gpio_init();
     tip_sense_gpio_init();
     LED_drive_gpio_init();


### PR DESCRIPTION
## Overview

We want to decide that a tip has been detected based on an EXTI interrupt. This PR adds the piping in HAL to support an EXTI interrupt. While making these changes, I also edited the code on the pressure sensor to support two data ready lines for the 96 channel. We'll also want to do this for DVT 8 channel pipettes since there are now two separate data ready lines.

## Test Plan

- [x] Test that the pressure sensor still functions normally on the single/eight channel
