### PR TITLE
feat(gripper) use eeprom to store Jaw force mode time

### DIFF
--- a/gripper/firmware/eeprom_keys.cpp
+++ b/gripper/firmware/eeprom_keys.cpp
@@ -15,8 +15,14 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
         std::make_pair(G_MOTOR_DIST_KEY,
                        usage_storage_task::distance_data_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2{
+    .data_rev = 2,
+    .data_table = {
+        std::make_pair(G_MOTOR_FORCE_TIME_KEY,
+                       usage_storage_task::force_time_data_usage_len)}};
+
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
         // vector with the new key/length pairs
-        data_table_rev1};
+        data_table_rev1, data_table_rev2};

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -19,7 +19,7 @@ constexpr uint32_t PWM_MIN = 7;
 
 struct motor_hardware::UsageEEpromConfig brushed_usage_config {
     std::array<UsageRequestSet, 2> {
-        UsageRequestSet {
+        UsageRequestSet{
             .eeprom_key = G_MOTOR_DIST_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -18,7 +18,7 @@ constexpr uint32_t PWM_MAX = 60;
 constexpr uint32_t PWM_MIN = 7;
 
 struct motor_hardware::UsageEEpromConfig brushed_usage_config {
-    std::array<UsageRequestSet, 1> {
+    std::array<UsageRequestSet, 2> {
         UsageRequestSet {
             .eeprom_key = G_MOTOR_DIST_KEY,
             .type_key =
@@ -113,7 +113,7 @@ struct brushed_motor_driver::DacConfig dac_config {
  * The brushed motor hardware interface.
  */
 static motor_hardware::BrushedMotorHardware brushed_motor_hardware_iface(
-    brushed_motor_conf, &htim2, brushed_usage_config);
+    brushed_motor_conf, &htim2, brushed_usage_config, &htim15);
 
 /**
  * The brushed motor driver hardware interface.

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -159,11 +159,19 @@ extern "C" void gripper_enc_idle_state_callback_glue(bool val) {
     brushed_motor_interrupt.set_enc_idle_state(val);
 }
 
+extern "C" void gripper_force_stopwatch_overflow_callback_glue(
+    uint16_t seconds) {
+    if (seconds > 0) {
+        brushed_motor_interrupt.stopwatch_overflow(seconds);
+    }
+}
+
 void grip_motor_iface::initialize() {
     initialize_hardware_g();
-    set_brushed_motor_timer_callback(call_brushed_motor_handler,
-                                     gripper_enc_overflow_callback_glue,
-                                     gripper_enc_idle_state_callback_glue);
+    set_brushed_motor_timer_callback(
+        call_brushed_motor_handler, gripper_enc_overflow_callback_glue,
+        gripper_enc_idle_state_callback_glue,
+        gripper_force_stopwatch_overflow_callback_glue);
 }
 
 auto grip_motor_iface::get_grip_motor()

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -23,7 +23,12 @@ struct motor_hardware::UsageEEpromConfig brushed_usage_config {
             .eeprom_key = G_MOTOR_DIST_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = G_MOTOR_FORCE_TIME_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::force_application_time),
+            .length = usage_storage_task::force_time_data_usage_len
         }
     }
 };

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -17,6 +17,9 @@
 #define GRIPPER_JAW_TIMER_FREQ (GRIPPER_JAW_PWM_FREQ_HZ * GRIPPER_JAW_PWM_WIDTH)
 
 #define GRIPPER_ENCODER_SPEED_TIMER_FREQ (1000000UL)
+// these values create the longest possible clock with at 16bit counter
+#define GRIPPER_ENCODER_FORCE_STOPWATCH_FREQ (2600UL)
+#define GRIPPER_ENCODER_FORCE_STOPWATCH_PERIOD (65000UL)
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +48,7 @@ extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim4;
+extern TIM_HandleTypeDef htim15;
 
 typedef void (*brushed_motor_interrupt_callback)();
 typedef void (*encoder_overflow_callback)(int32_t);

--- a/gripper/firmware/motor_hardware.h
+++ b/gripper/firmware/motor_hardware.h
@@ -53,6 +53,7 @@ extern TIM_HandleTypeDef htim15;
 typedef void (*brushed_motor_interrupt_callback)();
 typedef void (*encoder_overflow_callback)(int32_t);
 typedef void (*encoder_idle_state_callback)(bool);
+typedef void (*stopwatch_overflow_callback)(uint16_t seconds);
 
 void initialize_hardware_g();
 
@@ -61,7 +62,8 @@ void update_pwm(uint32_t duty_cycle);
 void set_brushed_motor_timer_callback(
     brushed_motor_interrupt_callback callback,
     encoder_overflow_callback g_enc_f_callback,
-    encoder_idle_state_callback g_enc_idle_callback);
+    encoder_idle_state_callback g_enc_idle_callback,
+    stopwatch_overflow_callback g_stopwatch_overflow_callback);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -65,6 +65,13 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
         HAL_NVIC_SetPriority(TIM4_IRQn, 6, 0);
         HAL_NVIC_EnableIRQ(TIM4_IRQn);
 
+    } else if (htim == &htim15) {
+        /* Peripheral clock enable */
+        __HAL_RCC_TIM15_CLK_ENABLE();
+        /* TIM15 interrupt Init */
+        HAL_NVIC_SetPriority(TIM1_BRK_TIM15_IRQn, 6, 0);
+        HAL_NVIC_EnableIRQ(TIM1_BRK_TIM15_IRQn);
+
     }
 }
 
@@ -95,6 +102,10 @@ void HAL_TIM_Base_MspDeInit(TIM_HandleTypeDef* htim_base) {
         /* Peripheral clock disable */
         __HAL_RCC_TIM4_CLK_DISABLE();
         HAL_NVIC_DisableIRQ(TIM4_IRQn);
+    } else if (htim_base->Instance == TIM15) {
+        /* Peripheral clock disable */
+        __HAL_RCC_TIM15_CLK_DISABLE();
+        HAL_NVIC_DisableIRQ(TIM1_BRK_TIM15_IRQn);
     }
 }
 
@@ -184,12 +195,18 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
         uint32_t direction = __HAL_TIM_IS_TIM_COUNTING_DOWN(htim);
         z_enc_overflow_callback(direction ? -1 : 1);
         __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
+    } else if (htim == &htim15 && gripper_force_stopwatch_overflow_callback) {
+        gripper_force_stopwatch_overflow_callback(
+            GRIPPER_ENCODER_FORCE_STOPWATCH_PERIOD/GRIPPER_ENCODER_FORCE_STOPWATCH_FREQ);
+        __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
     }
 }
 
 void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef* htim) {
     if (htim == &htim4 && gripper_enc_idle_state_overflow_callback) {
         gripper_enc_idle_state_overflow_callback(false);
+        __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC1);
+    } else if (htim == &htim15) {
         __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC1);
     }
 }

