### PR TITLE
fix(eeprom): general filesystem accessor bug fixes

### DIFF
--- a/eeprom/tests/test_dev_data.cpp
+++ b/eeprom/tests/test_dev_data.cpp
@@ -137,7 +137,7 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
         task::EEPromMessageHandler{writer, response_queue, hardware_iface};
     GIVEN("data accessor correctly initializes") {
         auto data = types::EepromData{};
-        data.fill(0x00);
+        data.fill(0xFF);
         auto read_message =
             std::get<message::ReadEepromMessage>(queue_client.messages[0]);
         read_message.callback(
@@ -151,6 +151,7 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
         eeprom.handle_message(config_msg);
         queue_client.messages.clear();
         THEN("accessor attemps to create data table entry") {
+            REQUIRE(subject.data_part_exists(0) == false);
             subject.create_data_part(0x00, 0x04);
             // for the first one we just expect a write to the first segment of
             // the table and we expect a read to the table_tail value so it can
@@ -169,6 +170,7 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
             REQUIRE(read_message.memory_address ==
                     addresses::lookup_table_tail_begin);
             REQUIRE(read_message.length == addresses::lookup_table_tail_length);
+            REQUIRE(subject.data_part_exists(0) == true);
         }
     }
 }

--- a/eeprom/tests/test_dev_data.cpp
+++ b/eeprom/tests/test_dev_data.cpp
@@ -24,8 +24,8 @@ SCENARIO("initalizing a data accessor") {
     auto queue_client = MockEEPromTaskClient{};
     auto read_listener = MockListener{};
     auto dev_data_buffer = dev_data::DataBufferType<64>{};
-    auto subject = dev_data::DevDataAccessor{queue_client, read_listener,
-                                                 dev_data_buffer};
+    auto subject =
+        dev_data::DevDataAccessor{queue_client, read_listener, dev_data_buffer};
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
     test_mocks::MockI2CResponseQueue response_queue{};
     auto writer = i2c::writer::Writer<test_mocks::MockMessageQueue>{};
@@ -36,7 +36,7 @@ SCENARIO("initalizing a data accessor") {
         task::EEPromMessageHandler{writer, response_queue, hardware_iface};
     GIVEN("A creating a data accessor entry for 256 byte chip") {
         auto data = types::EepromData{};
-        //256 byte chips have a zeroed out memory
+        // 256 byte chips have a zeroed out memory
         data.fill(0x00);
         THEN("accessor recieves config from task") {
             // make sure the second message is a config request
@@ -95,7 +95,7 @@ SCENARIO("creating a data table entry") {
         task::EEPromMessageHandler{writer, response_queue, hardware_iface};
     GIVEN("data accessor correctly initializes") {
         auto data = types::EepromData{};
-        //256 byte chips have a zeroed out memory
+        // 256 byte chips have a zeroed out memory
         data.fill(0x00);
         auto config_msg = task::TaskMessage(
             std::get<message::ConfigRequestMessage>(queue_client.messages[0]));
@@ -259,7 +259,7 @@ SCENARIO("writing to data partition") {
         // initalize the accessor driver by reading the data table length and
         // config
         auto data = types::EepromData{};
-        //256 byte chips have a zeroed out memory
+        // 256 byte chips have a zeroed out memory
         data.fill(0x00);
         auto config_msg = task::TaskMessage(
             std::get<message::ConfigRequestMessage>(queue_client.messages[0]));
@@ -370,7 +370,7 @@ SCENARIO("writing large data to partition") {
         // initalize the accessor driver by reading the data table length and
         // config
         auto data = types::EepromData{};
-        //16K byte chips have a 0xFF filled memory
+        // 16K byte chips have a 0xFF filled memory
         data.fill(0xFF);
         auto config_msg = task::TaskMessage(
             std::get<message::ConfigRequestMessage>(queue_client.messages[0]));
@@ -459,7 +459,7 @@ SCENARIO("reading from data partition") {
         // initalize the accessor driver by reading the data table length and
         // config
         auto data = types::EepromData{};
-        //256 byte chips have a zeroed out memory
+        // 256 byte chips have a zeroed out memory
         data.fill(0x00);
         auto config_msg = task::TaskMessage(
             std::get<message::ConfigRequestMessage>(queue_client.messages[0]));
@@ -568,7 +568,7 @@ SCENARIO("reading large data from partition") {
         // initalize the accessor driver by reading the data table length and
         // config
         auto data = types::EepromData{};
-        //16K byte chips have a 0xFF filled memory
+        // 16K byte chips have a 0xFF filled memory
         data.fill(0xFF);
         auto config_msg = task::TaskMessage(
             std::get<message::ConfigRequestMessage>(queue_client.messages[0]));
@@ -580,7 +580,8 @@ SCENARIO("reading large data from partition") {
                 .memory_address = read_message.memory_address,
                 .length = read_message.length,
                 .data = data},
-            read_message.callback_param);// after the read_message callback is called the driver should write the
+            read_message.callback_param);  // after the read_message callback is
+                                           // called the driver should write the
         // new tail to memory
         auto write_message =
             std::get<message::WriteEepromMessage>(queue_client.messages[2]);

--- a/eeprom/tests/test_dev_data.cpp
+++ b/eeprom/tests/test_dev_data.cpp
@@ -135,9 +135,10 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
 
     auto eeprom =
         task::EEPromMessageHandler{writer, response_queue, hardware_iface};
-    auto table_entry_length = static_cast<uint16_t>(
-                        hardware_iface::EEPromAddressType::EEPROM_ADDR_16_BIT) *
-                        2;
+    auto table_entry_length =
+        static_cast<uint16_t>(
+            hardware_iface::EEPromAddressType::EEPROM_ADDR_16_BIT) *
+        2;
     GIVEN("data accessor correctly initializes") {
         auto data = types::EepromData{};
         data.fill(0xFF);
@@ -168,11 +169,13 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
             REQUIRE(write_message.memory_address ==
                     addresses::data_address_begin);
             REQUIRE(write_message.length == table_entry_length);
-            // the address it writes should be 16k - 4 - 32 (0x4000-0x4 = 0x3FDC)
-            // the 32 is because this address is an offset from the data_address_begin
+            // the address it writes should be 16k - 4 - 32 (0x4000-0x4 =
+            // 0x3FDC) the 32 is because this address is an offset from the
+            // data_address_begin
             REQUIRE(write_message.data[0] == 0x3F);
             REQUIRE(write_message.data[1] == 0xDC);
-            // the update tail length should then be called which will call a read on the old tail
+            // the update tail length should then be called which will call a
+            // read on the old tail
             auto read_message =
                 std::get<message::ReadEepromMessage>(queue_client.messages[1]);
             REQUIRE(read_message.memory_address ==
@@ -185,8 +188,8 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
                 subject.create_data_part(0x01, 0x04);
                 // First we read the previous data tail address
                 REQUIRE(queue_client.messages.size() == 1);
-                read_message =
-                    std::get<message::ReadEepromMessage>(queue_client.messages[0]);
+                read_message = std::get<message::ReadEepromMessage>(
+                    queue_client.messages[0]);
                 REQUIRE(read_message.memory_address ==
                         addresses::data_address_begin);
                 REQUIRE(read_message.length == table_entry_length);
@@ -199,20 +202,23 @@ SCENARIO("creating a data table on 16 bit addresss entry") {
                     read_message.callback_param);
                 REQUIRE(queue_client.messages.size() == 2);
                 // First data write is adding the new table entry
-                auto write_message =
-                    std::get<message::WriteEepromMessage>(queue_client.messages[0]);
+                auto write_message = std::get<message::WriteEepromMessage>(
+                    queue_client.messages[0]);
                 REQUIRE(write_message.memory_address ==
                         addresses::data_address_begin + table_entry_length);
                 REQUIRE(write_message.length == table_entry_length);
-                // the address it writes should be the previous entry - 4 (0x3FDC-0x4 = 0x3FD8)
+                // the address it writes should be the previous entry - 4
+                // (0x3FDC-0x4 = 0x3FD8)
                 REQUIRE(write_message.data[0] == 0x3F);
                 REQUIRE(write_message.data[1] == 0xD8);
-                // the update tail length should then be called which will call a read on the old tail
-                read_message =
-                    std::get<message::ReadEepromMessage>(queue_client.messages[1]);
+                // the update tail length should then be called which will call
+                // a read on the old tail
+                read_message = std::get<message::ReadEepromMessage>(
+                    queue_client.messages[1]);
                 REQUIRE(read_message.memory_address ==
-                    addresses::lookup_table_tail_begin);
-                REQUIRE(read_message.length == addresses::lookup_table_tail_length);
+                        addresses::lookup_table_tail_begin);
+                REQUIRE(read_message.length ==
+                        addresses::lookup_table_tail_length);
                 REQUIRE(subject.data_part_exists(1) == true);
             }
         }

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -291,8 +291,10 @@ class DevDataAccessor
         // and not initatied from a can message
         std::ignore = message_index;
         // test if data is set to default
-        auto delivery_state = std::vector<uint8_t>(addresses::lookup_table_tail_length, conf.default_byte_value);
-        if (std::equal(delivery_state.begin(), delivery_state.end(), data_tail_buff.begin())) {
+        auto delivery_state = std::vector<uint8_t>(
+            addresses::lookup_table_tail_length, conf.default_byte_value);
+        if (std::equal(delivery_state.begin(), delivery_state.end(),
+                       data_tail_buff.begin())) {
             auto init_tail = DataTailType{};
             std::ignore = bit_utils::int_to_bytes(
                 addresses::data_address_begin, init_tail.begin(),

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -308,7 +308,7 @@ class DevDataAccessor
     auto data_part_exists(uint16_t key) -> bool {
         if (tail_updated && config_updated) {
             auto table_location = calculate_table_entry_start(key);
-            return table_location <= data_tail;
+            return table_location < data_tail;
         }
         return false;
     }

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -378,7 +378,6 @@ class DevDataAccessor
                     write.memory_address = data_tail;
                     write.length = 2 * conf.addr_bytes;
                     auto* write_iter = write.data.begin();
-                    printf("\n\n here: ");
                     write_iter = bit_utils::int_to_bytes(
                         uint16_t(data_addr - action_cmd_m.len), write_iter,
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -219,8 +219,9 @@ class DevDataAccessor
                 message::WriteEepromMessage write;
                 write.memory_address = addresses::data_address_begin;
                 write.length = 2 * conf.addr_bytes;
-                // data pointers are offsets from the start of the data section of the eeprom,
-                // so we subtract data_address_begin here to store the right value
+                // data pointers are offsets from the start of the data section
+                // of the eeprom, so we subtract data_address_begin here to
+                // store the right value
                 types::address new_ptr =
                     conf.mem_size - len - addresses::data_address_begin;
                 if (conf.chip ==
@@ -386,11 +387,13 @@ class DevDataAccessor
                         write_iter + conf.addr_bytes);
                     this->eeprom_client.send_eeprom_queue(write);
 
-                    //After writing the table entry use the tail accessor to update the tail
+                    // After writing the table entry use the tail accessor to
+                    // update the tail
                     tail_accessor.increase_data_tail(2 * conf.addr_bytes);
                     data_tail += 2 * conf.addr_bytes;
 
-                    // If we passed data into the create write that data into the memory
+                    // If we passed data into the create write that data into
+                    // the memory
                     if (do_initalize) {
                         this->write_at_offset(this->type_data,
                                               data_addr - action_cmd_m.len,

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -134,9 +134,9 @@ class DevDataAccessor
                   accessor::AccessorBuffer(buffer.begin(), buffer.end())),
           tail_accessor{DevDataTailAccessor<EEPromTaskClient>(
               eeprom_client, *this, data_tail_buff)} {
-        tail_accessor.start_read(0);
         eeprom_client.send_eeprom_queue(
             message::ConfigRequestMessage{config_req_callback, this});
+        tail_accessor.start_read(0);
     }
 
     template <std::size_t SIZE>
@@ -290,9 +290,9 @@ class DevDataAccessor
         // we don't need message_index since this is an internal call
         // and not initatied from a can message
         std::ignore = message_index;
-        // test for non 0x00 elements
-        if (data_tail_buff.end() ==
-            std::find(data_tail_buff.begin(), data_tail_buff.end(), true)) {
+        // test if data is set to default
+        auto delivery_state = std::vector<uint8_t>(addresses::lookup_table_tail_length, conf.default_byte_value);
+        if (std::equal(delivery_state.begin(), delivery_state.end(), data_tail_buff.begin())) {
             auto init_tail = DataTailType{};
             std::ignore = bit_utils::int_to_bytes(
                 addresses::data_address_begin, init_tail.begin(),

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -260,6 +260,7 @@ class DevDataAccessor
                 }
                 // call a read to the previous table entry so we know where
                 // to put the data
+                tail_updated = false;
                 this->eeprom_client.send_eeprom_queue(
                     message::ReadEepromMessage{
                         .memory_address = calculate_table_entry_start(key - 1),
@@ -300,6 +301,16 @@ class DevDataAccessor
         }
         tail_updated = true;
     }
+
+    auto data_part_exists(uint16_t key) -> bool {
+        if (tail_updated && config_updated) {
+            auto table_location = calculate_table_entry_start(key);
+            return table_location <= data_tail;
+        }
+        return false;
+    }
+
+    auto ready() -> bool { return tail_updated && config_updated; }
 
   private:
     DataTailType data_tail_buff = DataTailType{};
@@ -371,6 +382,7 @@ class DevDataAccessor
                                               data_addr - action_cmd_m.len,
                                               data_addr, m.message_index);
                     }
+                    tail_updated = true;
                 }
                 break;
             case TableAction::READ:

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -46,24 +46,16 @@ class EEPromHardwareIface {
                     static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_8_BIT);
                 eeprom_mem_size =
                     static_cast<size_t>(EEpromMemorySize::MICROCHIP_256_BYTE);
+                default_byte_value = 0x00;
                 break;
             case EEPromChipType::ST_M24128_BF:
-                eeprom_addr_bytes =
-                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_16_BIT);
-                eeprom_mem_size =
-                    static_cast<size_t>(EEpromMemorySize::ST_16_KBYTE);
-                break;
             case EEPromChipType::ST_M24128_DF:
-                eeprom_addr_bytes =
-                    static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_16_BIT);
-                eeprom_mem_size =
-                    static_cast<size_t>(EEpromMemorySize::ST_16_KBYTE);
-                break;
             case EEPromChipType::ST_M24128_DR:
                 eeprom_addr_bytes =
                     static_cast<size_t>(EEPromAddressType::EEPROM_ADDR_16_BIT);
                 eeprom_mem_size =
                     static_cast<size_t>(EEpromMemorySize::ST_16_KBYTE);
+                default_byte_value = 0xFF;
                 break;
         }
         eeprom_chip_type = chip;
@@ -111,6 +103,9 @@ class EEPromHardwareIface {
     [[nodiscard]] auto get_eeprom_mem_size() const -> types::data_length {
         return eeprom_mem_size;
     }
+    [[nodiscard]] auto get_eeprom_default_byte_value() const -> uint8_t {
+        return default_byte_value;
+    }
 
   private:
     // The number of times that disable has been called.
@@ -122,6 +117,7 @@ class EEPromHardwareIface {
     size_t eeprom_mem_size =
         static_cast<size_t>(EEpromMemorySize::MICROCHIP_256_BYTE);
     EEPromChipType eeprom_chip_type = EEPromChipType::MICROCHIP_24AA02T;
+    uint8_t default_byte_value = 0x00;
 };
 
 }  // namespace hardware_iface

--- a/include/eeprom/core/messages.hpp
+++ b/include/eeprom/core/messages.hpp
@@ -40,6 +40,7 @@ struct ConfigResponseMessage {
     eeprom::hardware_iface::EEPromChipType chip;
     types::address addr_bytes;
     types::data_length mem_size;
+    uint8_t default_byte_value;
 };
 
 using ConfigRequestCallback = void (*)(const ConfigResponseMessage&, void*);

--- a/include/eeprom/core/task.hpp
+++ b/include/eeprom/core/task.hpp
@@ -211,7 +211,8 @@ class EEPromMessageHandler {
         auto conf = message::ConfigResponseMessage{
             .chip = hw_iface.get_eeprom_chip_type(),
             .addr_bytes = hw_iface.get_eeprom_addr_bytes(),
-            .mem_size = hw_iface.get_eeprom_mem_size()};
+            .mem_size = hw_iface.get_eeprom_mem_size(),
+            .default_byte_value = hw_iface.get_eeprom_default_byte_value()};
         m.callback(conf, m.callback_param);
     }
 


### PR DESCRIPTION
We haven't used the general  filesystem handler yet for anything so this PR fixes a few bugs that cropped up during testing.

We needed to add another config value to the hw_iface for what the default value of eeprom memory was, and fetch that config value before doing anything else

added in some more test converge, and added lots of comments

also fixes a bug where integer promotion resulted in the wrong address being written to the lookup table.

