### PR TITLE
feat(eeprom): add a startup task that ensures the data table is up to date

### DIFF
--- a/gantry/core/tasks_rev1.cpp
+++ b/gantry/core/tasks_rev1.cpp
@@ -3,6 +3,7 @@
 #include "gantry/core/can_task.hpp"
 #include "gantry/core/queues.hpp"
 #include "gantry/core/utils.hpp"
+#include "gantry/firmware/eeprom_keys.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
 #include "motor-control/core/tasks/motor_hardware_task.hpp"
 #include "motor-control/core/tasks/move_group_task.hpp"
@@ -44,6 +45,10 @@ static auto i2c2_poll_client =
 static auto eeprom_task_builder =
     freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
 
+static auto eeprom_data_rev_update_builder =
+    freertos_task::TaskStarter<512, eeprom::data_rev_task::UpdateDataRevTask>{};
+
+static auto tail_accessor = eeprom::dev_data::DevDataTailAccessor{queues};
 /**
  * Start gantry ::tasks.
  */
@@ -78,6 +83,9 @@ void gantry::tasks::start_tasks(
     auto& eeprom_task = eeprom_task_builder.start(5, "eeprom", i2c2_task_client,
                                                   eeprom_hw_iface);
 
+    auto& eeprom_data_rev_update_task = eeprom_data_rev_update_builder.start(
+        5, "data_rev_update", ::queues, tail_accessor, table_updater);
+
     ::tasks.can_writer = &can_writer;
     ::tasks.motion_controller = &motion;
     ::tasks.tmc2160_driver = &tmc2160_driver;
@@ -87,6 +95,7 @@ void gantry::tasks::start_tasks(
     ::tasks.i2c2_task = &i2c2_task;
     ::tasks.i2c2_poller_task = &i2c2_poller_task;
     ::tasks.eeprom_task = &eeprom_task;
+    ::tasks.update_data_rev_task = &eeprom_data_rev_update_task;
 
     ::queues.motion_queue = &motion.get_queue();
     ::queues.motor_driver_queue = &tmc2160_driver.get_queue();

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CAN_FW_DIR "${CMAKE_SOURCE_DIR}/can/firmware")
 # Add source files that should be checked by clang-tidy here
 set(GANTRY_FW_LINTABLE_SRCS_COMMON
     ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_keys.cpp
     ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
     ${CAN_FW_DIR}/hal_can_bus.cpp
     ${CAN_FW_DIR}/utils.c

--- a/gantry/firmware/eeprom_keys.cpp
+++ b/gantry/firmware/eeprom_keys.cpp
@@ -1,0 +1,18 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+#include "gantry/firmware/eeprom_keys.hpp"
+
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {std::make_pair(
+        AXIS_DISTANCE_KEY, usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/gantry/simulator/CMakeLists.txt
+++ b/gantry/simulator/CMakeLists.txt
@@ -32,6 +32,7 @@ set(GANTRY_SIMULATOR_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_keys.cpp
         )
 foreach(AXIS IN LISTS AXES)
   add_executable(

--- a/gantry/simulator/eeprom_keys.cpp
+++ b/gantry/simulator/eeprom_keys.cpp
@@ -1,0 +1,19 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+#include "gantry/firmware/eeprom_keys.hpp"
+
+#include "eeprom/simulation/eeprom.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {std::make_pair(
+        AXIS_DISTANCE_KEY, usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -16,6 +16,7 @@ set(GRIPPER_FW_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/interfaces_grip_motor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/interfaces_z_motor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_keys.cpp
         ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
         ${CAN_FW_DIR}/hal_can_bus.cpp
         ${CAN_FW_DIR}/utils.c

--- a/gripper/firmware/eeprom_keys.cpp
+++ b/gripper/firmware/eeprom_keys.cpp
@@ -1,0 +1,22 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+
+#include "gripper/firmware/eeprom_keys.hpp"
+
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(Z_MOTOR_DIST_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(G_MOTOR_DIST_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/gripper/simulator/CMakeLists.txt
+++ b/gripper/simulator/CMakeLists.txt
@@ -30,6 +30,7 @@ set(GRIPPER_SIMULATOR_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_keys.cpp
         )
 
 add_executable(

--- a/gripper/simulator/eeprom_keys.cpp
+++ b/gripper/simulator/eeprom_keys.cpp
@@ -1,0 +1,22 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+#include "gripper/firmware/eeprom_keys.hpp"
+
+#include "eeprom/simulation/eeprom.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(Z_MOTOR_DIST_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(G_MOTOR_DIST_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/head/core/tasks_proto.cpp
+++ b/head/core/tasks_proto.cpp
@@ -4,6 +4,7 @@
 #include "head/core/can_task.hpp"
 #include "head/core/queues.hpp"
 #include "head/core/tasks/presence_sensing_driver_task.hpp"
+#include "head/firmware/eeprom_keys.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
 #include "motor-control/core/tasks/move_group_task.hpp"
 #include "motor-control/core/tasks/move_status_reporter_task.hpp"
@@ -69,6 +70,10 @@ static auto i2c3_poll_client =
     i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>{};
 static auto eeprom_task_builder =
     freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
+static auto eeprom_data_rev_update_builder =
+    freertos_task::TaskStarter<512, eeprom::data_rev_task::UpdateDataRevTask>{};
+
+static auto tail_accessor = eeprom::dev_data::DevDataTailAccessor{head_queues};
 /**
  * Start head tasks.
  */
@@ -108,12 +113,16 @@ void head_tasks::start_tasks(
     auto& eeprom_task = eeprom_task_builder.start(5, "eeprom", i2c3_task_client,
                                                   eeprom_hw_iface);
 
+    auto& eeprom_data_rev_update_task = eeprom_data_rev_update_builder.start(
+        5, "data_rev_update", head_queues, tail_accessor, table_updater);
+
     // Assign head task collection task pointers
     head_tasks_col.can_writer = &can_writer;
     head_tasks_col.presence_sensing_driver_task = &presence_sensing;
     head_tasks_col.i2c3_task = &i2c3_task;
     head_tasks_col.i2c3_poller_task = &i2c3_poller_task;
     head_tasks_col.eeprom_task = &eeprom_task;
+    head_tasks_col.update_data_rev_task = &eeprom_data_rev_update_task;
 
     // Assign head queue client message queue pointers
     head_queues.set_queue(&can_writer.get_queue());

--- a/head/firmware/CMakeLists.txt
+++ b/head/firmware/CMakeLists.txt
@@ -22,6 +22,7 @@ set(DEFAULT_REVISION c2)
 set(HEAD_FW_LINTABLE_SRCS
         ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/presence_sensing_hardware.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_keys.cpp
         ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
         ${CAN_FW_DIR}/hal_can.c
         ${CAN_FW_DIR}/hal_can_bus.cpp

--- a/head/firmware/eeprom_keys.cpp
+++ b/head/firmware/eeprom_keys.cpp
@@ -1,0 +1,21 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+#include "head/firmware/eeprom_keys.hpp"
+
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(L_MOTOR_DISTANCE_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(R_MOTOR_DISTANCE_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/head/simulator/CMakeLists.txt
+++ b/head/simulator/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
         head-simulator
         main.cpp
         freertos_idle_timer_task.cpp
+        eeprom_keys.cpp
         ${HEAD-CORE-SRC}
 )
 

--- a/head/simulator/eeprom_keys.cpp
+++ b/head/simulator/eeprom_keys.cpp
@@ -1,0 +1,22 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+#include "head/firmware/eeprom_keys.hpp"
+
+#include "eeprom/simulation/eeprom.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(L_MOTOR_DISTANCE_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(R_MOTOR_DISTANCE_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -61,10 +61,7 @@ class DevDataTailAccessor
 
     auto finish_data_rev() -> void { data_rev_finished = true; }
 
-    void read_complete(uint32_t message_index) final {
-        // we don't need message_index since this is an internal call
-        // and not initiated from a can message
-        std::ignore = message_index;
+    void read_complete(uint32_t) final {
         // test if data is set to default values at delivery
         auto delivery_state = std::vector<uint8_t>(
             addresses::lookup_table_tail_length, conf.default_byte_value);

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "accessor.hpp"
 #include "addresses.hpp"
 #include "can/core/message_core.hpp"

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -21,8 +21,9 @@ struct table_entry_action {
     types::data_length len;
     TableAction action;
 };
-/** Implementation Note: do not directly use this accessor, it should only
- * be used by the DevDataAccessor
+/** Implementation Note: This Accessor needs to be a singleton per device.
+ *  A pointer to this instance can be passed to any number of DevDataAccessor
+ *instances
  *
  * @tparam EEPromTaskClient client of eeprom task
  **/
@@ -30,24 +31,58 @@ struct table_entry_action {
 template <task::TaskClient EEPromTaskClient>
 class DevDataTailAccessor
     : public accessor::EEPromAccessor<EEPromTaskClient,
-                                      addresses::lookup_table_tail_begin> {
-    template <task::TaskClient FriendEEPromTaskClient>
-    friend class DevDataAccessor;
-
+                                      addresses::lookup_table_tail_begin>,
+      accessor::ReadListener {
     using accessor::EEPromAccessor<
         EEPromTaskClient, addresses::lookup_table_tail_begin>::EEPromAccessor;
 
-  private:
-    explicit DevDataTailAccessor(EEPromTaskClient& eeprom_client,
-                                 accessor::ReadListener& listener,
-                                 DataTailType& buffer)
+  public:
+    explicit DevDataTailAccessor(EEPromTaskClient& eeprom_client)
         : accessor::EEPromAccessor<EEPromTaskClient,
                                    addresses::lookup_table_tail_begin>::
-              EEPromAccessor(
-                  eeprom_client, listener,
-                  accessor::AccessorBuffer(buffer.begin(), buffer.end())) {}
+              EEPromAccessor(eeprom_client, *this,
+                             accessor::AccessorBuffer(data_tail_buff.begin(),
+                                                      data_tail_buff.end())) {}
+
+    auto start_update() -> void { tail_updated = false; }
+
+    auto get_tail_updated() -> bool { return config_updated && tail_updated; }
+
+    auto get_data_tail() -> types::address { return data_tail; }
+
+    void set_config(const message::ConfigResponseMessage& m) {
+        conf = m;
+        config_updated = true;
+    }
+
+    void read_complete(uint32_t message_index) final {
+        // we don't need message_index since this is an internal call
+        // and not initiated from a can message
+        std::ignore = message_index;
+        // test if data is set to default values at delivery
+        auto delivery_state = std::vector<uint8_t>(
+            addresses::lookup_table_tail_length, conf.default_byte_value);
+        if (std::equal(delivery_state.begin(), delivery_state.end(),
+                       data_tail_buff.begin())) {
+            // Value is set to default so update it to data section start
+            auto init_tail = DataTailType{};
+            data_tail = addresses::data_address_begin;
+            std::ignore = bit_utils::int_to_bytes(
+                data_tail, init_tail.begin(),
+                init_tail.begin() + addresses::lookup_table_tail_length);
+            this->write(init_tail, 0);
+        } else {
+            // load current data tail to memory
+            std::ignore = bit_utils::bytes_to_int(
+                data_tail_buff.begin(),
+                data_tail_buff.begin() + addresses::lookup_table_tail_length,
+                data_tail);
+        }
+        tail_updated = true;
+    }
 
     auto increase_data_tail(const DataTailType& data_added) -> void {
+        tail_updated = false;
         auto read_addr = addresses::lookup_table_tail_begin;
         auto bytes_remain = addresses::lookup_table_tail_length;
         types::data_length amount_to_read =
@@ -71,7 +106,7 @@ class DevDataTailAccessor
         increase_data_tail(typed_length);
     }
 
-    DataTailType data_to_add = DataTailType{};
+  private:
     /**
      * Handle a completed read that was triggered by a increase_usage_call.
      * @param msg The message
@@ -87,6 +122,8 @@ class DevDataTailAccessor
             current_data_length, new_data_length.begin(),
             new_data_length.begin() + addresses::lookup_table_tail_length);
         this->write(new_data_length, 0);
+        data_tail = current_data_length;
+        tail_updated = true;
     }
 
     /**
@@ -100,6 +137,14 @@ class DevDataTailAccessor
         auto* self = reinterpret_cast<DevDataTailAccessor*>(param);
         self->increase_tail_callback(msg);
     }
+
+    DataTailType data_tail_buff = DataTailType{};
+    types::address data_tail = 0;
+    bool tail_updated{false};
+    bool config_updated{false};
+    bool data_rev_finished{false};
+    message::ConfigResponseMessage conf = message::ConfigResponseMessage{};
+    DataTailType data_to_add = DataTailType{};
 };
 
 /**
@@ -117,26 +162,24 @@ class DevDataTailAccessor
 template <task::TaskClient EEPromTaskClient>
 class DevDataAccessor
     : public accessor::EEPromAccessor<EEPromTaskClient,
-                                      addresses::data_address_begin>,
-      accessor::ReadListener {
+                                      addresses::data_address_begin> {
     using accessor::EEPromAccessor<
         EEPromTaskClient, addresses::data_address_begin>::EEPromAccessor;
 
   public:
     template <std::size_t SIZE>
-    explicit DevDataAccessor(EEPromTaskClient& eeprom_client,
-                             accessor::ReadListener& listener,
-                             DataBufferType<SIZE>& buffer)
+    explicit DevDataAccessor(
+        EEPromTaskClient& eeprom_client, accessor::ReadListener& listener,
+        DataBufferType<SIZE>& buffer,
+        DevDataTailAccessor<EEPromTaskClient>& tail_accessor)
         : accessor::EEPromAccessor<EEPromTaskClient,
                                    addresses::data_address_begin>::
               EEPromAccessor(
                   eeprom_client, listener,
                   accessor::AccessorBuffer(buffer.begin(), buffer.end())),
-          tail_accessor{DevDataTailAccessor<EEPromTaskClient>(
-              eeprom_client, *this, data_tail_buff)} {
+          tail_accessor{tail_accessor} {
         eeprom_client.send_eeprom_queue(
             message::ConfigRequestMessage{config_req_callback, this});
-        tail_accessor.start_read(0);
     }
 
     template <std::size_t SIZE>
@@ -144,7 +187,7 @@ class DevDataAccessor
                     std::array<uint8_t, SIZE>& data) {
         if (tail_updated && config_updated) {
             auto table_location = calculate_table_entry_start(key);
-            if (table_location > data_tail) {
+            if (table_location > tail_accessor.get_data_tail()) {
                 LOG("Error, attemping to read uninitalized value");
                 return;
             }
@@ -184,7 +227,7 @@ class DevDataAccessor
                   uint32_t message_index) {
         if (tail_updated && config_updated) {
             auto table_location = calculate_table_entry_start(key);
-            if (table_location > data_tail) {
+            if (table_location > tail_accessor.get_data_tail()) {
                 LOG("Error, attemping to read uninitalized value");
                 return;
             }
@@ -238,7 +281,6 @@ class DevDataAccessor
                     len, data_iter, data_iter + conf.addr_bytes);
                 this->eeprom_client.send_eeprom_queue(write);
                 tail_accessor.increase_data_tail(2 * conf.addr_bytes);
-                data_tail += 2 * conf.addr_bytes;
                 if (!data.empty()) {
                     if (data.size() > len) {
                         LOG("Warning, sent too much data to initalize, "
@@ -250,11 +292,10 @@ class DevDataAccessor
                         new_ptr, len, 0);
                 }
             } else {
-                action_cmd_m =
-                    table_entry_action{.key = key,
-                                       .offset = 0,
-                                       .len = len,
-                                       .action = TableAction::CREATE};
+                action_cmd_m.key = key;
+                action_cmd_m.offset = 0;
+                action_cmd_m.len = len;
+                action_cmd_m.action = TableAction::CREATE;
                 if (!data.empty()) {
                     if (data.size() > len) {
                         LOG("Warning, sent too much data to initalize, "
@@ -266,7 +307,7 @@ class DevDataAccessor
                 }
                 // call a read to the previous table entry so we know where
                 // to put the data
-                tail_updated = false;
+                tail_accessor.start_update();
                 this->eeprom_client.send_eeprom_queue(
                     message::ReadEepromMessage{
                         .memory_address = calculate_table_entry_start(key - 1),
@@ -286,45 +327,20 @@ class DevDataAccessor
         create_data_part(key, len, dummy);
     }
 
-    void read_complete(uint32_t message_index) final {
-        // we don't need message_index since this is an internal call
-        // and not initatied from a can message
-        std::ignore = message_index;
-        // test if data is set to default
-        auto delivery_state = std::vector<uint8_t>(
-            addresses::lookup_table_tail_length, conf.default_byte_value);
-        if (std::equal(delivery_state.begin(), delivery_state.end(),
-                       data_tail_buff.begin())) {
-            auto init_tail = DataTailType{};
-            std::ignore = bit_utils::int_to_bytes(
-                addresses::data_address_begin, init_tail.begin(),
-                init_tail.begin() + addresses::lookup_table_tail_length);
-            tail_accessor.write(init_tail, 0);
-            data_tail = addresses::data_address_begin;
-        } else {
-            std::ignore = bit_utils::bytes_to_int(
-                data_tail_buff.begin(),
-                data_tail_buff.begin() + addresses::lookup_table_tail_length,
-                data_tail);
-        }
-        tail_updated = true;
-    }
-
     auto data_part_exists(uint16_t key) -> bool {
-        if (tail_updated && config_updated) {
-            auto table_location = calculate_table_entry_start(key);
-            return table_location < data_tail;
+        if (table_ready()) {
+            return calculate_table_entry_start(key) <
+                   tail_accessor.get_data_tail();
         }
         return false;
     }
 
-    auto ready() -> bool { return tail_updated && config_updated; }
+    auto table_ready() -> bool {
+        return config_updated && tail_accessor.get_tail_updated();
+    }
 
   private:
-    DataTailType data_tail_buff = DataTailType{};
-    DevDataTailAccessor<EEPromTaskClient> tail_accessor;
-    types::address data_tail = 0;
-    bool tail_updated{false};
+    DevDataTailAccessor<EEPromTaskClient>& tail_accessor;
     message::ConfigResponseMessage conf = message::ConfigResponseMessage{};
     bool config_updated{false};
     table_entry_action action_cmd_m = table_entry_action{};
@@ -333,6 +349,8 @@ class DevDataAccessor
     void config_req_callback(const message::ConfigResponseMessage& m) {
         conf = m;
         config_updated = true;
+        tail_accessor.set_config(conf);
+        tail_accessor.start_read(0);
     }
 
     static void config_req_callback(const message::ConfigResponseMessage& m,
@@ -368,14 +386,15 @@ class DevDataAccessor
                 // don't break this is just an extension of create
                 [[fallthrough]];
             case TableAction::CREATE:
-                if (data_tail + action_cmd_m.len + (2 * conf.addr_bytes) >
+                if (tail_accessor.get_data_tail() + action_cmd_m.len +
+                        (2 * conf.addr_bytes) >
                     data_addr) {
                     LOG("Error attempted to iniztialze value too large for "
                         "memory");
                 } else {
                     // First write the new table entry
                     message::WriteEepromMessage write;
-                    write.memory_address = data_tail;
+                    write.memory_address = tail_accessor.get_data_tail();
                     write.length = 2 * conf.addr_bytes;
                     auto* write_iter = write.data.begin();
                     write_iter = bit_utils::int_to_bytes(
@@ -391,7 +410,6 @@ class DevDataAccessor
                     // After writing the table entry use the tail accessor to
                     // update the tail
                     tail_accessor.increase_data_tail(2 * conf.addr_bytes);
-                    data_tail += 2 * conf.addr_bytes;
 
                     // If we passed data into the create write that data into
                     // the memory
@@ -400,7 +418,6 @@ class DevDataAccessor
                                               data_addr - action_cmd_m.len,
                                               data_addr, m.message_index);
                     }
-                    tail_updated = true;
                 }
                 break;
             case TableAction::READ:

--- a/include/eeprom/core/hardware_iface.hpp
+++ b/include/eeprom/core/hardware_iface.hpp
@@ -47,6 +47,7 @@ class EEPromHardwareIface {
                 eeprom_mem_size =
                     static_cast<size_t>(EEpromMemorySize::MICROCHIP_256_BYTE);
                 default_byte_value = 0x00;
+                page_boundary = 8;
                 break;
             case EEPromChipType::ST_M24128_BF:
             case EEPromChipType::ST_M24128_DF:
@@ -56,6 +57,7 @@ class EEPromHardwareIface {
                 eeprom_mem_size =
                     static_cast<size_t>(EEpromMemorySize::ST_16_KBYTE);
                 default_byte_value = 0xFF;
+                page_boundary = 64;
                 break;
         }
         eeprom_chip_type = chip;
@@ -106,6 +108,9 @@ class EEPromHardwareIface {
     [[nodiscard]] auto get_eeprom_default_byte_value() const -> uint8_t {
         return default_byte_value;
     }
+    [[nodiscard]] auto get_eeprom_page_boundary() const -> types::address {
+        return page_boundary;
+    }
 
   private:
     // The number of times that disable has been called.
@@ -118,6 +123,7 @@ class EEPromHardwareIface {
         static_cast<size_t>(EEpromMemorySize::MICROCHIP_256_BYTE);
     EEPromChipType eeprom_chip_type = EEPromChipType::MICROCHIP_24AA02T;
     uint8_t default_byte_value = 0x00;
+    types::address page_boundary = 8;
 };
 
 }  // namespace hardware_iface

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -32,7 +32,7 @@ class UpdateDataRevHandler : accessor::ReadListener {
     }
 
     auto ready() -> bool {
-        return ready_for_new_message && table_creator.ready();
+        return ready_for_new_message && table_creator.table_ready();
     }
 
   private:
@@ -45,7 +45,7 @@ class UpdateDataRevHandler : accessor::ReadListener {
                 // add the new data table entry
                 table_creator.create_data_part(i.first, i.second);
                 // wait for the table update to finish
-                while (!table_creator.ready()) {
+                while (!table_creator.table_ready()) {
                     vTaskDelay(10);
                 }
             }

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -56,11 +56,7 @@ class UpdateDataRevHandler : accessor::ReadListener {
         }
     }
 
-    void read_complete(uint32_t message_index) final {
-        // we don't send requests for reads to the DevDataAccessor so this will
-        // only be called by the data tail
-        std::ignore = message_index;
-
+    void read_complete(uint32_t) final {
         // test if data is set to 0xFFFF, some chips default to 0x0000 but this
         // is fine since if it's set to that then it's already where we want it
         // to be as a default

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "common/core/bit_utils.hpp"
+#include "eeprom/core/data_rev.hpp"
+#include "eeprom/core/dev_data.hpp"
+#include "eeprom/core/task.hpp"
+
+namespace eeprom {
+namespace data_rev_task {
+
+struct DataTableUpdateMessage {
+    uint16_t data_rev;
+    // list of new data table key/length pairs to add to the table
+    std::vector<std::pair<types::address, types::data_length>> data_table;
+};
+
+using TaskMessage = std::variant<std::monostate, DataTableUpdateMessage>;
+
+template <task::TaskClient EEPromClient>
+class UpdateDataRevHandler : accessor::ReadListener {
+  public:
+    UpdateDataRevHandler(
+        EEPromClient& eeprom_client,
+        dev_data::DevDataTailAccessor<EEPromClient>& tail_accessor)
+        : table_creator{eeprom_client, *this, accessor_backing, tail_accessor},
+          data_rev_accessor{eeprom_client, *this, data_rev_backing} {
+        data_rev_accessor.start_read(0);
+    }
+
+    void handle_message(const TaskMessage& message) {
+        std::visit([this](auto m) { this->visit(m); }, message);
+    }
+
+    auto ready() -> bool {
+        return ready_for_new_message && table_creator.ready();
+    }
+
+  private:
+    void visit(std::monostate&) {}
+
+    void visit(const DataTableUpdateMessage& m) {
+        // we really want to do this sequentially or the table can be malformed
+        if (m.data_rev == current_data_rev + 1) {
+            for (const auto& i : m.data_table) {
+                // add the new data table entry
+                table_creator.create_data_part(i.first, i.second);
+                // wait for the table update to finish
+                while (!table_creator.ready()) {
+                    vTaskDelay(10);
+                }
+            }
+            std::ignore = bit_utils::int_to_bytes(
+                m.data_rev, data_rev_backing.begin(), data_rev_backing.end());
+            data_rev_accessor.write(data_rev_backing, 0);
+            current_data_rev = m.data_rev;
+        }
+    }
+
+    void read_complete(uint32_t message_index) final {
+        // we don't send requests for reads to the DevDataAccessor so this will
+        // only be called by the data tail
+        std::ignore = message_index;
+
+        // test if data is set to 0xFFFF, some chips default to 0x0000 but this
+        // is fine since if it's set to that then it's already where we want it
+        // to be as a default
+        auto delivery_state =
+            std::vector<uint8_t>(addresses::data_revision_length, 0xFF);
+        if (std::equal(delivery_state.begin(), delivery_state.end(),
+                       data_rev_backing.begin())) {
+            data_rev_backing.fill(0x00);
+            data_rev_accessor.write(data_rev_backing, 0);
+        }
+
+        std::ignore = bit_utils::bytes_to_int(
+            data_rev_backing.begin(), data_rev_backing.end(), current_data_rev);
+        ready_for_new_message = true;
+    }
+    uint16_t current_data_rev = 0;
+    bool ready_for_new_message = false;
+    dev_data::DataBufferType<8> accessor_backing =
+        dev_data::DataBufferType<8>{};
+    dev_data::DevDataAccessor<EEPromClient> table_creator;
+    data_revision::DataRevisionType data_rev_backing =
+        data_revision::DataRevisionType{};
+    data_revision::DataRevAccessor<EEPromClient> data_rev_accessor;
+};
+
+/**
+ * The task type.
+ */
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
+class UpdateDataRevTask {
+  public:
+    using Messages = TaskMessage;
+    using QueueType = QueueImpl<TaskMessage>;
+    UpdateDataRevTask(QueueType& queue) : queue{queue} {}
+    UpdateDataRevTask(const UpdateDataRevTask& c) = delete;
+    UpdateDataRevTask(const UpdateDataRevTask&& c) = delete;
+    auto operator=(const UpdateDataRevTask& c) = delete;
+    auto operator=(const UpdateDataRevTask&& c) = delete;
+    ~UpdateDataRevTask() = default;
+
+    /**
+     * Task entry point.
+     */
+    template <task::TaskClient EEPromClient>
+    void operator()(
+        EEPromClient* eeprom_client,
+        dev_data::DevDataTailAccessor<EEPromClient>* tail_accessor,
+        const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>*
+            table_updater) {
+        auto handler = UpdateDataRevHandler(*eeprom_client, *tail_accessor);
+        for (const auto& i : *table_updater) {
+            while (!handler.ready()) {
+                vTaskDelay(10);
+            }
+            handler.handle_message(i);
+        }
+        tail_accessor->finish_data_rev();
+        vTaskDelete(nullptr);
+    }
+
+    [[nodiscard]] auto get_queue() const -> QueueType& { return queue; }
+
+  private:
+    QueueType& queue;
+};
+
+}  // namespace data_rev_task
+}  // namespace eeprom

--- a/include/gantry/core/tasks_proto.hpp
+++ b/include/gantry/core/tasks_proto.hpp
@@ -5,6 +5,7 @@
 #include "common/core/freertos_timer.hpp"
 #include "eeprom/core/hardware_iface.hpp"
 #include "eeprom/core/task.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
 #include "i2c/core/hardware_iface.hpp"
 #include "i2c/core/tasks/i2c_poller_task.hpp"
 #include "i2c/core/tasks/i2c_task.hpp"
@@ -60,6 +61,9 @@ struct AllTask {
         nullptr};
     eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
         eeprom_task{nullptr};
+    eeprom::data_rev_task::UpdateDataRevTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* update_data_rev_task{
+        nullptr};
 };
 
 /**

--- a/include/gantry/core/tasks_rev1.hpp
+++ b/include/gantry/core/tasks_rev1.hpp
@@ -5,6 +5,7 @@
 #include "common/core/freertos_timer.hpp"
 #include "eeprom/core/hardware_iface.hpp"
 #include "eeprom/core/task.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
 #include "i2c/core/hardware_iface.hpp"
 #include "i2c/core/tasks/i2c_poller_task.hpp"
 #include "i2c/core/tasks/i2c_task.hpp"
@@ -60,6 +61,9 @@ struct AllTask {
         nullptr};
     eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
         eeprom_task{nullptr};
+    eeprom::data_rev_task::UpdateDataRevTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* update_data_rev_task{
+        nullptr};
 };
 
 /**

--- a/include/gantry/firmware/eeprom_keys.hpp
+++ b/include/gantry/firmware/eeprom_keys.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "eeprom/core/update_data_rev_task.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+static constexpr uint16_t AXIS_DISTANCE_KEY = 0;
+
+static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {std::make_pair(
+        AXIS_DISTANCE_KEY, usage_storage_task::distance_data_usage_len)}};
+
+static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater = {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/include/gantry/firmware/eeprom_keys.hpp
+++ b/include/gantry/firmware/eeprom_keys.hpp
@@ -1,17 +1,10 @@
 #pragma once
 
 #include "eeprom/core/update_data_rev_task.hpp"
-#include "motor-control/core/tasks/usage_storage_task.hpp"
 
 static constexpr uint16_t AXIS_DISTANCE_KEY = 0;
 
-static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
-    .data_rev = 1,
-    .data_table = {std::make_pair(
-        AXIS_DISTANCE_KEY, usage_storage_task::distance_data_usage_len)}};
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1;
 
-static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
-    table_updater = {
-        // anytime there is an update to the data table add a message to this
-        // vector with the new key/length pairs
-        data_table_rev1};
+extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater;

--- a/include/gripper/core/tasks.hpp
+++ b/include/gripper/core/tasks.hpp
@@ -3,8 +3,10 @@
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
 #include "common/core/freertos_timer.hpp"
+#include "eeprom/core/dev_data.hpp"
 #include "eeprom/core/hardware_iface.hpp"
 #include "eeprom/core/task.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
 #include "i2c/core/hardware_iface.hpp"
 #include "i2c/core/tasks/i2c_poller_task.hpp"
 #include "i2c/core/tasks/i2c_task.hpp"
@@ -141,6 +143,9 @@ struct AllTask {
     sensors::tasks::CapacitiveSensorTask<
         freertos_message_queue::FreeRTOSMessageQueue>*
         capacitive_sensor_task_rear{nullptr};
+    eeprom::data_rev_task::UpdateDataRevTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* update_data_rev_task{
+        nullptr};
 };
 
 /**

--- a/include/gripper/firmware/eeprom_keys.hpp
+++ b/include/gripper/firmware/eeprom_keys.hpp
@@ -1,23 +1,11 @@
 #pragma once
 
 #include "eeprom/core/update_data_rev_task.hpp"
-#include "motor-control/core/tasks/usage_storage_task.hpp"
 
 static constexpr eeprom::types::address Z_MOTOR_DIST_KEY = 0x0000;
 static constexpr eeprom::types::address G_MOTOR_DIST_KEY = 0x0001;
 
-static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
-    .data_rev = 1,
-    .data_table = {
-        std::make_pair(Z_MOTOR_DIST_KEY,
-                       usage_storage_task::distance_data_usage_len),
-        std::make_pair(G_MOTOR_DIST_KEY,
-                       usage_storage_task::distance_data_usage_len)}};
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1;
 
-static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
-    table_updater = {
-        // anytime there is an update to the data table add a message to this
-        // vector with the new key/length pairs
-        data_table_rev1};
-
-// TODO Define keys for gripper motor
+extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater;

--- a/include/gripper/firmware/eeprom_keys.hpp
+++ b/include/gripper/firmware/eeprom_keys.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "eeprom/core/update_data_rev_task.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+static constexpr eeprom::types::address Z_MOTOR_DIST_KEY = 0x0000;
+static constexpr eeprom::types::address G_MOTOR_DIST_KEY = 0x0001;
+
+static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(Z_MOTOR_DIST_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(G_MOTOR_DIST_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater = {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};
+
+// TODO Define keys for gripper motor

--- a/include/head/core/tasks_proto.hpp
+++ b/include/head/core/tasks_proto.hpp
@@ -5,6 +5,7 @@
 #include "common/core/freertos_timer.hpp"
 #include "eeprom/core/hardware_iface.hpp"
 #include "eeprom/core/task.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
 #include "head/core/tasks/presence_sensing_driver_task.hpp"
 #include "i2c/core/hardware_iface.hpp"
 #include "i2c/core/tasks/i2c_poller_task.hpp"
@@ -58,6 +59,9 @@ struct HeadTasks {
         nullptr};
     eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
         eeprom_task{nullptr};
+    eeprom::data_rev_task::UpdateDataRevTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* update_data_rev_task{
+        nullptr};
 };
 
 /**

--- a/include/head/core/tasks_rev1.hpp
+++ b/include/head/core/tasks_rev1.hpp
@@ -5,6 +5,7 @@
 #include "common/core/freertos_timer.hpp"
 #include "eeprom/core/hardware_iface.hpp"
 #include "eeprom/core/task.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
 #include "head/core/tasks/presence_sensing_driver_task.hpp"
 #include "i2c/core/hardware_iface.hpp"
 #include "i2c/core/tasks/i2c_poller_task.hpp"
@@ -58,6 +59,9 @@ struct HeadTasks {
         nullptr};
     eeprom::task::EEPromTask<freertos_message_queue::FreeRTOSMessageQueue>*
         eeprom_task{nullptr};
+    eeprom::data_rev_task::UpdateDataRevTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* update_data_rev_task{
+        nullptr};
 };
 
 /**

--- a/include/head/firmware/eeprom_keys.hpp
+++ b/include/head/firmware/eeprom_keys.hpp
@@ -1,17 +1,21 @@
 #pragma once
 
-#include "motor-control/core/tasks/usage_storage_task.hpp"
 #include "eeprom/core/update_data_rev_task.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
 
 static constexpr uint16_t L_MOTOR_DISTANCE_KEY = 0;
 static constexpr uint16_t R_MOTOR_DISTANCE_KEY = 1;
 
 static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
-                .data_rev = 1,
-                .data_table = {std::make_pair(L_MOTOR_DISTANCE_KEY, usage_storage_task::distance_data_usage_len),
-                               std::make_pair(R_MOTOR_DISTANCE_KEY, usage_storage_task::distance_data_usage_len)}};
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(L_MOTOR_DISTANCE_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(R_MOTOR_DISTANCE_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
 
-static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater = {
-    // anytime there is an update to the data table add a message to this vector with the new key/length pairs
-    data_table_rev1
-};
+static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater = {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/include/head/firmware/eeprom_keys.hpp
+++ b/include/head/firmware/eeprom_keys.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
+
+static constexpr uint16_t L_MOTOR_DISTANCE_KEY = 0;
+static constexpr uint16_t R_MOTOR_DISTANCE_KEY = 1;
+
+static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+                .data_rev = 1,
+                .data_table = {std::make_pair(L_MOTOR_DISTANCE_KEY, usage_storage_task::distance_data_usage_len),
+                               std::make_pair(R_MOTOR_DISTANCE_KEY, usage_storage_task::distance_data_usage_len)}};
+
+static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater = {
+    // anytime there is an update to the data table add a message to this vector with the new key/length pairs
+    data_table_rev1
+};

--- a/include/head/firmware/eeprom_keys.hpp
+++ b/include/head/firmware/eeprom_keys.hpp
@@ -1,21 +1,11 @@
 #pragma once
 
 #include "eeprom/core/update_data_rev_task.hpp"
-#include "motor-control/core/tasks/usage_storage_task.hpp"
 
 static constexpr uint16_t L_MOTOR_DISTANCE_KEY = 0;
 static constexpr uint16_t R_MOTOR_DISTANCE_KEY = 1;
 
-static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
-    .data_rev = 1,
-    .data_table = {
-        std::make_pair(L_MOTOR_DISTANCE_KEY,
-                       usage_storage_task::distance_data_usage_len),
-        std::make_pair(R_MOTOR_DISTANCE_KEY,
-                       usage_storage_task::distance_data_usage_len)}};
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1;
 
-static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
-    table_updater = {
-        // anytime there is an update to the data table add a message to this
-        // vector with the new key/length pairs
-        data_table_rev1};
+extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater;

--- a/include/motor-control/core/tasks/usage_storage_task.hpp
+++ b/include/motor-control/core/tasks/usage_storage_task.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace usage_storage_task {
+
+static constexpr uint16_t distance_data_usage_len = 8;
+
+}  // namespace usage_storage_task

--- a/include/pipettes/core/linear_motor_tasks.hpp
+++ b/include/pipettes/core/linear_motor_tasks.hpp
@@ -3,6 +3,8 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/message_writer.hpp"
+#include "eeprom/core/dev_data.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/tasks/motion_controller_task.hpp"
 #include "motor-control/core/tasks/motor_hardware_task.hpp"
@@ -10,6 +12,7 @@
 #include "motor-control/core/tasks/move_status_reporter_task.hpp"
 #include "motor-control/core/tasks/tmc2130_motor_driver_task.hpp"
 #include "motor-control/core/tasks/tmc2160_motor_driver_task.hpp"
+#include "pipettes/core/sensor_tasks.hpp"
 #include "spi/core/writer.hpp"
 
 /**
@@ -28,22 +31,26 @@ using SPIWriterClient =
     spi::writer::Writer<freertos_message_queue::FreeRTOSMessageQueue>;
 
 // single channel/8 channel linear motor tasks
-void start_tasks(CanWriterTask& can_writer,
-                 motion_controller::MotionController<lms::LeadScrewConfig>&
-                     motion_controller,
-                 SPIWriterClient& spi_writer,
-                 tmc2130::configs::TMC2130DriverConfig& linear_driver_configs,
-                 can::ids::NodeId,
-                 motor_hardware_task::MotorHardwareTask& lmh_tsk);
+void start_tasks(
+    CanWriterTask& can_writer,
+    motion_controller::MotionController<lms::LeadScrewConfig>&
+        motion_controller,
+    SPIWriterClient& spi_writer,
+    tmc2130::configs::TMC2130DriverConfig& linear_driver_configs,
+    can::ids::NodeId, motor_hardware_task::MotorHardwareTask& lmh_tsk,
+    eeprom::dev_data::DevDataTailAccessor<sensor_tasks::QueueClient>&
+        tail_accessor);
 
 // 96/384 linear motor tasks
-void start_tasks(CanWriterTask& can_writer,
-                 motion_controller::MotionController<lms::LeadScrewConfig>&
-                     motion_controller,
-                 SPIWriterClient& spi_writer,
-                 tmc2160::configs::TMC2160DriverConfig& linear_driver_configs,
-                 can::ids::NodeId,
-                 motor_hardware_task::MotorHardwareTask& lmh_tsk);
+void start_tasks(
+    CanWriterTask& can_writer,
+    motion_controller::MotionController<lms::LeadScrewConfig>&
+        motion_controller,
+    SPIWriterClient& spi_writer,
+    tmc2160::configs::TMC2160DriverConfig& linear_driver_configs,
+    can::ids::NodeId, motor_hardware_task::MotorHardwareTask& lmh_tsk,
+    eeprom::dev_data::DevDataTailAccessor<sensor_tasks::QueueClient>&
+        tail_accessor);
 
 /**
  * Access to all the linear motion task queues on the pipette.
@@ -82,6 +89,9 @@ struct Tasks {
         nullptr};
     move_group_task::MoveGroupTask<
         freertos_message_queue::FreeRTOSMessageQueue>* move_group{nullptr};
+    eeprom::data_rev_task::UpdateDataRevTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* update_data_rev_task{
+        nullptr};
 };
 
 /**

--- a/include/pipettes/firmware/eeprom_keys.hpp
+++ b/include/pipettes/firmware/eeprom_keys.hpp
@@ -1,24 +1,14 @@
 #pragma once
 
 #include "eeprom/core/update_data_rev_task.hpp"
-#include "motor-control/core/tasks/usage_storage_task.hpp"
 
 static constexpr uint16_t PLUNGER_MOTOR_STEP_KEY = 0;
 static constexpr uint16_t GEAR_LEFT_MOTOR_KEY = 1;
 static constexpr uint16_t GEAR_RIGHT_MOTOR_KEY = 2;
 
-static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
-    .data_rev = 1,
-    .data_table = {
-        std::make_pair(PLUNGER_MOTOR_STEP_KEY,
-                       usage_storage_task::distance_data_usage_len),
-        std::make_pair(GEAR_LEFT_MOTOR_KEY,
-                       usage_storage_task::distance_data_usage_len),
-        std::make_pair(GEAR_RIGHT_MOTOR_KEY,
-                       usage_storage_task::distance_data_usage_len)}};
+extern const eeprom::data_rev_task::DataTableUpdateMessage
+    data_table_rev1_sing_mult;
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch;
 
-static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
-    table_updater = {
-        // anytime there is an update to the data table add a message to this
-        // vector with the new key/length pairs
-        data_table_rev1};
+extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater;

--- a/include/pipettes/firmware/eeprom_keys.hpp
+++ b/include/pipettes/firmware/eeprom_keys.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "eeprom/core/update_data_rev_task.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+
+static constexpr uint16_t PLUNGER_MOTOR_STEP_KEY = 0;
+static constexpr uint16_t GEAR_LEFT_MOTOR_KEY = 1;
+static constexpr uint16_t GEAR_RIGHT_MOTOR_KEY = 2;
+
+static const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(PLUNGER_MOTOR_STEP_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(GEAR_LEFT_MOTOR_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(GEAR_RIGHT_MOTOR_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+static const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
+    table_updater = {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        data_table_rev1};

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PIPETTE_FW_LINTABLE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/motor_configurations.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utility_configurations.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_keys.cpp
     ${COMMON_EXECUTABLE_DIR}/system/iwdg.cpp
     ${COMMON_EXECUTABLE_DIR}/gpio.cpp
     ${CAN_FW_DIR}/hal_can.c

--- a/pipettes/firmware/eeprom_keys.cpp
+++ b/pipettes/firmware/eeprom_keys.cpp
@@ -1,0 +1,30 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+#include "pipettes/firmware/eeprom_keys.hpp"
+
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+#include "pipettes/core/pipette_type.h"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_sing_mult{
+    .data_rev = 1,
+    .data_table = {std::make_pair(
+        PLUNGER_MOTOR_STEP_KEY, usage_storage_task::distance_data_usage_len)}};
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(PLUNGER_MOTOR_STEP_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(GEAR_LEFT_MOTOR_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(GEAR_RIGHT_MOTOR_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev1_96ch
+                                                 : data_table_rev1_sing_mult};

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -135,6 +135,9 @@ static auto tip_sense_gpio_primary = pins_for_sensor.primary.tip_sense.value();
 
 static auto& sensor_queue_client = sensor_tasks::get_queues();
 
+static auto tail_accessor =
+    eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
+
 #if PCBA_PRIMARY_REVISION == 'c' && PCBA_SECONDARY_REVISION == '2' && \
     PIPETTE_TYPE != NINETY_SIX_CHANNEL
 static constexpr bool pressure_sensor_available = false;
@@ -202,7 +205,8 @@ auto initialize_motor_tasks(
     initialize_enc_timer(encoder_callback);
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
-        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk);
+        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk,
+        tail_accessor);
     gear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, gear_motion,
         peripheral_tasks::get_spi_client(), conf, id, gmh_tsks);
@@ -236,7 +240,8 @@ auto initialize_motor_tasks(
     initialize_enc_timer(encoder_callback);
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
-        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk);
+        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk,
+        tail_accessor);
 }
 
 auto main() -> int {

--- a/pipettes/simulator/CMakeLists.txt
+++ b/pipettes/simulator/CMakeLists.txt
@@ -34,6 +34,7 @@ function(add_simulator_executable TARGET)
             ${CMAKE_CURRENT_SOURCE_DIR}/freertos_idle_timer_task.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/motor_configurations.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/eeprom_keys.cpp
             )
     add_revision(TARGET ${TARGET} REVISION b1)
     target_include_directories(${TARGET} PUBLIC ${PIPETTE_SIM_INCLUDE})

--- a/pipettes/simulator/eeprom_keys.cpp
+++ b/pipettes/simulator/eeprom_keys.cpp
@@ -1,0 +1,31 @@
+// clang-format off
+#include "FreeRTOS.h"
+#include "task.h"
+// clang-format on
+#include "pipettes/firmware/eeprom_keys.hpp"
+
+#include "eeprom/simulation/eeprom.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
+#include "pipettes/core/pipette_type.h"
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_sing_mult{
+    .data_rev = 1,
+    .data_table = {std::make_pair(
+        PLUNGER_MOTOR_STEP_KEY, usage_storage_task::distance_data_usage_len)}};
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch{
+    .data_rev = 1,
+    .data_table = {
+        std::make_pair(PLUNGER_MOTOR_STEP_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(GEAR_LEFT_MOTOR_KEY,
+                       usage_storage_task::distance_data_usage_len),
+        std::make_pair(GEAR_RIGHT_MOTOR_KEY,
+                       usage_storage_task::distance_data_usage_len)}};
+
+const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
+    {
+        // anytime there is an update to the data table add a message to this
+        // vector with the new key/length pairs
+        get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev1_96ch
+                                                 : data_table_rev1_sing_mult};

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -111,6 +111,11 @@ static const char* PipetteTypeString[] = {
     "SINGLE CHANNEL PIPETTE", "EIGHT CHANNEL PIPETTE",
     "NINETY SIX CHANNEL PIPETTE", "THREE EIGHTY FOUR CHANNEL PIPETTE"};
 
+static auto& sensor_queue_client = sensor_tasks::get_queues();
+
+static auto tail_accessor =
+    eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
+
 auto initialize_motor_tasks(
     can::ids::NodeId id,
     motor_configs::HighThroughputPipetteDriverHardware& conf,
@@ -128,7 +133,8 @@ auto initialize_motor_tasks(
 
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
-        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk);
+        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk,
+        tail_accessor);
 
     // TODO Convert gear motor tasks
     gear_motor_tasks::start_tasks(
@@ -152,7 +158,8 @@ auto initialize_motor_tasks(
                               fake_sensor_hw, id, sim_eeprom);
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
-        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk);
+        peripheral_tasks::get_spi_client(), conf.linear_motor, id, lmh_tsk,
+        tail_accessor);
 }
 
 auto handle_options(int argc, char** argv) -> po::variables_map {


### PR DESCRIPTION
The data table tail accessor is now created as a singleton that is shared across the various tasks that need to access the file system
this ensures that the various tasks don't try to edit the table simultaneously.

the new tasks is created at startup with a list of the table table revisions
the task then makes sure that any new data table updates are applied
when it's complete the task exits and signals to the eeprom filesystem that it's ready for use via the shared data table tail accessor