--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -8,6 +8,7 @@ static brushed_motor_interrupt_callback brushed_timer_callback = NULL;
 static encoder_overflow_callback gripper_enc_overflow_callback = NULL;
 static encoder_idle_state_callback gripper_enc_idle_state_overflow_callback =
     NULL;
+static stopwatch_overflow_callback gripper_force_stopwatch_overflow_callback = NULL;
 
 
 void set_z_motor_timer_callback(
@@ -20,10 +21,12 @@ void set_z_motor_timer_callback(
 void set_brushed_motor_timer_callback(
         brushed_motor_interrupt_callback callback,
         encoder_overflow_callback g_enc_f_callback,
-        encoder_idle_state_callback g_enc_idle_callback) {
+        encoder_idle_state_callback g_enc_idle_callback,
+        stopwatch_overflow_callback g_stopwatch_overflow_callback) {
     brushed_timer_callback = callback;
     gripper_enc_overflow_callback = g_enc_f_callback;
     gripper_enc_idle_state_overflow_callback = g_enc_idle_callback;
+    gripper_force_stopwatch_overflow_callback = g_stopwatch_overflow_callback;
 }
 
 

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -54,6 +54,7 @@ extern TIM_HandleTypeDef htim3;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim4;
 extern TIM_HandleTypeDef htim8;
+extern TIM_HandleTypeDef htim15;
 
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
@@ -160,6 +161,7 @@ void TIM3_IRQHandler(void) { HAL_TIM_IRQHandler(&htim3); }
 void TIM2_IRQHandler(void) { HAL_TIM_IRQHandler(&htim2); }
 
 void TIM4_IRQHandler(void) { HAL_TIM_IRQHandler(&htim4); }
+void TIM1_BRK_TIM15_IRQHandler(void) { HAL_TIM_IRQHandler(&htim15); }
 
 void TIM8_CC_IRQHandler(void) { HAL_TIM_IRQHandler(&htim8); }
 

--- a/gripper/simulator/eeprom_keys.cpp
+++ b/gripper/simulator/eeprom_keys.cpp
@@ -15,8 +15,14 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
         std::make_pair(G_MOTOR_DIST_KEY,
                        usage_storage_task::distance_data_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2{
+    .data_rev = 2,
+    .data_table = {
+        std::make_pair(G_MOTOR_FORCE_TIME_KEY,
+                       usage_storage_task::force_time_data_usage_len)}};
+
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
         // vector with the new key/length pairs
-        data_table_rev1};
+        data_table_rev1, data_table_rev2};

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -238,5 +238,6 @@ typedef enum {
     can_motorusagevaluetype_linear_motor_distance = 0x0,
     can_motorusagevaluetype_left_gear_motor_distance = 0x1,
     can_motorusagevaluetype_right_gear_motor_distance = 0x2,
+    can_motorusagevaluetype_force_application_time = 0x3,
 } CANMotorUsageValueType;
 

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -238,6 +238,7 @@ enum class MotorUsageValueType {
     linear_motor_distance = 0x0,
     left_gear_motor_distance = 0x1,
     right_gear_motor_distance = 0x2,
+    force_application_time = 0x3,
 };
 
 }  // namespace can::ids

