### PR TITLE
fix(pipettes): ensure that secondary hardware exists before trying to access the value

### DIFF
--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -128,7 +128,9 @@ static auto sensor_hardware_container =
 
 static auto data_ready_gpio_primary =
     pins_for_sensor.primary.data_ready.value();
-static auto data_ready_gpio_secondary = pins_for_sensor.secondary.value();
+static auto ok_for_secondary =
+    pins_for_sensor.secondary.has_value() &&
+    pins_for_sensor.secondary.value().data_ready.has_value();
 static auto tip_sense_gpio_primary = pins_for_sensor.primary.tip_sense.value();
 
 static auto& sensor_queue_client = sensor_tasks::get_queues();
@@ -147,8 +149,9 @@ extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
         static_cast<void>(
             sensor_queue_client.tip_notification_queue->try_write_isr(
                 sensors::tip_presence::TipStatusChangeDetected{}));
-    } else if (data_ready_gpio_secondary.data_ready.has_value() &&
-               GPIO_Pin == data_ready_gpio_secondary.data_ready.value().pin &&
+    } else if (ok_for_secondary &&
+               GPIO_Pin ==
+                   pins_for_sensor.secondary.value().data_ready.value().pin &&
                pressure_sensor_available) {
         if (sensor_hardware_container.secondary.has_value()) {
             sensor_hardware_container.secondary.value().data_ready();


### PR DESCRIPTION
## Overview

I previously thought calling `.value()` on an optional parameter meant that it would either return a nullptr or the object it was supposed to store. Mais **non**, I was wrong and therefore we have to do this gross check to make sure we don't brick pipette firmware. If anyone has any elegant solutions, definitely let me know.

We should be OK to not include this in the internal release b/c the breaking change was merged in after we cut the v4 tag.