### PR TITLE
refactor(motor-control): re-enable stall detection

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -215,6 +215,7 @@ typedef enum {
     can_movestopcondition_encoder_position = 0x4,
     can_movestopcondition_gripper_force = 0x8,
     can_movestopcondition_stall = 0x10,
+    can_movestopcondition_ignore_stalls = 0x20,
 } CANMoveStopCondition;
 
 /** A bit field of the arbitration id parts. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -224,6 +224,7 @@ enum class MoveStopCondition {
     encoder_position = 0x4,
     gripper_force = 0x8,
     stall = 0x10,
+    ignore_stalls = 0x20,
 };
 
 /** High-level type of pipette. */

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -134,6 +134,7 @@ class BrushedMotorInterruptHandler {
                         AckMessageId::complete_without_condition);
                 }
                 break;
+            case MoveStopCondition::ignore_stalls:
             case MoveStopCondition::sync_line:
                 // TODO write cap sensor move code
                 break;
@@ -275,6 +276,7 @@ class BrushedMotorInterruptHandler {
                 hardware.grip();
                 break;
             case MoveStopCondition::sync_line:
+            case MoveStopCondition::ignore_stalls:
                 // this is an unused move stop condition for the brushed motor
                 // just return with no condition
                 // TODO creat can bus error messages and send that instead

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -52,7 +52,7 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     steps_per_tick_sq acceleration;
     uint8_t group_id;
     uint8_t seq_id;
-    MoveStopCondition stop_condition = MoveStopCondition::none;
+    uint8_t stop_condition = static_cast<uint8_t>(MoveStopCondition::none);
     int32_t start_encoder_position;
     uint16_t usage_key;
 
@@ -69,6 +69,10 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
             .start_encoder_position = start_encoder_position,
             .usage_key = usage_key,
         };
+    }
+
+    auto check_stop_condition(MoveStopCondition cond) const -> bool {
+        return ((stop_condition & static_cast<uint8_t>(cond)) == static_cast<uint8_t>(cond));
     }
 };
 

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -72,7 +72,8 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     }
 
     auto check_stop_condition(MoveStopCondition cond) const -> bool {
-        return ((stop_condition & static_cast<uint8_t>(cond)) == static_cast<uint8_t>(cond));
+        return ((stop_condition & static_cast<uint8_t>(cond)) ==
+                static_cast<uint8_t>(cond));
     }
 };
 

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -71,7 +71,8 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
         };
     }
 
-    [[nodiscard]] auto check_stop_condition(MoveStopCondition cond) const -> bool {
+    [[nodiscard]] auto check_stop_condition(MoveStopCondition cond) const
+        -> bool {
         return ((stop_condition & static_cast<uint8_t>(cond)) ==
                 static_cast<uint8_t>(cond));
     }

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -71,7 +71,7 @@ struct Move {  // NOLINT(cppcoreguidelines-pro-type-member-init)
         };
     }
 
