### PR TITLE
feat(motor-control): use eeprom to track total error events

### DIFF
--- a/gantry/firmware/eeprom_keys.cpp
+++ b/gantry/firmware/eeprom_keys.cpp
@@ -11,8 +11,13 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
     .data_table = {std::make_pair(
         AXIS_DISTANCE_KEY, usage_storage_task::distance_data_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2{
+    .data_rev = 2,
+    .data_table = {std::make_pair(ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len)}};
+
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
         // vector with the new key/length pairs
-        data_table_rev1};
+        data_table_rev1, data_table_rev2};

--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -35,12 +35,17 @@ static spi::hardware::SPI_interface SPI_intf = {
 static spi::hardware::Spi spi_comms(SPI_intf);
 
 struct motor_hardware::UsageEEpromConfig usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = AXIS_DISTANCE_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -35,12 +35,17 @@ static spi::hardware::SPI_interface SPI_intf = {
 static spi::hardware::Spi spi_comms(SPI_intf);
 
 struct motor_hardware::UsageEEpromConfig usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = AXIS_DISTANCE_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };

--- a/gripper/firmware/eeprom_keys.cpp
+++ b/gripper/firmware/eeprom_keys.cpp
@@ -20,9 +20,15 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2{
     .data_table = {
         std::make_pair(G_MOTOR_FORCE_TIME_KEY,
                        usage_storage_task::force_time_data_usage_len)}};
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3{
+    .data_rev = 3,
+    .data_table = {std::make_pair(Z_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len),
+                   std::make_pair(G_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len)}};
 
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
         // vector with the new key/length pairs
-        data_table_rev1, data_table_rev2};
+        data_table_rev1, data_table_rev2, data_table_rev3};

--- a/gripper/firmware/interfaces_grip_motor.cpp
+++ b/gripper/firmware/interfaces_grip_motor.cpp
@@ -18,17 +18,22 @@ constexpr uint32_t PWM_MAX = 60;
 constexpr uint32_t PWM_MIN = 7;
 
 struct motor_hardware::UsageEEpromConfig brushed_usage_config {
-    std::array<UsageRequestSet, 2> {
+    std::array<UsageRequestSet, 3> {
         UsageRequestSet{
             .eeprom_key = G_MOTOR_DIST_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
             .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet{
+                .eeprom_key = G_MOTOR_FORCE_TIME_KEY,
+                .type_key = uint16_t(
+                    can::ids::MotorUsageValueType::force_application_time),
+                .length = usage_storage_task::force_time_data_usage_len},
             UsageRequestSet {
-            .eeprom_key = G_MOTOR_FORCE_TIME_KEY,
+            .eeprom_key = G_ERROR_COUNT_KEY,
             .type_key =
-                uint16_t(can::ids::MotorUsageValueType::force_application_time),
-            .length = usage_storage_task::force_time_data_usage_len
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -25,12 +25,17 @@ static spi::hardware::SPI_interface SPI_intf = {
 };
 
 struct motor_hardware::UsageEEpromConfig z_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = Z_MOTOR_DIST_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = Z_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };

--- a/head/firmware/eeprom_keys.cpp
+++ b/head/firmware/eeprom_keys.cpp
@@ -13,9 +13,15 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1{
                        usage_storage_task::distance_data_usage_len),
         std::make_pair(R_MOTOR_DISTANCE_KEY,
                        usage_storage_task::distance_data_usage_len)}};
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2{
+    .data_rev = 2,
+    .data_table = {std::make_pair(L_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len),
+                   std::make_pair(L_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len)}};
 
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
         // vector with the new key/length pairs
-        data_table_rev1};
+        data_table_rev1, data_table_rev2};

