### PR TITLE
fix(bootloader): present pipette information

### DIFF
--- a/bootloader/core/CMakeLists.txt
+++ b/bootloader/core/CMakeLists.txt
@@ -8,7 +8,6 @@ add_library(bootloader-core
         util.c
         message_handler.c
         update_state.c
-        pipette_node_id.c
         )
 add_dependencies(bootloader-core generate_version)
 target_include_directories(bootloader-core

--- a/bootloader/core/pipette_node_id.c
+++ b/bootloader/core/pipette_node_id.c
@@ -1,6 +1,0 @@
-#include "bootloader/core/node_id.h"
-
-CANNodeId determine_pipette_node_id(
-    bool mount_id) {
-    return mount_id ? can_nodeid_pipette_left_bootloader : can_nodeid_pipette_right_bootloader;
-}

--- a/bootloader/firmware/stm32G4/CMakeLists.txt
+++ b/bootloader/firmware/stm32G4/CMakeLists.txt
@@ -127,11 +127,13 @@ macro(pipettes_ninety_six_bootloader_loop)
     bootloader-core)
 endmacro()
 
+set(_pipette_sources ${_g4_sources} ./pipette_handle_messages.c)
+
 foreach_revision(
     PROJECT_NAME bootloader-pipettes-single
     CALL_FOREACH_REV pipettes_single_bootloader_loop
     REVISIONS b1 c2
-    SOURCES _g4_sources _g4_sources
+    SOURCES _pipette_sources _pipette_sources
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
     )
@@ -139,7 +141,7 @@ foreach_revision(
 foreach_revision(
     PROJECT_NAME bootloader-pipettes-multi
     CALL_FOREACH_REV pipettes_multi_bootloader_loop
-    SOURCES _g4_sources _g4_sources
+    SOURCES _pipette_sources _pipette_sources
     REVISIONS b1 c2
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
@@ -149,7 +151,7 @@ foreach_revision(
     PROJECT_NAME bootloader-pipettes-96
     CALL_FOREACH_REV pipettes_ninety_six_bootloader_loop
     REVISIONS b1 c1
-    SOURCES _g4_sources _g4_sources
+    SOURCES _pipette_sources _pipette_sources
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
     )

--- a/bootloader/firmware/stm32G4/node_id_stm32g4xx.c
+++ b/bootloader/firmware/stm32G4/node_id_stm32g4xx.c
@@ -8,6 +8,11 @@
 
 static CANNodeId dynamic_id_backing = can_nodeid_broadcast;
 
+static CANNodeId determine_pipette_node_id(
+    bool mount_id) {
+    return mount_id ? can_nodeid_pipette_left_bootloader : can_nodeid_pipette_right_bootloader;
+}
+
 
 static CANNodeId update_dynamic_nodeid() {
     PipetteType pipette_type = get_pipette_type();

--- a/bootloader/firmware/stm32G4/pipette_handle_messages.c
+++ b/bootloader/firmware/stm32G4/pipette_handle_messages.c
@@ -1,0 +1,52 @@
+#include <string.h> // memcpy
+
+#include "bootloader/core/message_handler.h"
+#include "bootloader/core/ids.h"
+#include "bootloader/core/pipette_type.h"
+#include "bootloader/core/node_id.h"
+#include "common/core/version.h"
+#include "bootloader/core/messages.h"
+#include "bootloader/core/util.h"
+
+static HandleMessageReturn handle_device_info_request(
+    const Message* request, Message* response);
+
+HandleMessageReturn system_specific_handle_message(
+    const Message* request, Message* response) {
+    switch (request->arbitration_id.parts.message_id) {
+        case can_messageid_device_info_request:
+            return handle_device_info_request(request, response);
+        default:
+            return handle_message_not_handled;
+    }
+}
+
+static CANPipetteType can_pipette_type_for_internal(PipetteType type);
+
+HandleMessageReturn handle_device_info_request(
+    const Message* request, Message* response) {
+    HandleMessageReturn system_ret = system_handle_message(request, response);
+    if (system_ret != handle_message_has_response) {
+        return system_ret;
+    }
+    size_t response_index =
+        sizeof(*version_get())   // all version info is in that struct
+        + sizeof(uint32_t) // message index
+        + revision_size(); // revision
+    uint8_t* pipette_id_loc = response->data + response_index;
+    *pipette_id_loc = can_pipette_type_for_internal(PIPETTE_TYPE_DEFINE);
+    return handle_message_has_response;
+}
+
+CANPipetteType can_pipette_type_for_internal(PipetteType type) {
+    switch (type) {
+        case SINGLE_CHANNEL:
+            return can_pipettetype_pipette_single;
+        case EIGHT_CHANNEL:
+            return can_pipettetype_pipette_multi;
+        case NINETY_SIX_CHANNEL:
+            return can_pipettetype_pipette_96;
+        default:
+            return 0;
+    }
+}

--- a/bootloader/tests/test_message_handler.cpp
+++ b/bootloader/tests/test_message_handler.cpp
@@ -68,7 +68,7 @@ SCENARIO("device info") {
                         can_messageid_device_info_response);
             }
             THEN("it populates response body") {
-                REQUIRE(response.size == 24);
+                REQUIRE(response.size == 25);
                 REQUIRE(response.data[0] == 0xD3);
                 REQUIRE(response.data[1] == 0x4D);
                 REQUIRE(response.data[2] == 0xB3);
@@ -93,6 +93,7 @@ SCENARIO("device info") {
                 REQUIRE(response.data[21] == '1');
                 REQUIRE(response.data[22] == 0);
                 REQUIRE(response.data[23] == 0);
+                REQUIRE(response.data[24] == 0);
             }
         }
     }

--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -226,7 +226,8 @@ SCENARIO("message serializing works") {
                                .flags = 0x11445566,
                                .shortsha{"abcdef0"},
                                .primary_revision = revision_get()->primary,
-                               .secondary_revision = revision_get()->secondary};
+                               .secondary_revision = revision_get()->secondary,
+                               .device_subidentifier = 0x9};
         message.tertiary_revision[0] = '.';
         message.tertiary_revision[1] = '2';
         auto arr = std::array<uint8_t, 30>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -287,11 +288,13 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[21] == revision_get()->secondary);
                 REQUIRE(body.data()[22] == '.');
                 REQUIRE(body.data()[23] == '2');
