### PR TITLE
feat(head, gantry): enable the eeprom for the head and gripper boards

### DIFF
--- a/gantry/core/tasks_rev1.cpp
+++ b/gantry/core/tasks_rev1.cpp
@@ -124,6 +124,10 @@ void gantry::queues::QueueClient::send_move_status_reporter_queue(
     static_cast<void>(move_status_report_queue->try_write_isr(m));
 }
 
+void gantry::queues::QueueClient::send_eeprom_queue(
+    const eeprom::task::TaskMessage& m) {
+    eeprom_queue->try_write(m);
+}
 /**
  * Access to the tasks singleton
  * @return

--- a/gantry/core/tasks_rev1.cpp
+++ b/gantry/core/tasks_rev1.cpp
@@ -30,6 +30,20 @@ static auto move_status_task_builder = freertos_task::TaskStarter<
 static auto spi_task_builder =
     freertos_task::TaskStarter<512, spi::tasks::Task>{};
 
+template <template <typename> typename QueueImpl>
+using PollerWithTimer =
+    i2c::tasks::I2CPollerTask<QueueImpl, freertos_timer::FreeRTOSTimer>;
+static auto i2c2_task_client =
+    i2c::writer::Writer<freertos_message_queue::FreeRTOSMessageQueue>();
+static auto i2c2_task_builder =
+    freertos_task::TaskStarter<512, i2c::tasks::I2CTask>{};
+static auto i2c2_poll_task_builder =
+    freertos_task::TaskStarter<1024, PollerWithTimer>{};
+static auto i2c2_poll_client =
+    i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>{};
+static auto eeprom_task_builder =
+    freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
+
 /**
  * Start gantry ::tasks.
  */
