### PR TITLE
feat(rear-panel): add light strip commands

### DIFF
--- a/include/rear-panel/core/bin_msg_ids.hpp
+++ b/include/rear-panel/core/bin_msg_ids.hpp
@@ -24,6 +24,9 @@ enum class BinaryMessageId : uint16_t {
     estop_button_detection_change = 0xc,
     door_switch_state_request = 0xd,
     door_switch_state_info = 0xe,
+    add_light_action = 0x400,
+    clear_light_action_staging_queue = 0x401,
+    start_light_action = 0x402,
 };
 
 /** The types of transitons that the lights can perform. */

--- a/include/rear-panel/core/lights/animation_handler.hpp
+++ b/include/rear-panel/core/lights/animation_handler.hpp
@@ -24,7 +24,6 @@ class AnimationHandler {
         : _step_starting_color{.r = 0, .g = 0, .b = 0, .w = 0},
           _most_recent_color{.r = 0, .g = 0, .b = 0, .w = 0},
           _current_step{std::nullopt},
-          _timer_ms(0),
           _queue() {}
 
     /**
@@ -84,7 +83,7 @@ class AnimationHandler {
     Color _step_starting_color;
     Color _most_recent_color;
     std::optional<Action> _current_step;
-    uint32_t _timer_ms;
+    uint32_t _timer_ms{0};
     AnimationBuffer<Size> _queue;
 };
 

--- a/include/rear-panel/core/lights/animation_queue.hpp
+++ b/include/rear-panel/core/lights/animation_queue.hpp
@@ -22,12 +22,12 @@ struct Action {
     uint32_t transition_time_ms;
 };
 
-inline bool operator==(const Color &lhs, const Color &rhs) {
+inline auto operator==(const Color &lhs, const Color &rhs) -> bool {
     return (lhs.r == rhs.r) && (lhs.g == rhs.g) && (lhs.b == rhs.b) &&
            (lhs.w == rhs.w);
 }
 
-inline bool operator==(const Action &lhs, const Action &rhs) {
+inline auto operator==(const Action &lhs, const Action &rhs) -> bool {
     return (lhs.color == rhs.color) && (lhs.transition == rhs.transition) &&
            (lhs.transition_time_ms == rhs.transition_time_ms);
 }
@@ -38,11 +38,7 @@ class AnimationQueue {
     static_assert(Size > 0, "AnimationQueue requires nonzero buffer size.");
 
   public:
-    AnimationQueue()
-        : _queue{},
-          _length(0),
-          _active_idx(0),
-          _animation(AnimationType::single_shot) {}
+    AnimationQueue() = default;
 
     auto start_animation(AnimationType type) -> void {
         _active_idx = 0;
@@ -63,7 +59,7 @@ class AnimationQueue {
         if (_length >= Size) {
             return false;
         }
-        _queue[_length++] = action;
+        _queue.at(_length++) = action;
         return true;
     }
 
@@ -73,10 +69,10 @@ class AnimationQueue {
     }
 
   private:
-    std::array<Action, Size> _queue;
-    size_t _length;
-    size_t _active_idx;
-    AnimationType _animation;
+    std::array<Action, Size> _queue{};
+    size_t _length{0};
+    size_t _active_idx{0};
+    AnimationType _animation{AnimationType::single_shot};
 };
 
 /**

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -367,6 +367,9 @@ struct AddLightActionRequest
             .white = 0};
 
         body = bit_utils::bytes_to_int(body, limit, type);
+        if(type != static_cast<uint16_t>(message_type)) {
+            return std::monostate();
+        }
         body = bit_utils::bytes_to_int(body, limit, ret.length);
         if (body == limit) {
             return std::monostate();
@@ -403,6 +406,31 @@ struct AddLightActionRequest
     auto operator==(const AddLightActionRequest& other) const -> bool = default;
 };
 
+struct ClearLightActionStagingQueueRequest
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::clear_light_action_staging_queue> {
+    static constexpr size_t LENGTH = 0;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit)
+        -> std::variant<std::monostate, ClearLightActionStagingQueueRequest> {
+        uint16_t type = 0;
+        uint16_t length;
+
+        body = bit_utils::bytes_to_int(body, limit, type);
+        if(type != static_cast<uint16_t>(message_type)) {
+            return std::monostate();
+        }
+        body = bit_utils::bytes_to_int(body, limit, length);
+        if(length != LENGTH) {
+            return std::monostate();
+        }
+        return ClearLightActionStagingQueueRequest{};
+    }
+
+    auto operator==(const ClearLightActionStagingQueueRequest& other) const -> bool = default;
+};
+
+
 // HostCommTaskMessage list must be a superset of the messages in the parser
 using HostCommTaskMessage =
     std::variant<std::monostate, Echo, DeviceInfoRequest, Ack, AckFailed,
@@ -425,7 +453,8 @@ static auto rear_panel_parser =
     binary_parse::Parser<Echo, DeviceInfoRequest, EnterBootloader,
                          EngageEstopRequest, EngageSyncRequest,
                          ReleaseEstopRequest, ReleaseSyncRequest,
-                         DoorSwitchStateRequest, AddLightActionRequest>{};
+                         DoorSwitchStateRequest, AddLightActionRequest,
+                         ClearLightActionStagingQueueRequest>{};
 
 };  // namespace messages
 };  // namespace rearpanel

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -468,7 +468,9 @@ using HostCommTaskMessage =
                  EnterBootloader, EnterBootloaderResponse, EngageEstopRequest,
                  EngageSyncRequest, ReleaseEstopRequest, ReleaseSyncRequest,
                  EstopStateChange, EstopButtonDetectionChange,
-                 DoorSwitchStateRequest, DoorSwitchStateInfo>;
+                 DoorSwitchStateRequest, DoorSwitchStateInfo,
+                 AddLightActionRequest, ClearLightActionStagingQueueRequest,
+                 StartLightActionRequest>;
 
 using SystemTaskMessage =
     std::variant<std::monostate, EnterBootloader, EngageEstopRequest,
@@ -476,7 +478,9 @@ using SystemTaskMessage =
                  DoorSwitchStateRequest>;
 
 using LightControlTaskMessage =
-    std::variant<std::monostate, UpdateLightControlMessage>;
+    std::variant<std::monostate, UpdateLightControlMessage,
+                 AddLightActionRequest, ClearLightActionStagingQueueRequest,
+                 StartLightActionRequest>;
 
 using HardwareTaskMessage = std::variant<std::monostate>;
 

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -432,6 +432,36 @@ struct ClearLightActionStagingQueueRequest
         -> bool = default;
 };
 
+struct StartLightActionRequest
+    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::start_light_action> {
+    static constexpr size_t LENGTH = sizeof(rearpanel::ids::LightAnimationType);
+    rearpanel::ids::LightAnimationType animation;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit)
+        -> std::variant<std::monostate, StartLightActionRequest> {
+        uint16_t type = 0;
+        uint16_t length;
+        uint8_t animation;
+
+        body = bit_utils::bytes_to_int(body, limit, type);
+        if (type != static_cast<uint16_t>(message_type)) {
+            return std::monostate();
+        }
+        body = bit_utils::bytes_to_int(body, limit, length);
+        if (length != LENGTH) {
+            return std::monostate();
+        }
+        body = bit_utils::bytes_to_int(body, limit, animation);
+        return StartLightActionRequest{
+            .animation =
+                static_cast<rearpanel::ids::LightAnimationType>(animation)};
+    }
+
+    auto operator==(const StartLightActionRequest& other) const
+        -> bool = default;
+};
+
 // HostCommTaskMessage list must be a superset of the messages in the parser
 using HostCommTaskMessage =
     std::variant<std::monostate, Echo, DeviceInfoRequest, Ack, AckFailed,
@@ -450,12 +480,11 @@ using LightControlTaskMessage =
 
 using HardwareTaskMessage = std::variant<std::monostate>;
 
-static auto rear_panel_parser =
-    binary_parse::Parser<Echo, DeviceInfoRequest, EnterBootloader,
-                         EngageEstopRequest, EngageSyncRequest,
-                         ReleaseEstopRequest, ReleaseSyncRequest,
-                         DoorSwitchStateRequest, AddLightActionRequest,
-                         ClearLightActionStagingQueueRequest>{};
+static auto rear_panel_parser = binary_parse::Parser<
+    Echo, DeviceInfoRequest, EnterBootloader, EngageEstopRequest,
+    EngageSyncRequest, ReleaseEstopRequest, ReleaseSyncRequest,
+    DoorSwitchStateRequest, AddLightActionRequest,
+    ClearLightActionStagingQueueRequest, StartLightActionRequest>{};
 
 };  // namespace messages
 };  // namespace rearpanel

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -367,7 +367,7 @@ struct AddLightActionRequest
             .white = 0};
 
         body = bit_utils::bytes_to_int(body, limit, type);
-        if(type != static_cast<uint16_t>(message_type)) {
+        if (type != static_cast<uint16_t>(message_type)) {
             return std::monostate();
         }
         body = bit_utils::bytes_to_int(body, limit, ret.length);
@@ -407,7 +407,8 @@ struct AddLightActionRequest
 };
 
 struct ClearLightActionStagingQueueRequest
-    : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::clear_light_action_staging_queue> {
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::clear_light_action_staging_queue> {
     static constexpr size_t LENGTH = 0;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -417,19 +418,19 @@ struct ClearLightActionStagingQueueRequest
         uint16_t length;
 
         body = bit_utils::bytes_to_int(body, limit, type);
-        if(type != static_cast<uint16_t>(message_type)) {
+        if (type != static_cast<uint16_t>(message_type)) {
             return std::monostate();
         }
         body = bit_utils::bytes_to_int(body, limit, length);
-        if(length != LENGTH) {
+        if (length != LENGTH) {
             return std::monostate();
         }
         return ClearLightActionStagingQueueRequest{};
     }
 
-    auto operator==(const ClearLightActionStagingQueueRequest& other) const -> bool = default;
+    auto operator==(const ClearLightActionStagingQueueRequest& other) const
+        -> bool = default;
 };
-
 
 // HostCommTaskMessage list must be a superset of the messages in the parser
 using HostCommTaskMessage =

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -339,6 +339,7 @@ struct DoorSwitchStateInfo
     auto operator==(const DoorSwitchStateInfo& other) const -> bool = default;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct AddLightActionRequest
     : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::add_light_action> {
     static constexpr size_t LENGTH =
@@ -356,7 +357,7 @@ struct AddLightActionRequest
     static auto parse(Input body, Limit limit)
         -> std::variant<std::monostate, AddLightActionRequest> {
         uint16_t type = 0;
-        uint8_t transition_buf;
+        uint8_t transition_buf = 0;
         auto ret = AddLightActionRequest{
             .length = 0,
             .transition_time_ms = 0,
@@ -415,7 +416,7 @@ struct ClearLightActionStagingQueueRequest
     static auto parse(Input body, Limit limit)
         -> std::variant<std::monostate, ClearLightActionStagingQueueRequest> {
         uint16_t type = 0;
-        uint16_t length;
+        uint16_t length = 0;
 
         body = bit_utils::bytes_to_int(body, limit, type);
         if (type != static_cast<uint16_t>(message_type)) {
@@ -432,6 +433,7 @@ struct ClearLightActionStagingQueueRequest
         -> bool = default;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct StartLightActionRequest
     : BinaryFormatMessage<rearpanel::ids::BinaryMessageId::start_light_action> {
     static constexpr size_t LENGTH = sizeof(rearpanel::ids::LightAnimationType);
@@ -441,8 +443,8 @@ struct StartLightActionRequest
     static auto parse(Input body, Limit limit)
         -> std::variant<std::monostate, StartLightActionRequest> {
         uint16_t type = 0;
-        uint16_t length;
-        uint8_t animation;
+        uint16_t length = 0;
+        uint8_t animation = 0;
 
         body = bit_utils::bytes_to_int(body, limit, type);
         if (type != static_cast<uint16_t>(message_type)) {

--- a/include/rear-panel/core/tasks/host_comms_task.hpp
+++ b/include/rear-panel/core/tasks/host_comms_task.hpp
@@ -214,6 +214,44 @@ class HostCommMessageHandler {
                        InputIt tx_into, InputLimit tx_limit) -> InputIt {
         return msg.serialize(tx_into, tx_limit);
     }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(rearpanel::messages::AddLightActionRequest &msg,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto queue_client = queue_client::get_main_queues();
+        queue_client.send_light_control_queue(msg);
+        static_cast<void>(tx_into);
+        static_cast<void>(tx_limit);
+        return tx_into;
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(
+        rearpanel::messages::ClearLightActionStagingQueueRequest &msg,
+        InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto queue_client = queue_client::get_main_queues();
+        queue_client.send_light_control_queue(msg);
+        static_cast<void>(tx_into);
+        static_cast<void>(tx_limit);
+        return tx_into;
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(rearpanel::messages::StartLightActionRequest &msg,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        auto queue_client = queue_client::get_main_queues();
+        queue_client.send_light_control_queue(msg);
+        static_cast<void>(tx_into);
+        static_cast<void>(tx_limit);
+        return tx_into;
+    }
+
     bool may_connect_latch = true;
 };
 

--- a/include/rear-panel/core/tasks/light_control_task.hpp
+++ b/include/rear-panel/core/tasks/light_control_task.hpp
@@ -91,12 +91,12 @@ class LightControlMessageHandler {
         ack();
     }
 
-    auto ack() -> void {
+    static auto ack() -> void {
         queue_client::get_main_queues().send_host_comms_queue(
             rearpanel::messages::Ack{});
     }
 
-    auto nack() -> void {
+    static auto nack() -> void {
         queue_client::get_main_queues().send_host_comms_queue(
             rearpanel::messages::AckFailed{});
     }

--- a/include/rear-panel/core/tasks/light_control_task.hpp
+++ b/include/rear-panel/core/tasks/light_control_task.hpp
@@ -41,7 +41,6 @@ class LightControlMessageHandler {
   public:
     LightControlMessageHandler(LightControlInterface& hardware)
         : _hardware(hardware), _animation() {
-        _hardware.set_led_power(DECK_LED, DECK_LED_ON_POWER);
     }
 
     auto handle_message(const TaskMessage& message) -> void {
@@ -53,6 +52,7 @@ class LightControlMessageHandler {
 
     auto handle(rearpanel::messages::UpdateLightControlMessage&) -> void {
         auto color = _animation.animate(DELAY_MS);
+        _hardware.set_led_power(DECK_LED, DECK_LED_ON_POWER);
         _hardware.set_led_power(RED_UI_LED, static_cast<uint32_t>(color.r));
         _hardware.set_led_power(GREEN_UI_LED, static_cast<uint32_t>(color.g));
         _hardware.set_led_power(BLUE_UI_LED, static_cast<uint32_t>(color.b));

--- a/rear-panel/core/queues.cpp
+++ b/rear-panel/core/queues.cpp
@@ -20,6 +20,11 @@ void queue_client::QueueClient::send_system_queue(
     system_queue->try_write(m);
 }
 
+void queue_client::QueueClient::send_light_control_queue(
+    const rearpanel::messages::LightControlTaskMessage& m) {
+    light_control_queue->try_write(m);
+}
+
 void queue_client::QueueClient::send_hardware_queue(
     const rearpanel::messages::HardwareTaskMessage& m) {
     hardware_queue->try_write(m);

--- a/rear-panel/core/queues.cpp
+++ b/rear-panel/core/queues.cpp
@@ -12,22 +12,30 @@ void queue_client::QueueClient::send_eeprom_queue(
 
 void queue_client::QueueClient::send_host_comms_queue(
     const rearpanel::messages::HostCommTaskMessage& m) {
-    host_comms_queue->try_write(m);
+    if (host_comms_queue) {
+        host_comms_queue->try_write(m);
+    }
 }
 
 void queue_client::QueueClient::send_system_queue(
     const rearpanel::messages::SystemTaskMessage& m) {
-    system_queue->try_write(m);
+    if (system_queue) {
+        system_queue->try_write(m);
+    }
 }
 
 void queue_client::QueueClient::send_light_control_queue(
     const rearpanel::messages::LightControlTaskMessage& m) {
-    light_control_queue->try_write(m);
+    if (light_control_queue) {
+        light_control_queue->try_write(m);
+    }
 }
 
 void queue_client::QueueClient::send_hardware_queue(
     const rearpanel::messages::HardwareTaskMessage& m) {
-    hardware_queue->try_write(m);
+    if (hardware_queue) {
+        hardware_queue->try_write(m);
+    }
 }
 
 /**

--- a/rear-panel/core/tasks.cpp
+++ b/rear-panel/core/tasks.cpp
@@ -2,6 +2,7 @@
 
 #include "common/core/freertos_task.hpp"
 #include "common/core/freertos_timer.hpp"
+#include "rear-panel/core/lights/animation_handler.hpp"
 #include "rear-panel/core/tasks/light_control_update_timer.hpp"
 #include "rear-panel/firmware/freertos_comms_task.hpp"
 #include "rear-panel/firmware/gpio_drive_hardware.hpp"
@@ -66,6 +67,8 @@ static auto light_control_timer = light_control_task::timer::LightControlTimer(
 static auto hardware_task_builder =
     freertos_task::TaskStarter<512, hardware_task::HardwareTask>{};
 
+static auto animation_handler = light_control_task::Animation();
+
 /**
  * Start rear tasks.
  */
@@ -91,8 +94,8 @@ void rear_panel_tasks::start_tasks(
     queues.host_comms_queue = &comms.task->get_queue();
     tasks.host_comms_task = comms.task;
 
-    auto& light_task =
-        light_control_task_builder.start(5, "lights", light_hardware);
+    auto& light_task = light_control_task_builder.start(
+        5, "lights", light_hardware, animation_handler);
     queues.light_control_queue = &light_task.get_queue();
     tasks.light_control_task = &light_task;
     light_control_timer.start();

--- a/rear-panel/firmware/freertos_idle_timer_task.cpp
+++ b/rear-panel/firmware/freertos_idle_timer_task.cpp
@@ -17,10 +17,10 @@ StaticTask_t
 StaticTask_t
     idle_timer_tcb;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-std::array<StackType_t, configMINIMAL_STACK_SIZE>
+std::array<StackType_t, 512>
     idle_task_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-std::array<StackType_t, configMINIMAL_STACK_SIZE>
+std::array<StackType_t, 512>
     idle_timer_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // This is a callback defined in a C file so it has to be linked as such
@@ -39,4 +39,16 @@ extern "C" void vApplicationGetTimerTaskMemory(
     *ppxTimerTaskTCBBuffer = &idle_timer_tcb;
     *ppxTimerTaskStackBuffer = idle_timer_stack.data();
     *pulTimerTaskStackSize = idle_timer_stack.size();
+}
+
+// We are matching the definition of this function in FreeRTOS, and thus
+// keep the function signature the same
+extern "C" void vApplicationStackOverflowHook(
+    TaskHandle_t xTask,
+    // NOLINTNEXTLINE(readability-non-const-parameter)
+    signed char *pcTaskName) {
+    static_cast<void>(xTask);
+    static_cast<void>(pcTaskName);
+    // Lock the processor forever
+    configASSERT(0);
 }

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -203,3 +203,30 @@ TEST_CASE("AddLightActionRequest parsing") {
         }
     }
 }
