### PR TITLE
feat(rear-panel): enable deck light on startup

### DIFF
--- a/include/rear-panel/core/tasks/light_control_task.hpp
+++ b/include/rear-panel/core/tasks/light_control_task.hpp
@@ -115,7 +115,7 @@ class LightControlMessageHandler {
 
     LightControlInterface& _hardware;
     Animation& _animation;
-    bool _deck_light_status = false;
+    bool _deck_light_status = true;
 };
 
 /**


### PR DESCRIPTION
Enables the deck light on startup, as requested by the hardware team.