### PR TITLE
refactor(pipettes): do not accept update position estimation messages for the gear motors

### DIFF
--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -70,7 +70,6 @@ using GearMotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::GearEnableMotorRequest,
     can::messages::GetMotionConstraintsRequest,
     can::messages::SetMotionConstraints, can::messages::ReadLimitSwitchRequest,
-    can::messages::UpdateMotorPositionEstimationRequest,
     can::messages::GetMotorUsageRequest>;
 
 using SystemDispatchTarget = can::dispatch::DispatchParseTarget<

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -80,16 +80,6 @@ class MoveStatusMessageHandler {
                     uint32_t(std::abs(distance_traveled_um))});
     }
 
-    void handle_message(const motor_messages::UpdatePositionResponse& message) {
-        can::messages::UpdateMotorPositionEstimationResponse msg = {
-            .message_index = message.message_index,
-            .current_position = fixed_point_multiply(
-                um_per_step, message.stepper_position_counts),
-            .encoder_position = 0,
-            .position_flags = message.position_flags};
-        can_client.send_can_message(can::ids::NodeId::host, msg);
-    }
-
     void handle_message(const can::messages::StopRequest& msg) {
         can_client.send_can_message(can::ids::NodeId::broadcast, msg);
     }

--- a/include/pipettes/core/tasks/message_handlers/motion.hpp
+++ b/include/pipettes/core/tasks/message_handlers/motion.hpp
@@ -18,7 +18,6 @@ class GearMotorMotionHandler {
         std::variant<std::monostate, GearDisableMotorRequest,
                      GearEnableMotorRequest, GetMotionConstraintsRequest,
                      SetMotionConstraints, ReadLimitSwitchRequest,
-                     UpdateMotorPositionEstimationRequest,
                      GetMotorUsageRequest>;
 
     GearMotorMotionHandler(GearMotionTaskClient &motion_client)

--- a/include/pipettes/core/tasks/messages.hpp
+++ b/include/pipettes/core/tasks/messages.hpp
@@ -9,15 +9,13 @@ namespace task_messages {
 
 namespace motor_control_task_messages {
 
-using MotionControlTaskMessage =
-    std::variant<std::monostate, can::messages::TipActionRequest,
-                 can::messages::GearDisableMotorRequest,
-                 can::messages::GearEnableMotorRequest,
-                 can::messages::GetMotionConstraintsRequest,
-                 can::messages::SetMotionConstraints,
-                 can::messages::StopRequest,
-                 can::messages::ReadLimitSwitchRequest,
-                 can::messages::GetMotorUsageRequest>;
+using MotionControlTaskMessage = std::variant<
+    std::monostate, can::messages::TipActionRequest,
+    can::messages::GearDisableMotorRequest,
+    can::messages::GearEnableMotorRequest,
+    can::messages::GetMotionConstraintsRequest,
+    can::messages::SetMotionConstraints, can::messages::StopRequest,
+    can::messages::ReadLimitSwitchRequest, can::messages::GetMotorUsageRequest>;
 
 using MoveStatusReporterTaskMessage =
     std::variant<std::monostate, motor_messages::GearMotorAck,

--- a/include/pipettes/core/tasks/messages.hpp
+++ b/include/pipettes/core/tasks/messages.hpp
@@ -17,7 +17,6 @@ using MotionControlTaskMessage =
                  can::messages::SetMotionConstraints,
                  can::messages::StopRequest,
                  can::messages::ReadLimitSwitchRequest,
-                 can::messages::UpdateMotorPositionEstimationRequest,
                  can::messages::GetMotorUsageRequest>;
 
 using MoveStatusReporterTaskMessage =

--- a/include/pipettes/core/tasks/motion_controller_task.hpp
+++ b/include/pipettes/core/tasks/motion_controller_task.hpp
@@ -113,19 +113,6 @@ class MotionControllerMessageHandler {
         can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 
-    void handle(const can::messages::UpdateMotorPositionEstimationRequest& m) {
-        if (!controller.update_position(m)) {
-            // If the motor controller can't ask the interrupt handler to
-            // handle the message, we respond with the current status as-is.
-            can::messages::UpdateMotorPositionEstimationResponse response{
-                .message_index = m.message_index,
-                .current_position = controller.read_motor_position(),
-                .encoder_position = 0,
-                .position_flags = controller.get_position_flags()};
-            can_client.send_can_message(can::ids::NodeId::host, response);
-        }
-    }
-
     void handle(const can::messages::GetMotorUsageRequest& m) {
         controller.send_usage_data(m.message_index, usage_client);
     }


### PR DESCRIPTION
## Overview

We don't care about encoder info for the tip motors because they do not have encoders. Since there aren't two separate node ids on the 96 channel pipettes, it's just easier to disable the update position estimation request for gear motors.