### PR TITLE
chore: Only build state manager wheel

### DIFF
--- a/state_manager/CMakeLists.txt
+++ b/state_manager/CMakeLists.txt
@@ -113,7 +113,7 @@ add_custom_target(
 add_custom_target(
 	state-manager-build
 	COMMAND ${Poetry_EXECUTABLE} --no-ansi config virtualenvs.path ${VIRTUAL_ENVIRONMENTS_ROOT_PATH} --local
-	COMMAND ${Poetry_EXECUTABLE} --no-ansi build
+	COMMAND ${Poetry_EXECUTABLE} --no-ansi build --format wheel
 	WORKING_DIRECTORY ../../state_manager
 	DEPENDS ${STATE_MANAGER_VIRTUALENV_ACTIVATE_FILE}
 )


### PR DESCRIPTION
Need to only build the wheel because when it builds both I get dependency resolution errors when doing pip install /ot3-firmware/state-manager/dist/*

Better to just not build it at all instead of filtering it out in the install.