### PR TITLE
fix(pipettes): switch the i2c bus of the pressure sensor to match primary and secondary conventions

### DIFF
--- a/pipettes/firmware/hardware_config.c
+++ b/pipettes/firmware/hardware_config.c
@@ -18,11 +18,11 @@ static PipetteHardwarePin get_gpio_ht(PipetteHardwareDevice device) {
             pinout.port = GPIOA;
             pinout.pin = GPIO_PIN_9;
             return pinout;
-        case pipette_hardware_device_data_ready_rear:
+        case pipette_hardware_device_data_ready_front:
             pinout.port = GPIOC;
             pinout.pin = GPIO_PIN_11;
             return pinout;
-        case pipette_hardware_device_data_ready_front:
+        case pipette_hardware_device_data_ready_rear:
             pinout.port = GPIOC;
             pinout.pin = GPIO_PIN_6;
             return pinout;
@@ -106,12 +106,12 @@ static PipetteHardwarePin get_gpio_lt(PipetteHardwareDevice device) {
             pinout.pin = GPIO_PIN_6;
             return pinout;
         case pipette_hardware_device_data_ready_rear:
-            pinout.port = GPIOC;
-            pinout.pin = GPIO_PIN_3;
-            return pinout;
-        case pipette_hardware_device_data_ready_front:
             pinout.port = GPIOB;
             pinout.pin = GPIO_PIN_1;
+            return pinout;
+        case pipette_hardware_device_data_ready_front:
+            pinout.port = GPIOC;
+            pinout.pin = GPIO_PIN_3;
             return pinout;
         default:
             pinout.port = 0;

--- a/pipettes/firmware/utility_configurations.cpp
+++ b/pipettes/firmware/utility_configurations.cpp
@@ -77,8 +77,8 @@ auto utility_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
                 .data_ready =
                     gpio::PinConfig{
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                        .port = GPIOC,
-                        .pin = GPIO_PIN_3,
+                        .port = GPIOB,
+                        .pin = GPIO_PIN_1,
                         .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     gpio::PinConfig{
@@ -94,8 +94,8 @@ auto utility_configs::sensor_configurations<PipetteType::EIGHT_CHANNEL>()
                  .active_setting = GPIO_PIN_RESET},
             .data_ready = gpio::PinConfig{
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-                .port = GPIOB,
-                .pin = GPIO_PIN_1,
+                .port = GPIOC,
+                .pin = GPIO_PIN_3,
                 .active_setting = GPIO_PIN_RESET}}};
     return pins;
 }
@@ -115,7 +115,7 @@ auto utility_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                     gpio::PinConfig{
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                         .port = GPIOC,
-                        .pin = GPIO_PIN_11,
+                        .pin = GPIO_PIN_6,
                         .active_setting = GPIO_PIN_RESET},
                 .tip_sense =
                     gpio::PinConfig{
@@ -133,7 +133,7 @@ auto utility_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                 gpio::PinConfig{
                     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                     .port = GPIOC,
-                    .pin = GPIO_PIN_6,
+                    .pin = GPIO_PIN_11,
                     .active_setting = GPIO_PIN_RESET},
             .tip_sense = gpio::PinConfig{
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -189,13 +189,18 @@ static void sync_drive_gpio_init() {
 
 static void data_ready_gpio_init() {
     PipetteType pipette_type = get_pipette_type();
+    // Note, only in this file are we using "front" to refer to
+    // the single channel's data ready line. Unfortunately, the data ready
+    // line on the single matches the front channel on the eight channel
+    // but we normally will refer to the rear sensor as the primary sensor
+    // in the rest of the codebase.
     PipetteHardwarePin hardware =
             pipette_hardware_get_gpio(
-                pipette_type, pipette_hardware_device_data_ready_rear);
+                pipette_type, pipette_hardware_device_data_ready_front);
     enable_gpio_port(hardware.port);
     if (pipette_type != SINGLE_CHANNEL) {
         PipetteHardwarePin hardware_front = pipette_hardware_get_gpio(
-            pipette_type, pipette_hardware_device_data_ready_front);
+            pipette_type, pipette_hardware_device_data_ready_rear);
         enable_gpio_port(hardware_front.port);
         /*Configure GPIO pin*/
         GPIO_InitTypeDef GPIO_InitStruct = {0};


### PR DESCRIPTION
## Overview

We are using the convention of "primary" and "secondary" to refer to multiple sensors of the same type. The primary channel should generally refer to the "A1" version of the pipette. The eight channel has a flipped "primary" bus for the pressure sensor.