@@ -38,7 +52,9 @@ void gantry::tasks::start_tasks(
     motion_controller::MotionController<lms::BeltConfig>& motion_controller,
     spi::hardware::SpiDeviceBase& spi_device,
     tmc2160::configs::TMC2160DriverConfig& driver_configs,
-    motor_hardware_task::MotorHardwareTask& mh_tsk) {
+    motor_hardware_task::MotorHardwareTask& mh_tsk,
+    i2c::hardware::I2CBase& i2c2,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface) {
     auto& can_writer = can_task::start_writer(can_bus);
     can_task::start_reader(can_bus);
     auto& motion = mc_task_builder.start(5, "motion controller",
@@ -53,12 +69,24 @@ void gantry::tasks::start_tasks(
     auto& spi_task = spi_task_builder.start(5, "spi task", spi_device);
     spi_task_client.set_queue(&spi_task.get_queue());
 
+    auto& i2c2_task = i2c2_task_builder.start(5, "i2c2", i2c2);
+    i2c2_task_client.set_queue(&i2c2_task.get_queue());
+    auto& i2c2_poller_task =
+        i2c2_poll_task_builder.start(5, "i2c2 poller", i2c2_task_client);
+    i2c2_poll_client.set_queue(&i2c2_poller_task.get_queue());
+
+    auto& eeprom_task = eeprom_task_builder.start(5, "eeprom", i2c2_task_client,
+                                                  eeprom_hw_iface);
+
     ::tasks.can_writer = &can_writer;
     ::tasks.motion_controller = &motion;
     ::tasks.tmc2160_driver = &tmc2160_driver;
     ::tasks.move_group = &move_group;
     ::tasks.move_status_reporter = &move_status_reporter;
     ::tasks.spi_task = &spi_task;
+    ::tasks.i2c2_task = &i2c2_task;
+    ::tasks.i2c2_poller_task = &i2c2_poller_task;
+    ::tasks.eeprom_task = &eeprom_task;
 
     ::queues.motion_queue = &motion.get_queue();
     ::queues.motor_driver_queue = &tmc2160_driver.get_queue();
@@ -66,6 +94,9 @@ void gantry::tasks::start_tasks(
     ::queues.set_queue(&can_writer.get_queue());
     ::queues.move_status_report_queue = &move_status_reporter.get_queue();
     ::queues.spi_queue = &spi_task.get_queue();
+    ::queues.i2c2_queue = &i2c2_task.get_queue();
+    ::queues.i2c2_poller_queue = &i2c2_poller_task.get_queue();
+    ::queues.eeprom_queue = &eeprom_task.get_queue();
 
     mh_tsk.start_task();
 }

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -23,6 +23,7 @@ set(GANTRY_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/utility_gpio.c
         ${CMAKE_CURRENT_SOURCE_DIR}/can.c
         ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/i2c_setup.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
         ${COMMON_EXECUTABLE_DIR}/system/app_update.c
         ${COMMON_EXECUTABLE_DIR}/system/iwdg.c
@@ -94,6 +95,7 @@ macro(gantry_loop_internal)
 
     target_gantry_core(${REVISION_TARGET} ${_gli_AXIS} ${REV})
     target_ot_motor_control(${REVISION_TARGET})
+    target_i2c_firmware(${REVISION_TARGET})
 
     target_link_libraries(${REVISION_TARGET}
             PUBLIC STM32G491RETx

--- a/gantry/firmware/i2c_setup.c
+++ b/gantry/firmware/i2c_setup.c
@@ -1,0 +1,98 @@
+#include "gantry/firmware/i2c_setup.h"
+
+#include "common/firmware/errors.h"
+#include "platform_specific_hal_conf.h"
+
+#define EEPROM_GPIO_BANK GPIOB
+#define EEPROM_GPIO_PIN GPIO_PIN_10
+
+static I2C_HandleTypeDef hi2c2;
+
+void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
+    (void)hi2c;
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+
+    // PIN PC4 is SCL
+    // PIN PA8 is SDA
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    GPIO_InitStruct.Pin = GPIO_PIN_8;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF4_I2C2;
+    HAL_GPIO_Init(
+        GPIOA,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+        &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+
+    GPIO_InitStruct.Pin = GPIO_PIN_4;
+    HAL_GPIO_Init(
+        GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+        &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+    __HAL_RCC_I2C2_CLK_ENABLE();
+}
+
+HAL_I2C_HANDLE MX_I2C2_Init() {
+    hi2c2.Instance = I2C2;
+    hi2c2.Init.Timing = 0x10C0ECFF;
+    hi2c2.Init.OwnAddress1 = 0;
+    hi2c2.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    hi2c2.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    hi2c2.Init.OwnAddress2 = 0;
+    hi2c2.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    hi2c2.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    hi2c2.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    if (HAL_I2C_Init(&hi2c2) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Analogue filter
+     */
+    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c2, I2C_ANALOGFILTER_ENABLE) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Digital filter
+     */
+    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c2, 0) != HAL_OK) {
+        Error_Handler();
+    }
+    return &hi2c2;
+}
+/**
+ * @brief enable the eeprom write protect pin.
+ */
+void eeprom_write_protect_init(void) {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+
+    /*Configure GPIO pin : B10 */
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = EEPROM_GPIO_PIN;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(EEPROM_GPIO_BANK, &GPIO_InitStruct);
+}
+
+/**
+ * @brief enable writing to the eeprom.
+ */
+void enable_eeprom_write() {
+    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_RESET);
+}
+
+/**
+ * @brief disable writing to the eeprom.
+ */
+void disable_eeprom_write() {
+    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_SET);
+}
+
+void i2c_setup(I2CHandlerStruct* i2c_handles) {
+    HAL_I2C_HANDLE i2c2 = MX_I2C2_Init();
+    i2c_handles->i2c2 = i2c2;
+    eeprom_write_protect_init();
+
+    // write protect the eeprom.
+    disable_eeprom_write();
+}

--- a/gantry/firmware/main_proto.cpp
+++ b/gantry/firmware/main_proto.cpp
@@ -6,6 +6,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 #include "system_stm32g4xx.h"
+#include "gantry/firmware/i2c_setup.h"
 // clang-format on
 
 #include "common/core/app_update.h"
@@ -13,6 +14,28 @@
 #include "common/firmware/utility_gpio.h"
 #include "gantry/core/interfaces_proto.hpp"
 #include "gantry/core/tasks_proto.hpp"
+#include "i2c/firmware/i2c_comms.hpp"
+
+static auto i2c_comms2 = i2c::hardware::I2C();
+static auto i2c_handles = I2CHandlerStruct{};
+
+static constexpr auto eeprom_chip =
+    eeprom::hardware_iface::EEPromChipType::ST_M24128_BF;
+
+class EEPromHardwareInterface
+    : public eeprom::hardware_iface::EEPromHardwareIface {
+  public:
+    EEPromHardwareInterface()
+        : eeprom::hardware_iface::EEPromHardwareIface(eeprom_chip) {}
+    void set_write_protect(bool enable) final {
+        if (enable) {
+            disable_eeprom_write();
+        } else {
+            enable_eeprom_write();
+        }
+    }
+};
+static auto eeprom_hw_iface = EEPromHardwareInterface();
 
 auto main() -> int {
     HardwareInit();
@@ -22,11 +45,13 @@ auto main() -> int {
     app_update_clear_flags();
 
     interfaces::initialize();
+    i2c_setup(&i2c_handles);
+    i2c_comms2.set_handle(i2c_handles.i2c2);
 
     gantry::tasks::start_tasks(
         interfaces::get_can_bus(), interfaces::get_motor().motion_controller,
         interfaces::get_spi(), interfaces::get_driver_config(),
-        interfaces::get_motor_hardware_task());
+        interfaces::get_motor_hardware_task(), i2c_comms2, eeprom_hw_iface);
 
     vTaskStartScheduler();
 }

--- a/gantry/firmware/main_rev1.cpp
+++ b/gantry/firmware/main_rev1.cpp
@@ -16,7 +16,6 @@
 #include "gantry/core/tasks_rev1.hpp"
 #include "i2c/firmware/i2c_comms.hpp"
 
-
 static auto i2c_comms2 = i2c::hardware::I2C();
 static auto i2c_handles = I2CHandlerStruct{};
 

--- a/gantry/firmware/main_rev1.cpp
+++ b/gantry/firmware/main_rev1.cpp
@@ -6,6 +6,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 #include "system_stm32g4xx.h"
+#include "gantry/firmware/i2c_setup.h"
 // clang-format on
 
 #include "common/core/app_update.h"
@@ -13,6 +14,29 @@
 #include "common/firmware/utility_gpio.h"
 #include "gantry/core/interfaces_rev1.hpp"
 #include "gantry/core/tasks_rev1.hpp"
+#include "i2c/firmware/i2c_comms.hpp"
+
+
+static auto i2c_comms2 = i2c::hardware::I2C();
+static auto i2c_handles = I2CHandlerStruct{};
+
+static constexpr auto eeprom_chip =
+    eeprom::hardware_iface::EEPromChipType::ST_M24128_BF;
+
+class EEPromHardwareInterface
+    : public eeprom::hardware_iface::EEPromHardwareIface {
+  public:
+    EEPromHardwareInterface()
+        : eeprom::hardware_iface::EEPromHardwareIface(eeprom_chip) {}
+    void set_write_protect(bool enable) final {
+        if (enable) {
+            disable_eeprom_write();
+        } else {
+            enable_eeprom_write();
+        }
+    }
+};
+static auto eeprom_hw_iface = EEPromHardwareInterface();
 
 auto main() -> int {
     HardwareInit();
@@ -22,11 +46,13 @@ auto main() -> int {
     app_update_clear_flags();
 
     interfaces::initialize();
+    i2c_setup(&i2c_handles);
+    i2c_comms2.set_handle(i2c_handles.i2c2);
 
     gantry::tasks::start_tasks(
         interfaces::get_can_bus(), interfaces::get_motor().motion_controller,
         interfaces::get_spi(), interfaces::get_driver_config(),
-        interfaces::get_motor_hardware_task());
+        interfaces::get_motor_hardware_task(), i2c_comms2, eeprom_hw_iface);
 
     vTaskStartScheduler();
 }

--- a/gantry/simulator/CMakeLists.txt
+++ b/gantry/simulator/CMakeLists.txt
@@ -52,6 +52,8 @@ foreach(AXIS IN LISTS AXES)
 
   target_ot_motor_control(gantry-${AXIS}-simulator)
 
+  target_i2c_simlib(gantry-${AXIS}-simulator)
+
   target_link_libraries(gantry-${AXIS}-simulator PRIVATE can-core common-simulation freertos-gantry pthread Boost::boost Boost::program_options state_manager)
 
   set_target_properties(gantry-${AXIS}-simulator

--- a/gantry/simulator/FreeRTOSConfig.h
+++ b/gantry/simulator/FreeRTOSConfig.h
@@ -61,8 +61,8 @@ extern uint32_t SystemCoreClock;
  * configMAX_PRIORITIES to 56
  *
  */
-/* #define configUSE_PORT_OPTIMISED_TASK_SELECTION	0*/
-/* #define configMAX_PRIORITIES					( 56 ) */
+/* #define configUSE_PORT_OPTIMISED_TASK_SELECTION  0*/
+/* #define configMAX_PRIORITIES                 ( 56 ) */
 #define configUSE_PREEMPTION 1
 #define configUSE_IDLE_HOOK 0
 #define configUSE_TICK_HOOK 0
@@ -92,8 +92,8 @@ extern uint32_t SystemCoreClock;
 #define configMAX_CO_ROUTINE_PRIORITIES (2)
 
 /* Software timer definitions. */
-#define configUSE_TIMERS 0
-#define configTIMER_TASK_PRIORITY (2)
+#define configUSE_TIMERS 1
+#define configTIMER_TASK_PRIORITY (6)
 #define configTIMER_QUEUE_LENGTH 10
 #define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 2)
 

--- a/gantry/simulator/freertos_idle_timer_task.cpp
+++ b/gantry/simulator/freertos_idle_timer_task.cpp
@@ -18,6 +18,12 @@ StaticTask_t
 std::array<StackType_t, configMINIMAL_STACK_SIZE>
     idle_task_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+StaticTask_t
+    timer_task_tcb;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+std::array<StackType_t, configMINIMAL_STACK_SIZE * 2>
+    timer_task_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 // This is a callback defined in a C file so it has to be linked as such
 extern "C" void vApplicationGetIdleTaskMemory(
     StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer,
@@ -26,4 +32,12 @@ extern "C" void vApplicationGetIdleTaskMemory(
     *ppxIdleTaskTCBBuffer = &idle_task_tcb;
     *ppxIdleTaskStackBuffer = idle_task_stack.data();
     *pulIdleTaskStackSize = idle_task_stack.size();
+}
+
+extern "C" void vApplicationGetTimerTaskMemory(
+    StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer,
+    uint32_t *pulTimerTaskStackSize) {
+    *ppxTimerTaskTCBBuffer = &timer_task_tcb;
+    *ppxTimerTaskStackBuffer = timer_task_stack.data();
+    *pulTimerTaskStackSize = timer_task_stack.size();
 }

--- a/gantry/simulator/main.cpp
+++ b/gantry/simulator/main.cpp
@@ -27,7 +27,8 @@ int main(int argc, char** argv) {
     gantry::tasks::start_tasks(
         interfaces::get_can_bus(), interfaces::get_motor().motion_controller,
         interfaces::get_spi(), interfaces::get_driver_config(),
-        interfaces::get_motor_hardware_task());
+        interfaces::get_motor_hardware_task(), *interfaces::get_sim_i2c2(),
+        *interfaces::get_sim_eeprom());
 
     vTaskStartScheduler();
 }

--- a/head/core/tasks_proto.cpp
+++ b/head/core/tasks_proto.cpp
@@ -56,6 +56,19 @@ static auto spi2_task_builder =
 static auto spi3_task_builder =
     freertos_task::TaskStarter<512, spi::tasks::Task>{};
 
+template <template <typename> typename QueueImpl>
+using PollerWithTimer =
+    i2c::tasks::I2CPollerTask<QueueImpl, freertos_timer::FreeRTOSTimer>;
+static auto i2c3_task_client =
+    i2c::writer::Writer<freertos_message_queue::FreeRTOSMessageQueue>();
+static auto i2c3_task_builder =
+    freertos_task::TaskStarter<512, i2c::tasks::I2CTask>{};
+static auto i2c3_poll_task_builder =
+    freertos_task::TaskStarter<1024, PollerWithTimer>{};
+static auto i2c3_poll_client =
+    i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>{};
+static auto eeprom_task_builder =
+    freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
 /**
  * Start head tasks.
  */
@@ -71,7 +84,9 @@ void head_tasks::start_tasks(
     tmc2130::configs::TMC2130DriverConfig& left_driver_configs,
     tmc2130::configs::TMC2130DriverConfig& right_driver_configs,
     motor_hardware_task::MotorHardwareTask& rmh_tsk,
-    motor_hardware_task::MotorHardwareTask& lmh_tsk) {
+    motor_hardware_task::MotorHardwareTask& lmh_tsk,
+    i2c::hardware::I2CBase& i2c3,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface) {
     // Start the head tasks
     auto& can_writer = can_task::start_writer(can_bus);
     can_task::start_reader(can_bus);
@@ -84,13 +99,28 @@ void head_tasks::start_tasks(
     auto& presence_sensing = presence_sensing_driver_task_builder.start(
         5, "presence", presence_sensing_driver, head_queues);
 
+    auto& i2c3_task = i2c3_task_builder.start(5, "i2c3", i2c3);
+    i2c3_task_client.set_queue(&i2c3_task.get_queue());
+    auto& i2c3_poller_task =
+        i2c3_poll_task_builder.start(5, "i2c3 poller", i2c3_task_client);
+    i2c3_poll_client.set_queue(&i2c3_poller_task.get_queue());
+
+    auto& eeprom_task = eeprom_task_builder.start(5, "eeprom", i2c3_task_client,
+                                                  eeprom_hw_iface);
+
     // Assign head task collection task pointers
     head_tasks_col.can_writer = &can_writer;
     head_tasks_col.presence_sensing_driver_task = &presence_sensing;
+    head_tasks_col.i2c3_task = &i2c3_task;
+    head_tasks_col.i2c3_poller_task = &i2c3_poller_task;
+    head_tasks_col.eeprom_task = &eeprom_task;
 
     // Assign head queue client message queue pointers
     head_queues.set_queue(&can_writer.get_queue());
     head_queues.presence_sensing_driver_queue = &presence_sensing.get_queue();
+    head_queues.i2c3_queue = &i2c3_task.get_queue();
+    head_queues.i2c3_poller_queue = &i2c3_poller_task.get_queue();
+    head_queues.eeprom_queue = &eeprom_task.get_queue();
 
     // Start the left motor tasks
     auto& left_motion = left_mc_task_builder.start(
@@ -183,6 +213,11 @@ void head_tasks::MotorQueueClient::send_move_group_queue(
 void head_tasks::MotorQueueClient::send_move_status_reporter_queue(
     const move_status_reporter_task::TaskMessage& m) {
     static_cast<void>(move_status_report_queue->try_write_isr(m));
+}
+
+void head_tasks::HeadQueueClient::send_eeprom_queue(
+    const eeprom::task::TaskMessage& m) {
+    eeprom_queue->try_write(m);
 }
 
 auto head_tasks::get_tasks() -> HeadTasks& { return head_tasks_col; }

--- a/head/core/tasks_rev1.cpp
+++ b/head/core/tasks_rev1.cpp
@@ -216,6 +216,11 @@ void head_tasks::MotorQueueClient::send_move_status_reporter_queue(
     static_cast<void>(move_status_report_queue->try_write_isr(m));
 }
 
+void head_tasks::HeadQueueClient::send_eeprom_queue(
+    const eeprom::task::TaskMessage& m) {
+    eeprom_queue->try_write(m);
+}
+
 auto head_tasks::get_tasks() -> HeadTasks& { return head_tasks_col; }
 
 auto head_tasks::get_queue_client() -> HeadQueueClient& { return head_queues; }

--- a/head/core/tasks_rev1.cpp
+++ b/head/core/tasks_rev1.cpp
@@ -123,7 +123,6 @@ void head_tasks::start_tasks(
     head_queues.i2c3_poller_queue = &i2c3_poller_task.get_queue();
     head_queues.eeprom_queue = &eeprom_task.get_queue();
 
-
     // Start the left motor tasks
     auto& left_motion = left_mc_task_builder.start(
         5, "left mc", left_motion_controller, left_queues);

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -35,6 +35,7 @@ set(HEAD_FW_NON_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/can.c
         ${CMAKE_CURRENT_SOURCE_DIR}/motor_hardware_common.c
         ${CMAKE_CURRENT_SOURCE_DIR}/utility_hardware.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/i2c_setup.c
         ${COMMON_EXECUTABLE_DIR}/errors/errors.c
         ${COMMON_EXECUTABLE_DIR}/system/app_update.c
         ${COMMON_EXECUTABLE_DIR}/system/iwdg.c
@@ -80,6 +81,8 @@ macro(_loop_body)
     target_head_core_rev1(${REVISION_TARGET})
   endif()
   target_ot_motor_control(${REVISION_TARGET})
+  target_i2c_firmware(${REVISION_TARGET})
+
   target_link_libraries(${REVISION_TARGET}
           PUBLIC STM32G491RETx
           STM32G4xx_Drivers_${_libname_suffix} STM32G4xx_FreeRTOS_${_libname_suffix}

--- a/head/firmware/i2c_setup.c
+++ b/head/firmware/i2c_setup.c
@@ -1,0 +1,97 @@
+#include "head/firmware/i2c_setup.h"
+
+#include "common/firmware/errors.h"
+#include "platform_specific_hal_conf.h"
+
+#define EEPROM_GPIO_BANK GPIOB
+#define EEPROM_GPIO_PIN GPIO_PIN_10
+
+static I2C_HandleTypeDef hi2c3;
+
+void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
+    (void)hi2c;
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+
+    // PIN PC8 is SCL
+    // PIN PC9 is SDA
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    GPIO_InitStruct.Pin = GPIO_PIN_8;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Alternate = GPIO_AF8_I2C3;
+    HAL_GPIO_Init(
+        GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+        &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+
+    GPIO_InitStruct.Pin = GPIO_PIN_9;
+    HAL_GPIO_Init(
+        GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+        &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
+    __HAL_RCC_I2C3_CLK_ENABLE();
+}
+
+HAL_I2C_HANDLE MX_I2C2_Init() {
+    hi2c3.Instance = I2C3;
+    hi2c3.Init.Timing = 0x10C0ECFF;
+    hi2c3.Init.OwnAddress1 = 0;
+    hi2c3.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+    hi2c3.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+    hi2c3.Init.OwnAddress2 = 0;
+    hi2c3.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
+    hi2c3.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+    hi2c3.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+    if (HAL_I2C_Init(&hi2c3) != HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Analogue filter
+     */
+    if (HAL_I2CEx_ConfigAnalogFilter(&hi2c3, I2C_ANALOGFILTER_ENABLE) !=
+        HAL_OK) {
+        Error_Handler();
+    }
+    /** Configure Digital filter
+     */
+    if (HAL_I2CEx_ConfigDigitalFilter(&hi2c3, 0) != HAL_OK) {
+        Error_Handler();
+    }
+    return &hi2c3;
+}
+/**
+ * @brief enable the eeprom write protect pin.
+ */
+void eeprom_write_protect_init(void) {
+    /* GPIO Ports Clock Enable */
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+
+    /*Configure GPIO pin : B10 */
+    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pin = EEPROM_GPIO_PIN;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(EEPROM_GPIO_BANK, &GPIO_InitStruct);
+}
+
+/**
+ * @brief enable writing to the eeprom.
+ */
+void enable_eeprom_write() {
+    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_RESET);
+}
+
+/**
+ * @brief disable writing to the eeprom.
+ */
+void disable_eeprom_write() {
+    HAL_GPIO_WritePin(GPIOC, EEPROM_GPIO_PIN, GPIO_PIN_SET);
+}
+
+void i2c_setup(I2CHandlerStruct* i2c_handles) {
+    HAL_I2C_HANDLE i2c3 = MX_I2C2_Init();
+    i2c_handles->i2c3 = i2c3;
+    eeprom_write_protect_init();
+
+    // write protect the eeprom.
+    disable_eeprom_write();
+}

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -9,6 +9,7 @@
 #include "common/firmware/errors.h"
 #include "common/core/app_update.h"
 #include "common/firmware/iwdg.hpp"
+#include "head/firmware/i2c_setup.h"
 // clang-format on
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
@@ -27,6 +28,7 @@
 #include "head/core/tasks_proto.hpp"
 #include "head/core/utils.hpp"
 #include "head/firmware/presence_sensing_hardware.hpp"
+#include "i2c/firmware/i2c_comms.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/motor.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
@@ -324,6 +326,27 @@ static auto rmh_tsk = motor_hardware_task::MotorHardwareTask{
 static auto lmh_tsk = motor_hardware_task::MotorHardwareTask{
     &motor_hardware_left, "left motor hardware task"};
 
+static auto i2c_comms3 = i2c::hardware::I2C();
+static auto i2c_handles = I2CHandlerStruct{};
+
+static constexpr auto eeprom_chip =
+    eeprom::hardware_iface::EEPromChipType::ST_M24128_BF;
+
+class EEPromHardwareInterface
+    : public eeprom::hardware_iface::EEPromHardwareIface {
+  public:
+    EEPromHardwareInterface()
+        : eeprom::hardware_iface::EEPromHardwareIface(eeprom_chip) {}
+    void set_write_protect(bool enable) final {
+        if (enable) {
+            disable_eeprom_write();
+        } else {
+            enable_eeprom_write();
+        }
+    }
+};
+static auto eeprom_hw_iface = EEPromHardwareInterface();
+
 auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
@@ -341,10 +364,15 @@ auto main() -> int {
 
     utility_gpio_init();
     can_bus_1.start(can_bit_timings);
+
+    i2c_setup(&i2c_handles);
+    i2c_comms3.set_handle(i2c_handles.i2c3);
+
     head_tasks::start_tasks(can_bus_1, motor_left.motion_controller,
                             motor_right.motion_controller, psd, spi_comms2,
                             spi_comms3, motor_driver_configs_left,
-                            motor_driver_configs_right, rmh_tsk, lmh_tsk);
+                            motor_driver_configs_right, rmh_tsk, lmh_tsk,
+                            i2c_comms3, eeprom_hw_iface);
 
     timer_for_notifier.start();
 

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -350,7 +350,6 @@ static auto rmh_tsk =
 static auto lmh_tsk =
     motor_hardware_task::MotorHardwareTask{&motor_hardware_left, "lmh task"};
 
-
 static auto i2c_comms3 = i2c::hardware::I2C();
 static auto i2c_handles = I2CHandlerStruct{};
 

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -9,6 +9,7 @@
 #include "common/firmware/errors.h"
 #include "common/core/app_update.h"
 #include "common/firmware/iwdg.hpp"
+#include "head/firmware/i2c_setup.h"
 // clang-format on
 #pragma GCC diagnostic push
 // NOLINTNEXTLINE(clang-diagnostic-unknown-warning-option)
@@ -27,6 +28,7 @@
 #include "head/core/tasks_rev1.hpp"
 #include "head/core/utils.hpp"
 #include "head/firmware/presence_sensing_hardware.hpp"
+#include "i2c/firmware/i2c_comms.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/motor.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
@@ -348,6 +350,28 @@ static auto rmh_tsk =
 static auto lmh_tsk =
     motor_hardware_task::MotorHardwareTask{&motor_hardware_left, "lmh task"};
 
+
+static auto i2c_comms3 = i2c::hardware::I2C();
+static auto i2c_handles = I2CHandlerStruct{};
+
+static constexpr auto eeprom_chip =
+    eeprom::hardware_iface::EEPromChipType::ST_M24128_BF;
+
+class EEPromHardwareInterface
+    : public eeprom::hardware_iface::EEPromHardwareIface {
+  public:
+    EEPromHardwareInterface()
+        : eeprom::hardware_iface::EEPromHardwareIface(eeprom_chip) {}
+    void set_write_protect(bool enable) final {
+        if (enable) {
+            disable_eeprom_write();
+        } else {
+            enable_eeprom_write();
+        }
+    }
+};
+static auto eeprom_hw_iface = EEPromHardwareInterface();
+
 auto main() -> int {
     HardwareInit();
     RCC_Peripheral_Clock_Select();
@@ -356,6 +380,9 @@ auto main() -> int {
 
     initialize_timer(motor_callback_glue, left_enc_overflow_callback_glue,
                      right_enc_overflow_callback_glue);
+
+    i2c_setup(&i2c_handles);
+    i2c_comms3.set_handle(i2c_handles.i2c3);
 
     if (initialize_spi(&hspi2) != HAL_OK) {
         Error_Handler();
@@ -369,7 +396,8 @@ auto main() -> int {
     head_tasks::start_tasks(can_bus_1, motor_left.motion_controller,
                             motor_right.motion_controller, psd, spi_comms2,
                             spi_comms3, motor_driver_configs_left,
-                            motor_driver_configs_right, rmh_tsk, lmh_tsk);
+                            motor_driver_configs_right, rmh_tsk, lmh_tsk,
+                            i2c_comms3, eeprom_hw_iface);
 
     timer_for_notifier.start();
 

--- a/head/simulator/CMakeLists.txt
+++ b/head/simulator/CMakeLists.txt
@@ -43,6 +43,8 @@ target_compile_definitions(head-simulator PUBLIC ENABLE_LOGGING)
 
 target_can_simlib(head-simulator)
 
+target_i2c_simlib(head-simulator)
+
 target_head_core_proto(head-simulator)
 
 target_ot_motor_control(head-simulator)

--- a/head/simulator/FreeRTOSConfig.h
+++ b/head/simulator/FreeRTOSConfig.h
@@ -61,8 +61,8 @@ extern uint32_t SystemCoreClock;
  * configMAX_PRIORITIES to 56
  *
  */
-/* #define configUSE_PORT_OPTIMISED_TASK_SELECTION	0*/
-/* #define configMAX_PRIORITIES					( 56 ) */
+/* #define configUSE_PORT_OPTIMISED_TASK_SELECTION  0*/
+/* #define configMAX_PRIORITIES                 ( 56 ) */
 #define configUSE_PREEMPTION 1
 #define configUSE_IDLE_HOOK 0
 #define configUSE_TICK_HOOK 0
@@ -92,8 +92,8 @@ extern uint32_t SystemCoreClock;
 #define configMAX_CO_ROUTINE_PRIORITIES (2)
 
 /* Software timer definitions. */
-#define configUSE_TIMERS 0
-#define configTIMER_TASK_PRIORITY (2)
+#define configUSE_TIMERS 1
+#define configTIMER_TASK_PRIORITY (6)
 #define configTIMER_QUEUE_LENGTH 10
 #define configTIMER_TASK_STACK_DEPTH (configMINIMAL_STACK_SIZE * 2)
 

--- a/head/simulator/freertos_idle_timer_task.cpp
+++ b/head/simulator/freertos_idle_timer_task.cpp
@@ -18,6 +18,12 @@ StaticTask_t
 std::array<StackType_t, configMINIMAL_STACK_SIZE>
     idle_task_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+StaticTask_t
+    timer_task_tcb;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+std::array<StackType_t, configMINIMAL_STACK_SIZE * 2>
+    timer_task_stack;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 // This is a callback defined in a C file so it has to be linked as such
 extern "C" void vApplicationGetIdleTaskMemory(
     StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer,
@@ -26,4 +32,12 @@ extern "C" void vApplicationGetIdleTaskMemory(
     *ppxIdleTaskTCBBuffer = &idle_task_tcb;
     *ppxIdleTaskStackBuffer = idle_task_stack.data();
     *pulIdleTaskStackSize = idle_task_stack.size();
+}
+
+extern "C" void vApplicationGetTimerTaskMemory(
+    StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer,
+    uint32_t *pulTimerTaskStackSize) {
+    *ppxTimerTaskTCBBuffer = &timer_task_tcb;
+    *ppxTimerTaskStackBuffer = timer_task_stack.data();
+    *pulTimerTaskStackSize = timer_task_stack.size();
 }

--- a/include/gantry/core/can_task.hpp
+++ b/include/gantry/core/can_task.hpp
@@ -7,6 +7,7 @@
 #include "can/core/message_handlers/move_group.hpp"
 #include "can/core/message_handlers/system.hpp"
 #include "common/core/freertos_message_queue.hpp"
+#include "eeprom/core/message_handler.hpp"
 #include "gantry/core/queues.hpp"
 #include "motor-control/core/stepper_motor/motor.hpp"
 
@@ -41,10 +42,15 @@ using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::DeviceInfoRequest, can::messages::InitiateFirmwareUpdate,
     can::messages::FirmwareUpdateStatusRequest, can::messages::TaskInfoRequest>;
 
+using EEpromDispatchTarget = can::dispatch::DispatchParseTarget<
+    eeprom::message_handler::EEPromHandler<gantry::queues::QueueClient,
+                                           gantry::queues::QueueClient>,
+    can::messages::WriteToEEPromRequest, can::messages::ReadFromEEPromRequest>;
+
 using GantryDispatcherType =
     can::dispatch::Dispatcher<MotorDispatchTarget, MoveGroupDispatchTarget,
                               MotionControllerDispatchTarget,
-                              SystemDispatchTarget>;
+                              SystemDispatchTarget, EEpromDispatchTarget>;
 
 auto constexpr reader_message_buffer_size = 1024;
 using CanMessageReaderTask =

--- a/include/gantry/core/queues.hpp
+++ b/include/gantry/core/queues.hpp
@@ -3,6 +3,12 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
+#include "eeprom/core/hardware_iface.hpp"
+#include "eeprom/core/task.hpp"
+#include "i2c/core/hardware_iface.hpp"
+#include "i2c/core/tasks/i2c_poller_task.hpp"
+#include "i2c/core/tasks/i2c_task.hpp"
+#include "i2c/core/writer.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
 #include "motor-control/core/tasks/move_group_task.hpp"
@@ -41,6 +47,12 @@ struct QueueClient : can::message_writer::MessageWriter {
         nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<spi::tasks::TaskMessage>*
         spi_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<i2c::writer::TaskMessage>*
+        i2c2_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<i2c::poller::TaskMessage>*
+        i2c2_poller_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<eeprom::task::TaskMessage>*
+        eeprom_queue{nullptr};
 };
 
 /**

--- a/include/gantry/core/queues.hpp
+++ b/include/gantry/core/queues.hpp
@@ -36,6 +36,8 @@ struct QueueClient : can::message_writer::MessageWriter {
     void send_move_status_reporter_queue(
         const move_status_reporter_task::TaskMessage& m);
 
+    void send_eeprom_queue(const eeprom::task::TaskMessage& m);
+
     freertos_message_queue::FreeRTOSMessageQueue<
         motion_controller_task::TaskMessage>* motion_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<tmc::tasks::TaskMessage>*

--- a/include/gantry/core/tasks_proto.hpp
+++ b/include/gantry/core/tasks_proto.hpp
@@ -2,6 +2,13 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
+#include "common/core/freertos_timer.hpp"
+#include "eeprom/core/hardware_iface.hpp"
+#include "eeprom/core/task.hpp"
+#include "i2c/core/hardware_iface.hpp"
+#include "i2c/core/tasks/i2c_poller_task.hpp"
+#include "i2c/core/tasks/i2c_task.hpp"
+#include "i2c/core/writer.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
@@ -24,7 +31,9 @@ void start_tasks(
     motion_controller::MotionController<lms::BeltConfig>& motion_controller,
     spi::hardware::SpiDeviceBase& spi_device,
     tmc2130::configs::TMC2130DriverConfig& driver_configs,
-    motor_hardware_task::MotorHardwareTask& mh_tsk);
+    motor_hardware_task::MotorHardwareTask& mh_tsk,
+    i2c::hardware::I2CBase& i2c2,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface);
 
 /**
  * Access to all tasks in the system.
@@ -44,6 +53,13 @@ struct AllTask {
         freertos_message_queue::FreeRTOSMessageQueue>* move_group{nullptr};
     spi::tasks::Task<freertos_message_queue::FreeRTOSMessageQueue>* spi_task{
         nullptr};
+    i2c::tasks::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        i2c2_task{nullptr};
+    i2c::tasks::I2CPollerTask<freertos_message_queue::FreeRTOSMessageQueue,
+                              freertos_timer::FreeRTOSTimer>* i2c2_poller_task{
+        nullptr};
+    eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        eeprom_task{nullptr};
 };
 
 /**

--- a/include/gantry/core/tasks_rev1.hpp
+++ b/include/gantry/core/tasks_rev1.hpp
@@ -2,6 +2,13 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
+#include "common/core/freertos_timer.hpp"
+#include "eeprom/core/hardware_iface.hpp"
+#include "eeprom/core/task.hpp"
+#include "i2c/core/hardware_iface.hpp"
+#include "i2c/core/tasks/i2c_poller_task.hpp"
+#include "i2c/core/tasks/i2c_task.hpp"
+#include "i2c/core/writer.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/tmc2160.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
@@ -24,7 +31,9 @@ void start_tasks(
     motion_controller::MotionController<lms::BeltConfig>& motion_controller,
     spi::hardware::SpiDeviceBase& spi_device,
     tmc2160::configs::TMC2160DriverConfig& driver_configs,
-    motor_hardware_task::MotorHardwareTask& mh_tsk);
+    motor_hardware_task::MotorHardwareTask& mh_tsk,
+    i2c::hardware::I2CBase& i2c2,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface);
 
 /**
  * Access to all tasks in the system.
@@ -44,6 +53,13 @@ struct AllTask {
         freertos_message_queue::FreeRTOSMessageQueue>* move_group{nullptr};
     spi::tasks::Task<freertos_message_queue::FreeRTOSMessageQueue>* spi_task{
         nullptr};
+    i2c::tasks::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        i2c2_task{nullptr};
+    i2c::tasks::I2CPollerTask<freertos_message_queue::FreeRTOSMessageQueue,
+                              freertos_timer::FreeRTOSTimer>* i2c2_poller_task{
+        nullptr};
+    eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        eeprom_task{nullptr};
 };
 
 /**

--- a/include/gantry/firmware/i2c_setup.h
+++ b/include/gantry/firmware/i2c_setup.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "i2c/firmware/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct HandlerStruct {
+    HAL_I2C_HANDLE i2c2;
+} I2CHandlerStruct;
+
+void i2c_setup(I2CHandlerStruct* i2c_handles);
+
+/**
+ * enable writing to the eeprom.
+ */
+void enable_eeprom_write();
+
+/**
+ * disable writing to the eeprom.
+ */
+void disable_eeprom_write();
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/include/gantry/simulator/interfaces.hpp
+++ b/include/gantry/simulator/interfaces.hpp
@@ -1,9 +1,12 @@
 #pragma once
-
+#include "eeprom/simulation/eeprom.hpp"
+#include "i2c/simulation/i2c_sim.hpp"
 /*
 ** Simulator-specific interfaces
 */
 
 namespace interfaces {
 void initialize_sim(int argc, char** argv);
-};
+auto get_sim_eeprom() -> std::shared_ptr<eeprom::simulator::EEProm>;
+auto get_sim_i2c2() -> std::shared_ptr<i2c::hardware::SimI2C>;
+};  // namespace interfaces

--- a/include/head/core/queues.hpp
+++ b/include/head/core/queues.hpp
@@ -2,7 +2,13 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
+#include "eeprom/core/hardware_iface.hpp"
+#include "eeprom/core/task.hpp"
 #include "head/core/tasks/presence_sensing_driver_task.hpp"
+#include "i2c/core/hardware_iface.hpp"
+#include "i2c/core/tasks/i2c_poller_task.hpp"
+#include "i2c/core/tasks/i2c_task.hpp"
+#include "i2c/core/writer.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
 #include "motor-control/core/tasks/move_group_task.hpp"
@@ -25,6 +31,12 @@ struct HeadQueueClient : can::message_writer::MessageWriter {
     freertos_message_queue::FreeRTOSMessageQueue<
         presence_sensing_driver_task::TaskMessage>*
         presence_sensing_driver_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<i2c::writer::TaskMessage>*
+        i2c3_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<i2c::poller::TaskMessage>*
+        i2c3_poller_queue{nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<eeprom::task::TaskMessage>*
+        eeprom_queue{nullptr};
 };
 
 /**

--- a/include/head/core/queues.hpp
+++ b/include/head/core/queues.hpp
@@ -28,6 +28,7 @@ struct HeadQueueClient : can::message_writer::MessageWriter {
     void send_presence_sensing_driver_queue(
         const presence_sensing_driver_task::TaskMessage& m);
 
+    void send_eeprom_queue(const eeprom::task::TaskMessage& m);
     freertos_message_queue::FreeRTOSMessageQueue<
         presence_sensing_driver_task::TaskMessage>*
         presence_sensing_driver_queue{nullptr};

--- a/include/head/core/tasks_proto.hpp
+++ b/include/head/core/tasks_proto.hpp
@@ -2,7 +2,14 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
+#include "common/core/freertos_timer.hpp"
+#include "eeprom/core/hardware_iface.hpp"
+#include "eeprom/core/task.hpp"
 #include "head/core/tasks/presence_sensing_driver_task.hpp"
+#include "i2c/core/hardware_iface.hpp"
+#include "i2c/core/tasks/i2c_poller_task.hpp"
+#include "i2c/core/tasks/i2c_task.hpp"
+#include "i2c/core/writer.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
@@ -31,7 +38,9 @@ void start_tasks(
     tmc2130::configs::TMC2130DriverConfig& left_driver_configs,
     tmc2130::configs::TMC2130DriverConfig& right_driver_configs,
     motor_hardware_task::MotorHardwareTask& right_motor_hardware,
-    motor_hardware_task::MotorHardwareTask& left_motor_hardware);
+    motor_hardware_task::MotorHardwareTask& left_motor_hardware,
+    i2c::hardware::I2CBase& i2c3,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface);
 
 /**
  * Access to all tasks not associated with a motor. This will be a singleton.
@@ -42,6 +51,13 @@ struct HeadTasks {
     presence_sensing_driver_task::PresenceSensingDriverTask<
         freertos_message_queue::FreeRTOSMessageQueue>*
         presence_sensing_driver_task{nullptr};
+    i2c::tasks::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        i2c3_task{nullptr};
+    i2c::tasks::I2CPollerTask<freertos_message_queue::FreeRTOSMessageQueue,
+                              freertos_timer::FreeRTOSTimer>* i2c3_poller_task{
+        nullptr};
+    eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        eeprom_task{nullptr};
 };
 
 /**

--- a/include/head/core/tasks_rev1.hpp
+++ b/include/head/core/tasks_rev1.hpp
@@ -2,7 +2,14 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
+#include "common/core/freertos_timer.hpp"
+#include "eeprom/core/hardware_iface.hpp"
+#include "eeprom/core/task.hpp"
 #include "head/core/tasks/presence_sensing_driver_task.hpp"
+#include "i2c/core/hardware_iface.hpp"
+#include "i2c/core/tasks/i2c_poller_task.hpp"
+#include "i2c/core/tasks/i2c_task.hpp"
+#include "i2c/core/writer.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/tmc2160.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
@@ -31,7 +38,9 @@ void start_tasks(
     tmc2160::configs::TMC2160DriverConfig& left_driver_configs,
     tmc2160::configs::TMC2160DriverConfig& right_driver_configs,
     motor_hardware_task::MotorHardwareTask& right_motor_hardware,
-    motor_hardware_task::MotorHardwareTask& left_motor_hardware);
+    motor_hardware_task::MotorHardwareTask& left_motor_hardware,
+    i2c::hardware::I2CBase& i2c3,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hw_iface);
 
 /**
  * Access to all tasks not associated with a motor. This will be a singleton.
@@ -42,6 +51,13 @@ struct HeadTasks {
     presence_sensing_driver_task::PresenceSensingDriverTask<
         freertos_message_queue::FreeRTOSMessageQueue>*
         presence_sensing_driver_task{nullptr};
+    i2c::tasks::I2CTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        i2c3_task{nullptr};
+    i2c::tasks::I2CPollerTask<freertos_message_queue::FreeRTOSMessageQueue,
+                              freertos_timer::FreeRTOSTimer>* i2c3_poller_task{
+        nullptr};
+    eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        eeprom_task{nullptr};
 };
 
 /**

--- a/include/head/firmware/i2c_setup.h
+++ b/include/head/firmware/i2c_setup.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "i2c/firmware/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct HandlerStruct {
+    HAL_I2C_HANDLE i2c3;
+} I2CHandlerStruct;
+
+void i2c_setup(I2CHandlerStruct* i2c_handles);
+
+/**
+ * enable writing to the eeprom.
+ */
+void enable_eeprom_write();
+
+/**
+ * disable writing to the eeprom.
+ */
+void disable_eeprom_write();
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus


### PR DESCRIPTION
In order to continue with RLAB-291 The gantry and head boards need to have the eeprom and i2c system setup.
This adds the i2c read/write tasks and the eeprom task so that further PR's can build on top of it

Tested reading and writing from eeprom on a DVT bot