### PR TITLE
feat(rear-panel): light action handler

### DIFF
--- a/generate_header.py
+++ b/generate_header.py
@@ -66,6 +66,8 @@ def generate_rearpanel_cpp(output: io.StringIO, constants_mod: ModuleType) -> No
             terminate="}  // namespace rearpanel::ids\n",
     ):
         write_enum_cpp(constants_mod.BinaryMessageId, output, 'uint16_t')
+        write_enum_cpp(constants_mod.LightTransitionType, output, 'uint8_t')
+        write_enum_cpp(constants_mod.LightAnimationType, output, 'uint8_t')
 
 
 def write_arbitration_id_c(output: io.StringIO, prefix: str, arbitration_id: ModuleType) -> None:

--- a/include/rear-panel/core/bin_msg_ids.hpp
+++ b/include/rear-panel/core/bin_msg_ids.hpp
@@ -26,4 +26,17 @@ enum class BinaryMessageId : uint16_t {
     door_switch_state_info = 0xe,
 };
 
+/** The types of transitons that the lights can perform. */
+enum class LightTransitionType : uint8_t {
+    linear = 0x0,
+    sinusoid = 0x1,
+    instant = 0x2,
+};
+
+/** Whether an action is looping or runs one single time. */
+enum class LightAnimationType : uint8_t {
+    looping = 0x0,
+    single_shot = 0x1,
+};
+
 }  // namespace rearpanel::ids

