### PR TITLE
fix(pipettes): mount id and bootloader

### DIFF
--- a/bootloader/firmware/stm32G4/node_id_stm32g4xx.c
+++ b/bootloader/firmware/stm32G4/node_id_stm32g4xx.c
@@ -35,7 +35,7 @@ static CANNodeId update_dynamic_nodeid() {
     }
 
     HAL_GPIO_Init(port, &GPIO_InitStruct);
-    HAL_Delay(2);
+    HAL_Delay(100);
     int level = HAL_GPIO_ReadPin(port, GPIO_InitStruct.Pin);
     CANNodeId id = determine_pipette_node_id(level == GPIO_PIN_RESET);
     GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -244,7 +244,7 @@ auto main() -> int {
     RCC_Peripheral_Clock_Select();
     utility_gpio_init();
 
-    delay_start(2);
+    delay_start(100);
     auto id =
         pipette_mounts::decide_id(utility_gpio_get_mount_id(PIPETTE_TYPE) == 1);
 

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -244,6 +244,20 @@ auto main() -> int {
     RCC_Peripheral_Clock_Select();
     utility_gpio_init();
 
+    /*
+    ** This delay exists after we set the mount ID pin to an input and before
+    ** we read it. The delay must exist and be long to cover the following
+    ** situations:
+    ** - When transitioning from the bootloader, which has already done the
+    **   mount ID process and driven the line, we need to release the line and
+    **   give it time to reestablish its intended voltage
+    ** - When the robot is turning on while we're plugged in, we need to give the
+    **   head board time to start up and establish the voltage before we try and
+    **   read it
+    **
+    ** Don't change this value without testing these scenarios in addition to
+    ** hotplugging the pipette into a running robot.
+     */
     delay_start(100);
     auto id =
         pipette_mounts::decide_id(utility_gpio_get_mount_id(PIPETTE_TYPE) == 1);

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -251,13 +251,14 @@ auto main() -> int {
     ** - When transitioning from the bootloader, which has already done the
     **   mount ID process and driven the line, we need to release the line and
     **   give it time to reestablish its intended voltage
-    ** - When the robot is turning on while we're plugged in, we need to give the
+    ** - When the robot is turning on while we're plugged in, we need to give
+    *the
     **   head board time to start up and establish the voltage before we try and
     **   read it
     **
     ** Don't change this value without testing these scenarios in addition to
     ** hotplugging the pipette into a running robot.
-     */
+    */
     delay_start(100);
     auto id =
         pipette_mounts::decide_id(utility_gpio_get_mount_id(PIPETTE_TYPE) == 1);

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -2,6 +2,7 @@
 #include "stm32g4xx_hal_conf.h"
 #include "hardware_config.h"
 #include "pipettes/core/pipette_type.h"
+#include "stm32g4xx_hal_gpio.h"
 
 static void enable_gpio_port(void* port) {
     if (port == GPIOA) {

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -251,7 +251,7 @@ static void mount_id_init() {
         GPIO_InitTypeDef GPIO_InitStruct = {0};
         GPIO_InitStruct.Pin = GPIO_PIN_3;
         GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-        GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     } else {
         // B0: mount id
@@ -259,7 +259,7 @@ static void mount_id_init() {
         GPIO_InitTypeDef GPIO_InitStruct = {0};
         GPIO_InitStruct.Pin = GPIO_PIN_0;
         GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-        GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
     }
 }


### PR DESCRIPTION
The mount ID for the right mount wasn't working properly in all electrical cases:
- Booting the robot while pipette plugged in
- Bootloader->application

This fixes the issue by moving to a 100ms startup delay between configuring the mount ID as an input, and reading/writing it. That's in both the application and the bootloader, and works under EE testing.