### PR TITLE
fix(gripper): collection of fixes found during bringup

### DIFF
--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -32,25 +32,25 @@ struct motor_hardware::BrushedHardwareConfig brushed_motor_conf {
             .channel = TIM_CHANNEL_1},
     .enable =
         {  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOC,
-            .pin = GPIO_PIN_11,
+            .port = G_MOT_ENABLE_PORT,
+            .pin = G_MOT_ENABLE_PIN,
             .active_setting = GPIO_PIN_SET},
     .limit_switch =
         {  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOC,
-            .pin = GPIO_PIN_2,
+            .port = G_LIM_SW_PORT,
+            .pin = G_LIM_SW_PIN,
             .active_setting = GPIO_PIN_SET},
     .sync_in =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_7,
+            .port = NSYNC_IN_PORT,
+            .pin = NSYNC_IN_PIN,
             .active_setting = GPIO_PIN_RESET},
     .estop_in =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOA,
-            .pin = GPIO_PIN_10,
+            .port = ESTOP_IN_PORT,
+            .pin = ESTOP_IN_PIN,
             .active_setting = GPIO_PIN_RESET},
     .encoder_interrupt_freq = double(GRIPPER_JAW_PWM_FREQ_HZ),
 

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -31,7 +31,9 @@ static spi::hardware::Spi spi_comms(SPI_intf);
 static void* enc_handle = nullptr;
 static constexpr float encoder_pulses = 0.0;
 static constexpr std::optional<gpio::PinConfig> ebrake = std::nullopt;
+static constexpr use_stop_enable = 0x1;
 #else
+static constexpr use_stop_enable = 0x0;
 static constexpr void* enc_handle = &htim8;
 static constexpr float encoder_pulses = 1024.0;
 static gpio::PinConfig ebrake = {
@@ -96,7 +98,7 @@ static motor_hardware::MotorHardware motor_hardware_iface(motor_pins, &htim7,
  * Motor driver configuration.
  */
 static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
-    .registers = {.gconfig = {.en_pwm_mode = 0x0, .stop_enable = 0x1},
+    .registers = {.gconfig = {.en_pwm_mode = 0x0, .stop_enable = use_stop_enable},
                   .ihold_irun = {.hold_current = 0x2,  // 0.177A
                                  .run_current = 0xA,   // 0.648A
                                  .hold_current_delay = 0x7},

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -2,6 +2,7 @@
 #include "gripper/core/can_task.hpp"
 #include "gripper/core/interfaces.hpp"
 #include "gripper/core/utils.hpp"
+#include "gripper/firmware/utility_gpio.h"
 #include "motor-control/core/stepper_motor/motion_controller.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
@@ -31,15 +32,15 @@ static spi::hardware::Spi spi_comms(SPI_intf);
 static void* enc_handle = nullptr;
 static constexpr float encoder_pulses = 0.0;
 static constexpr std::optional<gpio::PinConfig> ebrake = std::nullopt;
-static constexpr use_stop_enable = 0x1;
+static constexpr uint8_t use_stop_enable = 0x1;
 #else
-static constexpr use_stop_enable = 0x0;
+static constexpr uint8_t use_stop_enable = 0x0;
 static constexpr void* enc_handle = &htim8;
 static constexpr float encoder_pulses = 1024.0;
 static gpio::PinConfig ebrake = {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    .port = GPIOB,
-    .pin = GPIO_PIN_5,
+    .port = EBRAKE_PORT,
+    .pin = EBRAKE_PIN,
     .active_setting = GPIO_PIN_RESET};
 #endif
 
@@ -50,39 +51,39 @@ struct motion_controller::HardwareConfig motor_pins {
     .direction =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_10,
+            .port = Z_MOT_STEPDIR_PORT,
+            .pin = Z_MOT_DIR_PIN,
             .active_setting = GPIO_PIN_SET},
     .step =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_1,
+            .port = Z_MOT_STEPDIR_PORT,
+            .pin = Z_MOT_STEP_PIN,
             .active_setting = GPIO_PIN_SET},
     .enable =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOA,
-            .pin = GPIO_PIN_9,
+            .port = Z_MOT_ENABLE_PORT,
+            .pin = Z_MOT_ENABLE_PIN,
             .active_setting = GPIO_PIN_SET},
     .limit_switch =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOC,
-            .pin = GPIO_PIN_7,
+            .port = Z_LIM_SW_PORT,
+            .pin = Z_LIM_SW_PIN,
             .active_setting = GPIO_PIN_SET},
     .led = {},
     .sync_in =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOB,
-            .pin = GPIO_PIN_7,
+            .port = NSYNC_IN_PORT,
+            .pin = NSYNC_IN_PIN,
             .active_setting = GPIO_PIN_RESET},
     .estop_in =
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-            .port = GPIOA,
-            .pin = GPIO_PIN_10,
+            .port = ESTOP_IN_PORT,
+            .pin = ESTOP_IN_PIN,
             .active_setting = GPIO_PIN_RESET},
     .ebrake = ebrake,
 };
