### PR TITLE
feat(pipettes): add tip presence query request

### DIFF
--- a/gripper/core/tasks.cpp
+++ b/gripper/core/tasks.cpp
@@ -147,6 +147,9 @@ void gripper_tasks::QueueClient::send_pressure_sensor_queue_front(
 void gripper_tasks::QueueClient::send_pressure_sensor_queue_rear(
     const sensors::utils::TaskMessage&) {}
 
+void gripper_tasks::QueueClient::send_tip_notification_queue(
+    const sensors::tip_presence::TaskMessage&) {}
+
 /**
  * Access to the tasks singleton
  * @return

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -71,6 +71,7 @@ typedef enum {
     can_messageid_attached_tools_request = 0x700,
     can_messageid_tools_detected_notification = 0x701,
     can_messageid_tip_presence_notification = 0x702,
+    can_messageid_get_tip_status_request = 0x703,
     can_messageid_fw_update_initiate = 0x60,
     can_messageid_fw_update_data = 0x61,
     can_messageid_fw_update_data_ack = 0x62,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -73,6 +73,7 @@ enum class MessageId {
     attached_tools_request = 0x700,
     tools_detected_notification = 0x701,
     tip_presence_notification = 0x702,
+    get_tip_status_request = 0x703,
     fw_update_initiate = 0x60,
     fw_update_data = 0x61,
     fw_update_data_ack = 0x62,

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1224,6 +1224,8 @@ struct BindSensorOutputResponse
         -> bool = default;
 };
 
+using TipStatusQueryRequest = Empty<MessageId::get_tip_status_request>;
+
 struct PushTipPresenceNotification
     : BaseMessage<MessageId::tip_presence_notification> {
     uint32_t message_index;

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -60,8 +60,8 @@ using GripperInfoDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::InstrumentInfoRequest, can::messages::SetSerialNumber>;
 using SensorDispatchTarget = can::dispatch::DispatchParseTarget<
     sensors::handlers::SensorHandler<gripper_tasks::QueueClient>,
-    can::messages::ReadFromSensorRequest, can::messages::WriteToSensorRequest,
-    can::messages::BaselineSensorRequest,
+    can::messages::TipStatusQueryRequest, can::messages::ReadFromSensorRequest,
+    can::messages::WriteToSensorRequest, can::messages::BaselineSensorRequest,
     can::messages::SetSensorThresholdRequest,
     can::messages::BindSensorOutputRequest,
     can::messages::PeripheralStatusRequest>;

--- a/include/gripper/core/tasks.hpp
+++ b/include/gripper/core/tasks.hpp
@@ -69,6 +69,9 @@ struct QueueClient : can::message_writer::MessageWriter {
     void send_pressure_sensor_queue_front(const sensors::utils::TaskMessage& m);
     void send_pressure_sensor_queue_rear(const sensors::utils::TaskMessage& m);
 
+    void send_tip_notification_queue(
+        const sensors::tip_presence::TaskMessage& m);
+
     freertos_message_queue::FreeRTOSMessageQueue<
         brushed_motor_driver_task::TaskMessage>* brushed_motor_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -79,8 +79,8 @@ using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
 
 using SensorDispatchTarget = can::dispatch::DispatchParseTarget<
     sensors::handlers::SensorHandler<sensor_tasks::QueueClient>,
-    can::messages::ReadFromSensorRequest, can::messages::WriteToSensorRequest,
-    can::messages::BaselineSensorRequest,
+    can::messages::TipStatusQueryRequest, can::messages::ReadFromSensorRequest,
+    can::messages::WriteToSensorRequest, can::messages::BaselineSensorRequest,
     can::messages::SetSensorThresholdRequest,
     can::messages::BindSensorOutputRequest,
     can::messages::PeripheralStatusRequest>;

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -96,6 +96,9 @@ struct QueueClient : can::message_writer::MessageWriter {
 
     void send_pressure_sensor_queue_front(const sensors::utils::TaskMessage& m);
 
+    void send_tip_notification_queue(
+        const sensors::tip_presence::TaskMessage& m);
+
     freertos_message_queue::FreeRTOSMessageQueue<eeprom::task::TaskMessage>*
         eeprom_queue{nullptr};
     freertos_message_queue::FreeRTOSMessageQueue<sensors::utils::TaskMessage>*

--- a/include/sensors/core/message_handlers/sensors.hpp
+++ b/include/sensors/core/message_handlers/sensors.hpp
@@ -17,7 +17,7 @@ class SensorHandler {
     auto operator=(const SensorHandler &&) -> SensorHandler && = delete;
     ~SensorHandler() = default;
 
-    void handle(const utils::CanMessage &m) {
+    void handle(const utils::CanMessageHandler &m) {
         std::visit([this](auto o) { this->visit(o); }, m);
     }
 
@@ -54,6 +54,10 @@ class SensorHandler {
     void visit(const can::messages::PeripheralStatusRequest &m) {
         send_to_queue(can::ids::SensorType(m.sensor),
                       can::ids::SensorId(m.sensor_id), m);
+    }
+
+    void visit(const can::messages::TipStatusQueryRequest &m) {
+        client.send_tip_notification_queue(m);
     }
 
     void send_to_queue(can::ids::SensorType type, can::ids::SensorId id,

--- a/include/sensors/core/tasks/tip_presence_notification_task.hpp
+++ b/include/sensors/core/tasks/tip_presence_notification_task.hpp
@@ -32,6 +32,15 @@ class TipPresenceNotificationHandler {
                     static_cast<uint8_t>(hardware.check_tip_presence())});
     }
 
+    void visit(const can::messages::TipStatusQueryRequest &) {
+        can_client.send_can_message(
+            can::ids::NodeId::host,
+            can::messages::PushTipPresenceNotification{
+                .message_index = 0,
+                .ejector_flag_status =
+                    static_cast<uint8_t>(hardware.check_tip_presence())});
+    }
+
   private:
     CanClient &can_client;
     sensors::hardware::SensorHardwareBase &hardware;

--- a/include/sensors/core/tasks/tip_presence_notification_task.hpp
+++ b/include/sensors/core/tasks/tip_presence_notification_task.hpp
@@ -32,11 +32,11 @@ class TipPresenceNotificationHandler {
                     static_cast<uint8_t>(hardware.check_tip_presence())});
     }
 
-    void visit(const can::messages::TipStatusQueryRequest &) {
+    void visit(const can::messages::TipStatusQueryRequest &m) {
         can_client.send_can_message(
             can::ids::NodeId::host,
             can::messages::PushTipPresenceNotification{
-                .message_index = 0,
+                .message_index = m.message_index,
                 .ejector_flag_status =
                     static_cast<uint8_t>(hardware.check_tip_presence())});
     }

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -25,9 +25,9 @@ using CanMessageTuple = std::tuple<can::messages::ReadFromSensorRequest,
                                    can::messages::BindSensorOutputRequest,
                                    can::messages::PeripheralStatusRequest>;
 using OtherTaskMessagesTuple = std::tuple<i2c::messages::TransactionResponse>;
-using CanMessage =
-    typename ::utils::TuplesToVariants<std::tuple<std::monostate>,
-                                       CanMessageTuple>::type;
+using CanMessageHandler = typename ::utils::TuplesToVariants<
+    std::tuple<std::monostate, can::messages::TipStatusQueryRequest>,
+    CanMessageTuple>::type;
 using TaskMessage = typename ::utils::VariantCat<
     std::variant<std::monostate>,
     typename ::utils::TuplesToVariants<CanMessageTuple,

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -11,7 +11,7 @@ namespace sensors {
 namespace tip_presence {
 struct TipStatusChangeDetected {};
 
-using TaskMessage = std::variant<std::monostate, TipStatusChangeDetected>;
+using TaskMessage = std::variant<std::monostate, TipStatusChangeDetected, can::messages::TipStatusQueryRequest>;
 
 }  // namespace tip_presence
 

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -11,7 +11,8 @@ namespace sensors {
 namespace tip_presence {
 struct TipStatusChangeDetected {};
 
-using TaskMessage = std::variant<std::monostate, TipStatusChangeDetected, can::messages::TipStatusQueryRequest>;
+using TaskMessage = std::variant<std::monostate, TipStatusChangeDetected,
+                                 can::messages::TipStatusQueryRequest>;
 
 }  // namespace tip_presence
 

--- a/pipettes/core/sensor_tasks_g4.cpp
+++ b/pipettes/core/sensor_tasks_g4.cpp
@@ -188,6 +188,11 @@ void sensor_tasks::QueueClient::send_pressure_sensor_queue_front(
     }
 }
 
+void sensor_tasks::QueueClient::send_tip_notification_queue(
+    const sensors::tip_presence::TaskMessage& m) {
+    tip_notification_queue->try_write(m);
+}
+
 auto sensor_tasks::get_tasks() -> Tasks& { return tasks; }
 
 auto sensor_tasks::get_queues() -> QueueClient& { return queue_client; }


### PR DESCRIPTION
## Overview

Hardware team has requested a tip presence query message to manually request tip state. This will
help with some tests they are running internally. [Python PR.](https://github.com/Opentrons/opentrons/pull/12439)

Closes RLIQ-359