--- a/head/firmware/main_proto.cpp
+++ b/head/firmware/main_proto.cpp
@@ -78,23 +78,33 @@ spi::hardware::SPI_interface SPI_intf3 = {
 static spi::hardware::Spi spi_comms3(SPI_intf3);
 
 struct motor_hardware::UsageEEpromConfig left_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = L_MOTOR_DISTANCE_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = L_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };
 
 struct motor_hardware::UsageEEpromConfig right_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = R_MOTOR_DISTANCE_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = R_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -84,23 +84,33 @@ static constexpr int direction_active_level = GPIO_PIN_SET;
 #endif
 
 struct motor_hardware::UsageEEpromConfig left_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = L_MOTOR_DISTANCE_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = L_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };
 
 struct motor_hardware::UsageEEpromConfig right_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = R_MOTOR_DISTANCE_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = R_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -239,6 +239,7 @@ enum class MotorUsageValueType {
     left_gear_motor_distance = 0x1,
     right_gear_motor_distance = 0x2,
     force_application_time = 0x3,
+    total_error_count = 0x4,
 };
 
 }  // namespace can::ids

--- a/include/gantry/firmware/eeprom_keys.hpp
+++ b/include/gantry/firmware/eeprom_keys.hpp
@@ -3,8 +3,10 @@
 #include "eeprom/core/update_data_rev_task.hpp"
 
 static constexpr uint16_t AXIS_DISTANCE_KEY = 0;
+static constexpr uint16_t ERROR_COUNT_KEY = 1;
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1;
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2;
 
 extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
     table_updater;

--- a/include/gripper/firmware/eeprom_keys.hpp
+++ b/include/gripper/firmware/eeprom_keys.hpp
@@ -5,10 +5,12 @@
 static constexpr eeprom::types::address Z_MOTOR_DIST_KEY = 0x0000;
 static constexpr eeprom::types::address G_MOTOR_DIST_KEY = 0x0001;
 static constexpr eeprom::types::address G_MOTOR_FORCE_TIME_KEY = 0x0002;
+static constexpr eeprom::types::address Z_ERROR_COUNT_KEY = 0x0003;
+static constexpr eeprom::types::address G_ERROR_COUNT_KEY = 0x0004;
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1;
-
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2;
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3;
 
 extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
     table_updater;

--- a/include/head/firmware/eeprom_keys.hpp
+++ b/include/head/firmware/eeprom_keys.hpp
@@ -4,8 +4,11 @@
 
 static constexpr uint16_t L_MOTOR_DISTANCE_KEY = 0;
 static constexpr uint16_t R_MOTOR_DISTANCE_KEY = 1;
+static constexpr uint16_t L_ERROR_COUNT_KEY = 2;
+static constexpr uint16_t R_ERROR_COUNT_KEY = 3;
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1;
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2;
 
 extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
     table_updater;

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -184,6 +184,10 @@ class BrushedMotorInterruptHandler {
                         .message_index = 0,
                         .severity = can::ids::ErrorSeverity::warning,
                         .error_code = can::ids::ErrorCode::estop_released});
+                status_queue_client.send_brushed_move_status_reporter_queue(
+                    usage_messages::IncreaseErrorCount{
+                        .key = hardware.get_usage_eeprom_config()
+                                   .get_error_count_key()});
             }
         } else if (estop_triggered()) {
             cancel_and_clear_moves(can::ids::ErrorCode::estop_detected);
@@ -325,6 +329,10 @@ class BrushedMotorInterruptHandler {
             can::messages::ErrorMessage{.message_index = message_index,
                                         .severity = severity,
                                         .error_code = err_code});
+        status_queue_client.send_brushed_move_status_reporter_queue(
+            usage_messages::IncreaseErrorCount{
+                .key =
+                    hardware.get_usage_eeprom_config().get_error_count_key()});
         clear_queue_until_empty = true;
     }
 

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -59,6 +59,15 @@ class UsageEEpromConfig {
         }
         return 0xFFFF;
     }
