### PR TITLE
fix(rear-panel): incorrect limiting of msg size

### DIFF
--- a/include/rear-panel/core/messages.hpp
+++ b/include/rear-panel/core/messages.hpp
@@ -133,7 +133,8 @@ struct DeviceInfoResponse
             std::min(limit - iter, ptrdiff_t(sizeof(tertiary_revision))), iter);
         // This is only used for the rear panel and there is not currently a
         // subid required there
-        *iter++ = 0;
+        const uint8_t subid = 0;
+        iter = bit_utils::int_to_bytes(subid, iter, limit);
         return iter;
     }
 

--- a/rear-panel/test/test_messages.cpp
+++ b/rear-panel/test/test_messages.cpp
@@ -50,7 +50,7 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[0] == 0x00);
                 REQUIRE(body.data()[1] == 0x04);
                 REQUIRE(body.data()[2] == 0x00);
-                REQUIRE(body.data()[3] == 0x14);
+                REQUIRE(body.data()[3] == 0x15);
                 REQUIRE(body.data()[4] == 0x00);
                 REQUIRE(body.data()[5] == 0x22);
                 REQUIRE(body.data()[6] == 0x00);
@@ -77,7 +77,7 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[0] == 0x00);
                 REQUIRE(body.data()[1] == 0x04);
                 REQUIRE(body.data()[2] == 0x00);
-                REQUIRE(body.data()[3] == 0x14);
+                REQUIRE(body.data()[3] == 0x15);
                 REQUIRE(body.data()[4] == 0x00);
                 REQUIRE(body.data()[5] == 0x22);
                 REQUIRE(body.data()[6] == 0x00);


### PR DESCRIPTION
Missed a test failure that had a real bug! The raw iterator manipulation does not correctly handle the case where we're out of space in our write buffer.