@@ -98,7 +99,8 @@ static motor_hardware::MotorHardware motor_hardware_iface(motor_pins, &htim7,
  * Motor driver configuration.
  */
 static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
-    .registers = {.gconfig = {.en_pwm_mode = 0x0, .stop_enable = use_stop_enable},
+    .registers = {.gconfig = {.en_pwm_mode = 0x0,
+                              .stop_enable = use_stop_enable},
                   .ihold_irun = {.hold_current = 0x2,  // 0.177A
                                  .run_current = 0xA,   // 0.648A
                                  .hold_current_delay = 0x7},
@@ -121,9 +123,9 @@ static tmc2130::configs::TMC2130DriverConfig MotorDriverConfigurations{
             .v_sf = 0.32,
         },
     .chip_select = {
-        .cs_pin = GPIO_PIN_12,
+        .cs_pin = Z_MOT_DRIVE_CS,
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-        .GPIO_handle = GPIOB,
+        .GPIO_handle = Z_MOT_DRIVE_PORT,
     }};
 
 /**

--- a/gripper/firmware/main_rev1.cpp
+++ b/gripper/firmware/main_rev1.cpp
@@ -22,6 +22,7 @@
 #include "common/firmware/utility_gpio.h"
 #include "gripper/core/interfaces.hpp"
 #include "gripper/core/tasks.hpp"
+#include "gripper/firmware/utility_gpio.h"
 #include "i2c/firmware/i2c_comms.hpp"
 #include "sensors/firmware/sensor_hardware.hpp"
 
@@ -33,8 +34,8 @@ static auto iWatchdog = iwdg::IndependentWatchDog{};
 static auto canbus = can::hal::bus::HalCanBus(
     can_get_device_handle(),
     gpio::PinConfig{// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                    .port = GPIOC,
-                    .pin = GPIO_PIN_6,
+                    .port = LED_GPIO_PORT,
+                    .pin = LED_GPIO_PIN,
                     .active_setting = GPIO_PIN_RESET});
 // Unfortunately, these numbers need to be literals or defines
 // to get the compile-time checks to work so we can't actually
@@ -88,12 +89,12 @@ static auto eeprom_hw_iface = EEPromHardwareInterface();
 auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
     .sync_in =
         {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-         .port = GPIOB,
-         .pin = GPIO_PIN_7,
+         .port = NSYNC_IN_PORT,
+         .pin = NSYNC_IN_PIN,
          .active_setting = GPIO_PIN_RESET},
     .sync_out = {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                 .port = GPIOB,
-                 .pin = GPIO_PIN_6,
+                 .port = NSYNC_OUT_PORT,
+                 .pin = NSYNC_OUT_PIN,
                  .active_setting = GPIO_PIN_RESET}};
 
 auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins);

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "gripper/firmware/utility_gpio.h"
 #include "common/firmware/errors.h"
 #include "platform_specific_hal_conf.h"
 #include "stm32g4xx_it.h"

--- a/gripper/firmware/motor_hardware_g.c
+++ b/gripper/firmware/motor_hardware_g.c
@@ -51,23 +51,23 @@ static void HAL_TIM_MspPostInit(TIM_HandleTypeDef* htim) {
         /** TIM1 GPIO Configuration
             PC0     ------> TIM1_CH1
         */
-        GPIO_InitStruct.Pin = GPIO_PIN_0;
+        GPIO_InitStruct.Pin = G_MOT_PWM_CH1_PIN;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF2_TIM1;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+        HAL_GPIO_Init(G_MOT_PWM_CH1_PORT, &GPIO_InitStruct);
     } else if (htim->Instance == TIM3) {
         __HAL_RCC_GPIOA_CLK_ENABLE();
         /** TIM3 GPIO Configuration
             PA6     ------> TIM3_CH1
         */
-        GPIO_InitStruct.Pin = GPIO_PIN_6;
+        GPIO_InitStruct.Pin = G_MOT_PWM_CH2_PIN;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF2_TIM3;
-        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+        HAL_GPIO_Init(G_MOT_PWM_CH2_PORT, &GPIO_InitStruct);
     }
 }
 
