### PR TITLE
build(rear-panel): autogenerate comm protocol constants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,8 +196,9 @@ endif ()
 add_custom_target(update-headers
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         VERBATIM
-        COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/can/core/ids.hpp --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c++"
-        COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/bootloader/core/ids.h --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c")
+        COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/can/core/ids.hpp --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c++ --subsystem=can"
+        COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/bootloader/core/ids.h --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c --subsystem=can"
+        COMMAND ${SHELL_FOR_PYTHON} -c "python ./generate_header.py ${CMAKE_SOURCE_DIR}/include/rear-panel/core/bin_msg_ids.hpp --source-dir=${OPENTRONS_HARDWARE_PATH} --language=c++ --subsystem=rearpanel")
 
 set(_install_cmd "execute_process(\
         COMMAND ${SHELL_FOR_PYTHON} -c \"python3 ${CMAKE_SOURCE_DIR}/scripts/subsystem_versions.py\

--- a/generate_header.py
+++ b/generate_header.py
@@ -65,7 +65,7 @@ def generate_rearpanel_cpp(output: io.StringIO, constants_mod: ModuleType) -> No
             start="namespace rearpanel::ids {\n\n",
             terminate="}  // namespace rearpanel::ids\n",
     ):
-        write_enum_cpp(constants_mod.BinaryMessageId, output)
+        write_enum_cpp(constants_mod.BinaryMessageId, output, 'uint16_t')
 
 
 def write_arbitration_id_c(output: io.StringIO, prefix: str, arbitration_id: ModuleType) -> None:

--- a/generate_header.py
+++ b/generate_header.py
@@ -62,7 +62,7 @@ def generate_rearpanel_cpp(output: io.StringIO, constants_mod: ModuleType) -> No
     """Generate source code into output."""
     with Block(
             output=output,
-            start="namespace rearpanel::ids {\n\n",
+            start="#include <cstdint>\n\nnamespace rearpanel::ids {\n\n",
             terminate="}  // namespace rearpanel::ids\n",
     ):
         write_enum_cpp(constants_mod.BinaryMessageId, output, 'uint16_t')

--- a/generate_header.py
+++ b/generate_header.py
@@ -10,18 +10,19 @@ from types import ModuleType
 from header_generation_utils.header_generation_utils.utils import (
     Block,
     Languge,
+    Subsystem,
     generate_file_comment,
     write_enum_cpp,
     write_enum_c,
 )
 
 
-def generate_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
+def generate_can_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
     """Generate source code into output."""
     with Block(
             output=output,
             start="namespace can::ids {\n\n",
-            terminate="}  // namespace can::ids\n\n",
+            terminate="}  // namespace can::ids\n",
     ):
         write_enum_cpp(constants_mod.FunctionCode, output)
         write_enum_cpp(constants_mod.MessageId, output)
@@ -39,7 +40,7 @@ def generate_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
         write_enum_cpp(constants_mod.MoveStopCondition, output)
 
 
-def generate_c(output: io.StringIO, constants_mod: ModuleType, arbitration_id: ModuleType) -> None:
+def generate_can_c(output: io.StringIO, constants_mod: ModuleType, arbitration_id: ModuleType) -> None:
     """Generate source code into output."""
     can = "CAN"
     write_enum_c(constants_mod.FunctionCode, output, can)
@@ -56,6 +57,15 @@ def generate_c(output: io.StringIO, constants_mod: ModuleType, arbitration_id: M
     write_enum_c(constants_mod.MotorPositionFlags, output, can)
     write_enum_c(constants_mod.MoveStopCondition, output, can)
     write_arbitration_id_c(output, can, arbitration_id)
+
+def generate_rearpanel_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
+    """Generate source code into output."""
+    with Block(
+            output=output,
+            start="namespace rearpanel::ids {\n\n",
+            terminate="}  // namespace rearpanel::ids\n",
+    ):
+        write_enum_cpp(constants_mod.BinaryMessageId, output)
 
 
 def write_arbitration_id_c(output: io.StringIO, prefix: str, arbitration_id: ModuleType) -> None:
@@ -101,17 +111,36 @@ def main() -> None:
         help=f"language to use. can be one of {','.join(l.value for l in Languge)}",
     )
 
