### PR TITLE
fix(motor-control): allow StopRequests outside estop

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -142,6 +142,7 @@ typedef enum {
     can_errorcode_labware_dropped = 0x9,
     can_errorcode_estop_released = 0xa,
     can_errorcode_motor_busy = 0xb,
+    can_errorcode_stop_requested = 0xc,
 } CANErrorCode;
 
 /** Tool types detected on Head. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -144,6 +144,7 @@ enum class ErrorCode {
     labware_dropped = 0x9,
     estop_released = 0xa,
     motor_busy = 0xb,
+    stop_requested = 0xc,
 };
 
 /** Error Severity levels. */

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -97,6 +97,7 @@ class MotionController {
         if (!hardware.get_stay_enabled()) {
             disable_motor();
         }
+        hardware.request_cancel();
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -97,7 +97,9 @@ class MotionController {
         if (!hardware.get_stay_enabled()) {
             disable_motor();
         }
-        hardware.request_cancel();
+        if (hardware.is_timer_interrupt_running()) {
+            hardware.request_cancel();
+        }
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -31,6 +31,9 @@ class MotorHardwareIface {
     virtual void start_timer_interrupt() = 0;
     virtual void stop_timer_interrupt() = 0;
 
+    virtual auto has_cancel_request() -> bool = 0;
+    virtual void request_cancel() = 0;
+
     // This variable can remain public because the only public methods
     // to it are thread-safe anyways.
     MotorPositionStatus position_flags{};

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -30,6 +30,7 @@ class MotorHardwareIface {
     virtual void reset_encoder_pulses() = 0;
     virtual void start_timer_interrupt() = 0;
     virtual void stop_timer_interrupt() = 0;
+    virtual auto is_timer_interrupt_running() -> bool = 0;
 
     virtual auto has_cancel_request() -> bool = 0;
     virtual void request_cancel() = 0;

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -103,6 +103,7 @@ class MotionController {
     void stop() {
         queue.reset();
         disable_motor();
+        hardware.request_cancel();
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }
@@ -235,6 +236,7 @@ class PipetteMotionController {
     void stop() {
         queue.reset();
         disable_motor();
+        hardware.request_cancel();
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -103,7 +103,9 @@ class MotionController {
     void stop() {
         queue.reset();
         disable_motor();
-        hardware.request_cancel();
+        if (hardware.is_timer_interrupt_running()) {
+            hardware.request_cancel();
+        }
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -238,7 +238,12 @@ class PipetteMotionController {
     void stop() {
         queue.reset();
         disable_motor();
-        hardware.request_cancel();
+        // if the timer interrupt is running, cancel it. if it isn't running,
+        // don't submit a cancel because then the cancel won't be read until
+        // the timer starts the next time.
+        if (hardware.is_timer_interrupt_running()) {
+            hardware.request_cancel();
+        }
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -125,9 +125,9 @@ class MotorInterruptHandler {
                 std::ignore = move_queue.try_read_isr(&scratch);
                 status_queue_client.send_move_status_reporter_queue(
                     can::messages::ErrorMessage{
-                    .message_index = scratch.message_index,
-                    .severity = can::ids::ErrorSeverity::unrecoverable,
-                    .error_code = can::ids::ErrorCode::estop_detected});
+                        .message_index = scratch.message_index,
+                        .severity = can::ids::ErrorSeverity::unrecoverable,
+                        .error_code = can::ids::ErrorCode::estop_detected});
                 clear_queue_until_empty = move_queue.has_message_isr();
             }
         }
@@ -297,8 +297,8 @@ class MotorInterruptHandler {
         } else {
             hardware.negative_direction();
         }
-        if (has_active_move && buffered_move.stop_condition ==
-            MoveStopCondition::limit_switch) {
+        if (has_active_move &&
+            buffered_move.stop_condition == MoveStopCondition::limit_switch) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
             update_hardware_step_tracker();
         }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "can/core/ids.hpp"
 #include "common/core/logging.h"
 #include "common/core/message_queue.hpp"
 #include "motor-control/core/motor_hardware_interface.hpp"
@@ -82,7 +83,7 @@ class MotorInterruptHandler {
                     if (stalled_during_movement()) {
                         cancel_and_clear_moves(
                             can::ids::ErrorCode::collision_detected,
-                            can::ids::ErrorSeverity::recoverable, false);
+                            can::ids::ErrorSeverity::recoverable);
                     }
                 }
             }
@@ -108,55 +109,54 @@ class MotorInterruptHandler {
         } else {
             if (has_move_messages()) {
                 // If we're currently in the estop and we have messages, then
-                // either we're still clearing out the queued messages that we
-                // hadn't yet executed when the estop happened; or somebody sent
-                // us new moves while we were in the estop. In either case, we
-                // want the same top-level behavior: one such move gets an error
-                // response, and the others get deleted.
-                if (!clear_queue_until_empty) {
-                    // Nothing has set clear_queue_until_empty. That flag is set
-                    // from false to true by the code below; by
-                    // cancel_and_clear_moves; and nowhere else. That means that
-                    // no move from the group that is in the queue was currently
-                    // being executed when estop asserted (or it would have been
-                    // cancelled by cancel_and_clear_moves) and no move from the
-                    // group that is in the queue has been responded to with an
-                    // error (or the code below would have run and set the
-                    // flag). Therefore, we need to send an error, and set the
-                    // flag to consume the rest of the group.
-                    auto scratch = MotorMoveMessage{};
-                    std::ignore = move_queue.try_read_isr(&scratch);
-                    status_queue_client.send_move_status_reporter_queue(
-                        can::messages::ErrorMessage{
-                            .message_index = scratch.message_index,
-                            .severity = can::ids::ErrorSeverity::unrecoverable,
-                            .error_code = can::ids::ErrorCode::estop_detected});
-                    clear_queue_until_empty = move_queue.has_message_isr();
-                } else {
-                    // If we were executing a move when estop asserted, and
-                    // what's in the queue is the remaining enqueued moves from
-                    // that group, then we will have called
-                    // cancel_and_clear_moves and clear_queue_until_empty will
-                    // be true. That means we should pop out the queue.
-                    // clear_queue_until_empty will also be true if we were in
-                    // the steady-state estop asserted; got new messages; and
-                    // the other branch of this if asserted. In either case, an
-                    // error message has been sent, so we need to just keep
-                    // clearing the queue.
-                    clear_queue_until_empty = pop_and_discard_move();
-                }
+                // somebody sent us new moves while we were in the estop.
+
+                // Nothing has set clear_queue_until_empty. That flag is set
+                // from false to true by the code below; by
+                // cancel_and_clear_moves; and nowhere else. That means that
+                // no move from the group that is in the queue was currently
+                // being executed when estop asserted (or it would have been
+                // cancelled by cancel_and_clear_moves) and no move from the
+                // group that is in the queue has been responded to with an
+                // error (or the code below would have run and set the
+                // flag). Therefore, we need to send an error, and set the
+                // flag to consume the rest of the group.
+                auto scratch = MotorMoveMessage{};
+                std::ignore = move_queue.try_read_isr(&scratch);
+                status_queue_client.send_move_status_reporter_queue(
+                    can::messages::ErrorMessage{
+                    .message_index = scratch.message_index,
+                    .severity = can::ids::ErrorSeverity::unrecoverable,
+                    .error_code = can::ids::ErrorCode::estop_detected});
+                clear_queue_until_empty = move_queue.has_message_isr();
             }
         }
         return estop_status;
     }
 
     void run_interrupt() {
-        // handle error state
-        if (in_estop) {
+        // handle various error states
+        if (clear_queue_until_empty) {
+            // If we were executing a move when estop asserted, and
+            // what's in the queue is the remaining enqueued moves from
+            // that group, then we will have called
+            // cancel_and_clear_moves and clear_queue_until_empty will
+            // be true. That means we should pop out the queue.
+            // clear_queue_until_empty will also be true if we were in
+            // the steady-state estop asserted; got new messages; and
+            // the other branch of this if asserted. In either case, an
+            // error message has been sent, so we need to just keep
+            // clearing the queue.
+            clear_queue_until_empty = pop_and_discard_move();
+        } else if (in_estop) {
             handle_update_position_queue();
             in_estop = estop_update();
         } else if (estop_triggered()) {
             cancel_and_clear_moves(can::ids::ErrorCode::estop_detected);
+            in_estop = true;
+        } else if (hardware.has_cancel_request()) {
+            cancel_and_clear_moves(can::ids::ErrorCode::stop_requested,
+                                   can::ids::ErrorSeverity::warning);
         } else {
             // Normal Move logic
             run_normal_interrupt();
@@ -291,20 +291,16 @@ class MotorInterruptHandler {
     }
 
     void update_move() {
-        if (clear_queue_until_empty) {
-            clear_queue_until_empty = pop_and_discard_move();
+        has_active_move = move_queue.try_read_isr(&buffered_move);
+        if (set_direction_pin()) {
+            hardware.positive_direction();
         } else {
-            has_active_move = move_queue.try_read_isr(&buffered_move);
-            if (set_direction_pin()) {
-                hardware.positive_direction();
-            } else {
-                hardware.negative_direction();
-            }
-            if (has_active_move && buffered_move.stop_condition ==
-                                       MoveStopCondition::limit_switch) {
-                position_tracker = 0x7FFFFFFFFFFFFFFF;
-                update_hardware_step_tracker();
-            }
+            hardware.negative_direction();
+        }
+        if (has_active_move && buffered_move.stop_condition ==
+            MoveStopCondition::limit_switch) {
+            position_tracker = 0x7FFFFFFFFFFFFFFF;
+            update_hardware_step_tracker();
         }
     }
 
@@ -326,8 +322,7 @@ class MotorInterruptHandler {
     void cancel_and_clear_moves(
         can::ids::ErrorCode err_code = can::ids::ErrorCode::hardware,
         can::ids::ErrorSeverity severity =
-            can::ids::ErrorSeverity::unrecoverable,
-        bool send_stop_msg = true) {
+            can::ids::ErrorSeverity::unrecoverable) {
         // If there is a currently running move send a error corresponding
         // to it so the hardware controller can know what move was running
         // when the cancel happened
@@ -340,25 +335,14 @@ class MotorInterruptHandler {
                                         .severity = severity,
                                         .error_code = err_code});
 
-        // Broadcast a stop message
-        if (send_stop_msg) {
-            status_queue_client.send_move_status_reporter_queue(
-                can::messages::StopRequest{.message_index = 0});
-        } else {
-            // Even if we don't emit a stop message, we have to make sure that
-            // other steps in the queue DO NOT execute. A stop message will
-            // clear the whole queue from an interrupt, but with this flag we
-            // will clear out the interrupt's queue without having to send
-            // more messages around the system.
-            clear_queue_until_empty = true;
-        }
+        // We have to make sure that
+        // other steps in the queue DO NOT execute. With this flag we
+        // will clear out the interrupt's queue.
+        clear_queue_until_empty = true;
 
         // the queue will get reset during the stop message processing
         // we can't clear here from an interrupt context
         has_active_move = false;
-        if (err_code == can::ids::ErrorCode::estop_detected) {
-            in_estop = true;
-        }
     }
 
     void finish_current_move(

--- a/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
@@ -72,6 +72,10 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     void reset_control() final;
     void set_stay_enabled(bool state) final { stay_enabled = state; }
     auto get_stay_enabled() -> bool final { return stay_enabled; }
+    auto has_cancel_request() -> bool final {
+        return cancel_request.exchange(false);
+    }
+    void request_cancel() final { cancel_request.store(true); }
 
   private:
     bool stay_enabled = false;
@@ -83,6 +87,7 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     int32_t motor_encoder_overflow_count = 0;
     ot_utils::pid::PID controller_loop;
     std::atomic<ControlDirection> control_dir = ControlDirection::unset;
+    std::atomic<bool> cancel_request = false;
 };
 
 };  // namespace motor_hardware

--- a/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
@@ -65,6 +65,7 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     void reset_encoder_pulses() final;
     void start_timer_interrupt() final;
     void stop_timer_interrupt() final;
+    auto is_timer_interrupt_running() -> bool final;
 
     void encoder_overflow(int32_t direction);
 

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <stdbool.h>
 void motor_hardware_start_timer(void* tim_handle);
 void motor_hardware_stop_timer(void* tim_handle);
+bool motor_hardware_timer_running(void* tim_handle);
 bool motor_hardware_start_dac(void* dac_handle, uint32_t channel);
 bool motor_hardware_stop_dac(void* dac_handle, uint32_t channel);
 bool motor_hardware_set_dac_value(void* dac_handle, uint32_t channel,

--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -49,6 +49,10 @@ class MotorHardware : public StepperMotorHardwareIface {
     void set_LED(bool status) final;
     auto get_encoder_pulses() -> int32_t final;
     void reset_encoder_pulses() final;
+    auto has_cancel_request() -> bool final {
+        return cancel_request.exchange(false);
+    }
+    void request_cancel() final { cancel_request.store(true); }
 
     // downward interface - call from timer overflow handler
     void encoder_overflow(int32_t direction);
@@ -61,6 +65,7 @@ class MotorHardware : public StepperMotorHardwareIface {
     void* tim_handle;
     void* enc_handle;
     int32_t motor_encoder_overflow_count = 0;
+    std::atomic<bool> cancel_request = false;
 };
 
 };  // namespace motor_hardware

--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -40,6 +40,7 @@ class MotorHardware : public StepperMotorHardwareIface {
     void deactivate_motor() final;
     void start_timer_interrupt() final;
     void stop_timer_interrupt() final;
+    auto is_timer_interrupt_running() -> bool final;
     auto check_limit_switch() -> bool final { return limit.debounce_state(); }
     auto check_estop_in() -> bool final { return estop.debounce_state(); }
     auto check_sync_in() -> bool final { return sync.debounce_state(); }

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <concepts>
 #include <memory>
 
@@ -85,6 +86,10 @@ class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
     bool check_estop_in() final { return estop_detected; }
 
     void set_estop(bool estop_pressed) { estop_detected = estop_pressed; }
+    auto has_cancel_request() -> bool final {
+        return cancel_request.exchange(false);
+    }
+    void request_cancel() final { cancel_request.store(true); }
 
   private:
     bool limit_switch_status = false;
@@ -94,6 +99,7 @@ class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
     Direction _direction = Direction::POSITIVE;
     float _encoder_ticks_per_pulse = 0;
     bool estop_detected = false;
+    std::atomic<bool> cancel_request = false;
 };
 
 class SimBrushedMotorHardwareIface
@@ -146,6 +152,11 @@ class SimBrushedMotorHardwareIface
     void set_stay_enabled(bool state) final { stay_enabled = state; }
     auto get_stay_enabled() -> bool final { return stay_enabled; }
 
+    auto has_cancel_request() -> bool final {
+        return cancel_request.exchange(false);
+    }
+    void request_cancel() final { cancel_request.store(true); }
+
   private:
     bool stay_enabled = false;
     bool limit_switch_status = false;
@@ -158,6 +169,7 @@ class SimBrushedMotorHardwareIface
     StateManagerHandle _state_manager = nullptr;
     MoveMessageHardware _id;
     bool estop_detected = false;
+    std::atomic<bool> cancel_request = false;
 };
 
 class SimGearMotorHardwareIface
@@ -215,6 +227,10 @@ class SimGearMotorHardwareIface
     bool check_estop_in() final { return estop_detected; }
 
     void set_estop(bool estop_pressed) { estop_detected = estop_pressed; }
+    auto has_cancel_request() -> bool final {
+        return cancel_request.exchange(false);
+    }
+    void request_cancel() final { cancel_request.store(true); }
 
   private:
     bool limit_switch_status = false;
@@ -224,6 +240,7 @@ class SimGearMotorHardwareIface
     Direction _direction = Direction::POSITIVE;
     float _encoder_ticks_per_pulse = 0;
     bool estop_detected = false;
+    std::atomic<bool> cancel_request = false;
 };
 
 }  // namespace sim_motor_hardware_iface

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -40,6 +40,7 @@ class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
     void deactivate_motor() final {}
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
+    bool is_timer_interrupt_running() final { return true; }
     bool check_limit_switch() final {
         if (limit_switch_status) {
             limit_switch_status = false;
@@ -113,6 +114,7 @@ class SimBrushedMotorHardwareIface
     void deactivate_motor() final {}
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
+    bool is_timer_interrupt_running() final { return true; }
     bool check_limit_switch() final {
         if (limit_switch_status) {
             limit_switch_status = false;
@@ -185,6 +187,7 @@ class SimGearMotorHardwareIface
     void deactivate_motor() final {}
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
+    bool is_timer_interrupt_running() final { return true; }
     bool check_limit_switch() final {
         if (limit_switch_status) {
             limit_switch_status = false;

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -49,7 +49,7 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     void reset_encoder_pulses() final { enc_val = 0; }
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
-    bool is_timer_Interrupt_running() final { return timer_interrupt_running; }
+    bool is_timer_interrupt_running() final { return timer_interrupt_running; }
     void encoder_overflow(int32_t direction) {
         motor_encoder_overflow_count += direction;
     }

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -49,6 +49,7 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     void reset_encoder_pulses() final { enc_val = 0; }
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
+    bool is_timer_Interrupt_running() final { return timer_interrupt_running; }
     void encoder_overflow(int32_t direction) {
         motor_encoder_overflow_count += direction;
     }
@@ -73,6 +74,9 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
         return old_request;
     }
     void request_cancel() final { cancel_request = true; }
+    void set_timer_interrupt_running(bool is_running) {
+        timer_interrupt_running = is_running;
+    }
 
   private:
     bool stay_enabled = false;
@@ -91,6 +95,7 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     ot_utils::pid::PID controller_loop{0.008,         0.0045, 0.000015,
                                        1.F / 32000.0, 7,      -7};
     bool cancel_request = false;
+    bool timer_interrupt_running = true;
 };
 
 class MockBrushedMotorDriverIface : public BrushedMotorDriverIface {

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -67,6 +67,12 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     PWM_DIRECTION get_direction() { return move_dir; }
     void set_stay_enabled(bool state) { stay_enabled = state; }
     auto get_stay_enabled() -> bool { return stay_enabled; }
+    auto has_cancel_request() -> bool final {
+        bool old_request = cancel_request;
+        cancel_request = false;
+        return old_request;
+    }
+    void request_cancel() final { cancel_request = true; }
 
   private:
     bool stay_enabled = false;
@@ -84,6 +90,7 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     // when the "motor" instantly goes to top speed then instantly stops
     ot_utils::pid::PID controller_loop{0.008,         0.0045, 0.000015,
                                        1.F / 32000.0, 7,      -7};
+    bool cancel_request = false;
 };
 
 class MockBrushedMotorDriverIface : public BrushedMotorDriverIface {

--- a/include/motor-control/tests/mock_motor_hardware.hpp
+++ b/include/motor-control/tests/mock_motor_hardware.hpp
@@ -35,6 +35,12 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     void reset_encoder_pulses() final { test_pulses = 0; }
     int32_t get_encoder_pulses() final { return test_pulses; }
     void sim_set_encoder_pulses(int32_t pulses) { test_pulses = pulses; }
+    auto has_cancel_request() -> bool final {
+        bool old_request = cancel_request;
+        cancel_request = false;
+        return old_request;
+    }
+    void request_cancel() final { cancel_request = true; }
 
   private:
     bool mock_lim_sw_value = false;
@@ -44,6 +50,7 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     bool mock_dir_value = false;
     uint8_t finished_move_id = 0x0;
     int32_t test_pulses = 0x0;
+    bool cancel_request = false;
 };
 
 };  // namespace test_mocks

--- a/include/motor-control/tests/mock_motor_hardware.hpp
+++ b/include/motor-control/tests/mock_motor_hardware.hpp
@@ -12,7 +12,7 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     auto operator=(const MockMotorHardware&) -> MockMotorHardware& = default;
     MockMotorHardware(MockMotorHardware&&) = default;
     auto operator=(MockMotorHardware&&) -> MockMotorHardware& = default;
-    void step() final {}
+    void step() final { steps++; }
     void unstep() final {}
     void positive_direction() final {}
     void negative_direction() final {}
@@ -20,7 +20,9 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     void deactivate_motor() final {}
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
-    bool is_timer_interrupt_running() final { return timer_interrupt_running; }
+    bool is_timer_interrupt_running() final {
+        return mock_timer_interrupt_running;
+    }
     bool check_limit_switch() final { return mock_lim_sw_value; }
     bool check_estop_in() final { return mock_estop_in_value; }
     bool check_sync_in() final { return mock_sync_value; }
@@ -45,8 +47,10 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     void sim_set_timer_interrupt_running(bool is_running) {
         mock_timer_interrupt_running = is_running;
     }
+    auto steps_taken() -> uint64_t { return steps; }
 
   private:
+    uint64_t steps = 0;
     bool mock_lim_sw_value = false;
     bool mock_estop_in_value = false;
     bool mock_sync_value = false;

--- a/include/motor-control/tests/mock_motor_hardware.hpp
+++ b/include/motor-control/tests/mock_motor_hardware.hpp
@@ -20,6 +20,7 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     void deactivate_motor() final {}
     void start_timer_interrupt() final {}
     void stop_timer_interrupt() final {}
+    bool is_timer_interrupt_running() final { return timer_interrupt_running; }
     bool check_limit_switch() final { return mock_lim_sw_value; }
     bool check_estop_in() final { return mock_estop_in_value; }
     bool check_sync_in() final { return mock_sync_value; }
@@ -41,6 +42,9 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
         return old_request;
     }
     void request_cancel() final { cancel_request = true; }
+    void sim_set_timer_interrupt_running(bool is_running) {
+        mock_timer_interrupt_running = is_running;
+    }
 
   private:
     bool mock_lim_sw_value = false;
@@ -51,6 +55,7 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
     uint8_t finished_move_id = 0x0;
     int32_t test_pulses = 0x0;
     bool cancel_request = false;
+    bool mock_timer_interrupt_running = true;
 };
 
 };  // namespace test_mocks

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -28,6 +28,10 @@ void BrushedMotorHardware::stop_timer_interrupt() {
     motor_hardware_stop_timer(pins.pwm_2.tim);  // stop base timer
 }
 
+bool BrushedMotorHardware::is_timer_interrupt_running() {
+    return motor_hardware_timer_running(pins.pwm_2.tim);
+}
+
 void BrushedMotorHardware::activate_motor() { gpio::set(pins.enable); }
 
 void BrushedMotorHardware::deactivate_motor() { gpio::reset(pins.enable); }

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -6,6 +6,7 @@
 
 #include "FreeRTOS.h"
 #include "platform_specific_hal_conf.h"
+#include "stm32g4xx_hal_tim.h"
 #include "task.h"
 
 HAL_StatusTypeDef custom_stop_pwm_it(TIM_HandleTypeDef* htim,
@@ -44,9 +45,16 @@ HAL_StatusTypeDef custom_stop_pwm_it(TIM_HandleTypeDef* htim,
     return HAL_OK;
 }
 
-void motor_hardware_start_timer(void* htim) { HAL_TIM_Base_Start_IT(htim); }
+void motor_hardware_start_timer(void* tim_handle) { HAL_TIM_Base_Start_IT(tim_handle); }
 
-void motor_hardware_stop_timer(void* htim) { HAL_TIM_Base_Stop_IT(htim); }
+void motor_hardware_stop_timer(void* tim_handle) { HAL_TIM_Base_Stop_IT(tim_handle); }
+
+bool motor_hardware_timer_running(void* tim_handle) {
+    if (!tim_handle) {
+        return false;
+    }
+    return (HAL_TIM_Base_GetState(tim_handle) == HAL_TIM_STATE_BUSY);
+}
 
 bool motor_hardware_start_dac(void* hdac, uint32_t channel) {
     return HAL_DAC_Start(hdac, channel) == HAL_OK;

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -31,6 +31,11 @@ void MotorHardware::start_timer_interrupt() {
 void MotorHardware::stop_timer_interrupt() {
     motor_hardware_stop_timer(tim_handle);
 }
+
+bool MotorHardware::is_timer_interrupt_running() {
+    return motor_hardware_timer_running(tim_handle);
+}
+
 void MotorHardware::read_limit_switch() {
     limit.debounce_update(gpio::is_set(pins.limit_switch));
 }

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -236,16 +236,11 @@ SCENARIO("estop pressed during Brushed motor interrupt handler") {
             test_objs.hw.set_estop_in(true);
             test_objs.handler.run_interrupt();
             THEN("Errors are sent") {
-                REQUIRE(test_objs.reporter.messages.size() == 2);
+                REQUIRE(test_objs.reporter.messages.size() == 1);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
                 REQUIRE(err.error_code == can::ids::ErrorCode::estop_detected);
-
-                can::messages::StopRequest stop =
-                    std::get<can::messages::StopRequest>(
-                        test_objs.reporter.messages.back());
-                REQUIRE(stop.message_index == 0);
             }
         }
     }
@@ -285,16 +280,12 @@ SCENARIO("labware dropped during grip move") {
                 for (uint32_t i = 0; i <= HOLDOFF_TICKS; i++) {
                     test_objs.handler.run_interrupt();
                 }
-                REQUIRE(test_objs.reporter.messages.size() == 2);
+                REQUIRE(test_objs.reporter.messages.size() == 1);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
                 REQUIRE(err.error_code == can::ids::ErrorCode::labware_dropped);
 
-                can::messages::StopRequest stop =
-                    std::get<can::messages::StopRequest>(
-                        test_objs.reporter.messages.back());
-                REQUIRE(stop.message_index == 0);
                 REQUIRE(test_objs.hw.get_stay_enabled() == true);
             }
         }
@@ -338,17 +329,13 @@ SCENARIO("collision while homed") {
                 for (uint32_t i = 0; i <= HOLDOFF_TICKS; i++) {
                     test_objs.handler.run_interrupt();
                 }
-                REQUIRE(test_objs.reporter.messages.size() == 2);
+                REQUIRE(test_objs.reporter.messages.size() == 1);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
                 REQUIRE(err.error_code ==
                         can::ids::ErrorCode::collision_detected);
 
-                can::messages::StopRequest stop =
-                    std::get<can::messages::StopRequest>(
-                        test_objs.reporter.messages.back());
-                REQUIRE(stop.message_index == 0);
                 REQUIRE(test_objs.hw.get_stay_enabled() == false);
             }
         }
@@ -425,17 +412,13 @@ SCENARIO("A collision during position controlled move") {
                 for (uint32_t i = 0; i <= HOLDOFF_TICKS; i++) {
                     test_objs.handler.run_interrupt();
                 }
-                REQUIRE(test_objs.reporter.messages.size() == 2);
+                REQUIRE(test_objs.reporter.messages.size() == 1);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
                 REQUIRE(err.error_code ==
                         can::ids::ErrorCode::collision_detected);
 
-                can::messages::StopRequest stop =
-                    std::get<can::messages::StopRequest>(
-                        test_objs.reporter.messages.back());
-                REQUIRE(stop.message_index == 0);
                 REQUIRE(test_objs.hw.get_stay_enabled() == false);
             }
         }

--- a/motor-control/tests/test_motor_interrupt_queue.cpp
+++ b/motor-control/tests/test_motor_interrupt_queue.cpp
@@ -49,7 +49,7 @@ TEST_CASE("motor interrupt handler queue functionality") {
                     handler.run_interrupt();
                     handler.cancel_and_clear_moves(
                         can::ids::ErrorCode::hardware,
-                        can::ids::ErrorSeverity::warning, false);
+                        can::ids::ErrorSeverity::warning);
                     THEN("the other pending movements are cancelled") {
                         REQUIRE(handler.has_move_messages());
                         // There are 3 more messages to clear


### PR DESCRIPTION
When we implemented StopRequest, we were really doing it as a way to make sure everything got the message about an estop activation. 

We now need to use it to clean up after cancelling protocols, and send it from the host outside an estop situation... and that didn't really work.

This PR decouples the logic of
- estop handling
- canceling and clearing the interrupt handler move queue
- getting StopRequests

It's now safe to get an arbitrary stop request during a move or not during a move which will halt motion and clean up all the move state and clear out the queues. This also simplifies some of the interrupt handler state logic.

## Testing
- [x] on a loaded machine, send a stop request during a running move
- [x] on a loaded machine, hit the estop
- [x] on a loaded machine, send a move while estop is active
- [x] on a loaded machine, deactivate estop then send a move
- [x] on a loaded machine, send a stoprequest while estop is asserted

## Review requests
- logic look good

## Todo
- Tests