### PR TITLE
feat(rear-panel): add deck light messages

### DIFF
--- a/include/rear-panel/core/bin_msg_ids.hpp
+++ b/include/rear-panel/core/bin_msg_ids.hpp
@@ -27,6 +27,9 @@ enum class BinaryMessageId : uint16_t {
     add_light_action = 0x400,
     clear_light_action_staging_queue = 0x401,
     start_light_action = 0x402,
+    set_deck_light_request = 0x410,
+    get_deck_light_request = 0x411,
+    get_deck_light_response = 0x412,
 };
 
 /** The types of transitons that the lights can perform. */

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -464,6 +464,78 @@ struct StartLightActionRequest
         -> bool = default;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct SetDeckLightRequest
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::set_deck_light_request> {
+    static constexpr size_t LENGTH = sizeof(uint8_t);
+    uint8_t setting;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit)
+        -> std::variant<std::monostate, SetDeckLightRequest> {
+        uint16_t type = 0;
+        uint16_t length = 0;
+        uint8_t setting = 0;
+
+        body = bit_utils::bytes_to_int(body, limit, type);
+        if (type != static_cast<uint16_t>(message_type)) {
+            return std::monostate();
+        }
+        body = bit_utils::bytes_to_int(body, limit, length);
+        if (length != LENGTH) {
+            return std::monostate();
+        }
+        body = bit_utils::bytes_to_int(body, limit, setting);
+        return SetDeckLightRequest{.setting = setting};
+    }
+
+    auto operator==(const SetDeckLightRequest& other) const -> bool = default;
+};
+
+struct GetDeckLightRequest
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::get_deck_light_request> {
+    static constexpr size_t LENGTH = 0;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit)
+        -> std::variant<std::monostate, GetDeckLightRequest> {
+        uint16_t type = 0;
+        uint16_t length = 0;
+
+        body = bit_utils::bytes_to_int(body, limit, type);
+        if (type != static_cast<uint16_t>(message_type)) {
+            return std::monostate();
+        }
+        body = bit_utils::bytes_to_int(body, limit, length);
+        if (length != LENGTH) {
+            return std::monostate();
+        }
+        return GetDeckLightRequest{};
+    }
+
+    auto operator==(const GetDeckLightRequest& other) const -> bool = default;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct GetDeckLightResponse
+    : BinaryFormatMessage<
+          rearpanel::ids::BinaryMessageId::get_deck_light_response> {
+    static constexpr uint16_t LENGTH = sizeof(uint8_t);
+    uint8_t setting;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> Output {
+        auto iter =
+            bit_utils::int_to_bytes(uint16_t(message_type), body, limit);
+        iter = bit_utils::int_to_bytes(LENGTH, iter, limit);
+        iter = bit_utils::int_to_bytes(setting, iter, limit);
+        return iter;
+    }
+    auto operator==(const GetDeckLightResponse& other) const -> bool = default;
+};
+
 // HostCommTaskMessage list must be a superset of the messages in the parser
 using HostCommTaskMessage =
     std::variant<std::monostate, Echo, DeviceInfoRequest, Ack, AckFailed,
@@ -490,7 +562,8 @@ static auto rear_panel_parser = binary_parse::Parser<
     Echo, DeviceInfoRequest, EnterBootloader, EngageEstopRequest,
     EngageSyncRequest, ReleaseEstopRequest, ReleaseSyncRequest,
     DoorSwitchStateRequest, AddLightActionRequest,
-    ClearLightActionStagingQueueRequest, StartLightActionRequest>{};
+    ClearLightActionStagingQueueRequest, StartLightActionRequest,
+    SetDeckLightRequest, GetDeckLightRequest>{};
 
 };  // namespace messages
 };  // namespace rearpanel

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -544,7 +544,8 @@ using HostCommTaskMessage =
                  EstopStateChange, EstopButtonDetectionChange,
                  DoorSwitchStateRequest, DoorSwitchStateInfo,
                  AddLightActionRequest, ClearLightActionStagingQueueRequest,
-                 StartLightActionRequest>;
+                 StartLightActionRequest, SetDeckLightRequest,
+                 GetDeckLightRequest, GetDeckLightResponse>;
 
 using SystemTaskMessage =
     std::variant<std::monostate, EnterBootloader, EngageEstopRequest,
@@ -554,16 +555,17 @@ using SystemTaskMessage =
 using LightControlTaskMessage =
     std::variant<std::monostate, UpdateLightControlMessage,
                  AddLightActionRequest, ClearLightActionStagingQueueRequest,
-                 StartLightActionRequest>;
+                 StartLightActionRequest, SetDeckLightRequest,
+                 GetDeckLightRequest>;
 
 using HardwareTaskMessage = std::variant<std::monostate>;
 
-static auto rear_panel_parser = binary_parse::Parser<
+using Parser = binary_parse::Parser<
     Echo, DeviceInfoRequest, EnterBootloader, EngageEstopRequest,
     EngageSyncRequest, ReleaseEstopRequest, ReleaseSyncRequest,
     DoorSwitchStateRequest, AddLightActionRequest,
     ClearLightActionStagingQueueRequest, StartLightActionRequest,
