### PR TITLE
refactor(pipettes): change pipette microstep to 16

### DIFF
--- a/pipettes/core/configs.cpp
+++ b/pipettes/core/configs.cpp
@@ -10,7 +10,7 @@ auto configs::linear_motion_sys_config_by_axis(PipetteType which)
                     lms::LeadScrewConfig{.lead_screw_pitch = 2,
                                          .gear_reduction_ratio = 1.0},
                 .steps_per_rev = 200,
-                .microstep = 64,
+                .microstep = 16,
                 .encoder_pulses_per_rev = 1000};
         case PipetteType::EIGHT_CHANNEL:
         case PipetteType::SINGLE_CHANNEL:

--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -20,7 +20,7 @@ auto motor_configs::driver_config_by_axis(TMC2160PipetteAxis which)
                                    .hstrt = 0x5,
                                    .hend = 0x3,
                                    .tbl = 0x2,
-                                   .mres = 0x2},
+                                   .mres = 0x4},
                       .coolconf = {.sgt = 0x6},
                       .glob_scale = {.global_scaler = 0xA7}},
         .current_config =


### PR DESCRIPTION
When the plunger motors on the 96 channel pipette would stall with a microstep value of 64, the firmware would shut down. Decreasing the resolution to 16 seems to fix that problem and allow the pipette to keep operating after a stall.