-    auto check_stop_condition(MoveStopCondition cond) const -> bool {
+    [[nodiscard]] auto check_stop_condition(MoveStopCondition cond) const -> bool {
         return ((stop_condition & static_cast<uint8_t>(cond)) ==
                 static_cast<uint8_t>(cond));
     }

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -69,8 +69,7 @@ class MotionController {
             .acceleration = acceleration_steps,
             .group_id = can_msg.group_id,
             .seq_id = can_msg.seq_id,
-            .stop_condition =
-                static_cast<MoveStopCondition>(can_msg.request_stop_condition),
+            .stop_condition = can_msg.request_stop_condition,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
         if (!enabled) {
             enable_motor();
@@ -88,7 +87,7 @@ class MotionController {
             .acceleration = 0,
             .group_id = can_msg.group_id,
             .seq_id = can_msg.seq_id,
-            .stop_condition = MoveStopCondition::limit_switch,
+            .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch),
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
         if (!enabled) {
             enable_motor();
@@ -233,7 +232,7 @@ class PipetteMotionController {
             0,
             can_msg.group_id,
             can_msg.seq_id,
-            static_cast<MoveStopCondition>(can_msg.request_stop_condition),
+            can_msg.request_stop_condition,
             0,
             hardware.get_usage_eeprom_config().get_gear_distance_key(),
             hardware.get_step_tracker(),

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -87,7 +87,8 @@ class MotionController {
             .acceleration = 0,
             .group_id = can_msg.group_id,
             .seq_id = can_msg.seq_id,
-            .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch),
+            .stop_condition =
+                static_cast<uint8_t>(MoveStopCondition::limit_switch),
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
         if (!enabled) {
             enable_motor();

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -487,6 +487,8 @@ class MotorInterruptHandler {
                (buffered_move.check_stop_condition(MoveStopCondition::stall) or
                 !buffered_move.check_stop_condition(
                     MoveStopCondition::ignore_stalls)) &&
+               !buffered_move.check_stop_condition(
+                   MoveStopCondition::limit_switch) &&
                !hardware.position_flags.check_flag(
                    MotorPositionStatus::Flags::stepper_position_ok);
     }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -484,8 +484,9 @@ class MotorInterruptHandler {
 
     [[nodiscard]] auto stalled_during_movement() const -> bool {
         return has_active_move &&
-               !buffered_move.check_stop_condition(
-                   MoveStopCondition::ignore_stalls) &&
+               (buffered_move.check_stop_condition(MoveStopCondition::stall) or
+                !buffered_move.check_stop_condition(
+                    MoveStopCondition::ignore_stalls)) &&
                !hardware.position_flags.check_flag(
                    MotorPositionStatus::Flags::stepper_position_ok);
     }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -111,6 +111,10 @@ class MotorInterruptHandler {
                     .message_index = 0,
                     .severity = can::ids::ErrorSeverity::warning,
                     .error_code = can::ids::ErrorCode::collision_detected});
+            status_queue_client.send_move_status_reporter_queue(
+                    usage_messages::IncreaseErrorCount{
+                            .key = hardware.get_usage_eeprom_config()
+                                    .get_error_count_key()});
         } else {
             cancel_and_clear_moves(can::ids::ErrorCode::collision_detected);
         }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -80,7 +80,6 @@ class MotorInterruptHandler {
                     hardware.position_flags.clear_flag(
                         MotorPositionStatus::Flags::stepper_position_ok);
                     handle_stall_during_movement();
-
                 }
             }
             hardware.unstep();
@@ -110,8 +109,6 @@ class MotorInterruptHandler {
                     .severity = can::ids::ErrorSeverity::warning,
                     .error_code = can::ids::ErrorCode::collision_detected});
         } else {
-            hardware.position_flags.clear_flag(
-                    MotorPositionStatus::Flags::encoder_position_ok);
             cancel_and_clear_moves(can::ids::ErrorCode::collision_detected);
         }
     }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -81,12 +81,14 @@ class MotorInterruptHandler {
                     hardware.position_flags.clear_flag(
                         MotorPositionStatus::Flags::stepper_position_ok);
                     if (stalled_during_movement()) {
-                        if (buffered_move.check_stop_condition(MoveStopCondition::stall)) {
+                        if (buffered_move.check_stop_condition(
+                                MoveStopCondition::stall)) {
                             cancel_and_clear_moves(
                                 can::ids::ErrorCode::collision_detected,
                                 can::ids::ErrorSeverity::recoverable, false);
                         } else {
-                            cancel_and_clear_moves(can::ids::ErrorCode::collision_detected, can::ids::ErrorSeverity::recoverable);
+                            cancel_and_clear_moves(
+                                can::ids::ErrorCode::collision_detected, can::ids::ErrorSeverity::recoverable);
                         }
                     }
                 }
@@ -199,11 +201,13 @@ class MotorInterruptHandler {
         }
         if (has_active_move) {
             handle_update_position_queue_error();
-            if (buffered_move.check_stop_condition(MoveStopCondition::limit_switch) &&
+            if (buffered_move.check_stop_condition(
+                    MoveStopCondition::limit_switch) &&
                 homing_stopped()) {
                 return false;
             }
-            if (buffered_move.check_stop_condition(MoveStopCondition::sync_line) &&
+            if (buffered_move.check_stop_condition(
+                    MoveStopCondition::sync_line) &&
                 sync_triggered()) {
                 return false;
             }
@@ -308,7 +312,8 @@ class MotorInterruptHandler {
         } else {
             hardware.negative_direction();
         }
-        if (has_active_move && buffered_move.check_stop_condition(MoveStopCondition::limit_switch)) {
+        if (has_active_move && buffered_move.check_stop_condition(
+                                   MoveStopCondition::limit_switch)) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
             update_hardware_step_tracker();
         }
@@ -477,7 +482,9 @@ class MotorInterruptHandler {
     }
 
     [[nodiscard]] auto stalled_during_movement() const -> bool {
-        return has_active_move && !buffered_move.check_stop_condition(MoveStopCondition::ignore_stalls) &&
+        return has_active_move &&
+               !buffered_move.check_stop_condition(
+                   MoveStopCondition::ignore_stalls) &&
                !hardware.position_flags.check_flag(
                    MotorPositionStatus::Flags::stepper_position_ok);
     }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -81,9 +81,13 @@ class MotorInterruptHandler {
                     hardware.position_flags.clear_flag(
                         MotorPositionStatus::Flags::stepper_position_ok);
                     if (stalled_during_movement()) {
-                        cancel_and_clear_moves(
-                            can::ids::ErrorCode::collision_detected,
-                            can::ids::ErrorSeverity::recoverable);
+                        if (buffered_move.check_stop_condition(MoveStopCondition::stall)) {
+                            cancel_and_clear_moves(
+                                can::ids::ErrorCode::collision_detected,
+                                can::ids::ErrorSeverity::recoverable, false);
+                        } else {
+                            cancel_and_clear_moves(can::ids::ErrorCode::collision_detected, can::ids::ErrorSeverity::recoverable);
+                        }
                     }
                 }
             }
@@ -195,12 +199,11 @@ class MotorInterruptHandler {
         }
         if (has_active_move) {
             handle_update_position_queue_error();
-            if (buffered_move.stop_condition ==
-                    MoveStopCondition::limit_switch &&
+            if (buffered_move.check_stop_condition(MoveStopCondition::limit_switch) &&
                 homing_stopped()) {
                 return false;
             }
-            if (buffered_move.stop_condition == MoveStopCondition::sync_line &&
+            if (buffered_move.check_stop_condition(MoveStopCondition::sync_line) &&
                 sync_triggered()) {
                 return false;
             }
@@ -305,8 +308,7 @@ class MotorInterruptHandler {
         } else {
             hardware.negative_direction();
         }
-        if (has_active_move &&
-            buffered_move.stop_condition == MoveStopCondition::limit_switch) {
+        if (has_active_move && buffered_move.check_stop_condition(MoveStopCondition::limit_switch)) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
             update_hardware_step_tracker();
         }
@@ -475,8 +477,7 @@ class MotorInterruptHandler {
     }
 
     [[nodiscard]] auto stalled_during_movement() const -> bool {
-        return has_active_move &&
-               buffered_move.stop_condition == MoveStopCondition::stall &&
+        return has_active_move && !buffered_move.check_stop_condition(MoveStopCondition::ignore_stalls) &&
                !hardware.position_flags.check_flag(
                    MotorPositionStatus::Flags::stepper_position_ok);
     }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -80,7 +80,7 @@ class MotorInterruptHandler {
                     hardware.position_flags.clear_flag(
                         MotorPositionStatus::Flags::stepper_position_ok);
                     handle_stall_during_movement();
-                    }
+
                 }
             }
             hardware.unstep();
@@ -381,6 +381,7 @@ class MotorInterruptHandler {
         // the queue will get reset during the stop message processing
         // we can't clear here from an interrupt context
         has_active_move = false;
+        tick_count = 0x0;
     }
 
     void finish_current_move(

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -79,11 +79,7 @@ class MotorInterruptHandler {
                 if (stall_detected()) {
                     hardware.position_flags.clear_flag(
                         MotorPositionStatus::Flags::stepper_position_ok);
-                    // This is the first interrupt where a stall is detected
-                    // during a move
-                    if (!has_stalled) {
-                        handle_stall_during_movement();
-                        has_stalled = true;
+                    handle_stall_during_movement();
                     }
                 }
             }
@@ -415,7 +411,6 @@ class MotorInterruptHandler {
         has_active_move = false;
         hardware.reset_encoder_pulses();
         stall_checker.reset_itr_counts(0);
-        has_stalled = false;
     }
 
     [[nodiscard]] static auto overflow(q31_31 current, q31_31 future) -> bool {
@@ -440,7 +435,6 @@ class MotorInterruptHandler {
     }
     bool has_active_move = false;
     bool in_estop = false;
-    bool has_stalled = false;
     [[nodiscard]] auto get_buffered_move() const -> MotorMoveMessage {
         return buffered_move;
     }
@@ -475,7 +469,6 @@ class MotorInterruptHandler {
                 stall_checker.reset_itr_counts(stepper_tick_estimate);
                 hardware.position_flags.set_flag(
                     MotorPositionStatus::Flags::stepper_position_ok);
-                has_stalled = false;
             }
             // We send an ack even if the position wasn't updated
             auto ack = motor_messages::UpdatePositionResponse{

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -114,8 +114,9 @@ class MotorInterruptHandler {
                     .severity = can::ids::ErrorSeverity::warning,
                     .error_code = can::ids::ErrorCode::collision_detected});
         } else {
-            cancel_and_clear_moves(can::ids::ErrorCode::collision_detected,
-                                   can::ids::ErrorSeverity::recoverable);
+            hardware.position_flags.clear_flag(
+                    MotorPositionStatus::Flags::encoder_position_ok);
+            cancel_and_clear_moves(can::ids::ErrorCode::collision_detected);
         }
     }
 

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -112,9 +112,9 @@ class MotorInterruptHandler {
                     .severity = can::ids::ErrorSeverity::warning,
                     .error_code = can::ids::ErrorCode::collision_detected});
             status_queue_client.send_move_status_reporter_queue(
-                    usage_messages::IncreaseErrorCount{
-                            .key = hardware.get_usage_eeprom_config()
-                                    .get_error_count_key()});
+                usage_messages::IncreaseErrorCount{
+                    .key = hardware.get_usage_eeprom_config()
+                               .get_error_count_key()});
         } else {
             cancel_and_clear_moves(can::ids::ErrorCode::collision_detected);
         }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -418,6 +418,7 @@ class MotorInterruptHandler {
     void set_buffered_move(MotorMoveMessage new_move) {
         buffered_move = new_move;
     }
+    bool clear_queue_until_empty = false;
 
     /**
      * @brief While a move is NOT active, this function should be called
@@ -515,6 +516,5 @@ class MotorInterruptHandler {
     stall_check::StallCheck& stall_checker;
     UpdatePositionQueue& update_position_queue;
     MotorMoveMessage buffered_move = MotorMoveMessage{};
-    bool clear_queue_until_empty = false;
 };
 }  // namespace motor_handler

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -94,7 +94,9 @@ class MotorInterruptHandler {
     auto handle_stall_during_movement() -> void {
         if (!has_active_move or
             hardware.position_flags.check_flag(
-                MotorPositionStatus::Flags::stepper_position_ok)) {
+                MotorPositionStatus::Flags::stepper_position_ok) or
+            buffered_move.check_stop_condition(
+                MoveStopCondition::limit_switch)) {
             return;
         }
 

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -108,7 +108,7 @@ class MotorInterruptHandler {
             // send a warning
             status_queue_client.send_move_status_reporter_queue(
                 can::messages::ErrorMessage{
-                    .message_index = 0,
+                    .message_index = buffered_move.message_index,
                     .severity = can::ids::ErrorSeverity::warning,
                     .error_code = can::ids::ErrorCode::collision_detected});
             status_queue_client.send_move_status_reporter_queue(

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -85,7 +85,7 @@ class MotorInterruptHandler {
                                 MoveStopCondition::stall)) {
                             cancel_and_clear_moves(
                                 can::ids::ErrorCode::collision_detected,
-                                can::ids::ErrorSeverity::recoverable, false);
+                                can::ids::ErrorSeverity::recoverable);
                         } else {
                             cancel_and_clear_moves(
                                 can::ids::ErrorCode::collision_detected, can::ids::ErrorSeverity::recoverable);

--- a/include/motor-control/simulation/motor_interrupt_driver.hpp
+++ b/include/motor-control/simulation/motor_interrupt_driver.hpp
@@ -43,8 +43,8 @@ class MotorInterruptDriver {
                     do {
                         if (queue.peek(&move, 0)) {
                             if (move.stop_condition ==
-                                motor_messages::MoveStopCondition::
-                                    limit_switch) {
+                                static_cast<uint8_t>(motor_messages::MoveStopCondition::
+                                    limit_switch)) {
                                 iface.trigger_limit_switch();
                                 LOG("Received Home Request, triggering limit "
                                     "switch\n");

--- a/include/motor-control/simulation/motor_interrupt_driver.hpp
+++ b/include/motor-control/simulation/motor_interrupt_driver.hpp
@@ -43,8 +43,9 @@ class MotorInterruptDriver {
                     do {
                         if (queue.peek(&move, 0)) {
                             if (move.stop_condition ==
-                                static_cast<uint8_t>(motor_messages::MoveStopCondition::
-                                    limit_switch)) {
+                                static_cast<uint8_t>(
+                                    motor_messages::MoveStopCondition::
+                                        limit_switch)) {
                                 iface.trigger_limit_switch();
                                 LOG("Received Home Request, triggering limit "
                                     "switch\n");

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(motor-control
         test_motor_position_tracker.cpp
         test_stall_check.cpp
         test_brushed_motor_error_tolerance_handling.cpp
+        test_motor_stall_handling.cpp
         )
 
 target_ot_motor_control(motor-control)

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Move with stop condition == limit switch") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = MoveStopCondition::limit_switch};
+                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
 
     GIVEN("the move is in progress") {
         test_objs.queue.try_write_isr(msg1);
@@ -78,7 +78,7 @@ TEST_CASE("Move with stop condition == limit switch, case 2") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = MoveStopCondition::limit_switch};
+                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
     GIVEN("the limit switch has not been triggered") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_lim_sw(false);
@@ -114,7 +114,7 @@ TEST_CASE("Move with stop condition != limit switch") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = MoveStopCondition::none};
+                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::none)};
     GIVEN("Move with stop condition = none in progress") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_lim_sw(true);

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -37,7 +37,8 @@ TEST_CASE("Move with stop condition == limit switch") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
+                     .stop_condition =
+                         static_cast<uint8_t>(MoveStopCondition::limit_switch)};
 
     GIVEN("the move is in progress") {
         test_objs.queue.try_write_isr(msg1);
@@ -78,7 +79,8 @@ TEST_CASE("Move with stop condition == limit switch, case 2") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
+                     .stop_condition =
+                         static_cast<uint8_t>(MoveStopCondition::limit_switch)};
     GIVEN("the limit switch has not been triggered") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_lim_sw(false);
@@ -109,12 +111,13 @@ TEST_CASE("Move with stop condition == limit switch, case 2") {
 TEST_CASE("Move with stop condition != limit switch") {
     HandlerContainer test_objs{};
     test_objs.handler.set_current_position(0x0);
-    Move msg1 = Move{.duration = 2,
-                     .velocity = convert_velocity_to(.5),
-                     .acceleration = 0,
-                     .group_id = 1,
-                     .seq_id = 0,
-                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::none)};
+    Move msg1 =
+        Move{.duration = 2,
+             .velocity = convert_velocity_to(.5),
+             .acceleration = 0,
+             .group_id = 1,
+             .seq_id = 0,
+             .stop_condition = static_cast<uint8_t>(MoveStopCondition::none)};
     GIVEN("Move with stop condition = none in progress") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_lim_sw(true);

--- a/motor-control/tests/test_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_motor_interrupt_handler.cpp
@@ -77,7 +77,7 @@ SCENARIO("estop pressed during motor interrupt handler") {
                         .acceleration = 2,
                         .group_id = 0,
                         .seq_id = 0,
-                        .stop_condition = MoveStopCondition::limit_switch};
+                        .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
         test_objs.queue.try_write_isr(msg);
         test_objs.queue.try_write_isr(msg);
         test_objs.queue.try_write_isr(msg);

--- a/motor-control/tests/test_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_motor_interrupt_handler.cpp
@@ -31,7 +31,8 @@ SCENARIO("a move is cancelled due to a stop request") {
                         .acceleration = 2,
                         .group_id = 0,
                         .seq_id = 0,
-                        .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
+                        .stop_condition = static_cast<uint8_t>(
+                            MoveStopCondition::limit_switch)};
         test_objs.queue.try_write_isr(msg);
         test_objs.queue.try_write_isr(msg);
         test_objs.queue.try_write_isr(msg);
@@ -127,7 +128,8 @@ SCENARIO("estop is steady-state pressed") {
                         .acceleration = 2,
                         .group_id = 0,
                         .seq_id = 0,
-                        .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
+                        .stop_condition = static_cast<uint8_t>(
+                            MoveStopCondition::limit_switch)};
         test_objs.queue.try_write_isr(msg);
         msg.message_index = 2;
         test_objs.queue.try_write_isr(msg);

--- a/motor-control/tests/test_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_motor_interrupt_handler.cpp
@@ -77,7 +77,8 @@ SCENARIO("estop pressed during motor interrupt handler") {
                         .acceleration = 2,
                         .group_id = 0,
                         .seq_id = 0,
-                        .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
+                        .stop_condition = static_cast<uint8_t>(
+                            MoveStopCondition::limit_switch)};
         test_objs.queue.try_write_isr(msg);
         test_objs.queue.try_write_isr(msg);
         test_objs.queue.try_write_isr(msg);

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -319,7 +319,8 @@ TEST_CASE("Finishing a move") {
     GIVEN("a homing move") {
         auto move = Move{.group_id = 1,
                          .seq_id = 2,
-                         .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
+                         .stop_condition = static_cast<uint8_t>(
+                             MoveStopCondition::limit_switch)};
         test_objs.handler.set_buffered_move(move);
         uint64_t set_position = static_cast<uint64_t>(100) << 31;
         uint32_t set_encoder_position = static_cast<uint32_t>(200);
@@ -363,126 +364,4 @@ TEST_CASE("Finishing a move") {
             }
         }
     }
-}
-
-TEST_CASE("motor handler stall detection") {
-    HandlerContainer test_objs{};
-    using Flags = MotorPositionStatus::Flags;
-
-    test_objs.handler.set_current_position(0x0);
-    test_objs.hw.sim_set_encoder_pulses(0);
-    test_objs.hw.position_flags.set_flag(
-        MotorPositionStatus::Flags::encoder_position_ok);
-    test_objs.hw.position_flags.set_flag(
-        MotorPositionStatus::Flags::stepper_position_ok);
-    GIVEN("a duration of 1000 ticks and velocity at half a step per tick") {
-        Move msg1 = Move{.duration = 10, .velocity = convert_velocity(0.5), .stop_condition=static_cast<uint8_t>(static_cast<uint8_t>(MoveStopCondition::none))};
-        constexpr Move msg2 = Move{.duration = 400, .velocity = 50};
-        test_objs.queue.try_write(msg1);
-        test_objs.queue.try_write(msg2);
-        REQUIRE(test_objs.queue.get_size() == 2);
-        test_objs.handler.update_move();
-        WHEN("encoder doesn't update with the motor") {
-            for (int i = 0; i < (int)msg1.duration; ++i) {
-                test_objs.handler.run_interrupt();
-            }
-            THEN("the stall is detected") {
-                REQUIRE(!test_objs.hw.position_flags.check_flag(
-                    Flags::stepper_position_ok));
-                THEN("a unrecoverable collision error is raised") {
-                    REQUIRE(test_objs.reporter.messages.size() == 2);
-                    can::messages::ErrorMessage err =
-                        std::get<can::messages::ErrorMessage>(
-                            test_objs.reporter.messages.front());
-                    REQUIRE(err.error_code ==
-                            can::ids::ErrorCode::collision_detected);
-                    REQUIRE(err.severity ==
-                            can::ids::ErrorSeverity::unrecoverable);
-                }
-                THEN("a stop request is sent") {
-                    can::messages::StopRequest stop =
-                        std::get<can::messages::StopRequest>(
-                            test_objs.reporter.messages.back());
-                    REQUIRE(stop.message_index == 0);
-                }
-                THEN("the other message in the queue is simply cleared and not executed") {
-                    test_objs.reporter.messages.clear();
-                    REQUIRE(test_objs.handler.has_move_messages());
-                    test_objs.handler.run_interrupt();
-                    REQUIRE(!test_objs.handler.has_move_messages());
-                    REQUIRE(test_objs.reporter.messages.size() == 0);
-                }
-            }
-        }
-    }
-
-    GIVEN("a move with ignore_stalls stop condition") {
-        Move msg1 =
-            Move{.message_index = 13,
-                 .duration = 1000,
-                 .velocity = convert_velocity(0.5),
-                 .stop_condition =
-                     static_cast<uint8_t>(MoveStopCondition::ignore_stalls) ^
-                     static_cast<uint8_t>(MoveStopCondition::none)};
-        test_objs.queue.try_write(msg1);
-        constexpr Move msg2 = Move{.duration = 400, .velocity = 50};
-        test_objs.queue.try_write(msg1);
-        test_objs.queue.try_write(msg2);
-        REQUIRE(test_objs.queue.get_size() == 2);
-        test_objs.handler.update_move();
-        WHEN("encoder doesn't update with the motor") {
-            for (int i = 0; i < (int)msg1.duration; ++i) {
-                test_objs.handler.run_interrupt();
-            }
-            THEN("the stall is detected but it is ignored") {
-                REQUIRE(!test_objs.hw.position_flags.check_flag(
-                    Flags::stepper_position_ok));
-                REQUIRE(test_objs.reporter.messages.size() == 0);
-                AND_WHEN("the interrupt runs again") {
-                    test_objs.handler.run_interrupt();
-                    THEN("the second move is just ignored") {
-                        REQUIRE(test_objs.reporter.messages.size() == 1);
-                        Ack ack_msg =
-                            std::get<Ack>(test_objs.reporter.messages.front());
-                        REQUIRE(ack_msg.ack_id ==
-                                AckMessageId::complete_without_condition);
-                        REQUIRE(ack_msg.message_index == 13);
-                    }
-                }
-            }
-        }
-    }
-
-    GIVEN("a move with stall expected stop condition") {
-        Move msg1 =
-            Move{.duration = 1000,
-                 .velocity = convert_velocity(0.5),
-                 .stop_condition =
-                     static_cast<uint8_t>(MoveStopCondition::stall)};
-        constexpr Move msg2 = Move{.duration = 400, .velocity = 50};
-        test_objs.queue.try_write(msg1);
-        test_objs.queue.try_write(msg2);
-        REQUIRE(test_objs.queue.get_size() == 2);
-        test_objs.handler.update_move();
-        WHEN("encoder doesn't update with the motor") {
-            for (int i = 0; i < (int)msg1.duration; ++i) {
-                test_objs.handler.run_interrupt();
-            }
-            THEN("the stall is detected but it is expected") {
-                REQUIRE(!test_objs.hw.position_flags.check_flag(
-                    Flags::stepper_position_ok));
-                THEN("a recoverable collision error is raised") {
-                    REQUIRE(test_objs.reporter.messages.size() == 1);
-                    can::messages::ErrorMessage err =
-                        std::get<can::messages::ErrorMessage>(
-                            test_objs.reporter.messages.front());
-                    REQUIRE(err.error_code ==
-                            can::ids::ErrorCode::collision_detected);
-                    REQUIRE(err.severity ==
-                            can::ids::ErrorSeverity::recoverable);
-                }
-            }
-        }
-    }
-
 }

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -319,7 +319,7 @@ TEST_CASE("Finishing a move") {
     GIVEN("a homing move") {
         auto move = Move{.group_id = 1,
                          .seq_id = 2,
-                         .stop_condition = MoveStopCondition::limit_switch};
+                         .stop_condition = static_cast<uint8_t>(MoveStopCondition::limit_switch)};
         test_objs.handler.set_buffered_move(move);
         uint64_t set_position = static_cast<uint64_t>(100) << 31;
         uint32_t set_encoder_position = static_cast<uint32_t>(200);

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -1,7 +1,7 @@
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
-#include "motor-control/core/usage_messages.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
+#include "motor-control/core/usage_messages.hpp"
 #include "motor-control/tests/mock_motor_hardware.hpp"
 #include "motor-control/tests/mock_move_status_reporter_client.hpp"
 
@@ -72,7 +72,7 @@ SCENARIO("motor handler stall detection") {
                             can::ids::ErrorSeverity::unrecoverable);
                     usage_messages::IncreaseErrorCount inc_error_count =
                         std::get<usage_messages::IncreaseErrorCount>(
-                                test_objs.reporter.messages.back());
+                            test_objs.reporter.messages.back());
                     std::ignore = inc_error_count;
                 }
             }
@@ -114,8 +114,8 @@ SCENARIO("motor handler stall detection") {
                         can::ids::ErrorCode::collision_detected);
                 REQUIRE(err.severity == can::ids::ErrorSeverity::warning);
                 usage_messages::IncreaseErrorCount inc_error_count =
-                        std::get<usage_messages::IncreaseErrorCount>(
-                                test_objs.reporter.messages.back());
+                    std::get<usage_messages::IncreaseErrorCount>(
+                        test_objs.reporter.messages.back());
                 std::ignore = inc_error_count;
 
                 THEN("the move finishes") {
@@ -179,8 +179,8 @@ SCENARIO("motor handler stall detection") {
                         can::ids::ErrorCode::collision_detected);
                 REQUIRE(err.severity == can::ids::ErrorSeverity::warning);
                 auto inc_error_count =
-                        std::get<usage_messages::IncreaseErrorCount>(
-                                test_objs.reporter.messages[1]);
+                    std::get<usage_messages::IncreaseErrorCount>(
+                        test_objs.reporter.messages[1]);
                 std::ignore = inc_error_count;
                 Ack ack_msg = std::get<Ack>(test_objs.reporter.messages.back());
                 REQUIRE(ack_msg.ack_id ==

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -1,0 +1,177 @@
+#include "catch2/catch.hpp"
+#include "common/tests/mock_message_queue.hpp"
+#include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
+#include "motor-control/tests/mock_motor_hardware.hpp"
+#include "motor-control/tests/mock_move_status_reporter_client.hpp"
+
+using namespace motor_handler;
+
+#define TO_RADIX 31
+
+static constexpr float tick_per_um = 1;
+static constexpr uint32_t stall_threshold_um = 5;
+
+struct HandlerContainer {
+    test_mocks::MockMotorHardware hw{};
+    test_mocks::MockMessageQueue<Move> queue{};
+    test_mocks::MockMessageQueue<
+        can::messages::UpdateMotorPositionEstimationRequest>
+        update_position_queue{};
+    test_mocks::MockMoveStatusReporterClient reporter{};
+    stall_check::StallCheck stall{tick_per_um, tick_per_um, stall_threshold_um};
+    MotorInterruptHandler<test_mocks::MockMessageQueue,
+                          test_mocks::MockMoveStatusReporterClient, Move,
+                          test_mocks::MockMotorHardware>
+        handler{queue, reporter, hw, stall, update_position_queue};
+};
+
+sq0_31 convert_velocity(float f) {
+    return sq0_31(f * static_cast<float>(1LL << TO_RADIX));
+}
+
+q31_31 convert_distance(float f) {
+    return q31_31(f * static_cast<float>(1LL << TO_RADIX));
+}
+
+q31_31 get_distance(sq0_31 velocity, sq0_31 acceleration, uint64_t duration) {
+    int64_t s_duration = duration;
+    int64_t dist_1 = velocity * s_duration;
+    int64_t dist_2 = acceleration * s_duration * (s_duration + 1LL) / 2LL;
+    return q31_31(dist_1 + dist_2);
+}
+
+SCENARIO("motor handler stall detection") {
+    using Flags = MotorPositionStatus::Flags;
+    using Stops = MoveStopCondition;
+
+    HandlerContainer test_objs{};
+    test_objs.handler.set_current_position(0x0);
+    test_objs.hw.sim_set_encoder_pulses(0);
+    test_objs.hw.position_flags.set_flag(
+        MotorPositionStatus::Flags::encoder_position_ok);
+    test_objs.hw.position_flags.set_flag(
+        MotorPositionStatus::Flags::stepper_position_ok);
+
+    GIVEN("a linear move which is not expecting a stall") {
+        auto cond = GENERATE(Stops::none, Stops::sync_line);
+        auto msg1 = Move{.duration = 23,
+                         .velocity = convert_velocity(0.5),
+                         .stop_condition = static_cast<uint8_t>(cond)};
+        auto msg2 = Move{.duration = 10, .velocity = convert_velocity(0.5)};
+        test_objs.queue.try_write(msg1);
+        test_objs.queue.try_write(msg2);
+        REQUIRE(test_objs.queue.get_size() == 2);
+        test_objs.handler.run_interrupt();
+
+        WHEN("encoder doesn't update with the motor") {
+            REQUIRE(test_objs.queue.get_size() == 1);
+            REQUIRE(test_objs.reporter.messages.size() == 0);
+            for (int i = 0; i < (int)msg1.duration; ++i) {
+                test_objs.handler.run_interrupt();
+            }
+            THEN("the stall is detected") {
+                REQUIRE(!test_objs.hw.position_flags.check_flag(
+                    Flags::stepper_position_ok));
+                THEN(
+                    "a unrecoverable collision error is raised and a stop "
+                    "request is sent") {
+                    REQUIRE(test_objs.reporter.messages.size() == 2);
+                    can::messages::ErrorMessage err =
+                        std::get<can::messages::ErrorMessage>(
+                            test_objs.reporter.messages.front());
+                    REQUIRE(err.error_code ==
+                            can::ids::ErrorCode::collision_detected);
+                    REQUIRE(err.severity ==
+                            can::ids::ErrorSeverity::unrecoverable);
+                    can::messages::StopRequest stop =
+                        std::get<can::messages::StopRequest>(
+                            test_objs.reporter.messages.back());
+                    REQUIRE(stop.message_index == 0);
+                }
+            }
+        }
+    }
+
+    GIVEN("a move with ignore_stalls stop condition") {
+        auto cond =
+            static_cast<uint8_t>(GENERATE(Stops::none, Stops::sync_line));
+        auto msg1 =
+            Move{.message_index = 13,
+                 .duration = 23,
+                 .velocity = convert_velocity(0.5),
+                 .stop_condition = static_cast<uint8_t>(
+                     static_cast<uint8_t>(Stops::ignore_stalls) ^ cond)};
+        auto msg2 =
+            Move{.duration = 10,
+                 .velocity = convert_velocity(0.5),
+                 .stop_condition = static_cast<uint8_t>(
+                     static_cast<uint8_t>(Stops::ignore_stalls) ^ cond)};
+        test_objs.queue.try_write(msg1);
+        test_objs.queue.try_write(msg2);
+        REQUIRE(test_objs.queue.get_size() == 2);
+        test_objs.handler.run_interrupt();
+        WHEN("encoder doesn't update with the motor") {
+            REQUIRE(test_objs.queue.get_size() == 1);
+            REQUIRE(test_objs.reporter.messages.size() == 0);
+            for (int i = 0; i < (int)msg1.duration; ++i) {
+                test_objs.handler.run_interrupt();
+            }
+            THEN(
+                "the stall is detected but it is ignored, and the move is "
+                "completed") {
+                REQUIRE(!test_objs.hw.position_flags.check_flag(
+                    Flags::stepper_position_ok));
+                REQUIRE(test_objs.reporter.messages.size() == 1);
+                Ack ack_msg =
+                    std::get<Ack>(test_objs.reporter.messages.front());
+                REQUIRE(ack_msg.ack_id ==
+                        AckMessageId::complete_without_condition);
+                REQUIRE(ack_msg.message_index == 13);
+                THEN("the interrupt runs again") {
+                    test_objs.handler.run_interrupt();
+                    THEN("the second move will be executed as normal") {
+                        for (int i = 0; i < (int)msg2.duration; ++i) {
+                            test_objs.handler.run_interrupt();
+                        }
+                        REQUIRE(test_objs.reporter.messages.size() == 2);
+                        Ack ack_msg =
+                            std::get<Ack>(test_objs.reporter.messages.back());
+                        REQUIRE(ack_msg.ack_id ==
+                                AckMessageId::complete_without_condition);
+                    }
+                }
+            }
+        }
+    }
+
+    GIVEN("a move with stall expected stop condition") {
+        Move msg1 = Move{
+            .duration = 1000,
+            .velocity = convert_velocity(0.5),
+            .stop_condition = static_cast<uint8_t>(MoveStopCondition::stall)};
+        constexpr Move msg2 = Move{.duration = 400, .velocity = 50};
+        test_objs.queue.try_write(msg1);
+        test_objs.queue.try_write(msg2);
+        REQUIRE(test_objs.queue.get_size() == 2);
+        test_objs.handler.update_move();
+        WHEN("encoder doesn't update with the motor") {
+            for (int i = 0; i < (int)msg1.duration; ++i) {
+                test_objs.handler.run_interrupt();
+            }
+            THEN("the stall is detected but it is expected") {
+                REQUIRE(!test_objs.hw.position_flags.check_flag(
+                    Flags::stepper_position_ok));
+                THEN("a recoverable collision error is raised") {
+                    REQUIRE(test_objs.reporter.messages.size() == 1);
+                    can::messages::ErrorMessage err =
+                        std::get<can::messages::ErrorMessage>(
+                            test_objs.reporter.messages.front());
+                    REQUIRE(err.error_code ==
+                            can::ids::ErrorCode::collision_detected);
+                    REQUIRE(err.severity ==
+                            can::ids::ErrorSeverity::recoverable);
+                }
+            }
+        }
+    }
+}

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -110,6 +110,7 @@ SCENARIO("motor handler stall detection") {
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
+                REQUIRE(err.message_index == 13);
                 REQUIRE(err.error_code ==
                         can::ids::ErrorCode::collision_detected);
                 REQUIRE(err.severity == can::ids::ErrorSeverity::warning);
@@ -175,6 +176,7 @@ SCENARIO("motor handler stall detection") {
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
+                REQUIRE(err.message_index == 13);
                 REQUIRE(err.error_code ==
                         can::ids::ErrorCode::collision_detected);
                 REQUIRE(err.severity == can::ids::ErrorSeverity::warning);

--- a/motor-control/tests/test_sync_handling.cpp
+++ b/motor-control/tests/test_sync_handling.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Move with stop condition == cap sensor") {
                       .acceleration = 0,
                       .group_id = 1,
                       .seq_id = 0,
-                      .stop_condition = MoveStopCondition::sync_line};
+                      .stop_condition = static_cast<uint8_t>(MoveStopCondition::sync_line)};
 
     GIVEN("the move is in progress") {
         test_objs.queue.try_write_isr(msg10);
@@ -73,7 +73,7 @@ TEST_CASE("Move with stop condition == cap sensor, case 2") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = MoveStopCondition::sync_line};
+                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::sync_line)};
     GIVEN("the sync line has not been set") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_sync_line(false);
@@ -103,7 +103,7 @@ TEST_CASE("Move with stop condition != cap sensor") {
                      .acceleration = 0,
                      .group_id = 1,
                      .seq_id = 0,
-                     .stop_condition = MoveStopCondition::none};
+                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::none)};
     GIVEN("Move with stop condition = none in progress") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_sync_line(true);

--- a/motor-control/tests/test_sync_handling.cpp
+++ b/motor-control/tests/test_sync_handling.cpp
@@ -32,12 +32,13 @@ sq0_31 convert_velocity_to_f(float f) {
 
 TEST_CASE("Move with stop condition == cap sensor") {
     HandlerContainer test_objs{};
-    Move msg10 = Move{.duration = 2,
-                      .velocity = convert_velocity_to_f(.5),
-                      .acceleration = 0,
-                      .group_id = 1,
-                      .seq_id = 0,
-                      .stop_condition = static_cast<uint8_t>(MoveStopCondition::sync_line)};
+    Move msg10 = Move{
+        .duration = 2,
+        .velocity = convert_velocity_to_f(.5),
+        .acceleration = 0,
+        .group_id = 1,
+        .seq_id = 0,
+        .stop_condition = static_cast<uint8_t>(MoveStopCondition::sync_line)};
 
     GIVEN("the move is in progress") {
         test_objs.queue.try_write_isr(msg10);
@@ -68,12 +69,13 @@ TEST_CASE("Move with stop condition == cap sensor") {
 }
 TEST_CASE("Move with stop condition == cap sensor, case 2") {
     HandlerContainer test_objs{};
-    Move msg1 = Move{.duration = 2,
-                     .velocity = convert_velocity_to_f(.5),
-                     .acceleration = 0,
-                     .group_id = 1,
-                     .seq_id = 0,
-                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::sync_line)};
+    Move msg1 = Move{
+        .duration = 2,
+        .velocity = convert_velocity_to_f(.5),
+        .acceleration = 0,
+        .group_id = 1,
+        .seq_id = 0,
+        .stop_condition = static_cast<uint8_t>(MoveStopCondition::sync_line)};
     GIVEN("the sync line has not been set") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_sync_line(false);
@@ -98,12 +100,13 @@ TEST_CASE("Move with stop condition == cap sensor, case 2") {
 TEST_CASE("Move with stop condition != cap sensor") {
     HandlerContainer test_objs{};
     test_objs.handler.set_current_position(0x0);
-    Move msg1 = Move{.duration = 2,
-                     .velocity = convert_velocity_to_f(.5),
-                     .acceleration = 0,
-                     .group_id = 1,
-                     .seq_id = 0,
-                     .stop_condition = static_cast<uint8_t>(MoveStopCondition::none)};
+    Move msg1 =
+        Move{.duration = 2,
+             .velocity = convert_velocity_to_f(.5),
+             .acceleration = 0,
+             .group_id = 1,
+             .seq_id = 0,
+             .stop_condition = static_cast<uint8_t>(MoveStopCondition::none)};
     GIVEN("Move with stop condition = none in progress") {
         test_objs.queue.try_write_isr(msg1);
         test_objs.hw.set_mock_sync_line(true);


### PR DESCRIPTION
This PR adds a new MoveStopCondition called `ignore_stalls`. This can be used together with other conditions and the firmware will ignore and not raise an error if the motor stalls during movement. 

There are 3 different scenarios where a stall is handled:
1. **MoveStopCondition::none**
  This is a regular linear move where we're not expecting to see a stall. Therefore an unrecoverable error will be raised and a stop message will be broadcasted. 
3. **MoveStopCondition::stall**
  This is a move where a stall is expected and will be handled differently (not implemented yet). A recoverable error will be raised and we do not need to send a stop message.
4. **MoveStopCondition::ignore_stalls** 
  This move type should only be used during hardware testing. When a stall occurs, it doesn't raise any error and the rest of the moves in the queue are executed per usual. Note this only works if all of the subsequent moves also have the stall ignored flag. Therefore, it makes sense to use a feature flag on Python side to disable stall detection, where we can simply add the `ignore_stalls` condition to every single linear move message.