@@ -342,10 +342,10 @@ void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac) {
         /**DAC1 GPIO Configuration
         PA4     ------> DAC1_OUT1
         */
-        GPIO_InitStruct.Pin = GPIO_PIN_4;
+        GPIO_InitStruct.Pin = G_MOT_VREF_PIN;
         GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
-        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+        HAL_GPIO_Init(G_MOT_VREF_PORT, &GPIO_InitStruct);
     }
 }
 
@@ -358,7 +358,7 @@ void HAL_DAC_MspInit(DAC_HandleTypeDef* hdac) {
 void HAL_DAC_MspDeInit(DAC_HandleTypeDef* hdac) {
     if (hdac->Instance == DAC1) {
         __HAL_RCC_DAC1_CLK_DISABLE();
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_4);
+        HAL_GPIO_DeInit(G_MOT_VREF_PORT, G_MOT_VREF_PIN);
     }
 }
 

--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -142,9 +142,6 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
         GPIO_InitStruct.Alternate = GPIO_AF4_TIM8;
         HAL_GPIO_Init(Z_MOT_ENC_AB_PORT, &GPIO_InitStruct);
 
-        /* TIM8 interrupt Init */
-        HAL_NVIC_SetPriority(TIM8_UP_IRQn, 7, 0);
-        HAL_NVIC_EnableIRQ(TIM8_UP_IRQn);
     }
 }
 
@@ -160,7 +157,6 @@ void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim) {
         HAL_GPIO_DeInit(G_MOT_ENC_PORT, G_MOT_ENC_A_PIN | G_MOT_ENC_B_PIN);
     } else if (htim == &htim8) {
         __HAL_RCC_TIM8_CLK_DISABLE();
-        HAL_NVIC_DisableIRQ(TIM8_UP_IRQn);
         HAL_GPIO_DeInit(Z_MOT_ENC_AB_PORT, Z_MOT_ENC_A_PIN|Z_MOT_ENC_B_PIN);
     }
 }