--- a/include/gripper/firmware/eeprom_keys.hpp
+++ b/include/gripper/firmware/eeprom_keys.hpp
@@ -4,8 +4,11 @@
 
 static constexpr eeprom::types::address Z_MOTOR_DIST_KEY = 0x0000;
 static constexpr eeprom::types::address G_MOTOR_DIST_KEY = 0x0001;
+static constexpr eeprom::types::address G_MOTOR_FORCE_TIME_KEY = 0x0002;
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1;
+
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2;
 
 extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
     table_updater;

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -133,5 +133,6 @@ class BrushedMotorHardwareIface : virtual public MotorHardwareIface {
     virtual void reset_control() = 0;
     virtual void set_stay_enabled(bool state) = 0;
     virtual auto get_stay_enabled() -> bool = 0;
+    virtual auto get_stopwatch_pulses(bool clear) -> uint16_t = 0;
 };
 };  // namespace motor_hardware

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -48,6 +48,17 @@ class UsageEEpromConfig {
         }
         return 0xFFFF;
     }
+
+    [[nodiscard]] auto get_force_application_time_key() const -> uint16_t {
+        for (auto i : usage_requests) {
+            if (i.type_key ==
+                uint16_t(
+                    can::ids::MotorUsageValueType::force_application_time)) {
+                return i.eeprom_key;
+            }
+        }
+        return 0xFFFF;
+    }
     std::array<UsageRequestSet, max_requests_per_can_message> usage_requests{};
     size_t num_keys = 0;
 };

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -31,7 +31,8 @@ using MoveGroupTaskMessage =
 using MoveStatusReporterTaskMessage =
     std::variant<std::monostate, motor_messages::Ack,
                  motor_messages::UpdatePositionResponse,
-                 can::messages::ErrorMessage, can::messages::StopRequest>;
+                 can::messages::ErrorMessage, can::messages::StopRequest,
+                 usage_messages::IncreaseForceTimeUsage>;
 
 using BrushedMotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,
