### PR TITLE
fix(gripper): update sensor id for sensor tasks

### DIFF
--- a/gripper/core/tasks.cpp
+++ b/gripper/core/tasks.cpp
@@ -85,11 +85,11 @@ void gripper_tasks::start_tasks(
 
     auto& capacitive_sensor_task_front =
         capacitive_sensor_task_builder_front.start(
-            5, "capacitive sensor S1", i2c2_task_client, i2c2_poll_client,
+            5, "cap sensor S1", i2c2_task_client, i2c2_poll_client,
             sensor_hardware, queues);
     auto& capacitive_sensor_task_rear =
         capacitive_sensor_task_builder_rear.start(
-            5, "capacitive sensor S0", i2c3_task_client, i2c3_poll_client,
+            5, "cap sensor S0", i2c3_task_client, i2c3_poll_client,
             sensor_hardware, queues);
 
     tasks.i2c2_task = &i2c2_task;

--- a/gripper/core/tasks.cpp
+++ b/gripper/core/tasks.cpp
@@ -43,11 +43,11 @@ static auto i2c3_poll_client =
 
 static auto capacitive_sensor_task_builder_front =
     freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
-                               can::ids::SensorId>(can::ids::SensorId::S0);
+                               can::ids::SensorId>(can::ids::SensorId::S1);
 
 static auto capacitive_sensor_task_builder_rear =
     freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
-                               can::ids::SensorId>(can::ids::SensorId::S1);
+                               can::ids::SensorId>(can::ids::SensorId::S0);
 
 /**
  * Start gripper tasks.
@@ -85,11 +85,11 @@ void gripper_tasks::start_tasks(
 
     auto& capacitive_sensor_task_front =
         capacitive_sensor_task_builder_front.start(
-            5, "capacitive sensor S0", i2c2_task_client, i2c2_poll_client,
+            5, "capacitive sensor S1", i2c2_task_client, i2c2_poll_client,
             sensor_hardware, queues);
     auto& capacitive_sensor_task_rear =
         capacitive_sensor_task_builder_rear.start(
-            5, "capacitive sensor S1", i2c3_task_client, i2c3_poll_client,
+            5, "capacitive sensor S0", i2c3_task_client, i2c3_poll_client,
             sensor_hardware, queues);
 
     tasks.i2c2_task = &i2c2_task;


### PR DESCRIPTION
We've switched the cap sensor IDs for the gripper but we forgot to also update the sensor id on the sensor task, so it's reporting the wrong sensor id. 