### PR TITLE
fix(pipettes): completely disable NVIC for data ready across all 96 channels

### DIFF
--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -7,11 +7,8 @@
 // temporary workaround until we permanently disable
 // the data ready line interrupts and rely on a software
 // timer instead.
-#if PCBA_PRIMARY_REVISION == 'b'
-    static const int enable_96_chan_interrupts = 0;
-#else
-    static const int enable_96_chan_interrupts = 1;
-#endif
+
+static const int enable_96_chan_interrupts = 0;
 
 static void enable_gpio_port(void* port) {
     if (port == GPIOA) {


### PR DESCRIPTION
For some reason, on DVT 96 channels the hardware interrupt still seems to cause the firmware to crash. We should completely disable it on the 96 channel to unblock testing until switching the pressure sensor to a software timer is completed.