--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -82,14 +82,14 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base) {
         /* TIM1 interrupt DeInit */
         HAL_NVIC_DisableIRQ(TIM1_UP_TIM16_IRQn);
         HAL_NVIC_DisableIRQ(TIM1_CC_IRQn);
-        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_0);
+        HAL_GPIO_DeInit(G_MOT_PWM_CH1_PORT, G_MOT_PWM_CH1_PIN);
 
     } else if (htim_base->Instance == TIM3) {
         /* Peripheral clock disable */
         __HAL_RCC_TIM3_CLK_DISABLE();
         /* TIM3 interrupt DeInit */
         HAL_NVIC_DisableIRQ(TIM3_IRQn);
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_6);
+        HAL_GPIO_DeInit(G_MOT_PWM_CH2_PORT, G_MOT_PWM_CH2_PIN);
 
     } else if (htim_base->Instance == TIM4) {
         /* Peripheral clock disable */
@@ -115,12 +115,12 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
             PA1     ------> CHANNEL B
             PA5    ------> CHANNEL I (UNUSED)
         */
-        GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1;
+        GPIO_InitStruct.Pin = G_MOT_ENC_A_PIN | G_MOT_ENC_B_PIN;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
-        HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+        HAL_GPIO_Init(G_MOT_ENC_PORT, &GPIO_InitStruct);
 
         /* TIM2 interrupt Init */
         HAL_NVIC_SetPriority(TIM2_IRQn, 7, 0);
@@ -135,12 +135,12 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
             PC7     ------> TIM8_CH2
         */
         GPIO_InitTypeDef GPIO_InitStruct = {0};
-        GPIO_InitStruct.Pin = GPIO_PIN_6|GPIO_PIN_7;
+        GPIO_InitStruct.Pin = Z_MOT_ENC_A_PIN|Z_MOT_ENC_B_PIN;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
-        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF4_TIM8;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+        HAL_GPIO_Init(Z_MOT_ENC_AB_PORT, &GPIO_InitStruct);
 
         /* TIM8 interrupt Init */
         HAL_NVIC_SetPriority(TIM8_UP_IRQn, 7, 0);
@@ -157,11 +157,11 @@ void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim) {
     if (htim == &htim2) {
         __HAL_RCC_TIM2_CLK_DISABLE();
         HAL_NVIC_DisableIRQ(TIM2_IRQn);
-        HAL_GPIO_DeInit(GPIOA, GPIO_PIN_0 | GPIO_PIN_1);
+        HAL_GPIO_DeInit(G_MOT_ENC_PORT, G_MOT_ENC_A_PIN | G_MOT_ENC_B_PIN);
     } else if (htim == &htim8) {
         __HAL_RCC_TIM8_CLK_DISABLE();
         HAL_NVIC_DisableIRQ(TIM8_UP_IRQn);
-        HAL_GPIO_DeInit(GPIOC, GPIO_PIN_6|GPIO_PIN_7);
+        HAL_GPIO_DeInit(Z_MOT_ENC_AB_PORT, Z_MOT_ENC_A_PIN|Z_MOT_ENC_B_PIN);
     }
 }
 
@@ -181,7 +181,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
     } else if (htim == &htim4 && gripper_enc_idle_state_overflow_callback) {
         gripper_enc_idle_state_overflow_callback(true);
         __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
-        
+
     } else if (htim == &htim8 && z_enc_overflow_callback) {
         uint32_t direction = __HAL_TIM_IS_TIM_COUNTING_DOWN(htim);
         z_enc_overflow_callback(direction ? -1 : 1);

--- a/gripper/firmware/motor_hardware_z.c
+++ b/gripper/firmware/motor_hardware_z.c
@@ -115,16 +115,16 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef *hspi) {
         PB14  ------> SPI2_MISO
         PB15  ------> SPI2_MOSI
         */
-        GPIO_InitStruct.Pin = GPIO_PIN_13 | GPIO_PIN_14 | GPIO_PIN_15;
+        GPIO_InitStruct.Pin = Z_MOT_DRIVE_CLK | Z_MOT_DRIVE_MISO | Z_MOT_DRIVE_MOSI;
         GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
         GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         GPIO_InitStruct.Alternate = GPIO_AF5_SPI2;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+        HAL_GPIO_Init(Z_MOT_DRIVE_PORT, &GPIO_InitStruct);
 
-        GPIO_InitStruct.Pin = GPIO_PIN_12;
+        GPIO_InitStruct.Pin = Z_MOT_DRIVE_CS;
         GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-        HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
+        HAL_GPIO_Init(Z_MOT_DRIVE_PORT, &GPIO_InitStruct);
     }
 }
 
@@ -137,8 +137,8 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
     if (hspi->Instance == SPI2) {
         /* Peripheral clock disable */
         __HAL_RCC_SPI2_CLK_DISABLE();
-        HAL_GPIO_DeInit(GPIOB, GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 |
-                                   GPIO_PIN_15);
+        HAL_GPIO_DeInit(Z_MOT_DRIVE_PORT, Z_MOT_DRIVE_CS | Z_MOT_DRIVE_CLK | Z_MOT_DRIVE_MISO |
+                                   Z_MOT_DRIVE_MOSI);
     }
 }
 

