### PR TITLE
chore(pipettes): disable the pressure sensor for C2 pipette revisions

### DIFF
--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -135,7 +135,7 @@ static auto tip_sense_gpio_primary = pins_for_sensor.primary.tip_sense.value();
 static auto& sensor_queue_client = sensor_tasks::get_queues();
 
 #if PCBA_PRIMARY_REVISION == 'c' && PCBA_SECONDARY_REVISION == '2'
-static bool pressure_sensor_available = false;
+static constexpr bool pressure_sensor_available = false;
 #else
 static constexpr bool pressure_sensor_available = true;
 #endif

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -137,7 +137,7 @@ static auto& sensor_queue_client = sensor_tasks::get_queues();
 #if PCBA_PRIMARY_REVISION == 'c' && PCBA_SECONDARY_REVISION == '2'
 static bool pressure_sensor_available = false;
 #else
-static bool pressure_sensor_available = true;
+static constexpr bool pressure_sensor_available = true;
 #endif
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {


### PR DESCRIPTION
## Overview

We do not have filtering on the data ready line and thus the pressure sensor can be noisy. This causes issues with auto-calibration and so for now we should disable the pressure sensor.