@@ -55,6 +56,7 @@ using BrushedMoveGroupTaskMessage = std::variant<
 
 using UsageStorageTaskMessage =
     std::variant<std::monostate, usage_messages::IncreaseDistanceUsage,
-                 usage_messages::GetUsageRequest>;
+                 usage_messages::GetUsageRequest,
+                 usage_messages::IncreaseForceTimeUsage>;
 
 }  // namespace motor_control_task_messages

--- a/include/motor-control/core/tasks/move_status_reporter_task.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task.hpp
@@ -93,6 +93,10 @@ class MoveStatusMessageHandler {
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 
+    void handle_message(const usage_messages::IncreaseForceTimeUsage& message) {
+        usage_client.send_usage_storage_queue(message);
+    }
+
   private:
     CanClient& can_client;
     const lms::LinearMotionSystemConfig<LmsConfig>& lms_config;

--- a/include/motor-control/core/tasks/usage_storage_task.hpp
+++ b/include/motor-control/core/tasks/usage_storage_task.hpp
@@ -122,7 +122,7 @@ class UsageStorageTaskHandler : eeprom::accessor::ReadListener {
         std::ignore = bit_utils::bytes_to_int(
             accessor_backing.begin(),
             accessor_backing.begin() + force_time_data_usage_len, old_value);
-        if (old_value == 0xFFFFFFFF) {
+        if (old_value == std::numeric_limits<uint32_t>::max()) {
             // old_value must be an uninitialized data field so set it to 0
             old_value = 0;
         }

--- a/include/motor-control/core/tasks/usage_storage_task.hpp
+++ b/include/motor-control/core/tasks/usage_storage_task.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <limits>
+#include <type_traits>
 #include <variant>
 
 #include "can/core/can_writer_task.hpp"
@@ -31,6 +32,21 @@ using TaskMessage = motor_control_task_messages::UsageStorageTaskMessage;
 static constexpr uint16_t distance_data_usage_len = 8;
 static constexpr uint16_t force_time_data_usage_len = 4;
 
+template <typename NUM_T>
+requires std::is_integral_v<NUM_T> && std::is_unsigned_v<NUM_T>
+[[nodiscard]] auto check_for_default_val(NUM_T val, size_t len = 0) -> NUM_T {
+    // in most cases we want to use the compare to the actual max value,
+    // but during the processing of GetUsageRequest the NUM_T is always uint64_t
+    // so this lets us change shift over the MAX to the correct number of bytes
+    // to compare, the actual value is in the top bytes
+    NUM_T cmp = std::numeric_limits<NUM_T>::max()
+                << ((sizeof(NUM_T) - len) * 8);
+    if (val == cmp) {
+        // old_value must be an uninitialized data field so set it to 0
+        val = 0;
+    }
+    return val;
+}
 /**
  * The message queue message handler.
  */
@@ -100,7 +116,9 @@ class UsageStorageTaskHandler : eeprom::accessor::ReadListener {
         auto next_klv = can::messages::GetMotorUsageResponse::UsageValueField{
             .key = m.usage_conf.usage_requests[response.num_keys].type_key,
             .len = m.usage_conf.usage_requests[response.num_keys].length,
-            .value = read_value};
+            .value = check_for_default_val(
+                read_value,
+                m.usage_conf.usage_requests[response.num_keys].length)};
         // add the next value to the response, and increment num_keys
         response.values[response.num_keys] = next_klv;
         response.num_keys += 1;
@@ -122,10 +140,7 @@ class UsageStorageTaskHandler : eeprom::accessor::ReadListener {
         std::ignore = bit_utils::bytes_to_int(
             accessor_backing.begin(),
             accessor_backing.begin() + force_time_data_usage_len, old_value);
-        if (old_value == std::numeric_limits<uint32_t>::max()) {
-            // old_value must be an uninitialized data field so set it to 0
-            old_value = 0;
-        }
+        old_value = check_for_default_val(old_value);
         old_value += m.seconds;
         std::ignore = bit_utils::int_to_bytes(
             old_value, accessor_backing.begin(), accessor_backing.end());
@@ -146,10 +161,7 @@ class UsageStorageTaskHandler : eeprom::accessor::ReadListener {
         std::ignore = bit_utils::bytes_to_int(
             accessor_backing.begin(),
             accessor_backing.begin() + distance_data_usage_len, old_value);
-        if (old_value == std::numeric_limits<uint64_t>::max()) {
-            // old_value must be an uninitialized data field so set it to 0
-            old_value = 0;
-        }
+        old_value = check_for_default_val(old_value);
         old_value += m.distance_traveled_um;
         std::ignore = bit_utils::int_to_bytes(
             old_value, accessor_backing.begin(), accessor_backing.end());

--- a/include/motor-control/core/usage_messages.hpp
+++ b/include/motor-control/core/usage_messages.hpp
@@ -12,6 +12,11 @@ struct IncreaseDistanceUsage {
     uint32_t distance_traveled_um;
 };
 
+struct IncreaseForceTimeUsage {
+    uint16_t key;
+    uint16_t seconds;
+};
+
 struct GetUsageRequest {
     uint32_t message_index;
     motor_hardware::UsageEEpromConfig usage_conf;

--- a/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
@@ -38,13 +38,15 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     BrushedMotorHardware() = delete;
     BrushedMotorHardware(const BrushedHardwareConfig& config,
                          void* encoder_handle,
-                         const UsageEEpromConfig& eeprom_config)
+                         const UsageEEpromConfig& eeprom_config,
+                         void* stopwatch_handle)
         : pins(config),
           enc_handle(encoder_handle),
           controller_loop{config.pid_kp,  config.pid_ki,
                           config.pid_kd,  1.F / config.encoder_interrupt_freq,
                           config.wl_high, config.wl_low},
-          eeprom_config{eeprom_config} {}
+          eeprom_config{eeprom_config},
+          stopwatch_handle{stopwatch_handle} {}
     BrushedMotorHardware(const BrushedMotorHardware&) = delete;
     auto operator=(const BrushedMotorHardware&)
         -> BrushedMotorHardware& = delete;
@@ -68,6 +70,7 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     void start_timer_interrupt() final;
     void stop_timer_interrupt() final;
     auto is_timer_interrupt_running() -> bool final;
+    auto get_stopwatch_pulses(bool clear) -> uint16_t final;
 
     void encoder_overflow(int32_t direction);
 
@@ -95,6 +98,7 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     std::atomic<ControlDirection> control_dir = ControlDirection::unset;
     std::atomic<bool> cancel_request = false;
     const UsageEEpromConfig& eeprom_config;
+    void* stopwatch_handle;
 };
 
 };  // namespace motor_hardware

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -19,7 +19,7 @@ bool motor_hardware_start_pwm(void* tim_handle, uint32_t channel);
 bool motor_hardware_stop_pwm(void* tim_handle, uint32_t channel);
 int32_t motor_hardware_encoder_pulse_count(void* encoder_handle);
 void motor_hardware_reset_encoder_count(void* encoder_handle);
-
+uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -167,6 +167,13 @@ class SimBrushedMotorHardwareIface
         -> motor_hardware::UsageEEpromConfig & final {
         return eeprom_config;
     }
+    auto get_stopwatch_pulses(bool clear) -> uint16_t {
+        auto ret = stopwatch_pulses;
+        if (clear) {
+            stopwatch_pulses = 0;
+        }
+        return ret;
+    }
 
     auto has_cancel_request() -> bool final {
         return cancel_request.exchange(false);
@@ -177,6 +184,7 @@ class SimBrushedMotorHardwareIface
     bool stay_enabled = false;
     bool limit_switch_status = false;
     int32_t test_pulses = 0;
+    int16_t stopwatch_pulses = 0;
     // these controller loop values were selected just because testing
     // does not emulate change in speed and these give us pretty good values
     // when the "motor" instantly goes to top speed then instantly stops

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -46,6 +46,9 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     auto get_encoder_pulses() -> int32_t final {
         return (motor_encoder_overflow_count << 16) + enc_val;
     }
+    auto get_stopwatch_pulses(bool) -> uint16_t final {
+        return stopwatch_pulses;
+    }
     void reset_encoder_pulses() final { enc_val = 0; }
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
@@ -92,6 +95,7 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     bool motor_enabled = false;
     double pid_controller_output = 0.0;
     int32_t enc_val = 0;
+    uint16_t stopwatch_pulses = 0;
     // these controller loop values were selected just because testing
     // does not emulate change in speed and these give us pretty good values
     // when the "motor" instantly goes to top speed then instantly stops

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -66,6 +66,13 @@ int32_t BrushedMotorHardware::get_encoder_pulses() {
            motor_hardware_encoder_pulse_count(enc_handle);
 }
 
+uint16_t BrushedMotorHardware::get_stopwatch_pulses(bool clear) {
+    if (!stopwatch_handle) {
+        return 0;
+    }
+    return motor_hardware_get_stopwatch_pulses(stopwatch_handle, clear);
+}
+
 void BrushedMotorHardware::reset_encoder_pulses() {
     if (!enc_handle) {
         return;

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -98,9 +98,10 @@ void motor_hardware_reset_encoder_count(void* enc_htim) {
 }
 
 uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear) {
+    uint16_t count = _get_hal_timer_count(stopwatch_handle);
     if(stopwatch_handle != NULL && clear) {
         __HAL_TIM_SET_COUNTER((TIM_HandleTypeDef*)stopwatch_handle, 0);
     }
-    return _get_hal_timer_count(stopwatch_handle);
+    return count;
 }
 

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -77,19 +77,18 @@ bool motor_hardware_stop_pwm(void* htim, uint32_t channel) {
     return custom_stop_pwm_it(htim, channel) == HAL_OK;
 }
 /*
- * On the current prototype there are no encoders on XY axes, to handle that
- * this NULL condition was made to return a zero value for pulse counts.
- *
- * Note: Eventually we can remove these if statements when we get encoders on XY
- * Axes
+ * read a hal timer count value
+ * if the timer is NULL return 0
  */
-int32_t motor_hardware_encoder_pulse_count(void* enc_htim) {
-    int32_t pulses;
-    if (enc_htim != NULL) {
-        pulses = __HAL_TIM_GET_COUNTER((TIM_HandleTypeDef*)enc_htim);
-    } else {
-        pulses = 0;
+uint16_t _get_hal_timer_count(void* htim) {
+    if (htim != NULL) {
+        return __HAL_TIM_GET_COUNTER((TIM_HandleTypeDef*)htim);
     }
+    return 0;
+}
+
+int32_t motor_hardware_encoder_pulse_count(void* enc_htim) {
+    int32_t pulses = _get_hal_timer_count(enc_htim);
     return pulses;
 }
 
@@ -97,3 +96,11 @@ void motor_hardware_reset_encoder_count(void* enc_htim) {
     __HAL_TIM_CLEAR_FLAG((TIM_HandleTypeDef*)enc_htim, TIM_FLAG_UPDATE);
     __HAL_TIM_SET_COUNTER((TIM_HandleTypeDef*)enc_htim, 0);
 }
+
+uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear) {
+    if(stopwatch_handle != NULL && clear) {
+        __HAL_TIM_SET_COUNTER((TIM_HandleTypeDef*)stopwatch_handle, 0);
+    }
+    return _get_hal_timer_count(stopwatch_handle);
+}
+


### PR DESCRIPTION
This adds another timer to the gripper that counts up when movement on the gripper stops,
if the gripper is in force application mode when the counter overflows it increments its usage in eeprom
if the gripper starts a new move while in force application mode it fetches the current timer count and stores that data
also expands the GetUsageDataResponse to include the force application time

<s>depends on #635 </s>
and https://github.com/Opentrons/opentrons/pull/12499
