### PR TITLE
fix(build): background the process when restarting the server in the push script

### DIFF
--- a/push
+++ b/push
@@ -94,7 +94,7 @@ def _find_utils():
     return ssh, scp, cmake
 
 def _restart_robot(host, ssh):
-    _ssh(ssh, host, 'systemctl restart opentrons-robot-server &')
+    _ssh(ssh, host, 'nohup systemctl restart opentrons-robot-server &')
 
 def _do_push(host, repo_path, build, restart):
     ssh, scp, cmake = _find_utils()

--- a/push
+++ b/push
@@ -94,7 +94,7 @@ def _find_utils():
     return ssh, scp, cmake
 
 def _restart_robot(host, ssh):
-    _ssh(ssh, host, 'systemctl restart opentrons-robot-server')
+    _ssh(ssh, host, 'systemctl restart opentrons-robot-server &')
 
 def _do_push(host, repo_path, build, restart):
     ssh, scp, cmake = _find_utils()


### PR DESCRIPTION
It can take a while for the robot-server to start after pushing the firmware if the subsystems need to be updated, this means that the update can fail if the ssh session gets dropped for any reason, leaving devices in bootloader mode. So to prevent these types of issues let's background the restart robot-server command.