### PR TITLE
fix(gripper): add encoder timer interrupt handler & fix encoder dir

### DIFF
--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -142,6 +142,8 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
         GPIO_InitStruct.Alternate = GPIO_AF4_TIM8;
         HAL_GPIO_Init(Z_MOT_ENC_AB_PORT, &GPIO_InitStruct);
 
+        HAL_NVIC_SetPriority(TIM8_UP_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(TIM8_UP_IRQn);
     }
 }
 

--- a/gripper/firmware/motor_hardware_z.c
+++ b/gripper/firmware/motor_hardware_z.c
@@ -45,7 +45,7 @@ inline static void TIM8_EncoderZ_Init(void)
     htim8.Init.RepetitionCounter = 0;
     htim8.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_ENABLE;
     sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
-    sConfig.IC1Polarity = TIM_ICPOLARITY_RISING;
+    sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
     sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
     sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
     sConfig.IC1Filter = 0;

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -53,6 +53,7 @@ extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim4;
+extern TIM_HandleTypeDef htim8;
 
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
@@ -159,6 +160,10 @@ void TIM3_IRQHandler(void) { HAL_TIM_IRQHandler(&htim3); }
 void TIM2_IRQHandler(void) { HAL_TIM_IRQHandler(&htim2); }
 
 void TIM4_IRQHandler(void) { HAL_TIM_IRQHandler(&htim4); }
+
+void TIM8_CC_IRQHandler(void) { HAL_TIM_IRQHandler(&htim8); }
+
+void TIM8_UP_IRQHandler(void) { HAL_TIM_IRQHandler(&htim8); }
 /**
  * @brief This function handles TIM7 global interrupt.
  */

--- a/gripper/firmware/stm32g4xx_it.h
+++ b/gripper/firmware/stm32g4xx_it.h
@@ -46,6 +46,8 @@ void FDCAN1_IT0_IRQHandler(void);
 void TIM1_CC_IRQHandler(void);
 void TIM3_IRQHandler(void);
 void TIM7_IRQHandler(void);
+void TIM8_CC_IRQHandler(void);
+void TIM8_UP_IRQHandler(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
During initial DVT gripper testing, @ryanthecoder and I saw that the z encoder wasn't behaving correctly.

We found out that (1) encoder timer interrupt was not added, and the (2) encoder direction was flipped. This PR fixes the issues we saw on the Z motor.