--- a/include/gripper/firmware/utility_gpio.h
+++ b/include/gripper/firmware/utility_gpio.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+void utility_gpio_init();
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+
+#if PCBA_PRIMARY_REVISION == 'b' || PCBA_PRIMARY_REVISION == 'a'
+#define LED_GPIO_PIN GPIO_PIN_6
+#define Z_LIM_SW_PIN GPIO_PIN_7
+#define NSYNC_OUT_PORT GPIOB
+#define NSYNC_OUT_PIN GPIO_PIN_6
+#else
+#define LED_GPIO_PIN GPIO_PIN_10
+#define Z_LIM_SW_PIN GPIO_PIN_13
+#define NSYNC_OUT_PORT GPIOD
+#define NSYNC_OUT_PIN GPIO_PIN_2
+#define EBRAKE_PIN GPIO_PIN_5
+#define EBRAKE_PORT GPIOB
+#endif
+
+//common defines for above pins
+#define LED_GPIO_PORT GPIOC
+#define Z_LIM_SW_PORT GPIOC
+//general gpio pins
+#define NSYNC_IN_PIN GPIO_PIN_7
+#define NSYNC_IN_PORT GPIOB
+#define ESTOP_IN_PIN GPIO_PIN_10
+#define ESTOP_IN_PORT GPIOA
+#define TOOL_DETECT_PIN GPIO_PIN_0
+#define TOOL_DETECT_PORT GPIOB
+// g motor pins
+#define G_MOT_ENABLE_PIN GPIO_PIN_11
+#define G_MOT_ENABLE_PORT GPIOC
+#define G_MOT_PWM_CH1_PIN GPIO_PIN_0
+#define G_MOT_PWM_CH1_PORT GPIOC
+#define G_MOT_PWM_CH2_PIN GPIO_PIN_6
+#define G_MOT_PWM_CH2_PORT GPIOA
+#define G_MOT_VREF_PIN GPIO_PIN_4
+#define G_MOT_VREF_PORT GPIOA
+#define G_LIM_SW_PIN GPIO_PIN_2
+#define G_LIM_SW_PORT GPIOC
+#define G_MOT_ENC_A_PIN GPIO_PIN_0
+#define G_MOT_ENC_B_PIN GPIO_PIN_1
+#define G_MOT_ENC_I_PIN GPIO_PIN_5
+#define G_MOT_ENC_PORT GPIOA
+// z motor pins
+#define Z_MOT_DIR_PIN GPIO_PIN_10
+#define Z_MOT_STEP_PIN GPIO_PIN_1
+#define Z_MOT_STEPDIR_PORT GPIOB
+#define Z_MOT_ENABLE_PIN GPIO_PIN_9
+#define Z_MOT_ENABLE_PORT GPIOA
+#define Z_MOT_DRIVE_CS GPIO_PIN_12
+#define Z_MOT_DRIVE_CLK GPIO_PIN_13
+#define Z_MOT_DRIVE_MISO GPIO_PIN_14
+#define Z_MOT_DRIVE_MOSI GPIO_PIN_15
+#define Z_MOT_DRIVE_PORT GPIOB
+#define Z_MOT_ENC_A_PIN GPIO_PIN_6
+#define Z_MOT_ENC_B_PIN GPIO_PIN_7
+#define Z_MOT_ENC_AB_PORT GPIOC
+#define Z_MOT_ENC_I_PIN GPIO_PIN_6
+#define Z_MOT_ENC_I_PORT GPIOB


### PR DESCRIPTION
Was testing on the bench setup and found a few issues with the C1 version of the firmware,
- motor driver setting flag we don't need anymore needed to be cleared so the motor could move
         * old flag was a hack to get the z motor not to fall down when motor disabled
- add a common gpio pin define since they didn't match in different parts of the code
         * there was a mismatch since we used the GPIO_PIN_* in differed places
- remove an IRQ setup since we don't have downstream timers for the Z motor encoder
         *caused a crash when encoder was conencted

Bench setup was tested with the following
all z motor hardware connected and talking via can
called home via ot3repl and saw z motor moving
used limit switch to complete home
moved it relative in ot3repl 
