### PR TITLE
chore(rear-panel): add CI workflow

### DIFF
--- a/.github/workflows/rear_panel.yaml
+++ b/.github/workflows/rear_panel.yaml
@@ -57,6 +57,8 @@ jobs:
         run: cmake --build ./build-cross --target rear-panel-format-ci
       - name: "Lint"
         run: cmake --build ./build-cross --target rear-panel-lint
+      - name: "Build"
+        run: cmake --build ./build-cross --target rear-panel-applications
   host-compile-test:
     name: "Host-Compile/Test"
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/rear_panel.yaml
+++ b/.github/workflows/rear_panel.yaml
@@ -1,0 +1,78 @@
+name: "rear-panel build/test"
+on:
+  pull_request:
+    paths:
+      - "rear-panel/**"
+      - "include/rear-panel/**"
+      - "cmake/*"
+      - "!cmake/Arduino*"
+      - "include/common/**"
+      - "common/**"
+      - "CMakeLists.txt"
+      - "CMakePresets.json"
+      - ".clang-format"
+      - ".clang-tidy"
+  push:
+    paths:
+      - "rear-panel/**"
+      - "include/rear-panel/**"
+      - "include/common/**"
+      - "common/**"
+      - "cmake/*"
+      - "!cmake/Arduino*"
+      - "CMakeLists.txt"
+      - "CMakePresets.json"
+      - ".clang-format"
+      - ".clang-tidy"
+      - ".github/workflows/rear-panel.yaml"
+    branches:
+      - "*"
+    tags:
+      - "rear-panel@*"
+  workflow_dispatch:
+
+env:
+  ci: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cross-compile-check:
+    name: "Cross-Compile/Check"
+    runs-on: "ubuntu-20.04"
+    timeout-minutes: 10
+    steps:
+      - uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 0
+      - uses: "actions/cache@v3"
+        with:
+          path: "./stm32-tools"
+          key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
+      - name: "Configure"
+        run: cmake --preset=cross . -DCMAKE_BUILD_TYPE=debug
+      - name: "Format"
+        run: cmake --build ./build-cross --target rear-panel-format-ci
+      - name: "Lint"
+        run: cmake --build ./build-cross --target rear-panel-lint
+  host-compile-test:
+    name: "Host-Compile/Test"
+    runs-on: "ubuntu-20.04"
+    timeout-minutes: 10
+    steps:
+      - run: |
+          sudo apt update
+          sudo apt install gcc-10 g++-10
+      - uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 0
+      - uses: "actions/cache@v3"
+        with:
+          path: "./stm32-tools"
+          key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
+      - name: "Configure"
+        run: cmake --preset=host-gcc10 .
+      - name: 'Build and test'
+        run: cmake --build ./build-host --target rear-panel-build-and-test

--- a/rear-panel/CMakeLists.txt
+++ b/rear-panel/CMakeLists.txt
@@ -20,7 +20,7 @@ file(GLOB_RECURSE REAR_PANEL_SOURCES_FOR_FORMAT ./*.cpp ./*.hpp ../include/rear-
 add_custom_target(
   rear-panel-format
   ALL
-  COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -i ${REAR_SOURCES_FOR_FORMAT}
+  COMMAND ${Clang_CLANGFORMAT_EXECUTABLE} -style=file -i ${REAR_PANEL_SOURCES_FOR_FORMAT}
   )
 
 # Target for use in ci - warnings are errors, doesn't edit files

--- a/rear-panel/test/CMakeLists.txt
+++ b/rear-panel/test/CMakeLists.txt
@@ -5,18 +5,18 @@ include(Catch)
 include(AddBuildAndTestTarget)
 
 add_executable(
-        rear_panel
+        rear-panel
         test_main.cpp
         test_messages.cpp
 )
 
-target_include_directories(rear_panel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
-set_target_properties(rear_panel
+target_include_directories(rear-panel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+set_target_properties(rear-panel
         PROPERTIES
         CXX_STANDARD 20
         CXX_STANDARD_REQUIRED TRUE)
 
-target_compile_options(rear_panel
+target_compile_options(rear-panel
         PUBLIC
         -Wall
         -Werror
@@ -30,11 +30,11 @@ target_compile_options(rear_panel
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
 
-add_revision(TARGET rear_panel REVISION b1)
+add_revision(TARGET rear-panel REVISION b1)
 
-target_link_libraries(rear_panel PUBLIC Catch2::Catch2)
+target_link_libraries(rear-panel PUBLIC Catch2::Catch2)
 
-catch_discover_tests(rear_panel)
-add_build_and_test_target(rear_panel)
+catch_discover_tests(rear-panel)
+add_build_and_test_target(rear-panel)
 
-add_coverage(rear_panel)
+add_coverage(rear-panel)


### PR DESCRIPTION
Adding a CI workflow and some other little changes

* Added a github workflow configuration to build + test the rear panel on pushes/PR's
* Fixed the format target (was not working)
* Changed name of the `build-and-test` target to prefix with `rear-panel` instead of `rear_panel`