### PR TITLE
build: add a workflow to make gh releases from tags

### DIFF
--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: 'Create a release'
         uses: 'ncipollo/release-action@v1.12.0'
         with:
-          artifacts: ./firmware-images-${{github.ref_name}}, ./firmware-robot-images-${{github.ref_name}}, ./firmware-pipette-images-${{github.ref_name}}, ./firmware-gripper-images-${{github.ref_name}}
+          artifacts: ./firmware-images-${{github.ref_name}}/*, ./firmware-robot-images-${{github.ref_name}}/*, ./firmware-pipette-images-${{github.ref_name}}/*, ./firmware-gripper-images-${{github.ref_name}}/*
           artifactContentType: application/zip
           draft: true
           generateReleaseNotes: true

--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -80,10 +80,11 @@ jobs:
       - name: 'Create zips for each sub-artifact'
         run: |
           ls -l .
+          ls -l ./*
           for artifactname in $(ls *-images-*) ; do
-              pushd $artifactname
+              cd ./$artifactname
               zip ../${artifactname}.zip ./*
-              popd
+              cd ..
           done
 
       - name: 'Create a release'

--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -79,6 +79,7 @@ jobs:
           path: .
       - name: 'Create zips for each sub-artifact'
         run: |
+          ls -l .
           for artifactname in $(ls *-images-*) ; do
               pushd $artifactname
               zip ../${artifactname}.zip ./*

--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -79,12 +79,11 @@ jobs:
           path: .
       - name: 'Create zips for each sub-artifact'
         run: |
-          ls -l .
-          ls -l ./*
-          for artifactname in $(ls *-images-*) ; do
-              cd ./$artifactname
+          for artifactname in *-images-* ; do
+              echo "running in $artifactname "
+              pushd ./$artifactname
               zip ../${artifactname}.zip ./*
-              cd ..
+              popd
           done
 
       - name: 'Create a release'

--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -77,12 +77,73 @@ jobs:
         uses: 'actions/download-artifact@v3'
         with:
           path: .
+      - name: 'Create zips for each sub-artifact'
+        run: |
+          for artifactname in $(ls *-images-*) ; do
+              pushd $artifactname
+              zip ../${artifactname}.zip ./*
+              popd
+          done
+
       - name: 'Create a release'
         uses: 'ncipollo/release-action@v1.12.0'
         with:
-          artifacts: ./firmware-images-${{github.ref_name}}/*, ./firmware-robot-images-${{github.ref_name}}/*, ./firmware-pipette-images-${{github.ref_name}}/*, ./firmware-gripper-images-${{github.ref_name}}/*
-          artifactContentType: application/zip
           draft: true
           generateReleaseNotes: true
           replacesArtifacts: true
           allowUpdates: true
+
+      - name: 'Add firmware images artifact'
+        uses: 'ncipollo/release-action@v1.12.0'
+        with:
+          artifacts: ./firmware-images-${{github.ref_name}}.zip
+          artifactContentType: application/zip
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+
+      - name: 'Add firmware robot images artifact'
+        uses: 'ncipollo/release-action@v1.12.0'
+        with:
+          artifacts: ./firmware-robot-images-${{github.ref_name}}.zip
+          artifactContentType: application/zip
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+
+      - name: 'Add firmware pipette images artifact'
+        uses: 'ncipollo/release-action@v1.12.0'
+        with:
+          artifacts: ./firmware-pipette-images-${{github.ref_name}}.zip
+          artifactContentType: application/zip
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+
+      - name: 'Add firmware gripper images artifact'
+        uses: 'ncipollo/release-action@v1.12.0'
+        with:
+          artifacts: ./firmware-gripper-images-${{github.ref_name}}.zip
+          artifactContentType: application/zip
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+
+      - name: 'Add firmware applications artifact'
+        uses: 'ncipollo/release-action@v1.12.0'
+        with:
+          artifacts: ./firmware-applications-${{github.ref_name}}.zip
+          artifactContentType: application/zip
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true

--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -79,8 +79,7 @@ jobs:
           path: .
       - name: 'Create zips for each sub-artifact'
         run: |
-          for artifactname in *-images-* ; do
-              echo "running in $artifactname "
+          for artifactname in firmware-*-*${{github.ref_name}} ; do
               pushd ./$artifactname
               zip ../${artifactname}.zip ./*
               popd

--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -66,3 +66,23 @@ jobs:
           name: 'firmware-gripper-images-${{github.ref_name}}'
           path: |
             dist/gripper-images/*.hex
+  release:
+    name: 'Do a release'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    needs: ['build']
+    if: github.ref_type == 'tag'
+    steps:
+      - name: 'Download artifacts'
+        uses: 'actions/download-artifact@v3'
+        with:
+          path: .
+      - name: 'Create a release'
+        uses: 'ncipollo/release-action@v1.12.0'
+        with:
+          artifacts: ./firmware-images-${{github.ref_name}}, ./firmware-robot-images-${{github.ref_name}}, ./firmware-pipette-images-${{github.ref_name}}, ./firmware-gripper-images-${{github.ref_name}}
+          artifactContentType: application/zip
+          draft: true
+          generateReleaseNotes: true
+          replacesArtifacts: true
+          allowUpdates: true

--- a/.github/workflows/start-ot3-build.yaml
+++ b/.github/workflows/start-ot3-build.yaml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v*'
+      - '*@*'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
It will add artifacts to the releases and autogenerate some changelogs also.

Here's an example of a release created by this workflow: https://github.com/Opentrons/ot3-firmware/releases/tag/untagged-3121c9b9dc94a5ac5aee

It will stay as a draft until somebody clicks release, but will automatically get the release artifacts uploaded to it. 