+    parser.add_argument(
+        "--subsystem",
+        metavar="subsystem",
+        type=Subsystem,
+        default=Subsystem.CAN,
+        choices=Subsystem,
+        nargs="?",
+        help=f"subsystem to generate constants for. can be one of {','.join(s.value for s in Subsystem)}",
+    )
+
     args = parser.parse_args()
     if args.source_dir:
         sys.path.append(os.path.join(args.source_dir, os.path.pardir))
     constants = importlib.import_module('opentrons_hardware.firmware_bindings.constants')
     arbid = importlib.import_module('opentrons_hardware.firmware_bindings.arbitration_id')
+    rearpanel_constants = importlib.import_module('opentrons_hardware.firmware_bindings.binary_constants')
     output = args.target
     generate_file_comment(output)
-    if args.language in {Languge.CPP, Languge.CPP_alt}:
-        generate_cpp(output, constants)
-    if args.language in {Languge.C}:
-        generate_c(output, constants, arbid)
+
+    if args.subsystem in {Subsystem.CAN}:
+        if args.language in {Languge.CPP, Languge.CPP_alt}:
+            generate_can_cpp(output, constants)
+        if args.language in {Languge.C}:
+            generate_can_c(output, constants, arbid)
+    elif args.subsystem in {Subsystem.REARPANEL}:
+        if args.language in {Languge.CPP, Languge.CPP_alt}:
+            generate_rearpanel_cpp(output, rearpanel_constants)
+        if args.language in {Languge.C}:
+            raise RuntimeError(f"C header unsupported for subsystem={args.subsystem}")
+
 
 
 if __name__ == "__main__":

--- a/header_generation_utils/header_generation_utils/utils.py
+++ b/header_generation_utils/header_generation_utils/utils.py
@@ -5,6 +5,7 @@ from io import StringIO
 from typing import (
     Any,
     Type,
+    Optional,
 )
 
 
@@ -41,11 +42,12 @@ def generate_file_comment(output: StringIO) -> None:
     output.write("#pragma once\n\n")
 
 
-def write_enum_cpp(e: Type[Enum], output: StringIO) -> None:
+def write_enum_cpp(e: Type[Enum], output: StringIO, type: Optional[str] = None) -> None:
     """Generate enum class from enumeration."""
     output.write(f"/** {e.__doc__} */\n")
+    typestr = f" : {type}" if type else ""
     with Block(
-            output=output, start=f"enum class {e.__name__} {{\n", terminate="};\n\n"
+            output=output, start=f"enum class {e.__name__}{typestr} {{\n", terminate="};\n\n"
     ):
         for i in e:
             output.write(f"    {i.name} = 0x{i.value:x},\n")

--- a/header_generation_utils/header_generation_utils/utils.py
+++ b/header_generation_utils/header_generation_utils/utils.py
@@ -70,3 +70,10 @@ class Languge(str, Enum):
     C = "c"
     CPP = "c++"
     CPP_alt = "cpp"
+
+
+class Subsystem(str, Enum):
+    """Subsystem enum."""
+
+    CAN = "can"
+    REARPANEL = "rearpanel"

--- a/include/rear-panel/core/bin_msg_ids.hpp
+++ b/include/rear-panel/core/bin_msg_ids.hpp
@@ -1,26 +1,27 @@
+/********************************************
+ * This is a generated file. Do not modify.  *
+ ********************************************/
 #pragma once