-    SetDeckLightRequest, GetDeckLightRequest>{};
+    SetDeckLightRequest, GetDeckLightRequest>;
 
 };  // namespace messages
 };  // namespace rearpanel

--- a/include/rear-panel/core/tasks/host_comms_task.hpp
+++ b/include/rear-panel/core/tasks/host_comms_task.hpp
@@ -252,6 +252,34 @@ class HostCommMessageHandler {
         return tx_into;
     }
 
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(rearpanel::messages::SetDeckLightRequest &msg,
+                       InputIt tx_into, InputLimit) -> InputIt {
+        auto queue_client = queue_client::get_main_queues();
+        queue_client.send_light_control_queue(msg);
+        return tx_into;
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(rearpanel::messages::GetDeckLightRequest &msg,
+                       InputIt tx_into, InputLimit) -> InputIt {
+        auto queue_client = queue_client::get_main_queues();
+        queue_client.send_light_control_queue(msg);
+        return tx_into;
+    }
+
+    template <typename InputIt, typename InputLimit>
+    requires std::forward_iterator<InputIt> &&
+        std::sized_sentinel_for<InputLimit, InputIt>
+    auto visit_message(rearpanel::messages::GetDeckLightResponse &msg,
+                       InputIt tx_into, InputLimit tx_limit) -> InputIt {
+        return msg.serialize(tx_into, tx_limit);
+    }
+
     bool may_connect_latch = true;
 };
 

--- a/include/rear-panel/core/tasks/light_control_task.hpp
+++ b/include/rear-panel/core/tasks/light_control_task.hpp
@@ -97,7 +97,7 @@ class LightControlMessageHandler {
         ack();
     }
 