+    [[nodiscard]] auto get_error_count_key() const -> uint16_t {
+        for (auto i : usage_requests) {
+            if (i.type_key ==
+                uint16_t(can::ids::MotorUsageValueType::total_error_count)) {
+                return i.eeprom_key;
+            }
+        }
+        return 0xFFFF;
+    }
     std::array<UsageRequestSet, max_requests_per_can_message> usage_requests{};
     size_t num_keys = 0;
 };

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -128,6 +128,10 @@ class MotorInterruptHandler {
                         .message_index = scratch.message_index,
                         .severity = can::ids::ErrorSeverity::unrecoverable,
                         .error_code = can::ids::ErrorCode::estop_detected});
+                status_queue_client.send_move_status_reporter_queue(
+                    usage_messages::IncreaseErrorCount{
+                        .key = hardware.get_usage_eeprom_config()
+                                   .get_error_count_key()});
                 clear_queue_until_empty = move_queue.has_message_isr();
             }
         }
@@ -342,6 +346,10 @@ class MotorInterruptHandler {
             can::messages::ErrorMessage{.message_index = message_index,
                                         .severity = severity,
                                         .error_code = err_code});
+        status_queue_client.send_move_status_reporter_queue(
+            usage_messages::IncreaseErrorCount{
+                .key =
+                    hardware.get_usage_eeprom_config().get_error_count_key()});
 
         // We have to make sure that
         // other steps in the queue DO NOT execute. With this flag we
@@ -471,6 +479,10 @@ class MotorInterruptHandler {
 
             static_cast<void>(
                 status_queue_client.send_move_status_reporter_queue(response));
+            status_queue_client.send_move_status_reporter_queue(
+                usage_messages::IncreaseErrorCount{
+                    .key = hardware.get_usage_eeprom_config()
+                               .get_error_count_key()});
         }
     }
 

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -28,11 +28,10 @@ using MoveGroupTaskMessage =
                  can::messages::GetMoveGroupRequest, can::messages::HomeRequest,
                  can::messages::StopRequest>;
 
-using MoveStatusReporterTaskMessage =
-    std::variant<std::monostate, motor_messages::Ack,
-                 motor_messages::UpdatePositionResponse,
-                 can::messages::ErrorMessage, can::messages::StopRequest,
-                 usage_messages::IncreaseForceTimeUsage>;
+using MoveStatusReporterTaskMessage = std::variant<
+    std::monostate, motor_messages::Ack, motor_messages::UpdatePositionResponse,
+    can::messages::ErrorMessage, can::messages::StopRequest,
+    usage_messages::IncreaseForceTimeUsage, usage_messages::IncreaseErrorCount>;
 
 using BrushedMotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,
@@ -57,6 +56,7 @@ using BrushedMoveGroupTaskMessage = std::variant<
 using UsageStorageTaskMessage =
     std::variant<std::monostate, usage_messages::IncreaseDistanceUsage,
                  usage_messages::GetUsageRequest,
-                 usage_messages::IncreaseForceTimeUsage>;
+                 usage_messages::IncreaseForceTimeUsage,
+                 usage_messages::IncreaseErrorCount>;
 
 }  // namespace motor_control_task_messages

--- a/include/motor-control/core/tasks/move_status_reporter_task.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task.hpp
@@ -97,6 +97,10 @@ class MoveStatusMessageHandler {
         usage_client.send_usage_storage_queue(message);
     }
 
+    void handle_message(const usage_messages::IncreaseErrorCount& message) {
+        usage_client.send_usage_storage_queue(message);
+    }
+
   private:
     CanClient& can_client;
     const lms::LinearMotionSystemConfig<LmsConfig>& lms_config;