--- a/include/rear-panel/core/lights/animation_handler.hpp
+++ b/include/rear-panel/core/lights/animation_handler.hpp
@@ -9,7 +9,12 @@
 namespace lights {
 
 /**
- * @brief Acts as an interface for an AnimationQueue
+ * @brief Acts as an interface for an AnimationQueue.
+ * 
+ * @note This class if NOT thread safe - it accesses the same queue in
+ * multiple functions and, if they are called from different threads,
+ * race conditions may arise. If this class is accessed from different
+ * threads, wrap access to all member functions with a mutex.
  *
  */
 template <size_t Size>

--- a/include/rear-panel/core/lights/animation_handler.hpp
+++ b/include/rear-panel/core/lights/animation_handler.hpp
@@ -44,8 +44,8 @@ class AnimationHandler {
             ret = calculate_step_power();
             if (_timer_ms >= _current_step.value().transition_time_ms) {
                 _step_starting_color = _current_step.value().color;
-                _timer_ms = 0;
-                _current_step = _queue.get_next_active_step();
+                // Signal that we need a new message next time through
+                _current_step = std::nullopt;
             }
         }
         _most_recent_color = ret;

--- a/include/rear-panel/core/lights/animation_handler.hpp
+++ b/include/rear-panel/core/lights/animation_handler.hpp
@@ -41,7 +41,10 @@ class AnimationHandler {
         if (_current_step.has_value()) {
             // We are in a step, calculate the next increment
             _timer_ms += time_increment_ms;
-            ret = calculate_step_power();
+            ret = lights::math::color_interpolate(
+                _step_starting_color, _current_step.value().color,
+                _current_step.value().transition, _timer_ms,
+                _current_step.value().transition_time_ms);
             if (_timer_ms >= _current_step.value().transition_time_ms) {
                 _step_starting_color = _current_step.value().color;
                 // Signal that we need a new message next time through
@@ -69,26 +72,6 @@ class AnimationHandler {
     auto clear_staging() -> void { _queue.clear_staging(); }
 
   private:
-    auto calculate_step_power() -> Color {
-        auto &step = _current_step.value();
-        auto timer =
-            std::clamp(_timer_ms, uint32_t(0), step.transition_time_ms);
-        return Color{
-            .r = lights::math::calculate_power(
-                step.transition, _step_starting_color.r, step.color.r, timer,
-                step.transition_time_ms),
-            .g = lights::math::calculate_power(
-                step.transition, _step_starting_color.g, step.color.g, timer,
-                step.transition_time_ms),
-            .b = lights::math::calculate_power(
-                step.transition, _step_starting_color.b, step.color.b, timer,
-                step.transition_time_ms),
-            .w = lights::math::calculate_power(
-                step.transition, _step_starting_color.w, step.color.w, timer,
-                step.transition_time_ms),
-        };
-    }
-
     Color _step_starting_color;
     Color _most_recent_color;
     std::optional<Action> _current_step;

--- a/include/rear-panel/core/lights/animation_handler.hpp
+++ b/include/rear-panel/core/lights/animation_handler.hpp
@@ -9,8 +9,8 @@
 namespace lights {
 
 /**
- * @brief Acts as an interface for an AnimationQueue.
- * 
+ * @brief Acts as an interface for an AnimationBuffer.
+ *
  * @note This class if NOT thread safe - it accesses the same queue in
  * multiple functions and, if they are called from different threads,
  * race conditions may arise. If this class is accessed from different
@@ -85,7 +85,7 @@ class AnimationHandler {
     Color _most_recent_color;
     std::optional<Action> _current_step;
     uint32_t _timer_ms;
-    AnimationQueue<Size> _queue;
+    AnimationBuffer<Size> _queue;
 };
 
 }  // namespace lights

--- a/include/rear-panel/core/lights/animation_handler.hpp
+++ b/include/rear-panel/core/lights/animation_handler.hpp
@@ -17,6 +17,7 @@ class AnimationHandler {
   public:
     AnimationHandler()
         : _step_starting_color{.r = 0, .g = 0, .b = 0, .w = 0},
+          _most_recent_color{.r = 0, .g = 0, .b = 0, .w = 0},
           _current_step{std::nullopt},
           _timer_ms(0),
           _queue() {}
@@ -47,12 +48,17 @@ class AnimationHandler {
                 _current_step = _queue.get_next_active_step();
             }
         }
+        _most_recent_color = ret;
         return ret;
     }
 
     auto start_staged_animation(AnimationType animation) -> void {
         _timer_ms = 0;
         _current_step = std::nullopt;
+        // If we were in the middle of animating a step, we cache the most
+        // recent setting to be the "starting" value for the step that's about
+        // to start in order to eliminate any possible jitter.
+        _step_starting_color = _most_recent_color;
         _queue.start_staged_animation(animation);
     }
 
@@ -84,6 +90,7 @@ class AnimationHandler {
     }
 
     Color _step_starting_color;
+    Color _most_recent_color;
     std::optional<Action> _current_step;
     uint32_t _timer_ms;
     AnimationQueue<Size> _queue;

--- a/include/rear-panel/core/lights/animation_handler.hpp
+++ b/include/rear-panel/core/lights/animation_handler.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <algorithm>
+#include <optional>
+
+#include "rear-panel/core/lights/animation_math.hpp"
+#include "rear-panel/core/lights/animation_queue.hpp"
+
+namespace lights {
+
+/**
+ * @brief Acts as an interface for an AnimationQueue
+ *
+ */
+template <size_t Size>
+class AnimationHandler {
+  public:
+    AnimationHandler()
+        : _step_starting_color{.r = 0, .g = 0, .b = 0, .w = 0},
+          _current_step{std::nullopt},
+          _timer_ms(0),
+          _queue() {}
+
+    /**
+     * @brief Advance the animation and get the next color setting.
+     *
+     * @param time_increment_ms The amount of time that has passed, in
+     * milliseconds.
+     * @return Color
+     */
+    auto animate(uint32_t time_increment_ms) -> Color {
+        Color ret = _step_starting_color;
+        if (!_current_step.has_value()) {
+            // We were not in an active animation last update, but
+            // one may have started since then. Try to get a new step.
+            _timer_ms = 0;
+            _current_step = _queue.get_next_active_step();
+        }
+
+        if (_current_step.has_value()) {
+            // We are in a step, calculate the next increment
+            _timer_ms += time_increment_ms;
+            ret = calculate_step_power();
+            if (_timer_ms >= _current_step.value().transition_time_ms) {
+                _step_starting_color = _current_step.value().color;
+                _timer_ms = 0;
+                _current_step = _queue.get_next_active_step();
+            }
+        }
+        return ret;
+    }
+
+    auto start_staged_animation(AnimationType animation) -> void {
+        _timer_ms = 0;
+        _current_step = std::nullopt;
+        _queue.start_staged_animation(animation);
+    }
+
+    auto add_to_staging(const Action &action) -> bool {
+        return _queue.add_to_staging(action);
+    }
+
+    auto clear_staging() -> void { _queue.clear_staging(); }
+
+  private:
+    auto calculate_step_power() -> Color {
+        auto &step = _current_step.value();
+        auto timer =
+            std::clamp(_timer_ms, uint32_t(0), step.transition_time_ms);
+        return Color{
+            .r = lights::math::calculate_power(
+                step.transition, _step_starting_color.r, step.color.r, timer,
+                step.transition_time_ms),
+            .g = lights::math::calculate_power(
+                step.transition, _step_starting_color.g, step.color.g, timer,
+                step.transition_time_ms),
+            .b = lights::math::calculate_power(
+                step.transition, _step_starting_color.b, step.color.b, timer,
+                step.transition_time_ms),
+            .w = lights::math::calculate_power(
+                step.transition, _step_starting_color.w, step.color.w, timer,
+                step.transition_time_ms),
+        };
+    }
+
+    Color _step_starting_color;
+    std::optional<Action> _current_step;
+    uint32_t _timer_ms;
+    AnimationQueue<Size> _queue;
+};
+
+}  // namespace lights

--- a/include/rear-panel/core/lights/animation_math.hpp
+++ b/include/rear-panel/core/lights/animation_math.hpp
@@ -10,4 +10,8 @@ auto calculate_power(lights::Transition transition, double start_power,
                      double end_power, uint32_t ms_count, uint32_t ms_total)
     -> double;
 
-}
+auto color_interpolate(const lights::Color& first, const lights::Color& second,
+                       lights::Transition transition, uint32_t ms_count,
+                       uint32_t ms_total) -> lights::Color;
+
+}  // namespace lights::math

--- a/include/rear-panel/core/lights/animation_math.hpp
+++ b/include/rear-panel/core/lights/animation_math.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+#include "rear-panel/core/lights/animation_queue.hpp"
+
+namespace lights::math {
+
+auto calculate_power(lights::Transition transition, double start_power,
+                     double end_power, uint32_t ms_count, uint32_t ms_total)
+    -> double;
+
+}

--- a/include/rear-panel/core/lights/animation_queue.hpp
+++ b/include/rear-panel/core/lights/animation_queue.hpp
@@ -94,7 +94,8 @@ class AnimationQueue {
  */
 template <size_t Size>
 class AnimationBuffer {
-    public : AnimationBuffer() : _a(), _b(), _active(&_a), _staging(&_b) {}
+  public:
+    AnimationBuffer() : _a(), _b(), _active(&_a), _staging(&_b) {}
 
     auto get_next_active_step() -> std::optional<Action> {
         return _active->get_next();

--- a/include/rear-panel/core/lights/animation_queue.hpp
+++ b/include/rear-panel/core/lights/animation_queue.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+#include "rear-panel/core/bin_msg_ids.hpp"
+#include "rear-panel/core/double_buffer.hpp"
+
+namespace lights {
+
+using Transition = rearpanel::ids::LightTransitionType;
+using AnimationType = rearpanel::ids::LightAnimationType;
+
+struct Color {
+    // Colors are expressed as a range of [0, 1.0]
+    double r = 0, g = 0, b = 0, w = 0;
+};
+
+struct Action {
+    Color color;
+    Transition transition;
+    uint32_t transition_time_ms;
+};
+
+inline bool operator==(const Color &lhs, const Color &rhs) {
+    return (lhs.r == rhs.r) && (lhs.g == rhs.g) && (lhs.b == rhs.b) &&
+           (lhs.w == rhs.w);
+}
+
+inline bool operator==(const Action &lhs, const Action &rhs) {
+    return (lhs.color == rhs.color) && (lhs.transition == rhs.transition) &&
+           (lhs.transition_time_ms == rhs.transition_time_ms);
+}
+
+/**
+ * @brief The AnimationQueue class is used to arrange light actions in an
+ * ordered sequence to generate animations. Each Action is defined by an
+ * RGBW color, a transition time, and a transition type.
+ *
+ * The AnimationQueue holds both an active queue and a staging queue. New
+ * actions are added to the staging queue linearly, and then when a new
+ * animation is started the staging queue is swapped with the active queue.
+ * This allows a new animation to be constructed in the background while the
+ * current animation continues running.
+ *
+ * @tparam Size The maximum number of elements in the queue. Must be nonzero.
+ */
+template <size_t Size>
+class AnimationQueue {
+  private:
+    static_assert(Size > 0, "AnimationQueue requires nonzero buffer size.");
+
+  public:
+    AnimationQueue()
+        : _actions{},
+          _active_idx(0),
+          _staging_idx(0),
+          _animation(AnimationType::single_shot) {}
+
+    auto get_next_active_step() -> std::optional<Action> {
+        if ((!get_active_idx(_active_idx).has_value()) &&
+            _animation == AnimationType::looping) {
+            _active_idx = 0;
+        }
+
+        return get_active_idx(_active_idx++);
+    }
+
+    /**
+     * @brief Start a new animation. This function swaps the staging queue to
+     * be the active queue and clears out the new staging queue.
+     *
+     * @param animation The type of animation.
+     */
+    auto start_staged_animation(AnimationType animation) -> void {
+        // Before swapping, cap off the staging queue with a nullopt to
+        // ensure it won't overrun.
+        if (_staging_idx < Size) {
+            _actions.committed()->at(0) = std::nullopt;
+        }
+        _actions.swap();
+        _active_idx = 0;
+        _animation = animation;
+        clear_staging();
+    }
+
+    /**
+     * @brief Add a step to the staging queue
+     *
+     * @param action The action to add
+     * @return true if the action was added, false if the queue is full.
+     */
+    auto add_to_staging(Action action) -> bool {
+        if (_staging_idx >= Size) {
+            return false;
+        }
+        _actions.accessible()->at(_staging_idx++) = action;
+        return true;
+    }
+
+    /**
+     * @brief Empty out the staging queue.
+     *
+     */
+    auto clear_staging() -> void {
+        _staging_idx = 0;
+        _actions.accessible()->at(0) = std::nullopt;
+    }
+
+  private:
+    auto get_active_idx(size_t idx) -> std::optional<Action> {
+        if (idx >= Size) {
+            return std::nullopt;
+        }
+        return _actions.committed()->at(idx);
+    }
+
+    double_buffer::DoubleBuffer<std::optional<Action>, Size> _actions;
+    size_t _active_idx, _staging_idx;
+    AnimationType _animation;  // Current active animation type
+};
+
+}  // namespace lights

--- a/rear-panel/core/CMakeLists.txt
+++ b/rear-panel/core/CMakeLists.txt
@@ -2,6 +2,7 @@ function(target_rear_panel_core_rev1 TARGET)
     target_sources(${TARGET} PUBLIC
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/tasks.cpp
             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/queues.cpp
+            ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/lights/animation_math.cpp
         )
     target_include_directories(${TARGET} PUBLIC 
         ${CMAKE_CURRENT_FUNCTION_LIST_DIR}

--- a/rear-panel/core/lights/animation_math.cpp
+++ b/rear-panel/core/lights/animation_math.cpp
@@ -11,24 +11,27 @@ static auto calculate_linear_power(double start_power, double end_power,
     -> double {
     // Simple linear regression. At count of 0ms we return start_power, and at
     // the end we return the end_power.
-    double slope = end_power - start_power;
+    double powerdiff = end_power - start_power;
     double scale =
         static_cast<double>(ms_count) / static_cast<double>(ms_total);
-    return (scale * slope) + start_power;
+    return (scale * powerdiff) + start_power;
 }
 
 static auto calculate_sin_power(double start_power, double end_power,
                                 uint32_t ms_count, uint32_t ms_total)
     -> double {
-    double slope = end_power - start_power;
+    double powerdiff = end_power - start_power;
     // Percent done (count / total)
     double pct = static_cast<double>(ms_count) / static_cast<double>(ms_total);
-    // Scale to rads. 0% should be π rads, 100% should be 2π
+
+    // We want to use the range of cosine that will generate a curve from 
+    // [-1,1]. Therefore, when scaling from time, 0% progress should be π 
+    // rads, and 100% progress should be 2π rads
     double rads = PI + (pct * PI);
     // We want to scale the cosine of the angle in the range [0,1], so we add
     // 1 to the cos and then divide the result by 2
     double scale = (1.0 + std::cos(rads)) / 2.0F;
-    return (scale * slope) + start_power;
+    return (scale * powerdiff) + start_power;
 }
 
 auto lights::math::calculate_power(lights::Transition transition,

--- a/rear-panel/core/lights/animation_math.cpp
+++ b/rear-panel/core/lights/animation_math.cpp
@@ -24,8 +24,8 @@ static auto calculate_sin_power(double start_power, double end_power,
     // Percent done (count / total)
     double pct = static_cast<double>(ms_count) / static_cast<double>(ms_total);
 
-    // We want to use the range of cosine that will generate a curve from 
-    // [-1,1]. Therefore, when scaling from time, 0% progress should be π 
+    // We want to use the range of cosine that will generate a curve from
+    // [-1,1]. Therefore, when scaling from time, 0% progress should be π
     // rads, and 100% progress should be 2π rads
     double rads = PI + (pct * PI);
     // We want to scale the cosine of the angle in the range [0,1], so we add
@@ -56,4 +56,19 @@ auto lights::math::calculate_power(lights::Transition transition,
         default:
             return end_power;
     }
+}
+
+auto lights::math::color_interpolate(const lights::Color& first,
+                                     const lights::Color& second,
+                                     lights::Transition transition,
+                                     uint32_t ms_count, uint32_t ms_total)
+    -> lights::Color {
+    using namespace lights::math;
+    ms_count = std::min(ms_total, ms_count);
+    return lights::Color{
+        .r = calculate_power(transition, first.r, second.r, ms_count, ms_total),
+        .g = calculate_power(transition, first.g, second.g, ms_count, ms_total),
+        .b = calculate_power(transition, first.b, second.b, ms_count, ms_total),
+        .w = calculate_power(transition, first.w, second.w, ms_count, ms_total),
+    };
 }

--- a/rear-panel/core/lights/animation_math.cpp
+++ b/rear-panel/core/lights/animation_math.cpp
@@ -1,0 +1,56 @@
+#include "rear-panel/core/lights/animation_math.hpp"
+
+#include <cmath>
+
+#include "rear-panel/core/lights/animation_queue.hpp"
+
+static constexpr double PI = std::acos(-1);
+
+static auto calculate_linear_power(double start_power, double end_power,
+                                   uint32_t ms_count, uint32_t ms_total)
+    -> double {
+    // Simple linear regression. At count of 0ms we return start_power, and at
+    // the end we return the end_power.
+    double slope = end_power - start_power;
+    double scale =
+        static_cast<double>(ms_count) / static_cast<double>(ms_total);
+    return (scale * slope) + start_power;
+}
+
+static auto calculate_sin_power(double start_power, double end_power,
+                                uint32_t ms_count, uint32_t ms_total)
+    -> double {
+    double slope = end_power - start_power;
+    // Percent done (count / total)
+    double pct = static_cast<double>(ms_count) / static_cast<double>(ms_total);
+    // Scale to rads. 0% should be π rads, 100% should be 2π
+    double rads = PI + (pct * PI);
+    // We want to scale the cosine of the angle in the range [0,1], so we add
+    // 1 to the cos and then divide the result by 2
+    double scale = (1.0 + std::cos(rads)) / 2.0F;
+    return (scale * slope) + start_power;
+}
+
+auto lights::math::calculate_power(lights::Transition transition,
+                                   double start_power, double end_power,
+                                   uint32_t ms_count, uint32_t ms_total)
+    -> double {
+    if (ms_total == 0) {
+        transition = lights::Transition::instant;
+    }
+    switch (transition) {
+        case lights::Transition::linear:
+            return calculate_linear_power(start_power, end_power, ms_count,
+                                          ms_total);
+            break;
+        case lights::Transition::sinusoid:
+            return calculate_sin_power(start_power, end_power, ms_count,
+                                       ms_total);
+            break;
+        case lights::Transition::instant:
+            return end_power;
+            break;
+        default:
+            return end_power;
+    }
+}

--- a/rear-panel/test/CMakeLists.txt
+++ b/rear-panel/test/CMakeLists.txt
@@ -8,6 +8,14 @@ add_executable(
         rear-panel
         test_main.cpp
         test_messages.cpp
+        test_light_animation.cpp
+)
+
+# TODO(FS, 2023/03/22): We can't actually add in the entire rear-panel/core 
+# function since it uses FreeRTOS-specific headers... so instead I guess we 
+# can manually add source files? Fix this in the future.
+target_sources(rear-panel PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/lights/animation_math.cpp
 )
 
 target_include_directories(rear-panel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../include)

--- a/rear-panel/test/test_light_animation.cpp
+++ b/rear-panel/test/test_light_animation.cpp
@@ -1,0 +1,281 @@
+#include <iostream>
+#include <utility>
+#include <vector>
+
+#include "catch2/catch.hpp"
+#include "rear-panel/core/lights/animation_handler.hpp"
+#include "rear-panel/core/lights/animation_math.hpp"
+#include "rear-panel/core/lights/animation_queue.hpp"
+
+using namespace lights;
+
+TEST_CASE("animation math: instant transition") {
+    GIVEN("any combination of input values") {
+        double start_power = GENERATE(0, 100, 255);
+        double end_power = GENERATE(0, 100, 255);
+        uint8_t ms_count = GENERATE(0, 100, 255);
+        uint8_t ms_total = GENERATE(0, 100, 255);
+        THEN(
+            "calculating power with transition type of instant returns the "
+            "end_power") {
+            auto res = math::calculate_power(Transition::instant, start_power,
+                                             end_power, ms_count, ms_total);
+            REQUIRE(res == end_power);
+        }
+    }
+}
+
+TEST_CASE("animation math: linear transition") {
+    GIVEN("positive regression (end > start)") {
+        static constexpr double end = 100;
+        static constexpr double start = 0;
+        static constexpr uint32_t total_time = 100;
+        WHEN("calculating a point on the line") {
+            auto expected = std::vector<std::pair<uint32_t, double>>{
+                std::make_pair(0, 0),
+                std::make_pair(20, 20),
+                std::make_pair(50, 50),
+                std::make_pair(100, 100),
+            };
+            for (auto& item : expected) {
+                DYNAMIC_SECTION("point = " << item.first) {
+                    auto res = math::calculate_power(
+                        Transition::linear, start, end, item.first, total_time);
+                    REQUIRE(res == item.second);
+                }
+            }
+        }
+    }
+    GIVEN("negative regression (end < start)") {
+        static constexpr double end = 0;
+        static constexpr double start = 200;
+        static constexpr uint32_t total_time = 1000;
+        WHEN("calculating a point on the line") {
+            auto expected = std::vector<std::pair<uint32_t, double>>{
+                std::make_pair(0, 200),
+                std::make_pair(1000, 0),
+                std::make_pair(500, 100),
+                std::make_pair(750, 50),
+            };
+            for (auto& item : expected) {
+                DYNAMIC_SECTION("point = " << item.first) {
+                    auto res = math::calculate_power(
+                        Transition::linear, start, end, item.first, total_time);
+                    REQUIRE(res == item.second);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("animation math: sinusoid transition") {
+    GIVEN("positive regression (end > start)") {
+        static constexpr double end = 100;
+        static constexpr double start = 0;
+        static constexpr uint32_t total_time = 1000;
+        WHEN("calculating a point on the line") {
+            auto expected = std::vector<std::pair<uint32_t, double>>{
+                std::make_pair(0, 0),    std::make_pair(1000, 100),
+                std::make_pair(500, 50), std::make_pair(100, 2),
+                std::make_pair(200, 10), std::make_pair(300, 20),
+            };
+            for (auto& item : expected) {
+                DYNAMIC_SECTION("point = " << item.first) {
+                    auto res =
+                        math::calculate_power(Transition::sinusoid, start, end,
+                                              item.first, total_time);
+                    // Little bit of slop when dealing with the trig
+                    // functions...
+                    REQUIRE_THAT(res,
+                                 Catch::Matchers::WithinAbs(item.second, 1));
+                }
+            }
+        }
+    }
+    GIVEN("negative regression (end > start)") {
+        static constexpr double end = 15;
+        static constexpr double start = 255;
+        static constexpr uint32_t total_time = 1000;
+        WHEN("calculating a point on the line") {
+            auto expected = std::vector<std::pair<uint32_t, double>>{
+                std::make_pair(0, 255),   std::make_pair(1000, 15),
+                std::make_pair(100, 249), std::make_pair(200, 232),
+                std::make_pair(300, 205), std::make_pair(400, 172),
+            };
+            for (auto& item : expected) {
+                DYNAMIC_SECTION("point = " << item.first) {
+                    auto res =
+                        math::calculate_power(Transition::sinusoid, start, end,
+                                              item.first, total_time);
+                    // Little bit of slop when dealing with the trig
+                    // functions...
+                    REQUIRE_THAT(res,
+                                 Catch::Matchers::WithinAbs(item.second, 1));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("AnimationQueue basics") {
+    GIVEN("a new animation queue") {
+        constexpr size_t LENGTH = 10;
+        auto subject = AnimationQueue<LENGTH>();
+        WHEN("getting next step") {
+            auto res = subject.get_next_active_step();
+            THEN("it is nothing") { REQUIRE(!res.has_value()); }
+        }
+        WHEN("starting an animation and getting the next step") {
+            auto animation =
+                GENERATE(AnimationType::single_shot, AnimationType::looping);
+            subject.start_staged_animation(animation);
+            auto res = subject.get_next_active_step();
+            THEN("it is nothing") { REQUIRE(!res.has_value()); }
+        }
+        WHEN("adding a few steps") {
+            std::array<Action, 3> actions = {
+                Action{.color{.r = 10},
+                       .transition{Transition::linear},
+                       .transition_time_ms{0}},
+                Action{.color{.w = 200},
+                       .transition{Transition::sinusoid},
+                       .transition_time_ms{1}},
+                Action{.color{.b = 40},
+                       .transition{Transition::instant},
+                       .transition_time_ms{2}},
+            };
+            for (auto& action : actions) {
+                subject.add_to_staging(action);
+            }
+            WHEN("getting next step") {
+                auto res = subject.get_next_active_step();
+                THEN("it is nothing") { REQUIRE(!res.has_value()); }
+            }
+            WHEN("starting a single-shot animation") {
+                subject.start_staged_animation(AnimationType::single_shot);
+                THEN("the steps come back in order") {
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[0]);
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[1]);
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[2]);
+                    AND_THEN("the next step has no value") {
+                        REQUIRE(!subject.get_next_active_step().has_value());
+                    }
+                }
+            }
+            WHEN("starting a looping animation") {
+                subject.start_staged_animation(AnimationType::looping);
+                THEN("the steps come back in order, multiple times in a row") {
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[0]);
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[1]);
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[2]);
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[0]);
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[1]);
+                    REQUIRE(subject.get_next_active_step().value() ==
+                            actions[2]);
+                }
+            }
+        }
+        WHEN("filling the queue to its limit") {
+            bool ret = true;
+            auto action = Action{.color{.r = 10},
+                                 .transition{Transition::linear},
+                                 .transition_time_ms{100}};
+            for (size_t i = 0; i < LENGTH; ++i) {
+                ret = ret && subject.add_to_staging(action);
+            }
+            REQUIRE(ret);
+            THEN("adding one more action fails") {
+                REQUIRE(!subject.add_to_staging(action));
+            }
+        }
+    }
+}
+
+TEST_CASE("animation handler functionality") {
+    constexpr size_t LENGTH = 10;
+    GIVEN("a new animation handler") {
+        auto subject = AnimationHandler<LENGTH>();
+        auto colors_off = Color{.r = 0, .g = 0, .b = 0, .w = 0};
+        WHEN("calling animate()") {
+            auto res = subject.animate(10);
+            THEN("the result color is all-off") { REQUIRE(res == colors_off); }
+        }
+        WHEN("adding a step to turn on all lights") {
+            auto transition =
+                GENERATE(Transition::linear, Transition::sinusoid);
+            auto colors_on = Color{.r = 1, .g = 1, .b = 1, .w = 1};
+            auto action = Action{.color = colors_on,
+                                 .transition = transition,
+                                 .transition_time_ms = 500};
+            REQUIRE(subject.add_to_staging(action));
+            subject.start_staged_animation(AnimationType::single_shot);
+            THEN("calling animate will turn on the lights") {
+                constexpr uint32_t time_inc = 100;
+                uint32_t time = 0;
+                Color last = colors_off;
+                while (time <= 500) {
+                    auto next = subject.animate(time_inc);
+                    time += time_inc;
+                    DYNAMIC_SECTION("time = " << time) {
+                        REQUIRE(next.r >= last.r);
+                        REQUIRE(next.g >= last.g);
+                        REQUIRE(next.b >= last.b);
+                        REQUIRE(next.w >= last.w);
+                    }
+                    last = next;
+                }
+                REQUIRE(last == colors_on);
+                AND_THEN(
+                    "continuing to call animate will just return the last "
+                    "state") {
+                    REQUIRE(subject.animate(time_inc) == colors_on);
+                    REQUIRE(subject.animate(time_inc) == colors_on);
+                    REQUIRE(subject.animate(time_inc) == colors_on);
+                }
+            }
+        }
+    }
+    GIVEN("animation handler with a simple looping animation") {
+        auto subject = AnimationHandler<LENGTH>();
+        auto blue_on = Color{.b = 1.0};
+        auto green_on = Color{.g = 1.0};
+
+        auto action = Action{.color = blue_on,
+                             .transition = Transition::linear,
+                             .transition_time_ms = 200};
+        REQUIRE(subject.add_to_staging(action));
+        action.color = green_on;
+        REQUIRE(subject.add_to_staging(action));
+        subject.start_staged_animation(AnimationType::looping);
+        THEN("animating provides the correct colors") {
+            // At 100ms updates
+            auto expected = std::vector<Color>{
+                Color{.g = 0.0, .b = 0.5}, Color{.g = 0.0, .b = 1.0},
+                Color{.g = 0.5, .b = 0.5}, Color{.g = 1.0, .b = 0.0},
+                Color{.g = 0.5, .b = 0.5}, Color{.g = 0.0, .b = 1.0},
+                Color{.g = 0.5, .b = 0.5}, Color{.g = 1.0, .b = 0.0},
+            };
+            auto res = std::vector<Color>();
+            for (auto& e : expected) {
+                std::ignore = e;
+                res.push_back(subject.animate(100));
+            }
+            for (size_t i = 0; i < expected.size(); ++i) {
+                DYNAMIC_SECTION("increment " << i) {
+                    auto& e = expected.at(i);
+                    auto& r = res.at(i);
+                    REQUIRE_THAT(r.g, Catch::Matchers::WithinAbs(e.g, 0.01));
+                    REQUIRE_THAT(r.b, Catch::Matchers::WithinAbs(e.b, 0.01));
+                }
+            }
+        }
+    }
+}

--- a/rear-panel/test/test_light_animation.cpp
+++ b/rear-panel/test/test_light_animation.cpp
@@ -117,10 +117,10 @@ TEST_CASE("animation math: sinusoid transition") {
     }
 }
 
-TEST_CASE("AnimationQueue basics") {
+TEST_CASE("AnimationBuffer basics") {
     GIVEN("a new animation queue") {
         constexpr size_t LENGTH = 10;
-        auto subject = AnimationQueue<LENGTH>();
+        auto subject = AnimationBuffer<LENGTH>();
         WHEN("getting next step") {
             auto res = subject.get_next_active_step();
             THEN("it is nothing") { REQUIRE(!res.has_value()); }

--- a/rear-panel/test/test_light_animation.cpp
+++ b/rear-panel/test/test_light_animation.cpp
@@ -277,5 +277,34 @@ TEST_CASE("animation handler functionality") {
                 }
             }
         }
+        WHEN("switching the animation to an empty one mid-step") {
+            auto res = subject.animate(100);
+            REQUIRE(res == Color{.b = 0.5});
+            subject.clear_staging();
+            subject.start_staged_animation(AnimationType::looping);
+            THEN("animating returns the same color forever") {
+                REQUIRE(res == subject.animate(100));
+                REQUIRE(res == subject.animate(100));
+                REQUIRE(res == subject.animate(100));
+            }
+        }
+        WHEN("switching the animation to a different one mid-step") {
+            auto res = subject.animate(100);
+            REQUIRE(res == Color{.b = 0.5});
+            subject.clear_staging();
+            auto action = Action{
+                .color{.w = 1.0},
+                .transition = Transition::instant,
+                .transition_time_ms = 1000,
+            };
+            REQUIRE(subject.add_to_staging(action));
+            subject.start_staged_animation(AnimationType::looping);
+            THEN("animating returns the same color forever") {
+                auto expected = action.color;
+                REQUIRE(expected == subject.animate(10));
+                REQUIRE(expected == subject.animate(10));
+                REQUIRE(expected == subject.animate(10));
+            }
+        }
     }
 }

--- a/rear-panel/test/test_light_animation.cpp
+++ b/rear-panel/test/test_light_animation.cpp
@@ -222,7 +222,9 @@ TEST_CASE("animation handler functionality") {
                 uint32_t time = 0;
                 Color last = colors_off;
                 while (time <= 500) {
+                    // First step LOADS the message, second step starts it...
                     auto next = subject.animate(time_inc);
+                    next = subject.animate(time_inc);
                     time += time_inc;
                     DYNAMIC_SECTION("time = " << time) {
                         REQUIRE(next.r >= last.r);
@@ -258,10 +260,15 @@ TEST_CASE("animation handler functionality") {
         THEN("animating provides the correct colors") {
             // At 100ms updates
             auto expected = std::vector<Color>{
-                Color{.g = 0.0, .b = 0.5}, Color{.g = 0.0, .b = 1.0},
-                Color{.g = 0.5, .b = 0.5}, Color{.g = 1.0, .b = 0.0},
-                Color{.g = 0.5, .b = 0.5}, Color{.g = 0.0, .b = 1.0},
-                Color{.g = 0.5, .b = 0.5}, Color{.g = 1.0, .b = 0.0},
+                Color{},
+                Color{.g = 0.0, .b = 0.5},
+                Color{.g = 0.0, .b = 1.0},
+                Color{.g = 0.5, .b = 0.5},
+                Color{.g = 1.0, .b = 0.0},
+                Color{.g = 0.5, .b = 0.5},
+                Color{.g = 0.0, .b = 1.0},
+                Color{.g = 0.5, .b = 0.5},
+                Color{.g = 1.0, .b = 0.0},
             };
             auto res = std::vector<Color>();
             for (auto& e : expected) {
@@ -278,17 +285,20 @@ TEST_CASE("animation handler functionality") {
             }
         }
         WHEN("switching the animation to an empty one mid-step") {
+            std::ignore = subject.animate(100);
             auto res = subject.animate(100);
             REQUIRE(res == Color{.b = 0.5});
             subject.clear_staging();
             subject.start_staged_animation(AnimationType::looping);
             THEN("animating returns the same color forever") {
+                std::ignore = subject.animate(100);
                 REQUIRE(res == subject.animate(100));
                 REQUIRE(res == subject.animate(100));
                 REQUIRE(res == subject.animate(100));
             }
         }
         WHEN("switching the animation to a different one mid-step") {
+            std::ignore = subject.animate(100);
             auto res = subject.animate(100);
             REQUIRE(res == Color{.b = 0.5});
             subject.clear_staging();
@@ -300,6 +310,7 @@ TEST_CASE("animation handler functionality") {
             REQUIRE(subject.add_to_staging(action));
             subject.start_staged_animation(AnimationType::looping);
             THEN("animating returns the same color forever") {
+                std::ignore = subject.animate(100);
                 auto expected = action.color;
                 REQUIRE(expected == subject.animate(10));
                 REQUIRE(expected == subject.animate(10));


### PR DESCRIPTION
This PR adds in an AnimationHandler class that is responsible for handling rear panel light animations. The AnimationHandler is backed by an AnimationBuffer (a double-buffered array) which stores a series of individual "actions". Each action contains:
- A color to transition to
- A transition type
  - Instant will instantly change the color and then hold at it for the remainder of the step
  - Linear will just change the color linearly over time from the previous setting to the new setting
  - Sinusoid will transition in a smoother, pulse-like fashion between the previous color and the new color
- A transition time, which is the amount of time in milliseconds that this step should take

The double buffer is utilized to provide an "active" queue, for the animation that is currently running; and a "staging" queue, where individual Actions can be added to create an animation. When the controller wants to run a new animation, it can send all of the individual steps over USB (in a future PR) and then request to start an animation (either looping or single shot), which will swap the staging buffer to be the active buffer and begin running through it.

Also requires https://github.com/Opentrons/opentrons/pull/12345 