-#include <cstdint>
-namespace rearpanel {
-namespace messages {
-// TODO(ryan): as part of RET-1307 create an auto gen of the ids like the can
-// messages
-enum class MessageType : uint16_t {
-    ECHO = 0x00,
-    ACK = 0x01,
-    ACK_FAILED = 0x02,
-    DEVICE_INFO_REQ = 0x03,
-    DEVICE_INFO_RESP = 0x04,
-    ENTER_BOOTLOADER = 0x05,
-    ENTER_BOOTLOADER_RESPONSE = 0x06,
-    ENGAGE_ESTOP_REQUEST = 0x07,
-    RELEASE_ESTOP_REQUEST = 0x08,
-    ENGAGE_SYNC_REQUEST = 0x09,
-    RELEASE_SYNC_REQUEST = 0x0A,
-    ESTOP_STATE_CHANGE = 0x0B,
-    ESTOP_BUTTON_DETECTION_CHANGE = 0x0C,
-    DOOR_SWITCH_STATE_REQUEST = 0x0D,
-    DOOR_SWITCH_STATE_INFO = 0x0E,
+
+namespace rearpanel::ids {
+
+/** USB Binary message ID. */
+enum class BinaryMessageId : uint16_t {
+    echo = 0x0,
+    ack = 0x1,
+    ack_failed = 0x2,
+    device_info_request = 0x3,
+    device_info_response = 0x4,
+    enter_bootloader_request = 0x5,
+    enter_bootloader_response = 0x6,
+    engage_estop = 0x7,
+    release_estop = 0x8,
+    engage_nsync_out = 0x9,
+    release_nsync_out = 0xa,
+    estop_state_change = 0xb,
+    estop_button_detection_change = 0xc,
+    door_switch_state_request = 0xd,
+    door_switch_state_info = 0xe,
 };
 
-};  // namespace messages
-};  // namespace rearpanel
+}  // namespace rearpanel::ids

--- a/include/rear-panel/core/bin_msg_ids.hpp
+++ b/include/rear-panel/core/bin_msg_ids.hpp
@@ -3,6 +3,8 @@
  ********************************************/
 #pragma once
 
+#include <cstdint>
+
 namespace rearpanel::ids {
 
 /** USB Binary message ID. */

--- a/include/rear-panel/core/binary_parse.hpp
+++ b/include/rear-panel/core/binary_parse.hpp
@@ -42,7 +42,7 @@ class Parser {
      * @return A Result variant
      */
     template <bit_utils::ByteIterator Iterator>
-    auto parse(rearpanel::messages::MessageType message_type,
+    auto parse(rearpanel::ids::BinaryMessageId message_type,
                const Iterator& payload, const Iterator& limit) -> Result {
         auto result = Result{std::monostate{}};
         // Fold expression over Parsable template type.

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -13,13 +13,13 @@ constexpr size_t MAX_MESSAGE_SIZE = 512U * 2;
 namespace rearpanel {
 namespace messages {
 
-template <MessageType MType>
+template <rearpanel::ids::BinaryMessageId MType>
 struct BinaryFormatMessage {
     static const auto message_type = MType;
     auto operator==(const BinaryFormatMessage& other) const -> bool = default;
 };
 
-struct Echo : BinaryFormatMessage<MessageType::ECHO> {
+struct Echo : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::echo> {
     uint16_t length;
     std::array<uint8_t, MAX_MESSAGE_SIZE> data;
 
@@ -51,7 +51,7 @@ struct Echo : BinaryFormatMessage<MessageType::ECHO> {
     auto operator==(const Echo& other) const -> bool = default;
 };
 
-struct Ack : BinaryFormatMessage<MessageType::ACK> {
+struct Ack : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::ack> {
     uint16_t length;
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> Output {
@@ -62,7 +62,8 @@ struct Ack : BinaryFormatMessage<MessageType::ACK> {
     }
 };
 
-struct AckFailed : BinaryFormatMessage<MessageType::ACK_FAILED> {
+struct AckFailed
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::ack_failed> {
     uint16_t length;
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> Output {
@@ -73,7 +74,9 @@ struct AckFailed : BinaryFormatMessage<MessageType::ACK_FAILED> {
     }
 };
 
-struct DeviceInfoRequest : BinaryFormatMessage<MessageType::DEVICE_INFO_REQ> {
+struct DeviceInfoRequest
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::device_info_request> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -95,7 +98,9 @@ struct DeviceInfoRequest : BinaryFormatMessage<MessageType::DEVICE_INFO_REQ> {
 // Empty message sent periodically to drive timing of the light task
 struct UpdateLightControlMessage {};
 
-struct DeviceInfoResponse : BinaryFormatMessage<MessageType::DEVICE_INFO_RESP> {
+struct DeviceInfoResponse
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::device_info_response> {
     uint16_t length;
     uint32_t version;
     uint32_t flags;
@@ -136,7 +141,9 @@ struct DeviceInfoResponse : BinaryFormatMessage<MessageType::DEVICE_INFO_RESP> {
     auto operator==(const DeviceInfoResponse& other) const -> bool = default;
 };
 
-struct EnterBootloader : BinaryFormatMessage<MessageType::ENTER_BOOTLOADER> {
+struct EnterBootloader
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::enter_bootloader_request> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -157,7 +164,8 @@ struct EnterBootloader : BinaryFormatMessage<MessageType::ENTER_BOOTLOADER> {
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct EnterBootloaderResponse
-    : BinaryFormatMessage<MessageType::ENTER_BOOTLOADER_RESPONSE> {
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::enter_bootloader_response> {
     uint16_t length = sizeof(bool);
     bool success;
 
@@ -174,7 +182,7 @@ struct EnterBootloaderResponse
 };
 
 struct EngageEstopRequest
-    : BinaryFormatMessage<MessageType::ENGAGE_ESTOP_REQUEST> {
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::engage_estop> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -194,7 +202,7 @@ struct EngageEstopRequest
 };
 
 struct ReleaseEstopRequest
-    : BinaryFormatMessage<MessageType::RELEASE_ESTOP_REQUEST> {
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::release_estop> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -214,7 +222,7 @@ struct ReleaseEstopRequest
 };
 
 struct EngageSyncRequest
-    : BinaryFormatMessage<MessageType::ENGAGE_SYNC_REQUEST> {
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::engage_nsync_out> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -234,7 +242,7 @@ struct EngageSyncRequest
 };
 
 struct ReleaseSyncRequest
-    : BinaryFormatMessage<MessageType::RELEASE_SYNC_REQUEST> {
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::release_nsync_out> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -254,7 +262,8 @@ struct ReleaseSyncRequest
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct EstopStateChange : BinaryFormatMessage<MessageType::ESTOP_STATE_CHANGE> {
+struct EstopStateChange
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::estop_state_change> {
     uint16_t length = sizeof(bool);
     bool engaged;
 
@@ -271,7 +280,8 @@ struct EstopStateChange : BinaryFormatMessage<MessageType::ESTOP_STATE_CHANGE> {
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct EstopButtonDetectionChange
-    : BinaryFormatMessage<MessageType::ESTOP_BUTTON_DETECTION_CHANGE> {
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::estop_button_detection_change> {
     uint16_t length = 2 * sizeof(bool);
     bool aux1_present;
     bool aux2_present;
@@ -290,7 +300,8 @@ struct EstopButtonDetectionChange
 };
 
 struct DoorSwitchStateRequest
-    : BinaryFormatMessage<MessageType::DOOR_SWITCH_STATE_REQUEST> {
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::door_switch_state_request> {
     uint16_t length;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -312,7 +323,8 @@ struct DoorSwitchStateRequest
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct DoorSwitchStateInfo
-    : BinaryFormatMessage<MessageType::DOOR_SWITCH_STATE_INFO> {
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::door_switch_state_info> {
     uint16_t length = sizeof(bool);
     bool open;
 

--- a/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
@@ -154,9 +154,9 @@ static auto cdc_rx_handler(uint8_t *Buf, uint32_t *Len) -> uint8_t * {
     uint16_t type = 0;
     std::ignore = bit_utils::bytes_to_int(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        Buf, Buf + sizeof(rearpanel::messages::MessageType), type);
+        Buf, Buf + sizeof(rearpanel::ids::BinaryMessageId), type);
     auto message = rearpanel::messages::rear_panel_parser.parse(
-        rearpanel::messages::MessageType(type),
+        rearpanel::ids::BinaryMessageId(type),
         _local_task.rx_buf.committed()->data(),
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         Buf + *Len);

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -113,7 +113,7 @@ SCENARIO("message parsing") {
         auto arr = std::array<uint8_t, 4>{0x00, 0x03, 0x00, 0x00};
         WHEN("constructed") {
             auto message = rearpanel::messages::rear_panel_parser.parse(
-                rearpanel::messages::MessageType(0x0003), arr.begin(),
+                rearpanel::ids::BinaryMessageId(0x0003), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
             THEN("monostate is not returned") { REQUIRE(message.index() != 0); }
@@ -129,7 +129,7 @@ SCENARIO("message parsing") {
         auto arr = std::array<uint8_t, 4>{0x00, 0x03, 0x00, 0x0A};
         WHEN("constructed") {
             auto message = rearpanel::messages::rear_panel_parser.parse(
-                rearpanel::messages::MessageType(0x0003), arr.begin(),
+                rearpanel::ids::BinaryMessageId(0x0003), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
             THEN("monostate is returned") {
@@ -143,7 +143,7 @@ SCENARIO("message parsing") {
         auto arr = std::array<uint8_t, 4>{0xAB, 0xCD, 0x00, 0x00};
         WHEN("constructed") {
             auto message = rearpanel::messages::rear_panel_parser.parse(
-                rearpanel::messages::MessageType(0xABCD), arr.begin(),
+                rearpanel::ids::BinaryMessageId(0xABCD), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
             THEN("monostate is returned") {


### PR DESCRIPTION
Adds the rear-panel binary message protocol to the `generate_headers.py` script and integrates it with cmake workflows. Also generated the header and fixed references to it in code.

Also fixed a little issue where the autogen script was adding an extra newline that the formatter doesn't like.