-    auto handle(rearpanel::messages::GetDeckLightRequest&) -> void {
+    auto handle(rearpanel::messages::GetDeckLightRequest&) const -> void {
         queue_client::get_main_queues().send_host_comms_queue(
             rearpanel::messages::GetDeckLightResponse{
                 .setting = static_cast<uint8_t>(_deck_light_status)});

--- a/include/rear-panel/core/tasks/light_control_task.hpp
+++ b/include/rear-panel/core/tasks/light_control_task.hpp
@@ -115,7 +115,7 @@ class LightControlMessageHandler {
 
     LightControlInterface& _hardware;
     Animation& _animation;
-    bool _deck_light_status = true;
+    bool _deck_light_status = false;
 };
 
 /**

--- a/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
+++ b/rear-panel/firmware/host_comms_task/freertos_comms_task.cpp
@@ -31,6 +31,8 @@ static auto cdc_deinit_handler() -> void;
 // NOLINTNEXTLINE(readability-named-parameter)
 static auto cdc_rx_handler(uint8_t *, uint32_t *) -> uint8_t *;
 
+static auto rear_panel_parser = rearpanel::messages::Parser{};
+
 namespace host_comms_control_task {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -155,7 +157,7 @@ static auto cdc_rx_handler(uint8_t *Buf, uint32_t *Len) -> uint8_t * {
     std::ignore = bit_utils::bytes_to_int(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         Buf, Buf + sizeof(rearpanel::ids::BinaryMessageId), type);
-    auto message = rearpanel::messages::rear_panel_parser.parse(
+    auto message = rear_panel_parser.parse(
         rearpanel::ids::BinaryMessageId(type),
         _local_task.rx_buf.committed()->data(),
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -109,10 +109,11 @@ SCENARIO("message serializing works") {
 }
 
 SCENARIO("message parsing") {
+    auto rear_panel_parser = rearpanel::messages::Parser{};
     GIVEN("a valid message id body") {
         auto arr = std::array<uint8_t, 4>{0x00, 0x03, 0x00, 0x00};
         WHEN("constructed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
+            auto message = rear_panel_parser.parse(
                 rearpanel::ids::BinaryMessageId(0x0003), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
@@ -128,7 +129,7 @@ SCENARIO("message parsing") {
     GIVEN("a invalid message length") {
         auto arr = std::array<uint8_t, 4>{0x00, 0x03, 0x00, 0x0A};
         WHEN("constructed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
+            auto message = rear_panel_parser.parse(
                 rearpanel::ids::BinaryMessageId(0x0003), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
@@ -142,7 +143,7 @@ SCENARIO("message parsing") {
     GIVEN("a invalid message id body") {
         auto arr = std::array<uint8_t, 4>{0xAB, 0xCD, 0x00, 0x00};
         WHEN("constructed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
+            auto message = rear_panel_parser.parse(
                 rearpanel::ids::BinaryMessageId(0xABCD), arr.begin(),
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
                 arr.end());
@@ -156,6 +157,7 @@ SCENARIO("message parsing") {
 }
 
 TEST_CASE("AddLightActionRequest parsing") {
+    auto rear_panel_parser = rearpanel::messages::Parser{};
     using namespace rearpanel;
     GIVEN("valid input") {
         auto input = std::array<uint8_t, 11>{// Header
@@ -167,8 +169,8 @@ TEST_CASE("AddLightActionRequest parsing") {
                                              // Colors RGBW
                                              0x10, 0x20, 0x30, 0x40};
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0400), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0400),
+                                                   input.begin(), input.end());
             THEN("the message is correctly parsed") {
                 REQUIRE(std::holds_alternative<messages::AddLightActionRequest>(
                     message));
@@ -195,8 +197,8 @@ TEST_CASE("AddLightActionRequest parsing") {
                                              // Colors RGBW
                                              0x10, 0x20, 0x30, 0x40};
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0400), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0400),
+                                                   input.begin(), input.end());
             THEN("the message is not parsed") {
                 REQUIRE(std::holds_alternative<std::monostate>(message));
             }
@@ -205,6 +207,7 @@ TEST_CASE("AddLightActionRequest parsing") {
 }
 
 TEST_CASE("ClearLightActionStagingQueueRequest parsing") {
+    auto rear_panel_parser = rearpanel::messages::Parser{};
     using namespace rearpanel;
     GIVEN("valid input") {
         auto input = std::array<uint8_t, 4>{
@@ -215,8 +218,8 @@ TEST_CASE("ClearLightActionStagingQueueRequest parsing") {
             0x00,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0401), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0401),
+                                                   input.begin(), input.end());
             THEN("the message is correctly parsed") {
                 REQUIRE(std::holds_alternative<
                         messages::ClearLightActionStagingQueueRequest>(
@@ -233,8 +236,8 @@ TEST_CASE("ClearLightActionStagingQueueRequest parsing") {
             0x10,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0401), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0401),
+                                                   input.begin(), input.end());
             THEN("the message is not parsed") {
                 REQUIRE(std::holds_alternative<std::monostate>(message));
             }
@@ -243,6 +246,7 @@ TEST_CASE("ClearLightActionStagingQueueRequest parsing") {
 }
 
 TEST_CASE("StartLightActionRequest parsing") {
+    auto rear_panel_parser = rearpanel::messages::Parser{};
     using namespace rearpanel;
     GIVEN("valid input") {
         auto input = std::array<uint8_t, 5>{
@@ -255,8 +259,8 @@ TEST_CASE("StartLightActionRequest parsing") {
             0x00,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0402), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0402),
+                                                   input.begin(), input.end());
             THEN("the message is correctly parsed") {
                 REQUIRE(
                     std::holds_alternative<messages::StartLightActionRequest>(
@@ -276,8 +280,8 @@ TEST_CASE("StartLightActionRequest parsing") {
             0x10,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0402), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0402),
+                                                   input.begin(), input.end());
             THEN("the message is not parsed") {
                 REQUIRE(std::holds_alternative<std::monostate>(message));
             }
@@ -286,6 +290,7 @@ TEST_CASE("StartLightActionRequest parsing") {
 }
 
 TEST_CASE("SetDeckLightRequest parsing") {
+    auto rear_panel_parser = rearpanel::messages::Parser{};
     using namespace rearpanel;
     GIVEN("valid input") {
         auto input = std::array<uint8_t, 5>{
@@ -298,8 +303,8 @@ TEST_CASE("SetDeckLightRequest parsing") {
             0x01,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0410), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0410),
+                                                   input.begin(), input.end());
             THEN("the message is correctly parsed") {
                 REQUIRE(std::holds_alternative<messages::SetDeckLightRequest>(
                     message));
@@ -317,8 +322,8 @@ TEST_CASE("SetDeckLightRequest parsing") {
             0x10,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0410), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0410),
+                                                   input.begin(), input.end());
             THEN("the message is not parsed") {
                 REQUIRE(std::holds_alternative<std::monostate>(message));
             }
@@ -327,6 +332,7 @@ TEST_CASE("SetDeckLightRequest parsing") {
 }
 
 TEST_CASE("GetDeckLightRequest parsing") {
+    auto rear_panel_parser = rearpanel::messages::Parser{};
     using namespace rearpanel;
     GIVEN("valid input") {
         auto input = std::array<uint8_t, 5>{
@@ -337,8 +343,8 @@ TEST_CASE("GetDeckLightRequest parsing") {
             0x00,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0411), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0411),
+                                                   input.begin(), input.end());
             THEN("the message is correctly parsed") {
                 REQUIRE(std::holds_alternative<messages::GetDeckLightRequest>(
                     message));
@@ -354,8 +360,8 @@ TEST_CASE("GetDeckLightRequest parsing") {
             0x10,
         };
         WHEN("parsed") {
-            auto message = rearpanel::messages::rear_panel_parser.parse(
-                ids::BinaryMessageId(0x0411), input.begin(), input.end());
+            auto message = rear_panel_parser.parse(ids::BinaryMessageId(0x0411),
+                                                   input.begin(), input.end());
             THEN("the message is not parsed") {
                 REQUIRE(std::holds_alternative<std::monostate>(message));
             }


### PR DESCRIPTION
Adds messages to control the deck lights, and adds handling in the host & light tasks to process them.

Also moved `rear_panel_parser` to be statically defined in a source file & updated tests to match.

Tested with [monorepo PR](https://github.com/Opentrons/opentrons/pull/12359) and was able to set the deck lights on & off, and get the status correctly.