### PR TITLE
chore: add rear panel and manifest to application artifact

### DIFF
--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: 'firmware-applications-${{github.ref_name}}'
           path: |
-            dist/applications/*.hex
+            dist/applications/*
       - name: 'Upload all-images artifact'
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The previous file only installed .hex files but we also want the rear panel's .bin file and the manifest .json file.

with this new workflow you can download the application artifact and unzip it into your ot3firmware repo and push it onto the bot with <code>./push [IP] --no-build</code>