### PR TITLE
fix(motor-control): handling underflow values

### DIFF
--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -64,7 +64,8 @@ int32_t MotorHardware::get_encoder_pulses() {
         return 0;
     }
     if (motor_encoder_overflow_count < 0) {
-        return motor_encoder_overflow_count * motor_hardware_encoder_pulse_count(enc_handle);
+        return ((motor_encoder_overflow_count + 1) << 16) -
+               motor_hardware_encoder_pulse_count(enc_handle);
     }
     return (motor_encoder_overflow_count << 16) +
            motor_hardware_encoder_pulse_count(enc_handle);

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -63,6 +63,9 @@ int32_t MotorHardware::get_encoder_pulses() {
     if (!enc_handle) {
         return 0;
     }
+    if (motor_encoder_overflow_count < 0) {
+        return motor_encoder_overflow_count * motor_hardware_encoder_pulse_count(enc_handle);
+    }
     return (motor_encoder_overflow_count << 16) +
            motor_hardware_encoder_pulse_count(enc_handle);
 }


### PR DESCRIPTION
This PR handles negative encoder value properly.
 
When the encoder counter underflows once, the overflow counter becomes -1. The calculation for the encoder pulses interpreted this we've gone through -65535 pulse, but we actually haven't.