+
+                REQUIRE(body.data()[24] == 0x9);
             }
             THEN("it does not write past the end of the buffer") {
-                REQUIRE(body.data()[24] == 0);
+                REQUIRE(body.data()[25] == 0);
             }
-            THEN("size must be returned") { REQUIRE(size == 24); }
+            THEN("size must be returned") { REQUIRE(size == 25); }
         }
     }
 

--- a/common/core/revision.c.in
+++ b/common/core/revision.c.in
@@ -1,5 +1,6 @@
 #include "common/core/version.h"
 
+// Do not change this without changing revision_size
 static const struct revision _revision = {
     .primary = '${PRIMARY_REVISION}',
     .secondary = '${SECONDARY_REVISION}',
@@ -8,4 +9,9 @@ static const struct revision _revision = {
 
 const struct revision* revision_get() {
     return &_revision;
+}
+
+// change this when changing revision
+size_t revision_size() {
+    return sizeof(_revision.primary) + sizeof(_revision.secondary) + sizeof(_revision.tertiary);
 }

--- a/generate_header.py
+++ b/generate_header.py
@@ -38,6 +38,7 @@ def generate_can_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
         write_enum_cpp(constants_mod.GearMotorId, output)
         write_enum_cpp(constants_mod.MotorPositionFlags, output)
         write_enum_cpp(constants_mod.MoveStopCondition, output)
+        write_enum_cpp(constants_mod.PipetteType, output)
 
 
 def generate_can_c(output: io.StringIO, constants_mod: ModuleType, arbitration_id: ModuleType) -> None:
@@ -57,6 +58,7 @@ def generate_can_c(output: io.StringIO, constants_mod: ModuleType, arbitration_i
     write_enum_c(constants_mod.MotorPositionFlags, output, can)
     write_enum_c(constants_mod.MoveStopCondition, output, can)
     write_arbitration_id_c(output, can, arbitration_id)
+    write_enum_c(constants_mod.PipetteType, output, can)
 
 def generate_rearpanel_cpp(output: io.StringIO, constants_mod: ModuleType) -> None:
     """Generate source code into output."""

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -222,3 +222,10 @@ typedef struct {
     unsigned int padding: 3;
 } CANArbitrationIdParts;
 
+/** High-level type of pipette. */
+typedef enum {
+    can_pipettetype_pipette_single = 0x1,
+    can_pipettetype_pipette_multi = 0x2,
+    can_pipettetype_pipette_96 = 0x3,
+} CANPipetteType;
+

--- a/include/bootloader/core/message_handler.h
+++ b/include/bootloader/core/message_handler.h
@@ -30,7 +30,8 @@ typedef struct {
 typedef enum {
     handle_message_ok,
     handle_message_has_response,
-    handle_message_error
+    handle_message_error,
+    handle_message_not_handled,
 }  HandleMessageReturn;
 
 /**
@@ -40,6 +41,25 @@ typedef enum {
  * @return Return code
  */
 HandleMessageReturn handle_message(const Message * request, Message * response);
+
+/**
+ * The message handler for the system. Useful to call in a system-specific
+ * handler if you need to override part of what it rreturns.
+ * @param request The request; check that it is non-null.
+ * @param response The response to be filled out; check that it is non-null.
+ * */
+HandleMessageReturn system_handle_message(const Message * request, Message * response);
+
+/**
+ * Systems may implement to customize their message handling.
+ *
+ * This will be called before the core handle_message; it should return
+ * handle_message_not_handled if there was nothing to do.
+ *
+ * The message pointers will be non-null; they're checked before call.
+ * */
+HandleMessageReturn system_specific_handle_message(
+    const Message* request, Message* response);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/bootloader/core/message_handler.h
+++ b/include/bootloader/core/message_handler.h
@@ -44,7 +44,7 @@ HandleMessageReturn handle_message(const Message * request, Message * response);
 
 /**
  * The message handler for the system. Useful to call in a system-specific
- * handler if you need to override part of what it rreturns.
+ * handler if you need to override part of what it returns.
  * @param request The request; check that it is non-null.
  * @param response The response to be filled out; check that it is non-null.
  * */

--- a/include/bootloader/core/node_id.h
+++ b/include/bootloader/core/node_id.h
@@ -16,11 +16,6 @@ extern "C" {
  */
 CANNodeId get_node_id(void);
 
-/**
- * Get the node id for a pipette from the value of the mount id pin.
- * Implemented in core, but only relevant in the pipettes.
- * */
-CANNodeId determine_pipette_node_id(bool mount_id);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/include/bootloader/core/system_specific_message_handlers.h
+++ b/include/bootloader/core/system_specific_message_handlers.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "bootloader/core/message_handler.h"
+
+HandleMessageReturn system_sepcific_handle_message(const Message* request, Message* response);

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -222,4 +222,11 @@ enum class MoveStopCondition {
     stall = 0x10,
 };
 
+/** High-level type of pipette. */
+enum class PipetteType {
+    pipette_single = 0x1,
+    pipette_multi = 0x2,
+    pipette_96 = 0x3,
+};
+
 }  // namespace can::ids

--- a/include/can/core/message_handlers/system.hpp
+++ b/include/can/core/message_handlers/system.hpp
@@ -28,12 +28,14 @@ class SystemMessageHandler {
      */
     SystemMessageHandler(CanClient &writer, uint32_t version, uint32_t flags,
                          std::span<const char> version_sha,
-                         char primary_revision, char secondary_revision)
+                         char primary_revision, char secondary_revision,
+                         uint8_t device_subid = 0)
         : writer(writer),
           response{.version = version,
                    .flags = flags,
                    .primary_revision = primary_revision,
-                   .secondary_revision = secondary_revision} {
+                   .secondary_revision = secondary_revision,
+                   .device_subidentifier = device_subid} {
         std::copy_n(version_sha.begin(),
                     std::min(version_sha.size(), response.shortsha.size()),
                     response.shortsha.begin());

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -127,6 +127,7 @@ struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
     char primary_revision;
     char secondary_revision;
     std::array<char, 2> tertiary_revision;
+    uint8_t device_subidentifier;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {
@@ -148,6 +149,7 @@ struct DeviceInfoResponse : BaseMessage<MessageId::device_info_response> {
         iter = std::copy_n(
             &tertiary_revision[0],
             std::min(limit - iter, ptrdiff_t(sizeof(tertiary_revision))), iter);
+        iter = bit_utils::int_to_bytes(device_subidentifier, iter, limit);
         return iter - body;
     }
     auto operator==(const DeviceInfoResponse& other) const -> bool = default;

--- a/include/common/core/version.h
+++ b/include/common/core/version.h
@@ -1,6 +1,7 @@
 #ifndef COMMON_CORE_VERSION_H_
 #define COMMON_CORE_VERSION_H_
 #include <stdint.h> // uint32_t
+#include <stdlib.h> // size_t
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -33,11 +34,17 @@ struct version {
 
 const struct version* version_get();
 
-struct revision {
+// Do not base the size of messages that include this data on the size of
+// this struct, since it is not packed. Instead, use revision_size(), and if
+// you update this struct make sure to update that value.
+struct  revision {
     char primary;
     char secondary;
     char tertiary[2];
 };
+
+// What the size of the revision struct would be if it was packed.
+size_t revision_size();
 
 const struct revision* revision_get();
 

--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -131,12 +131,15 @@ struct DeviceInfoResponse
         iter = std::copy_n(
             &tertiary_revision[0],
             std::min(limit - iter, ptrdiff_t(sizeof(tertiary_revision))), iter);
+        // This is only used for the rear panel and there is not currently a
+        // subid required there
+        *iter++ = 0;
         return iter;
     }
 
     static auto get_length() -> uint16_t {
         return sizeof(uint32_t) + sizeof(uint32_t) + VERSION_SHORTSHA_SIZE +
-               sizeof(revision);
+               revision_size() + sizeof(uint8_t);
     }
     auto operator==(const DeviceInfoResponse& other) const -> bool = default;
 };

--- a/pipettes/core/can_task_high_throughput.cpp
+++ b/pipettes/core/can_task_high_throughput.cpp
@@ -47,13 +47,12 @@ static auto eeprom_handler = eeprom::message_handler::EEPromHandler{
 
 static auto system_message_handler =
     can::message_handlers::system::SystemMessageHandler{
-        central_queue_client,
-        version_get()->version,
-        version_get()->flags,
+        central_queue_client, version_get()->version, version_get()->flags,
         std::span(std::cbegin(version_get()->sha),
                   std::cend(version_get()->sha)),
-        revision_get()->primary,
-        revision_get()->secondary};
+        revision_get()->primary, revision_get()->secondary,
+        // this is the high-throughput path so we can only be a 96
+        static_cast<uint8_t>(can::ids::PipetteType::pipette_96)};
 
 static auto sensor_handler =
     sensors::handlers::SensorHandler{sensor_queue_client};

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -97,12 +97,13 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[20] == 'A');
                 REQUIRE(body.data()[21] == 'B');
                 REQUIRE(body.data()[22] == 'C');
-            }
-            THEN("it does not write past the end of the buffer") {
                 REQUIRE(body.data()[23] == 0);
             }
+            THEN("it does not write past the end of the buffer") {
+                REQUIRE(body.data()[24] == 0);
+            }
             THEN("size must be returned") {
-                REQUIRE(next_free == arr.begin() + 24);
+                REQUIRE(next_free == arr.begin() + 25);
             }
         }
     }


### PR DESCRIPTION
The bootlaoder has no way to indicate what kind of pipette it is. This means that if a pipette is stuck in its bootloader, it cannot be automatically and safely updated.

To fix this, let's add a new byte to the device info and put the pipette type in it (for a pipette, anyway). The byte will be interpreted differently depending on the canbus node id that the device info response comes from, so there's no need for a ton of space here.

This is implemented in the bootloader with another attribute-weak hook that will only get compiled for the pipette itself. While I was here, I refactored the way we do node IDs to make things a little better.

Closes RQA-584

## Risks
This is a bootloader change! We need to test it on lots of kinds of devices.
We also need to add handling for this byte to the python side, but that's not that big a deal since we already are accepting of device info responses with more than we think in them.

## Testing
- Put it on pipettes of various types and check that the right byte comes back and that it works
- Put it on other stuff and check that the 0 byte comes back.