--- a/include/motor-control/core/tasks/usage_storage_task.hpp
+++ b/include/motor-control/core/tasks/usage_storage_task.hpp
@@ -183,10 +183,7 @@ class UsageStorageTaskHandler : eeprom::accessor::ReadListener {
         std::ignore = bit_utils::bytes_to_int(
             accessor_backing.begin(),
             accessor_backing.begin() + error_count_usage_len, old_value);
-        if (old_value == std::numeric_limits<uint32_t>::max()) {
-            // old_value must be an uninitialized data field so set it to 0
-            old_value = 0;
-        }
+        old_value = check_for_default_val(old_value);
         old_value += 1;
         std::ignore = bit_utils::int_to_bytes(
             old_value, accessor_backing.begin(), accessor_backing.end());

--- a/include/motor-control/core/tasks/usage_storage_task.hpp
+++ b/include/motor-control/core/tasks/usage_storage_task.hpp
@@ -182,7 +182,7 @@ class UsageStorageTaskHandler : eeprom::accessor::ReadListener {
         uint32_t old_value = 0;
         std::ignore = bit_utils::bytes_to_int(
             accessor_backing.begin(),
-            accessor_backing.begin() + distance_data_usage_len, old_value);
+            accessor_backing.begin() + error_count_usage_len, old_value);
         if (old_value == std::numeric_limits<uint32_t>::max()) {
             // old_value must be an uninitialized data field so set it to 0
             old_value = 0;
@@ -190,7 +190,7 @@ class UsageStorageTaskHandler : eeprom::accessor::ReadListener {
         old_value += 1;
         std::ignore = bit_utils::int_to_bytes(
             old_value, accessor_backing.begin(), accessor_backing.end());
-        usage_data_accessor.write_data(m.key, distance_data_usage_len,
+        usage_data_accessor.write_data(m.key, error_count_usage_len,
                                        accessor_backing);
         ready_for_new_message = true;
         buffered_task = TaskMessage{};

--- a/include/motor-control/core/usage_messages.hpp
+++ b/include/motor-control/core/usage_messages.hpp
@@ -17,6 +17,10 @@ struct IncreaseForceTimeUsage {
     uint16_t seconds;
 };
 
+struct IncreaseErrorCount {
+    uint16_t key;
+};
+
 struct GetUsageRequest {
     uint32_t message_index;
     motor_hardware::UsageEEpromConfig usage_conf;

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -94,6 +94,11 @@ class MoveStatusMessageHandler {
         can_client.send_can_message(can::ids::NodeId::broadcast, msg);
     }
 
+    void handle_message(const usage_messages::IncreaseErrorCount& message) {
+        usage_client.send_usage_storage_queue(message);
+    }
+
+
   private:
     CanClient& can_client;
     const lms::LinearMotionSystemConfig<LmsConfig>& lms_config;

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -98,7 +98,6 @@ class MoveStatusMessageHandler {
         usage_client.send_usage_storage_queue(message);
     }
 
-
   private:
     CanClient& can_client;
     const lms::LinearMotionSystemConfig<LmsConfig>& lms_config;

--- a/include/pipettes/core/tasks/messages.hpp
+++ b/include/pipettes/core/tasks/messages.hpp
@@ -2,6 +2,7 @@
 
 #include "can/core/messages.hpp"
 #include "motor-control/core/motor_messages.hpp"
+#include "motor-control/core/usage_messages.hpp"
 
 namespace pipettes {
 
@@ -23,7 +24,8 @@ using MotionControlTaskMessage =
 using MoveStatusReporterTaskMessage =
     std::variant<std::monostate, motor_messages::GearMotorAck,
                  motor_messages::UpdatePositionResponse,
-                 can::messages::StopRequest, can::messages::ErrorMessage>;
+                 can::messages::StopRequest, can::messages::ErrorMessage,
+                 usage_messages::IncreaseErrorCount>;
 
 }  // namespace motor_control_task_messages
 

--- a/include/pipettes/firmware/eeprom_keys.hpp
+++ b/include/pipettes/firmware/eeprom_keys.hpp
@@ -5,10 +5,17 @@
 static constexpr uint16_t PLUNGER_MOTOR_STEP_KEY = 0;
 static constexpr uint16_t GEAR_LEFT_MOTOR_KEY = 1;
 static constexpr uint16_t GEAR_RIGHT_MOTOR_KEY = 2;
+static constexpr uint16_t P_96_ERROR_COUNT_KEY = 3;
+static constexpr uint16_t P_SM_ERROR_COUNT_KEY = 1;
+static constexpr uint16_t L_ERROR_COUNT_KEY = 4;
+static constexpr uint16_t R_ERROR_COUNT_KEY = 5;
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev1_sing_mult;
+extern const eeprom::data_rev_task::DataTableUpdateMessage
+    data_table_rev2_sing_mult;
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch;
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_96ch;
 
 extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
     table_updater;

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -236,7 +236,8 @@ SCENARIO("estop pressed during Brushed motor interrupt handler") {
             test_objs.hw.set_estop_in(true);
             test_objs.handler.run_interrupt();
             THEN("Errors are sent") {
-                REQUIRE(test_objs.reporter.messages.size() == 1);
+                // An error and increase error count is sent
+                REQUIRE(test_objs.reporter.messages.size() == 2);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
@@ -280,7 +281,8 @@ SCENARIO("labware dropped during grip move") {
                 for (uint32_t i = 0; i <= HOLDOFF_TICKS; i++) {
                     test_objs.handler.run_interrupt();
                 }
-                REQUIRE(test_objs.reporter.messages.size() == 1);
+                // An error and increase error count is sent
+                REQUIRE(test_objs.reporter.messages.size() == 2);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
@@ -329,7 +331,8 @@ SCENARIO("collision while homed") {
                 for (uint32_t i = 0; i <= HOLDOFF_TICKS; i++) {
                     test_objs.handler.run_interrupt();
                 }
-                REQUIRE(test_objs.reporter.messages.size() == 1);
+                // An error and increase error count is sent
+                REQUIRE(test_objs.reporter.messages.size() == 2);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
@@ -412,7 +415,8 @@ SCENARIO("A collision during position controlled move") {
                 for (uint32_t i = 0; i <= HOLDOFF_TICKS; i++) {
                     test_objs.handler.run_interrupt();
                 }
-                REQUIRE(test_objs.reporter.messages.size() == 1);
+                // An error and increase error count is sent
+                REQUIRE(test_objs.reporter.messages.size() == 2);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());

--- a/motor-control/tests/test_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_motor_interrupt_handler.cpp
@@ -42,8 +42,8 @@ SCENARIO("a move is cancelled due to a stop request") {
             CHECK(test_objs.hw.steps_taken() == 1);
             test_objs.hw.request_cancel();
             test_objs.handler.run_interrupt();
-            THEN("An error is sent") {
-                REQUIRE(test_objs.reporter.messages.size() == 1);
+            THEN("An error and increase error count is sent") {
+                REQUIRE(test_objs.reporter.messages.size() == 2);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
@@ -87,8 +87,8 @@ SCENARIO("estop pressed during motor interrupt handler") {
             CHECK(test_objs.hw.steps_taken() == 1);
             test_objs.hw.set_mock_estop_in(true);
             test_objs.handler.run_interrupt();
-            THEN("An error is sent") {
-                REQUIRE(test_objs.reporter.messages.size() == 1);
+            THEN("An error and increase error count is sent") {
+                REQUIRE(test_objs.reporter.messages.size() == 2);
                 can::messages::ErrorMessage err =
                     std::get<can::messages::ErrorMessage>(
                         test_objs.reporter.messages.front());
@@ -117,8 +117,8 @@ SCENARIO("estop is steady-state pressed") {
     test_objs.hw.set_mock_estop_in(true);
     test_objs.handler.run_interrupt();
     test_objs.handler.run_interrupt();
-    // estop-active message
-    CHECK(test_objs.reporter.messages.size() == 1);
+    // estop-active message and increase error count message
+    CHECK(test_objs.reporter.messages.size() == 2);
     test_objs.reporter.messages.clear();
     GIVEN("some moves in its queue") {
         auto msg = Move{.message_index = 1,
@@ -135,16 +135,19 @@ SCENARIO("estop is steady-state pressed") {
             test_objs.handler.run_interrupt();
             THEN("the first move gets an error") {
                 REQUIRE(test_objs.queue.get_size() == 1);
-                REQUIRE(test_objs.reporter.messages.size() == 1);
+                REQUIRE(test_objs.reporter.messages.size() == 2);
                 auto err = std::get<can::messages::ErrorMessage>(
                     test_objs.reporter.messages.front());
                 REQUIRE(err.error_code == can::ids::ErrorCode::estop_detected);
                 REQUIRE(err.message_index == 1);
+                auto inc_err_cnt = std::get<usage_messages::IncreaseErrorCount>(
+                    test_objs.reporter.messages[1]);
+                std::ignore = inc_err_cnt;
                 AND_WHEN("the interrupt runs again") {
                     test_objs.handler.run_interrupt();
                     THEN("the second move is just ignored") {
                         REQUIRE(test_objs.queue.get_size() == 0);
-                        REQUIRE(test_objs.reporter.messages.size() == 1);
+                        REQUIRE(test_objs.reporter.messages.size() == 2);
                     }
                 }
             }

--- a/pipettes/firmware/eeprom_keys.cpp
+++ b/pipettes/firmware/eeprom_keys.cpp
@@ -12,6 +12,11 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_sing_mult{
     .data_table = {std::make_pair(
         PLUNGER_MOTOR_STEP_KEY, usage_storage_task::distance_data_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_sing_mult{
+    .data_rev = 2,
+    .data_table = {std::make_pair(P_SM_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len)}};
+
 const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch{
     .data_rev = 1,
     .data_table = {
@@ -22,9 +27,20 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch{
         std::make_pair(GEAR_RIGHT_MOTOR_KEY,
                        usage_storage_task::distance_data_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_96ch{
+    .data_rev = 2,
+    .data_table = {std::make_pair(P_96_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len),
+                   std::make_pair(L_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len),
+                   std::make_pair(R_ERROR_COUNT_KEY,
+                                  usage_storage_task::error_count_usage_len)}};
+
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
         // vector with the new key/length pairs
         get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev1_96ch
-                                                 : data_table_rev1_sing_mult};
+                                                 : data_table_rev1_sing_mult,
+        get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev2_96ch
+                                                 : data_table_rev2_sing_mult};

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -73,13 +73,20 @@ auto linear_motor::get_interrupt(motor_hardware::MotorHardware& hw,
         queues.plunger_update_queue);
 }
 
-struct motor_hardware::UsageEEpromConfig single_multi_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+struct motor_hardware::UsageEEpromConfig plunger_usage_config {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = PLUNGER_MOTOR_STEP_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
+                              ? P_96_ERROR_COUNT_KEY
+                              : P_SM_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };
@@ -87,7 +94,7 @@ struct motor_hardware::UsageEEpromConfig single_multi_usage_config {
 auto linear_motor::get_motor_hardware(motor_hardware::HardwareConfig pins)
     -> motor_hardware::MotorHardware {
     return motor_hardware::MotorHardware(pins, &htim7, &htim2,
-                                         single_multi_usage_config);
+                                         plunger_usage_config);
 }
 
 auto linear_motor::get_motion_control(motor_hardware::MotorHardware& hw,
@@ -143,23 +150,33 @@ auto gear_motor::get_motor_hardware(
 }
 
 struct motor_hardware::UsageEEpromConfig gear_left_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = GEAR_LEFT_MOTOR_KEY,
             .type_key = uint16_t(
                 can::ids::MotorUsageValueType::left_gear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = L_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };
 
 struct motor_hardware::UsageEEpromConfig gear_right_usage_config {
-    std::array<UsageRequestSet, 1> {
-        UsageRequestSet {
+    std::array<UsageRequestSet, 2> {
+        UsageRequestSet{
             .eeprom_key = GEAR_RIGHT_MOTOR_KEY,
             .type_key = uint16_t(
                 can::ids::MotorUsageValueType::left_gear_motor_distance),
-            .length = usage_storage_task::distance_data_usage_len
+            .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet {
+            .eeprom_key = R_ERROR_COUNT_KEY,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
         }
     }
 };


### PR DESCRIPTION
Uses the eeprom to store a count of the number of errors thrown by each board