+
+TEST_CASE("ClearLightActionStagingQueueRequest parsing") {
+    using namespace rearpanel;
+    GIVEN("valid input") {
+        auto input = std::array<uint8_t, 4>{// Header
+                                             0x04, 0x01, 0x00, 0x00,};
+        WHEN("parsed") {
+            auto message = rearpanel::messages::rear_panel_parser.parse(
+                ids::BinaryMessageId(0x0401), input.begin(), input.end());
+            THEN("the message is correctly parsed") {
+                REQUIRE(std::holds_alternative<messages::ClearLightActionStagingQueueRequest>(
+                    message));
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        auto input = std::array<uint8_t, 4>{// Header w/ wrong length
+                                             0x04, 0x01, 0x00, 0x10,};
+        WHEN("parsed") {
+            auto message = rearpanel::messages::rear_panel_parser.parse(
+                ids::BinaryMessageId(0x0401), input.begin(), input.end());
+            THEN("the message is not parsed") {
+                REQUIRE(std::holds_alternative<std::monostate>(message));
+            }
+        }
+    }
+}

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -241,3 +241,46 @@ TEST_CASE("ClearLightActionStagingQueueRequest parsing") {
         }
     }
 }
+
+TEST_CASE("StartLightActionRequest parsing") {
+    using namespace rearpanel;
+    GIVEN("valid input") {
+        auto input = std::array<uint8_t, 5>{
+            // Header
+            0x04,
+            0x02,
+            0x00,
+            0x01,
+            // Animation type looping
+            0x00,
+        };
+        WHEN("parsed") {
+            auto message = rearpanel::messages::rear_panel_parser.parse(
+                ids::BinaryMessageId(0x0402), input.begin(), input.end());
+            THEN("the message is correctly parsed") {
+                REQUIRE(
+                    std::holds_alternative<messages::StartLightActionRequest>(
+                        message));
+                auto request =
+                    std::get<messages::StartLightActionRequest>(message);
+                REQUIRE(request.animation == ids::LightAnimationType::looping);
+            }
+        }
+    }
+    GIVEN("invalid input") {
+        auto input = std::array<uint8_t, 4>{
+            // Header w/ wrong length
+            0x04,
+            0x02,
+            0x00,
+            0x10,
+        };
+        WHEN("parsed") {
+            auto message = rearpanel::messages::rear_panel_parser.parse(
+                ids::BinaryMessageId(0x0402), input.begin(), input.end());
+            THEN("the message is not parsed") {
+                REQUIRE(std::holds_alternative<std::monostate>(message));
+            }
+        }
+    }
+}

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -207,20 +207,31 @@ TEST_CASE("AddLightActionRequest parsing") {
 TEST_CASE("ClearLightActionStagingQueueRequest parsing") {
     using namespace rearpanel;
     GIVEN("valid input") {
-        auto input = std::array<uint8_t, 4>{// Header
-                                             0x04, 0x01, 0x00, 0x00,};
+        auto input = std::array<uint8_t, 4>{
+            // Header
+            0x04,
+            0x01,
+            0x00,
+            0x00,
+        };
         WHEN("parsed") {
             auto message = rearpanel::messages::rear_panel_parser.parse(
                 ids::BinaryMessageId(0x0401), input.begin(), input.end());
             THEN("the message is correctly parsed") {
-                REQUIRE(std::holds_alternative<messages::ClearLightActionStagingQueueRequest>(
+                REQUIRE(std::holds_alternative<
+                        messages::ClearLightActionStagingQueueRequest>(
                     message));
             }
         }
     }
     GIVEN("invalid input") {
-        auto input = std::array<uint8_t, 4>{// Header w/ wrong length
-                                             0x04, 0x01, 0x00, 0x10,};
+        auto input = std::array<uint8_t, 4>{
+            // Header w/ wrong length
+            0x04,
+            0x01,
+            0x00,
+            0x10,
+        };
         WHEN("parsed") {
             auto message = rearpanel::messages::rear_panel_parser.parse(
                 ids::BinaryMessageId(0x0401), input.begin(), input.end());


### PR DESCRIPTION
This PR adds three commands for interacting with the light strip on the rear panel:

- A command to add a step to the animation in the staging queue
- A command to clear the staging queue
- A command to start running the animation in the staging queue

An `AnimationHandler` is added to the light control task's message handler, and it is used as the source of the color values when the periodic update message is parsed. 

Tested on an OT-3 with https://github.com/Opentrons/opentrons/pull/12350 using the `usb_comm` script. Uploading a series of actions and then running an animation will, in fact, run that animation.

Other misc stuff
- Bumped up the stack size of the idle task and the timer task; I was getting overflows from them and this fixed it.
- Added a handler to enable using the FreeRTOS stack overflow features
- Added implementation of `send_light_control_queue` because I forgot to do that
- Added `nullptr` checking for all of the queue-send commands. The queues _should_ be set before they're ever accessed, but belt-and-suspenders isn't the worst thing...
- Added a bunch of linter-related changes for the AnimationHandler & friends because they weren't being compiled into the firmware before so the linter didn't check them.