### PR TITLE
refactor(include): convert pressure driver to use a software timer rather than hardware interrupts

### DIFF
--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -104,14 +104,14 @@ struct __attribute__((packed, __may_alias__)) Reset {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 0;
-    const uint8_t C6 : 1 = 1;
-    const uint8_t C5 : 1 = 1;
-    const uint8_t C4 : 1 = 1;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 0;
-    const uint8_t C1 : 1 = 1;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 0;
+    uint8_t C6 : 1 = 1;
+    uint8_t C5 : 1 = 1;
+    uint8_t C4 : 1 = 1;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 0;
+    uint8_t C1 : 1 = 1;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) Idle {
@@ -120,14 +120,14 @@ struct __attribute__((packed, __may_alias__)) Idle {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 0;
-    const uint8_t C5 : 1 = 0;
-    const uint8_t C4 : 1 = 1;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 1;
-    const uint8_t C1 : 1 = 0;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 0;
+    uint8_t C5 : 1 = 0;
+    uint8_t C4 : 1 = 1;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 1;
+    uint8_t C1 : 1 = 0;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode1 {
@@ -136,14 +136,14 @@ struct __attribute__((packed, __may_alias__)) MeasureMode1 {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 0;
-    const uint8_t C5 : 1 = 1;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 0;
-    const uint8_t C1 : 1 = 0;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 0;
+    uint8_t C5 : 1 = 1;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 0;
+    uint8_t C1 : 1 = 0;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode2 {
@@ -152,14 +152,14 @@ struct __attribute__((packed, __may_alias__)) MeasureMode2 {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 0;
-    const uint8_t C5 : 1 = 1;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 0;
-    const uint8_t C1 : 1 = 1;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 0;
+    uint8_t C5 : 1 = 1;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 0;
+    uint8_t C1 : 1 = 1;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode3 {
@@ -168,14 +168,14 @@ struct __attribute__((packed, __may_alias__)) MeasureMode3 {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 0;
-    const uint8_t C5 : 1 = 1;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 1;
-    const uint8_t C1 : 1 = 0;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 0;
+    uint8_t C5 : 1 = 1;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 1;
+    uint8_t C1 : 1 = 0;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode4 {
@@ -184,14 +184,14 @@ struct __attribute__((packed, __may_alias__)) MeasureMode4 {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 0;
-    const uint8_t C5 : 1 = 1;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 1;
-    const uint8_t C1 : 1 = 1;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 0;
+    uint8_t C5 : 1 = 1;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 1;
+    uint8_t C1 : 1 = 1;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) PressureCommand {
@@ -200,14 +200,14 @@ struct __attribute__((packed, __may_alias__)) PressureCommand {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 1;
-    const uint8_t C5 : 1 = 0;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 0;
-    const uint8_t C1 : 1 = 0;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 1;
+    uint8_t C5 : 1 = 0;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 0;
+    uint8_t C1 : 1 = 0;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) LowPassPressureCommand {
@@ -216,14 +216,14 @@ struct __attribute__((packed, __may_alias__)) LowPassPressureCommand {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 1;
-    const uint8_t C5 : 1 = 0;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 0;
-    const uint8_t C1 : 1 = 0;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 1;
+    uint8_t C5 : 1 = 0;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 0;
+    uint8_t C1 : 1 = 0;
+    uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) TemperatureCommand {
@@ -232,14 +232,14 @@ struct __attribute__((packed, __may_alias__)) TemperatureCommand {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 1;
-    const uint8_t C5 : 1 = 0;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 0;
-    const uint8_t C1 : 1 = 1;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 1;
+    uint8_t C5 : 1 = 0;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 0;
+    uint8_t C1 : 1 = 1;
+    uint8_t C0 : 1 = 0;
 
 };
 
@@ -248,14 +248,14 @@ struct __attribute__((packed, __may_alias__)) StatusCommand {
     static constexpr bool writable = true;
     static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    const uint8_t C7 : 1 = 1;
-    const uint8_t C6 : 1 = 0;
-    const uint8_t C5 : 1 = 0;
-    const uint8_t C4 : 1 = 0;
-    const uint8_t C3 : 1 = 0;
-    const uint8_t C2 : 1 = 0;
-    const uint8_t C1 : 1 = 0;
-    const uint8_t C0 : 1 = 0;
+    uint8_t C7 : 1 = 1;
+    uint8_t C6 : 1 = 0;
+    uint8_t C5 : 1 = 0;
+    uint8_t C4 : 1 = 0;
+    uint8_t C3 : 1 = 0;
+    uint8_t C2 : 1 = 0;
+    uint8_t C1 : 1 = 0;
+    uint8_t C0 : 1 = 0;
 };
 
 struct PressureResult {

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -263,9 +263,9 @@ struct PressureResult {
     static constexpr float PA_PER_COUNT =
         1e-5 * CMH20_TO_PASCALS;  // 1.0e-5cmH2O/count * 98.0665Pa/cmH2O
 
-    int32_t reading : 32 = 0;
+    uint32_t reading : 32 = 0;
 
-    [[nodiscard]] static auto to_pressure(int32_t reg) -> float {
+    [[nodiscard]] static auto to_pressure(uint32_t reg) -> float {
         // Pressure is converted to pascals
         // Sign extend pressure result
         if ((reg & 0x00800000) != 0) {
@@ -283,9 +283,16 @@ struct TemperatureResult {
     static constexpr uint32_t MAX_SIZE = (2 << 7);
     static constexpr float CONVERT_TO_CELSIUS = 0.0078125;
 
-    int32_t reading : 32 = 0;
+    uint32_t reading : 32 = 0;
 
-    [[nodiscard]] static auto to_temperature(int32_t reg) -> float {
+    [[nodiscard]] static auto to_temperature(uint32_t reg) -> float {
+        // Pressure is converted to pascals
+        // Sign extend pressure result
+        if ((reg & 0x00800000) != 0) {
+            reg |= 0xFF000000;
+        } else {
+            reg &= 0x007FFFFF;
+        }
         float temperature =
             CONVERT_TO_CELSIUS * (static_cast<float>(reg) / MAX_SIZE);
         return temperature;

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -36,6 +36,26 @@ enum class SensorStatus : uint8_t {
     UNKNOWN = 0xFF
 };
 
+enum class FilterSetting : uint8_t {
+    NO_FILTER,
+    /// @brief Cutoff Frequency
+    // The cutoff frequency filter coefficient varies
+    // depending on the measure mode you are using.
+    // mode, no filter, fc@10Hz, fc@100Hz
+    // MODE1, 0.019, 0.012, 0.0068
+    // MODE2, 0.008, 0.0064, 0.0034
+    // MODE3, 0.0044, 0.0036, 0.0022
+    // MODE4, 0.0025, 0.0023, 0.0013
+    LOW_PASS_FILTER
+};
+
+enum class MeasurementRate : int {
+    MEASURE_1 = 0, // 3.1msec
+    MEASURE_2 = 1, // 6.1msec
+    MEASURE_3 = 2, // 12.2msec
+    MEASURE_4 = 3 // 24.3msec
+};
+
 enum class Registers : uint8_t {
     RESET = 0x72,
     IDLE = 0x94,
@@ -73,7 +93,7 @@ template <typename Reg>
 // Struct has a valid register address
 // Struct has an integer with the total number of bits in a register.
 // This is used to mask the value before writing it to the sensor.
-concept MMR920C04Register =
+concept MMR920C04CommandRegister =
     std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
                  std::remove_cvref_t<Registers&>> &&
     std::integral<decltype(Reg::value_mask)>;
@@ -82,120 +102,171 @@ struct __attribute__((packed, __may_alias__)) Reset {
     static constexpr Registers address = Registers::RESET;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    uint8_t C7 : 1 = 0;
-    uint8_t C6 : 1 = 1;
-    uint8_t C5 : 1 = 1;
-    uint8_t C4 : 1 = 1;
-    uint8_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 0;
-    uint32_t C1 : 1 = 1;
-    uint32_t C0 : 1 = 0;
+    const uint8_t C7 : 1 = 0;
+    const uint8_t C6 : 1 = 1;
+    const uint8_t C5 : 1 = 1;
+    const uint8_t C4 : 1 = 1;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 0;
+    const uint8_t C1 : 1 = 1;
+    const uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) Idle {
     static constexpr Registers address = Registers::IDLE;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    uint8_t C7 : 1 = 1;
-    uint8_t C6 : 1 = 0;
-    uint8_t C5 : 1 = 0;
-    uint8_t C4 : 1 = 1;
-    uint8_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 1;
-    uint32_t C1 : 1 = 0;
-    uint32_t C0 : 1 = 0;
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 0;
+    const uint8_t C5 : 1 = 0;
+    const uint8_t C4 : 1 = 1;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 1;
+    const uint8_t C1 : 1 = 0;
+    const uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode1 {
     static constexpr Registers address = Registers::MEASURE_MODE_1;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    uint8_t C7 : 1 = 1;
-    uint8_t C6 : 1 = 0;
-    uint8_t C5 : 1 = 1;
-    uint8_t C4 : 1 = 0;
-    uint8_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 0;
-    uint32_t C1 : 1 = 0;
-    uint32_t C0 : 1 = 0;
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 0;
+    const uint8_t C5 : 1 = 1;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 0;
+    const uint8_t C1 : 1 = 0;
+    const uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode2 {
     static constexpr Registers address = Registers::MEASURE_MODE_2;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    uint8_t C7 : 1 = 1;
-    uint8_t C6 : 1 = 0;
-    uint8_t C5 : 1 = 1;
-    uint8_t C4 : 1 = 0;
-    uint8_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 0;
-    uint32_t C1 : 1 = 1;
-    uint32_t C0 : 1 = 0;
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 0;
+    const uint8_t C5 : 1 = 1;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 0;
+    const uint8_t C1 : 1 = 1;
+    const uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode3 {
     static constexpr Registers address = Registers::MEASURE_MODE_3;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    uint8_t C7 : 1 = 1;
-    uint8_t C6 : 1 = 0;
-    uint8_t C5 : 1 = 1;
-    uint8_t C4 : 1 = 0;
-    uint8_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 1;
-    uint32_t C1 : 1 = 0;
-    uint32_t C0 : 1 = 0;
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 0;
+    const uint8_t C5 : 1 = 1;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 1;
+    const uint8_t C1 : 1 = 0;
+    const uint8_t C0 : 1 = 0;
 };
 
 struct __attribute__((packed, __may_alias__)) MeasureMode4 {
     static constexpr Registers address = Registers::MEASURE_MODE_4;
     static constexpr bool readable = false;
     static constexpr bool writable = true;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    uint8_t C7 : 1 = 1;
-    uint8_t C6 : 1 = 0;
-    uint8_t C5 : 1 = 1;
-    uint8_t C4 : 1 = 0;
-    uint8_t C3 : 1 = 0;
-    uint8_t C2 : 1 = 1;
-    uint8_t C1 : 1 = 1;
-    uint8_t C0 : 1 = 0;
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 0;
+    const uint8_t C5 : 1 = 1;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 1;
+    const uint8_t C1 : 1 = 1;
+    const uint8_t C0 : 1 = 0;
 };
 
-struct __attribute__((packed, __may_alias__)) Pressure {
+struct __attribute__((packed, __may_alias__)) PressureCommand {
     static constexpr Registers address = Registers::PRESSURE_READ;
-    static constexpr bool readable = true;
-    static constexpr bool writable = false;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 1;
+    const uint8_t C5 : 1 = 0;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 0;
+    const uint8_t C1 : 1 = 0;
+    const uint8_t C0 : 1 = 0;
+};
+
+struct __attribute__((packed, __may_alias__)) LowPassPressureCommand {
+    static constexpr Registers address = Registers::LOW_PASS_PRESSURE_READ;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
+
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 1;
+    const uint8_t C5 : 1 = 0;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 0;
+    const uint8_t C1 : 1 = 0;
+    const uint8_t C0 : 1 = 0;
+};
+
+struct __attribute__((packed, __may_alias__)) TemperatureCommand {
+    static constexpr Registers address = Registers::TEMPERATURE_READ;
+    static constexpr bool readable = false;
+    static constexpr bool writable = true;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
+
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 1;
+    const uint8_t C5 : 1 = 0;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 0;
+    const uint8_t C1 : 1 = 1;
+    const uint8_t C0 : 1 = 0;
+
+};
+
+struct __attribute__((packed, __may_alias__)) StatusCommand {
+    static constexpr Registers address = Registers::STATUS;
+    static constexpr bool writable = true;
+    static constexpr uint8_t value_mask = (1 << 8) - 1;
+
+    const uint8_t C7 : 1 = 1;
+    const uint8_t C6 : 1 = 0;
+    const uint8_t C5 : 1 = 0;
+    const uint8_t C4 : 1 = 0;
+    const uint8_t C3 : 1 = 0;
+    const uint8_t C2 : 1 = 0;
+    const uint8_t C1 : 1 = 0;
+    const uint8_t C0 : 1 = 0;
+};
+
+struct PressureResult {
     // Pascals per 1 cmH20
     static constexpr float CMH20_TO_PASCALS = 98.0665;
     static constexpr float PA_PER_COUNT =
         1e-5 * CMH20_TO_PASCALS;  // 1.0e-5cmH2O/count * 98.0665Pa/cmH2O
 
-    uint32_t C7 : 1 = 1;
-    uint32_t C6 : 1 = 1;
-    uint32_t C5 : 1 = 0;
-    uint32_t C4 : 1 = 0;
-    uint32_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 0;
-    uint32_t C1 : 1 = 0;
-    uint32_t C0 : 1 = 0;
-    uint32_t reading : 24 = 0;
+    int32_t reading : 24 = 0;
 
-    [[nodiscard]] static auto to_pressure(uint32_t reg) -> float {
+    [[nodiscard]] static auto to_pressure(int32_t reg) -> float {
         // Sign extend pressure result
         if ((reg & 0x00800000) != 0) {
             reg |= 0xFF000000;
@@ -206,76 +277,29 @@ struct __attribute__((packed, __may_alias__)) Pressure {
             static_cast<float>(static_cast<int32_t>(reg)) * PA_PER_COUNT;
         return pressure;
     }
-};
 
-struct __attribute__((packed, __may_alias__)) LowPassPressure {
-    static constexpr Registers address = Registers::LOW_PASS_PRESSURE_READ;
-    static constexpr bool readable = true;
-    static constexpr bool writable = false;
-    static constexpr uint32_t value_mask = (1 << 8) - 1;
-
-    // Pascals per 1 cmH20
-    static constexpr float CMH20_TO_PASCALS = 98.0665;
-    static constexpr float PA_PER_COUNT =
-        1e-5 * CMH20_TO_PASCALS;  // 1.0e-5cmH2O/count * 98.0665Pa/cmH2O
-
-    uint32_t C7 : 1 = 1;
-    uint32_t C6 : 1 = 1;
-    uint32_t C5 : 1 = 0;
-    uint32_t C4 : 1 = 0;
-    uint32_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 1;
-    uint32_t C1 : 1 = 0;
-    uint32_t C0 : 1 = 0;
-    uint32_t reading : 24 = 0;
-
-    [[nodiscard]] static auto to_pressure(uint32_t reg) -> float {
-        return Pressure::to_pressure(reg);
+    [[nodiscard]] static auto to_fixed_point(int32_t pressure) -> sq15_16 {
+        return convert_to_fixed_point(pressure, S15Q16_RADIX);
     }
 };
 
-struct __attribute__((packed, __may_alias__)) Temperature {
-    static constexpr Registers address = Registers::TEMPERATURE_READ;
-    static constexpr bool readable = true;
-    static constexpr bool writable = false;
-    static constexpr uint32_t value_mask = (1 << 24) - 1;
-
+struct TemperatureResult {
     static constexpr uint32_t MAX_SIZE = (2 << 7);
-
     static constexpr float CONVERT_TO_CELSIUS = 0.0078125;
 
-    uint32_t C7 : 1 = 1;
-    uint32_t C6 : 1 = 1;
-    uint32_t C5 : 1 = 0;
-    uint32_t C4 : 1 = 0;
-    uint32_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 0;
-    uint32_t C1 : 1 = 1;
-    uint32_t C0 : 1 = 0;
-    uint32_t reading : 24 = 0;
+    int32_t reading : 24 = 0;
 
-    [[nodiscard]] static auto to_temperature(uint32_t reg) -> sq15_16 {
+    [[nodiscard]] static auto to_temperature(int32_t reg) -> float {
         float temperature =
             CONVERT_TO_CELSIUS * (static_cast<float>(reg) / MAX_SIZE);
-        return convert_to_fixed_point(temperature, S15Q16_RADIX);
+        return temperature;
     }
+
 };
 
-struct __attribute__((packed, __may_alias__)) Status {
-    static constexpr Registers address = Registers::STATUS;
-    static constexpr bool readable = true;
-    static constexpr bool writable = false;
-    static constexpr uint8_t value_mask = (1 << 8) - 1;
 
-    uint32_t C7 : 1 = 1;
-    uint32_t C6 : 1 = 0;
-    uint32_t C5 : 1 = 0;
-    uint32_t C4 : 1 = 0;
-    uint32_t C3 : 1 = 0;
-    uint32_t C2 : 1 = 0;
-    uint32_t C1 : 1 = 0;
-    uint32_t C0 : 1 = 0;
-    uint32_t reading : 8 = 0;
+struct StatusResult {
+    uint8_t reading : 8 = 0;
 
     [[nodiscard]] static auto to_status(uint8_t reg) -> SensorStatus {
         switch (static_cast<SensorStatus>(reg)) {
@@ -291,6 +315,10 @@ struct __attribute__((packed, __may_alias__)) Status {
     }
 };
 
+[[nodiscard]] inline static auto reading_to_fixed_point(int32_t reading) -> sq15_16 {
+    return convert_to_fixed_point(reading, S15Q16_RADIX);
+}
+
 struct MMR920C04RegisterMap {
     Reset reset = {};
     Idle idle = {};
@@ -298,15 +326,20 @@ struct MMR920C04RegisterMap {
     MeasureMode2 measure_mode_2 = {};
     MeasureMode3 measure_mode_3 = {};
     MeasureMode4 measure_mode_4 = {};
-    Pressure pressure = {};
-    LowPassPressure low_pass_pressure = {};
-    Temperature temperature = {};
-    Status status = {};
+    PressureCommand pressure_command = {};
+    LowPassPressureCommand low_pass_pressure_command = {};
+    TemperatureCommand temperature_command = {};
+    StatusCommand status_command = {};
+    PressureResult pressure_result = {};
+    TemperatureResult temperature_result = {};
+    StatusResult status_result = {};
 };
 
-// Registers are all 32 bits
-using RegisterSerializedType = uint32_t;
+// Result registers are a mixture of 
+using RegisterSerializedType = uint8_t;
+
+// Command Registers are all 8 bits
 // Type definition to allow type aliasing for pointer dereferencing
-using RegisterSerializedTypeA = __attribute__((__may_alias__)) uint32_t;
+using RegisterSerializedTypeA = __attribute__((__may_alias__)) uint8_t;
 };  // namespace mmr920C04
 };  // namespace sensors

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -50,10 +50,10 @@ enum class FilterSetting : uint8_t {
 };
 
 enum class MeasurementRate : int {
-    MEASURE_1 = 0, // 3.1msec
-    MEASURE_2 = 1, // 6.1msec
-    MEASURE_3 = 2, // 12.2msec
-    MEASURE_4 = 3 // 24.3msec
+    MEASURE_1 = 0,  // 3.1msec
+    MEASURE_2 = 1,  // 6.1msec
+    MEASURE_3 = 2,  // 12.2msec
+    MEASURE_4 = 3   // 24.3msec
 };
 
 enum class Registers : uint8_t {
@@ -240,7 +240,6 @@ struct __attribute__((packed, __may_alias__)) TemperatureCommand {
     uint8_t C2 : 1 = 0;
     uint8_t C1 : 1 = 1;
     uint8_t C0 : 1 = 0;
-
 };
 
 struct __attribute__((packed, __may_alias__)) StatusCommand {
@@ -264,9 +263,10 @@ struct PressureResult {
     static constexpr float PA_PER_COUNT =
         1e-5 * CMH20_TO_PASCALS;  // 1.0e-5cmH2O/count * 98.0665Pa/cmH2O
 
-    int32_t reading : 24 = 0;
+    int32_t reading : 32 = 0;
 
     [[nodiscard]] static auto to_pressure(int32_t reg) -> float {
+        // Pressure is converted to pascals
         // Sign extend pressure result
         if ((reg & 0x00800000) != 0) {
             reg |= 0xFF000000;
@@ -277,26 +277,20 @@ struct PressureResult {
             static_cast<float>(static_cast<int32_t>(reg)) * PA_PER_COUNT;
         return pressure;
     }
-
-    [[nodiscard]] static auto to_fixed_point(int32_t pressure) -> sq15_16 {
-        return convert_to_fixed_point(pressure, S15Q16_RADIX);
-    }
 };
 
 struct TemperatureResult {
     static constexpr uint32_t MAX_SIZE = (2 << 7);
     static constexpr float CONVERT_TO_CELSIUS = 0.0078125;
 
-    int32_t reading : 24 = 0;
+    int32_t reading : 32 = 0;
 
     [[nodiscard]] static auto to_temperature(int32_t reg) -> float {
         float temperature =
             CONVERT_TO_CELSIUS * (static_cast<float>(reg) / MAX_SIZE);
         return temperature;
     }
-
 };
-
 
 struct StatusResult {
     uint8_t reading : 8 = 0;
@@ -315,7 +309,8 @@ struct StatusResult {
     }
 };
 
-[[nodiscard]] inline static auto reading_to_fixed_point(int32_t reading) -> sq15_16 {
+[[nodiscard]] inline static auto reading_to_fixed_point(float reading)
+    -> sq15_16 {
     return convert_to_fixed_point(reading, S15Q16_RADIX);
 }
 
@@ -335,7 +330,7 @@ struct MMR920C04RegisterMap {
     StatusResult status_result = {};
 };
 
-// Result registers are a mixture of 
+// Result registers are a mixture of
 using RegisterSerializedType = uint8_t;
 
 // Command Registers are all 8 bits

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -28,8 +28,6 @@ class SensorHardwareBase {
     virtual auto set_sync() -> void = 0;
     virtual auto reset_sync() -> void = 0;
     virtual auto check_tip_presence() -> bool = 0;
-    virtual auto add_data_ready_callback(std::function<void()> callback)
-        -> bool = 0;
 };
 
 struct SensorHardwareContainer {

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -130,6 +130,8 @@ class CapacitiveMessageHandler {
                             utils::ResponseTag::IS_BASELINE,
                             utils::ResponseTag::IS_THRESHOLD_SENSE};
             auto tags_as_int = utils::byte_from_tags(tags);
+            driver.prime_autothreshold(
+                fixed_point_to_float(m.threshold, S15Q16_RADIX));
             driver.poll_limited_capacitance(
                 10, static_cast<can::ids::SensorId>(m.sensor_id), tags_as_int);
         }

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -130,8 +130,6 @@ class CapacitiveMessageHandler {
                             utils::ResponseTag::IS_BASELINE,
                             utils::ResponseTag::IS_THRESHOLD_SENSE};
             auto tags_as_int = utils::byte_from_tags(tags);
-            driver.prime_autothreshold(
-                fixed_point_to_float(m.threshold, S15Q16_RADIX));
             driver.poll_limited_capacitance(
                 10, static_cast<can::ids::SensorId>(m.sensor_id), tags_as_int);
         }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -278,10 +278,9 @@ class MMR920C04 {
                                                   m.read_buffer.cend(),
                                                   temporary_data_store));
 
-        int32_t signed_data_store =
-            static_cast<int32_t>(temporary_data_store >> 8);
+        uint32_t shifted_data_store = temporary_data_store >> 8;
 
-        save_pressure(signed_data_store);
+        save_pressure(shifted_data_store);
         auto pressure = mmr920C04::PressureResult::to_pressure(
             _registers.pressure_result.reading);
         if (bind_sync) {
@@ -319,10 +318,9 @@ class MMR920C04 {
                                                   m.read_buffer.cend(),
                                                   temporary_data_store));
 
-        int32_t signed_data_store =
-            static_cast<int32_t>(temporary_data_store >> 8);
+        uint32_t shifted_data_store = temporary_data_store >> 8;
 
-        save_temperature(signed_data_store);
+        save_temperature(shifted_data_store);
 
         if (echoing) {
             auto temperature = mmr920C04::TemperatureResult::to_temperature(
@@ -344,11 +342,10 @@ class MMR920C04 {
                                                   m.read_buffer.cend(),
                                                   temporary_data_store));
 
-        int32_t signed_data_store =
-            static_cast<int32_t>(temporary_data_store >> 8);
+        uint32_t shifted_data_store = temporary_data_store >> 8;
 
         auto pressure =
-            mmr920C04::PressureResult::to_pressure(signed_data_store);
+            mmr920C04::PressureResult::to_pressure(shifted_data_store);
         pressure_running_total += pressure;
 
         if (!m.id.is_completed_poll) {
@@ -392,11 +389,10 @@ class MMR920C04 {
                                                   m.read_buffer.cend(),
                                                   temporary_data_store));
 
-        int32_t signed_data_store =
-            static_cast<int32_t>(temporary_data_store >> 8);
+        uint32_t shifted_data_store = temporary_data_store >> 8;
 
         auto temperature =
-            mmr920C04::TemperatureResult::to_temperature(signed_data_store);
+            mmr920C04::TemperatureResult::to_temperature(shifted_data_store);
         temperature_running_total += temperature;
 
         if (!m.id.is_completed_poll) {
@@ -432,8 +428,7 @@ class MMR920C04 {
     mmr920C04::FilterSetting filter_setting =
         mmr920C04::FilterSetting::LOW_PASS_FILTER;
 
-    static constexpr float MeasurementTimings[] = {3.1, 6.1, 12.2,
-                                                   24.3};  // in msec
+    static constexpr std::array<float, 4> MeasurementTimings{3.1, 6.1, 12.2, 24.3};  // in msec
     static constexpr float DEFAULT_DELAY_BUFFER =
         1.0;  // in msec (TODO might need to change to fit in uint16_t)
     static constexpr uint16_t STOP_DELAY = 0;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -58,7 +58,9 @@ class MMR920C04 {
 
     auto get_host_id() -> NodeId { return NodeId::host; }
 
-    void set_filter(uint8_t should_filter) { filter_setting = static_cast<mmr920C04::FilterSetting>(should_filter); }
+    void set_filter(uint8_t should_filter) {
+        filter_setting = static_cast<mmr920C04::FilterSetting>(should_filter);
+    }
 
     void set_echoing(bool should_echo) { echoing = should_echo; }
 
@@ -71,27 +73,30 @@ class MMR920C04 {
 
     auto set_threshold(float threshold_pa,
                        can::ids::SensorThresholdMode from_mode,
-                       uint32_t message_index) -> void {
+                       uint32_t message_index, bool send_threshold = true)
+        -> void {
         threshold_pascals = threshold_pa;
-        auto message = can::messages::SensorThresholdResponse{
-            .message_index = message_index,
-            .sensor = SensorType::pressure,
-            .sensor_id = sensor_id,
-            .threshold =
-                convert_to_fixed_point(threshold_pascals, S15Q16_RADIX),
-            .mode = from_mode};
-        can_client.send_can_message(can::ids::NodeId::host, message);
+        if (send_threshold) {
+            auto message = can::messages::SensorThresholdResponse{
+                .message_index = message_index,
+                .sensor = SensorType::pressure,
+                .sensor_id = sensor_id,
+                .threshold =
+                    convert_to_fixed_point(threshold_pascals, S15Q16_RADIX),
+                .mode = from_mode};
+            can_client.send_can_message(can::ids::NodeId::host, message);
+        }
     }
 
     auto write(mmr920C04::Registers reg, uint8_t command_data) -> bool {
         return writer.write(mmr920C04::ADDRESS, static_cast<uint8_t>(reg),
-                     command_data);
+                            command_data);
     }
 
     auto transact(mmr920C04::Registers reg) -> bool {
         std::array reg_buf{static_cast<uint8_t>(reg)};
         return writer.transact(
-            mmr920C04::ADDRESS, reg_buf, 4, own_queue,
+            mmr920C04::ADDRESS, reg_buf, 3, own_queue,
             utils::build_id(mmr920C04::ADDRESS, static_cast<uint8_t>(reg)));
     }
 
@@ -104,51 +109,64 @@ class MMR920C04 {
     }
 
     auto poll_limited_pressure(uint16_t number_reads, uint8_t tags) -> void {
-        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
-        auto command_data = build_register_command(_registers.low_pass_pressure_command);
+        auto mode_delay_with_buffer =
+            MeasurementTimings[static_cast<int>(measurement_mode_rate)] +
+            DEFAULT_DELAY_BUFFER;
+        auto command_data =
+            build_register_command(_registers.low_pass_pressure_command);
         if (filter_setting == mmr920C04::FilterSetting::NO_FILTER) {
             command_data = build_register_command(_registers.pressure_command);
         }
         total_baseline_reads = number_reads;
-
         set_measure_mode(measurement_mode_rate);
         poller.single_register_poll(
-            mmr920C04::ADDRESS, command_data, 3, number_reads, mode_delay_with_buffer, own_queue,
-            utils::build_id(mmr920C04::ADDRESS, command_data, tags)
-        );
+            mmr920C04::ADDRESS, command_data, 3, number_reads,
+            mode_delay_with_buffer, own_queue,
+            utils::build_id(mmr920C04::ADDRESS, command_data, tags));
     }
 
     auto poll_limited_temperature(uint16_t number_reads, uint8_t tags) -> void {
-        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
-        auto command_data = build_register_command(_registers.temperature_command);
+        auto mode_delay_with_buffer =
+            MeasurementTimings[static_cast<int>(measurement_mode_rate)] +
+            DEFAULT_DELAY_BUFFER;
+        auto command_data =
+            build_register_command(_registers.temperature_command);
         total_baseline_reads = number_reads;
 
         set_measure_mode(measurement_mode_rate);
         poller.single_register_poll(
-            mmr920C04::ADDRESS, command_data, 3, number_reads, mode_delay_with_buffer, own_queue,
-            utils::build_id(mmr920C04::ADDRESS, command_data, tags)
-        );
+            mmr920C04::ADDRESS, command_data, 3, number_reads,
+            mode_delay_with_buffer, own_queue,
+            utils::build_id(mmr920C04::ADDRESS, command_data, tags));
     }
 
     auto poll_continuous_pressure(uint8_t tags) -> void {
-        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
-        auto command_data = build_register_command(_registers.low_pass_pressure_command);
+        auto mode_delay_with_buffer =
+            MeasurementTimings[static_cast<int>(measurement_mode_rate)] +
+            DEFAULT_DELAY_BUFFER;
+        auto command_data =
+            build_register_command(_registers.low_pass_pressure_command);
         if (filter_setting == mmr920C04::FilterSetting::NO_FILTER) {
             command_data = build_register_command(_registers.pressure_command);
         }
 
         set_measure_mode(measurement_mode_rate);
         poller.continuous_single_register_poll(
-            mmr920C04::ADDRESS, command_data, 3, mode_delay_with_buffer, own_queue, utils::build_id(mmr920C04::ADDRESS, command_data, tags));
+            mmr920C04::ADDRESS, command_data, 3, mode_delay_with_buffer,
+            own_queue, utils::build_id(mmr920C04::ADDRESS, command_data, tags));
     }
 
     auto poll_continuous_temperature(uint8_t tags) -> void {
-        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
-        auto command_data = build_register_command(_registers.temperature_command);
+        auto mode_delay_with_buffer =
+            MeasurementTimings[static_cast<int>(measurement_mode_rate)] +
+            DEFAULT_DELAY_BUFFER;
+        auto command_data =
+            build_register_command(_registers.temperature_command);
 
         set_measure_mode(measurement_mode_rate);
         poller.continuous_single_register_poll(
-            mmr920C04::ADDRESS, command_data, 3, mode_delay_with_buffer, own_queue, utils::build_id(mmr920C04::ADDRESS, command_data, tags));
+            mmr920C04::ADDRESS, command_data, 3, mode_delay_with_buffer,
+            own_queue, utils::build_id(mmr920C04::ADDRESS, command_data, tags));
     }
 
     auto set_measure_mode(mmr920C04::MeasurementRate rate) -> bool {
@@ -156,7 +174,6 @@ class MMR920C04 {
         switch (rate) {
             case mmr920C04::MeasurementRate::MEASURE_1:
                 if (set_register(_registers.measure_mode_1)) {
-
                     return true;
                 }
                 return false;
@@ -190,13 +207,15 @@ class MMR920C04 {
 
     auto save_pressure(int32_t data) -> bool {
         _registers.pressure_result.reading = data;
-        LOG("Updated pressure reading is %u", _registers.pressure_result.reading);
+        LOG("Updated pressure reading is %u",
+            _registers.pressure_result.reading);
         return true;
     }
 
     auto save_temperature(int32_t data) -> bool {
         _registers.temperature_result.reading = data;
-        LOG("Updated temperature reading is %u", _registers.temperature_result.reading);
+        LOG("Updated temperature reading is %u",
+            _registers.temperature_result.reading);
         return true;
     }
 
@@ -206,7 +225,8 @@ class MMR920C04 {
     }
 
     auto send_status(uint32_t message_index) -> void {
-        auto status = mmr920C04::StatusResult::to_status(_registers.status_result.reading);
+        auto status = mmr920C04::StatusResult::to_status(
+            _registers.status_result.reading);
         auto message = can::messages::ReadFromSensorResponse{
             .message_index = message_index,
             .sensor = get_sensor_type(),
@@ -239,40 +259,59 @@ class MMR920C04 {
     }
 
     void stop_continuous_polling(uint8_t transaction_index, uint8_t reg_id) {
-        poller.continuous_single_register_poll(
-            fdc1004::ADDRESS, reg_id, 3,
-            STOP_DELAY, own_queue, transaction_index);
+        poller.continuous_single_register_poll(mmr920C04::ADDRESS, reg_id, 3,
+                                               STOP_DELAY, own_queue,
+                                               transaction_index);
     }
 
-    auto handle_ongoing_response(i2c::messages::TransactionResponse &m) -> void {
+    auto handle_ongoing_response(i2c::messages::TransactionResponse &m)
+        -> void {
         auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
+        std::cout << "echoing" << echoing << "\n";
+        std::cout << "binding" << bind_sync << "\n";
         if (!bind_sync && !echoing) {
-            stop_continuous_polling(m.id.transaction_index, static_cast<uint8_t>(reg_id));
+            stop_continuous_polling(m.id.transaction_index,
+                                    static_cast<uint8_t>(reg_id));
             reset_readings();
         }
 
         // Pressure is always a three-byte value
-        static_cast<void>(bit_utils::bytes_to_int(
-            m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
+        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
+                                                  m.read_buffer.cend(),
+                                                  temporary_data_store));
 
-        auto pressure_read = reg_id == mmr920C04::Registers::LOW_PASS_PRESSURE_READ || reg_id == mmr920C04::Registers::PRESSURE_READ;
-        auto temperature_read = reg_id == mmr920C04::Registers::TEMPERATURE_READ;
+        int32_t signed_data_store =
+            static_cast<int32_t>(temporary_data_store >> 8);
+
+        auto pressure_read =
+            reg_id == mmr920C04::Registers::LOW_PASS_PRESSURE_READ ||
+            reg_id == mmr920C04::Registers::PRESSURE_READ;
+        auto temperature_read =
+            reg_id == mmr920C04::Registers::TEMPERATURE_READ;
         if (pressure_read) {
-            save_pressure(temporary_data_store);
+            save_pressure(signed_data_store);
         }
         if (temperature_read) {
-            save_temperature(temporary_data_store);
+            save_temperature(signed_data_store);
         }
         if (bind_sync && pressure_read) {
-            auto pressure = mmr920C04::PressureResult::to_pressure(temporary_data_store);
-            if (std::fabs(pressure) - std::fabs(current_pressure_baseline_pa) > threshold_pascals) {
+            auto pressure = mmr920C04::PressureResult::to_pressure(
+                _registers.pressure_result.reading);
+            auto signed_pressure =
+                mmr920C04::PressureResult::to_pressure(signed_data_store);
+            std::cout << "I'm in bind sync and pressure is" << pressure << "\n";
+            std::cout << "but signed data is" << signed_pressure << "\n";
+            if (std::fabs(pressure) - std::fabs(current_pressure_baseline_pa) >
+                threshold_pascals) {
                 hardware.set_sync();
             } else {
                 hardware.reset_sync();
             }
         }
+
         if (echoing && pressure_read) {
-            auto pressure = mmr920C04::PressureResult::to_pressure(temporary_data_store);
+            auto pressure = mmr920C04::PressureResult::to_pressure(
+                _registers.pressure_result.reading);
             can_client.send_can_message(
                 can::ids::NodeId::host,
                 can::messages::ReadFromSensorResponse{
@@ -283,7 +322,8 @@ class MMR920C04 {
                         mmr920C04::reading_to_fixed_point(pressure)});
         }
         if (echoing && temperature_read) {
-            auto temperature = mmr920C04::PressureResult::to_pressure(temporary_data_store);
+            auto temperature = mmr920C04::TemperatureResult::to_temperature(
+                _registers.temperature_result.reading);
             can_client.send_can_message(
                 can::ids::NodeId::host,
                 can::messages::ReadFromSensorResponse{
@@ -295,53 +335,86 @@ class MMR920C04 {
         }
     }
 
-    auto handle_baseline_response(i2c::messages::TransactionResponse &m) -> void {
-        static_cast<void>(bit_utils::bytes_to_int(
-            m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
+    auto handle_baseline_response(i2c::messages::TransactionResponse &m)
+        -> void {
+        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
+                                                  m.read_buffer.cend(),
+                                                  temporary_data_store));
 
         auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
 
-        auto pressure_read = reg_id == mmr920C04::Registers::LOW_PASS_PRESSURE_READ || reg_id == mmr920C04::Registers::PRESSURE_READ;
-        auto temperature_read = reg_id == mmr920C04::Registers::TEMPERATURE_READ;
+        int32_t signed_data_store =
+            static_cast<int32_t>(temporary_data_store >> 8);
+
+        auto pressure_read =
+            reg_id == mmr920C04::Registers::LOW_PASS_PRESSURE_READ ||
+            reg_id == mmr920C04::Registers::PRESSURE_READ;
+        auto temperature_read =
+            reg_id == mmr920C04::Registers::TEMPERATURE_READ;
+        std::cout << "pressure totale before add " << pressure_running_total
+                  << "\n";
         if (pressure_read) {
-            auto pressure = mmr920C04::PressureResult::to_pressure(temporary_data_store);
+            auto pressure =
+                mmr920C04::PressureResult::to_pressure(signed_data_store);
             pressure_running_total += pressure;
+            std::cout << "pressure totale after add " << pressure_running_total
+                      << "\n";
         }
         if (temperature_read) {
-            auto temperature = mmr920C04::TemperatureResult::to_temperature(temporary_data_store);
+            auto temperature =
+                mmr920C04::TemperatureResult::to_temperature(signed_data_store);
             temperature_running_total += temperature;
         }
         if (!m.id.is_completed_poll) {
             return;
         }
         reset_readings();
-    
 
+        std::cout << "baseline reads " << total_baseline_reads << "\n";
         if (pressure_read) {
-            auto current_pressure_baseline_pa = pressure_running_total / total_baseline_reads;
-            auto offset_fixed_point =
-                   mmr920C04::reading_to_fixed_point(current_pressure_baseline_pa);
+            auto current_pressure_baseline_pa =
+                pressure_running_total / total_baseline_reads;
+            auto pressure_fixed_point =
+                mmr920C04::reading_to_fixed_point(current_pressure_baseline_pa);
+            std::cout << "averaged pressure " << current_pressure_baseline_pa
+                      << "\n";
             // FIXME This should be tied to the set threshold
             // command so we can completely remove the base line sensor
             // request from all sensors!
-            can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::BaselineSensorResponse{
-                .message_index = m.message_index,
-                .sensor = can::ids::SensorType::pressure,
-                .offset_average = offset_fixed_point});
+            if (utils::tag_in_token(m.id.token,
+                                    utils::ResponseTag::IS_THRESHOLD_SENSE)) {
+                can_client.send_can_message(
+                    can::ids::NodeId::host,
+                    can::messages::BaselineSensorResponse{
+                        .message_index = m.message_index,
+                        .sensor = can::ids::SensorType::pressure_temperature,
+                        .offset_average = pressure_fixed_point});
+                set_threshold(current_pressure_baseline_pa,
+                              can::ids::SensorThresholdMode::auto_baseline,
+                              m.message_index, false);
+            } else {
+                auto message = can::messages::ReadFromSensorResponse{
+                    .message_index = m.message_index,
+                    .sensor = SensorType::pressure,
+                    .sensor_id = sensor_id,
+                    .sensor_data = pressure_fixed_point};
+                can_client.send_can_message(can::ids::NodeId::host, message);
+            }
             pressure_running_total = 0x0;
         }
         if (temperature_read) {
-            auto current_temperature_baseline = temperature_running_total / total_baseline_reads;
+            auto current_temperature_baseline =
+                temperature_running_total / total_baseline_reads;
             auto offset_fixed_point =
-                    mmr920C04::reading_to_fixed_point(current_temperature_baseline);
-            can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::BaselineSensorResponse{
-                .message_index = m.message_index,
-                .sensor = can::ids::SensorType::pressure_temperature,
-                .offset_average = offset_fixed_point});
+                mmr920C04::reading_to_fixed_point(current_temperature_baseline);
+            if (echoing) {
+                can_client.send_can_message(
+                    can::ids::NodeId::host,
+                    can::messages::BaselineSensorResponse{
+                        .message_index = m.message_index,
+                        .sensor = can::ids::SensorType::pressure_temperature,
+                        .offset_average = offset_fixed_point});
+            }
             temperature_running_total = 0x0;
         }
     }
@@ -357,12 +430,16 @@ class MMR920C04 {
     const can::ids::SensorId &sensor_id;
 
     mmr920C04::MMR920C04RegisterMap _registers{};
-    mmr920C04::FilterSetting filter_setting = mmr920C04::FilterSetting::LOW_PASS_FILTER;
-    
-    static constexpr float MeasurementTimings[] = {3.1, 6.1, 12.2, 24.3}; // in msec
-    static constexpr float DEFAULT_DELAY_BUFFER = 1.0; // in msec (TODO might need to change to fit in uint16_t)
+    mmr920C04::FilterSetting filter_setting =
+        mmr920C04::FilterSetting::LOW_PASS_FILTER;
+
+    static constexpr float MeasurementTimings[] = {3.1, 6.1, 12.2,
+                                                   24.3};  // in msec
+    static constexpr float DEFAULT_DELAY_BUFFER =
+        1.0;  // in msec (TODO might need to change to fit in uint16_t)
     static constexpr uint16_t STOP_DELAY = 0;
-    mmr920C04::MeasurementRate measurement_mode_rate = mmr920C04::MeasurementRate::MEASURE_4;
+    mmr920C04::MeasurementRate measurement_mode_rate =
+        mmr920C04::MeasurementRate::MEASURE_4;
 
     bool _initialized = false;
     bool echoing = false;
@@ -370,7 +447,7 @@ class MMR920C04 {
 
     float pressure_running_total = 0;
     float temperature_running_total = 0;
-    uint16_t total_baseline_reads = 0x8;
+    uint16_t total_baseline_reads = 1;
     // TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
     // sure this is an arbitrarily large number to enable continuous reads.
     float current_pressure_baseline_pa = 0;
@@ -378,18 +455,12 @@ class MMR920C04 {
     float threshold_pascals = 100.0F;
     float offset_average = 0;
 
-    int32_t temporary_data_store = 0x0;
+    uint32_t temporary_data_store = 0x0;
 
     template <mmr920C04::MMR920C04CommandRegister Reg>
     requires registers::WritableRegister<Reg>
     auto build_register_command(Reg &reg) -> uint8_t {
-        auto value =
-            // Ignore the typical linter warning because we're only using
-            // this on __packed structures that mimic hardware registers
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            *reinterpret_cast<mmr920C04::RegisterSerializedTypeA *>(&reg);
-        value &= Reg::value_mask;
-        return value;
+        return static_cast<uint8_t>(reg.address);
     }
 
     template <mmr920C04::MMR920C04CommandRegister Reg>
@@ -403,7 +474,6 @@ class MMR920C04 {
         value &= Reg::value_mask;
         return write(Reg::address, value);
     }
-
 };
 
 }  // namespace tasks

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -41,10 +41,7 @@ class MMR920C04 {
           can_client(can_client),
           own_queue(own_queue),
           hardware(hardware),
-          sensor_id(id) {
-        hardware.add_data_ready_callback(
-            [this]() -> void { this->sensor_callback(); });
-    }
+          sensor_id(id) {}
 
     /**
      * @brief Check if the MMR92C04 has been initialized.
@@ -61,35 +58,41 @@ class MMR920C04 {
 
     auto get_host_id() -> NodeId { return NodeId::host; }
 
-    auto get_threshold() -> int32_t { return threshold_pascals; }
+    void set_filter(uint8_t should_filter) { filter_setting = static_cast<mmr920C04::FilterSetting>(should_filter); }
 
-    auto set_threshold(int32_t new_threshold) -> void {
-        threshold_pascals = fixed_point_to_float(new_threshold, S15Q16_RADIX);
+    void set_echoing(bool should_echo) { echoing = should_echo; }
+
+    void set_bind_sync(bool should_bind) {
+        bind_sync = should_bind;
+        hardware.reset_sync();
     }
 
-    auto write(mmr920C04::Registers reg, uint32_t command_data) -> void {
-        writer.write(mmr920C04::ADDRESS, static_cast<uint8_t>(reg),
+    auto get_threshold() -> int32_t { return threshold_pascals; }
+
+    auto set_threshold(float threshold_pa,
+                       can::ids::SensorThresholdMode from_mode,
+                       uint32_t message_index) -> void {
+        threshold_pascals = threshold_pa;
+        auto message = can::messages::SensorThresholdResponse{
+            .message_index = message_index,
+            .sensor = SensorType::pressure,
+            .sensor_id = sensor_id,
+            .threshold =
+                convert_to_fixed_point(threshold_pascals, S15Q16_RADIX),
+            .mode = from_mode};
+        can_client.send_can_message(can::ids::NodeId::host, message);
+    }
+
+    auto write(mmr920C04::Registers reg, uint8_t command_data) -> bool {
+        return writer.write(mmr920C04::ADDRESS, static_cast<uint8_t>(reg),
                      command_data);
     }
 
-    auto write(mmr920C04::Registers reg) -> void {
-        writer.write(mmr920C04::ADDRESS, static_cast<uint8_t>(reg));
-    }
-
-    auto transact(mmr920C04::Registers reg) -> void {
+    auto transact(mmr920C04::Registers reg) -> bool {
         std::array reg_buf{static_cast<uint8_t>(reg)};
-        writer.transact(
+        return writer.transact(
             mmr920C04::ADDRESS, reg_buf, 4, own_queue,
             utils::build_id(mmr920C04::ADDRESS, static_cast<uint8_t>(reg)));
-    }
-
-    auto poll_read(mmr920C04::Registers reg, uint16_t number_reads) -> void {
-        std::array reg_buf{static_cast<uint8_t>(reg)};
-        poller.single_register_poll(
-            mmr920C04::ADDRESS, reg_buf, 4, number_reads, DELAY, own_queue,
-            utils::build_id(
-                mmr920C04::ADDRESS, static_cast<uint8_t>(reg),
-                utils::byte_from_tag(utils::ResponseTag::IS_PART_OF_POLL)));
     }
 
     auto write_config() -> bool {
@@ -103,46 +106,74 @@ class MMR920C04 {
         return true;
     }
 
-    auto set_measure_mode(mmr920C04::Registers reg) -> bool {
-        switch (reg) {
-            case mmr920C04::Registers::MEASURE_MODE_1:
+    auto poll_limited_pressure(uint16_t number_reads, uint8_t tags) -> void {
+        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
+        auto command_data = build_register_command(_registers.low_pass_pressure_command);
+        if (filter_setting == mmr920C04::FilterSetting::NO_FILTER) {
+            command_data = build_register_command(_registers.pressure_command);
+        }
+        total_baseline_reads = number_reads;
+        poller.single_register_poll(
+            mmr920C04::ADDRESS, command_data, 3, number_reads, mode_delay_with_buffer, own_queue,
+            utils::build_id(mmr920C04::ADDRESS, command_data, tags)
+        );
+    }
+
+    auto poll_limited_temperature(uint16_t number_reads, uint8_t tags) -> void {
+        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
+        auto command_data = build_register_command(_registers.temperature_command);
+        total_baseline_reads = number_reads;
+        poller.single_register_poll(
+            mmr920C04::ADDRESS, command_data, 3, number_reads, mode_delay_with_buffer, own_queue,
+            utils::build_id(mmr920C04::ADDRESS, command_data, tags)
+        );
+    }
+
+    auto poll_continuous_pressure(uint8_t tags) -> void {
+        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
+        auto command_data = build_register_command(_registers.low_pass_pressure_command);
+        if (filter_setting == mmr920C04::FilterSetting::NO_FILTER) {
+            command_data = build_register_command(_registers.pressure_command);
+        }
+        poller.continuous_single_register_poll(
+            mmr920C04::ADDRESS, command_data, 3, mode_delay_with_buffer, own_queue, utils::build_id(mmr920C04::ADDRESS, command_data, tags));
+    }
+
+    auto poll_continuous_temperature(uint8_t tags) -> void {
+        auto mode_delay_with_buffer = MeasurementTimings[static_cast<int>(measurement_mode_rate)] + DEFAULT_DELAY_BUFFER;
+        auto command_data = build_register_command(_registers.temperature_command);
+        poller.continuous_single_register_poll(
+            mmr920C04::ADDRESS, command_data, 3, mode_delay_with_buffer, own_queue, utils::build_id(mmr920C04::ADDRESS, command_data, tags));
+    }
+
+    // call this in the task.
+    auto set_measure_mode(mmr920C04::MeasurementRate rate) -> bool {
+        measurement_mode_rate = rate;
+        switch (rate) {
+            case mmr920C04::MeasurementRate::MEASURE_1:
                 if (set_register(_registers.measure_mode_1)) {
+
                     return true;
                 }
                 return false;
-            case mmr920C04::Registers::MEASURE_MODE_2:
+            case mmr920C04::MeasurementRate::MEASURE_2:
                 if (set_register(_registers.measure_mode_2)) {
                     return true;
                 }
                 return false;
-            case mmr920C04::Registers::MEASURE_MODE_3:
+            case mmr920C04::MeasurementRate::MEASURE_3:
                 if (set_register(_registers.measure_mode_3)) {
                     return true;
                 }
                 return false;
-            case mmr920C04::Registers::MEASURE_MODE_4:
+            case mmr920C04::MeasurementRate::MEASURE_4:
                 if (set_register(_registers.measure_mode_4)) {
-                    return true;
-                }
-                return false;
-            case mmr920C04::Registers::TEMPERATURE_READ:
-                if (set_register(_registers.temperature)) {
                     return true;
                 }
                 return false;
             default:
                 return false;
         }
-    }
-
-    auto get_pressure() -> bool {
-        read_register = mmr920C04::Registers::PRESSURE_READ;
-        return set_measure_mode(mmr920C04::Registers::MEASURE_MODE_4);
-    }
-
-    auto get_temperature() -> bool {
-        read_register = mmr920C04::Registers::TEMPERATURE_READ;
-        return set_measure_mode(mmr920C04::Registers::MEASURE_MODE_4);
     }
 
     auto reset(mmr920C04::Reset reg) -> bool {
@@ -153,78 +184,25 @@ class MMR920C04 {
         return false;
     }
 
-    auto read_pressure(uint32_t data) -> bool {
-        LOG("Updated pressure reading is %u", data);
-        _registers.pressure.reading = data;
+    auto save_pressure(int32_t data) -> bool {
+        _registers.pressure_result.reading = data;
+        LOG("Updated pressure reading is %u", _registers.pressure_result.reading);
         return true;
     }
 
-    auto read_pressure_low_pass(uint32_t data) -> bool {
-        _registers.low_pass_pressure.reading = data;
+    auto save_temperature(int32_t data) -> bool {
+        _registers.temperature_result.reading = data;
+        LOG("Updated temperature reading is %u", _registers.temperature_result.reading);
         return true;
     }
 
-    auto read_temperature(uint32_t data) -> bool {
-        _registers.temperature.reading = data;
+    auto read_status(uint8_t data) -> bool {
+        _registers.status_result.reading = data;
         return true;
-    }
-
-    auto read_status(uint32_t data) -> bool {
-        _registers.status.reading = data & mmr920C04::Status::value_mask;
-        return true;
-    }
-
-    auto send_pressure(uint32_t message_index) -> void {
-        // Pressure is sent via CAN in pascals as a fixed point value
-        auto pressure_pascals =
-            mmr920C04::Pressure::to_pressure(_registers.pressure.reading);
-        auto pressure_fixed_point =
-            convert_to_fixed_point(pressure_pascals, S15Q16_RADIX);
-        auto message = can::messages::ReadFromSensorResponse{
-            .message_index = message_index,
-            .sensor = get_sensor_type(),
-            .sensor_id = sensor_id,
-            .sensor_data = pressure_fixed_point};
-        can_client.send_can_message(get_host_id(), message);
-    }
-
-    auto send_baseline_response(uint32_t message_index) -> void {
-        auto offset_fixed_point =
-            convert_to_fixed_point(offset_average, S15Q16_RADIX);
-        auto message = can::messages::BaselineSensorResponse{
-            .message_index = message_index,
-            .sensor = get_sensor_type(),
-            .offset_average = offset_fixed_point};
-        auto host_id = get_host_id();
-        can_client.send_can_message(host_id, message);
-    }
-
-    auto send_pressure_low_pass(uint32_t message_index) -> void {
-        auto pressure = mmr920C04::LowPassPressure::to_pressure(
-            _registers.low_pass_pressure.reading);
-        auto pressure_fixed_point =
-            convert_to_fixed_point(pressure, S15Q16_RADIX);
-        auto message = can::messages::ReadFromSensorResponse{
-            .message_index = message_index,
-            .sensor = get_sensor_type(),
-            .sensor_id = sensor_id,
-            .sensor_data = pressure_fixed_point};
-        can_client.send_can_message(get_host_id(), message);
-    }
-
-    auto send_temperature(uint32_t message_index) -> void {
-        auto temperature = mmr920C04::Temperature::to_temperature(
-            _registers.low_pass_pressure.reading);
-        auto message = can::messages::ReadFromSensorResponse{
-            .message_index = message_index,
-            .sensor = get_sensor_type(),
-            .sensor_id = sensor_id,
-            .sensor_data = temperature};
-        can_client.send_can_message(get_host_id(), message);
     }
 
     auto send_status(uint32_t message_index) -> void {
-        auto status = mmr920C04::Status::to_status(_registers.status.reading);
+        auto status = mmr920C04::StatusResult::to_status(_registers.status_result.reading);
         auto message = can::messages::ReadFromSensorResponse{
             .message_index = message_index,
             .sensor = get_sensor_type(),
@@ -251,125 +229,122 @@ class MMR920C04 {
         can_client.send_can_message(get_host_id(), message);
     }
 
-    auto sensor_callback() -> void {
-        writer.transact_isr(mmr920C04::ADDRESS,
-                            static_cast<uint8_t>(read_register),
-                            static_cast<std::size_t>(3), own_queue,
-                            static_cast<uint8_t>(read_register));
-        if (limited_poll && !stop_polling) {
-            readings_taken++;
-            if (readings_taken >= total_baseline_reads) {
-                stop_polling = true;
+    void reset_readings() {
+        writer.write(mmr920C04::ADDRESS,
+                     static_cast<uint8_t>(mmr920C04::Registers::RESET));
+    }
+
+    void stop_continuous_polling(uint8_t transaction_index, uint8_t reg_id) {
+        poller.continuous_single_register_poll(
+            fdc1004::ADDRESS, reg_id, 3,
+            STOP_DELAY, own_queue, transaction_index);
+    }
+
+    auto handle_ongoing_response(i2c::messages::TransactionResponse &m) -> void {
+        auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
+        if (!bind_sync && !echoing) {
+            stop_continuous_polling(m.id.transaction_index, static_cast<uint8_t>(reg_id));
+            reset_readings();
+        }
+
+        // Pressure is always a three-byte value
+        static_cast<void>(bit_utils::bytes_to_int(
+            m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
+
+        auto pressure_read = reg_id == mmr920C04::Registers::LOW_PASS_PRESSURE_READ || reg_id == mmr920C04::Registers::PRESSURE_READ;
+        auto temperature_read = reg_id == mmr920C04::Registers::TEMPERATURE_READ;
+        if (pressure_read) {
+            save_pressure(temporary_data_store);
+        }
+        if (temperature_read) {
+            save_temperature(temporary_data_store);
+        }
+        if (bind_sync && pressure_read) {
+            auto pressure = mmr920C04::PressureResult::to_pressure(temporary_data_store);
+            if (std::fabs(pressure) - std::fabs(current_pressure_baseline_pa) > threshold_pascals) {
+                hardware.set_sync();
+            } else {
+                hardware.reset_sync();
             }
         }
-        if (stop_polling) {
-            writer.write_isr(mmr920C04::ADDRESS,
-                             static_cast<uint8_t>(mmr920C04::Registers::RESET));
+        if (echoing && pressure_read) {
+            auto pressure = mmr920C04::PressureResult::to_pressure(temporary_data_store);
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::ReadFromSensorResponse{
+                    .message_index = m.message_index,
+                    .sensor = can::ids::SensorType::pressure,
+                    .sensor_id = sensor_id,
+                    .sensor_data =
+                        mmr920C04::reading_to_fixed_point(pressure)});
+        }
+        if (echoing && temperature_read) {
+            auto temperature = mmr920C04::PressureResult::to_pressure(temporary_data_store);
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::ReadFromSensorResponse{
+                    .message_index = m.message_index,
+                    .sensor = can::ids::SensorType::pressure_temperature,
+                    .sensor_id = sensor_id,
+                    .sensor_data =
+                        mmr920C04::reading_to_fixed_point(temperature)});
         }
     }
 
-    auto set_sync_bind(SensorOutputBinding binding) -> void {
-        hardware.reset_sync();
-        set_sync(binding);
-        set_report(binding);
-        set_stop_polling(binding);
-    }
+    auto handle_baseline_response(i2c::messages::TransactionResponse &m) -> void {
+        static_cast<void>(bit_utils::bytes_to_int(
+            m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
 
-    auto handle_baseline_poll(uint32_t message_index, float data) -> void {
-        running_total += data;
-        if (readings_taken == total_baseline_reads) {
-            offset_average = running_total / total_baseline_reads;
-            send_baseline_response(message_index);
-            set_number_of_reads(0);
+        auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
+
+        auto pressure_read = reg_id == mmr920C04::Registers::LOW_PASS_PRESSURE_READ || reg_id == mmr920C04::Registers::PRESSURE_READ;
+        auto temperature_read = reg_id == mmr920C04::Registers::TEMPERATURE_READ;
+        if (pressure_read) {
+            auto pressure = mmr920C04::PressureResult::to_pressure(temporary_data_store);
+            pressure_running_total += pressure;
         }
-    }
+        if (temperature_read) {
+            auto temperature = mmr920C04::TemperatureResult::to_temperature(temporary_data_store);
+            temperature_running_total += temperature;
+        }
+        if (!m.id.is_completed_poll) {
+            return;
+        }
+        reset_readings();
+    
 
-    void set_number_of_reads(uint16_t number_of_reads) {
-        this->total_baseline_reads = number_of_reads;
-        this->readings_taken = 0;
-        this->running_total = 0;
-        this->offset_average = 0;
-        this->stop_polling = false;
-    }
-
-    void set_limited_poll(bool _limited) { limited_poll = _limited; }
-
-    auto handle_response(const i2c::messages::TransactionResponse &tm) {
-        uint32_t raw_data = 0x00;
-        int32_t data = 0x0;
-        const auto *iter = tm.read_buffer.cbegin();
-        // Pressure is always a three-byte value
-        iter = bit_utils::bytes_to_int(iter, tm.read_buffer.cend(), raw_data);
-        data = static_cast<int32_t>(raw_data >> 8);
-        auto pressure_pascals = mmr920C04::Pressure::to_pressure(data);
-        switch (static_cast<mmr920C04::Registers>(tm.id.token)) {
-            case mmr920C04::Registers::PRESSURE_READ:
-                read_pressure(data);
-                if (sync) {
-                    if (std::fabs(pressure_pascals) -
-                            std::fabs(offset_average) >
-                        threshold_pascals) {
-                        hardware.set_sync();
-                        stop_polling = true;
-                    } else {
-                        hardware.reset_sync();
-                    }
-                }
-                if (report) {
-                    send_pressure(tm.message_index);
-                }
-                if (limited_poll) {
-                    handle_baseline_poll(tm.message_index, pressure_pascals);
-                }
-                break;
-            case mmr920C04::Registers::LOW_PASS_PRESSURE_READ:
-                read_pressure_low_pass(data);
-                send_pressure_low_pass(tm.message_index);
-                break;
-            case mmr920C04::Registers::TEMPERATURE_READ:
-                read_temperature(data);
-                if (report) {
-                    send_temperature(tm.message_index);
-                }
-                if (limited_poll) {
-                    auto temperature_celsius =
-                        mmr920C04::Temperature::to_temperature(data);
-                    handle_baseline_poll(tm.message_index, temperature_celsius);
-                }
-                break;
-            case mmr920C04::Registers::STATUS:
-                read_status(data);
-                send_status(tm.message_index);
-                break;
-            case mmr920C04::Registers::RESET:
-            case mmr920C04::Registers::IDLE:
-            case mmr920C04::Registers::MEASURE_MODE_1:
-            case mmr920C04::Registers::MEASURE_MODE_2:
-            case mmr920C04::Registers::MEASURE_MODE_3:
-            case mmr920C04::Registers::MEASURE_MODE_4:
-            case mmr920C04::Registers::MACRAM_WRITE:
-                break;
+        if (pressure_read) {
+            auto current_pressure_baseline_pa = pressure_running_total / total_baseline_reads;
+            auto offset_fixed_point =
+                   mmr920C04::reading_to_fixed_point(current_pressure_baseline_pa);
+            // FIXME This should be tied to the set threshold
+            // command so we can completely remove the base line sensor
+            // request from all sensors!
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::BaselineSensorResponse{
+                .message_index = m.message_index,
+                .sensor = can::ids::SensorType::pressure,
+                .offset_average = offset_fixed_point});
+            pressure_running_total = 0x0;
+        }
+        if (temperature_read) {
+            auto current_temperature_baseline = temperature_running_total / total_baseline_reads;
+            auto offset_fixed_point =
+                    mmr920C04::reading_to_fixed_point(current_temperature_baseline);
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::BaselineSensorResponse{
+                .message_index = m.message_index,
+                .sensor = can::ids::SensorType::pressure_temperature,
+                .offset_average = offset_fixed_point});
+            temperature_running_total = 0x0;
         }
     }
 
     auto get_can_client() -> CanClient & { return can_client; }
 
   private:
-    mmr920C04::MMR920C04RegisterMap _registers{};
-    bool _initialized = false;
-    bool stop_polling = true;
-    bool sync = false;
-    bool report = true;
-    bool limited_poll = true;
-    uint16_t readings_taken = 0x1;
-    float running_total = 0;
-    uint16_t total_baseline_reads = 0x8;
-    // TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
-    // sure this is an arbitrarily large number to enable continuous reads.
-    float threshold_pascals = 100.0F;
-    float offset_average = 0;
-    const uint16_t DELAY = 20;
-    mmr920C04::Registers read_register = mmr920C04::Registers::PRESSURE_READ;
     I2CQueueWriter &writer;
     I2CQueuePoller &poller;
     CanClient &can_client;
@@ -377,29 +352,57 @@ class MMR920C04 {
     hardware::SensorHardwareBase &hardware;
     const can::ids::SensorId &sensor_id;
 
-    template <mmr920C04::MMR920C04Register Reg>
+    mmr920C04::MMR920C04RegisterMap _registers{};
+    mmr920C04::FilterSetting filter_setting = mmr920C04::FilterSetting::LOW_PASS_FILTER;
+    
+    static constexpr float MeasurementTimings[] = {3.1, 6.1, 12.2, 24.3}; // in msec
+    static constexpr float DEFAULT_DELAY_BUFFER = 1.0; // in msec (TODO might need to change to fit in uint16_t)
+    static constexpr uint16_t STOP_DELAY = 0;
+    mmr920C04::MeasurementRate measurement_mode_rate = mmr920C04::MeasurementRate::MEASURE_4;
+
+    bool _initialized = false;
+    bool stop_polling = true;
+    bool echoing = false;
+    bool bind_sync = false;
+    bool limited_poll = true;
+
+    float pressure_running_total = 0;
+    float temperature_running_total = 0;
+    uint16_t total_baseline_reads = 0x8;
+    // TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
+    // sure this is an arbitrarily large number to enable continuous reads.
+    float current_pressure_baseline_pa = 0;
+    float current_temperature_baseline = 0;
+    float threshold_pascals = 100.0F;
+    float offset_average = 0;
+
+    int32_t temporary_data_store = 0x0;
+
+    template <mmr920C04::MMR920C04CommandRegister Reg>
     requires registers::WritableRegister<Reg>
-    auto set_register(Reg) -> bool {
-        write(Reg::address);
-        return true;
+    auto build_register_command(Reg &reg) -> uint8_t {
+        auto value =
+            // Ignore the typical linter warning because we're only using
+            // this on __packed structures that mimic hardware registers
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            *reinterpret_cast<mmr920C04::RegisterSerializedTypeA *>(&reg);
+        value &= Reg::value_mask;
+        return value;
     }
 
-    auto set_sync(SensorOutputBinding binding) -> void {
-        sync = (static_cast<uint8_t>(binding) &
-                static_cast<uint8_t>(SensorOutputBinding::sync)) ==
-               static_cast<uint8_t>(SensorOutputBinding::sync);
+    template <mmr920C04::MMR920C04CommandRegister Reg>
+    requires registers::WritableRegister<Reg>
+    auto set_register(Reg &reg) -> bool {
+        auto value =
+            // Ignore the typical linter warning because we're only using
+            // this on __packed structures that mimic hardware registers
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            *reinterpret_cast<mmr920C04::RegisterSerializedTypeA *>(&reg);
+        value &= Reg::value_mask;
+        return write(Reg::address, value);
     }
 
-    auto set_report(SensorOutputBinding binding) -> void {
-        report = (static_cast<uint8_t>(binding) &
-                  static_cast<uint8_t>(SensorOutputBinding::report)) ==
-                 static_cast<uint8_t>(SensorOutputBinding::report);
-    }
-
-    auto set_stop_polling(SensorOutputBinding binding) -> void {
-        stop_polling = (static_cast<uint8_t>(binding) ==
-                        static_cast<uint8_t>(SensorOutputBinding::none));
-    }
 };
-};  // namespace tasks
-};  // namespace sensors
+
+}  // namespace tasks
+}  // namespace sensors

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -258,18 +258,17 @@ class MMR920C04 {
                      static_cast<uint8_t>(mmr920C04::Registers::RESET));
     }
 
-    void stop_continuous_polling(uint8_t transaction_index, uint8_t reg_id) {
+    void stop_continuous_polling(uint32_t transaction_id, uint8_t reg_id) {
         poller.continuous_single_register_poll(mmr920C04::ADDRESS, reg_id, 3,
                                                STOP_DELAY, own_queue,
-                                               transaction_index);
+                                               transaction_id);
     }
 
     auto handle_ongoing_pressure_response(i2c::messages::TransactionResponse &m)
         -> void {
         if (!bind_sync && !echoing) {
             auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
-            stop_continuous_polling(m.id.transaction_index,
-                                    static_cast<uint8_t>(reg_id));
+            stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
             reset_readings();
         }
 
@@ -308,8 +307,7 @@ class MMR920C04 {
         i2c::messages::TransactionResponse &m) -> void {
         if (!bind_sync && !echoing) {
             auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
-            stop_continuous_polling(m.id.transaction_index,
-                                    static_cast<uint8_t>(reg_id));
+            stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
             reset_readings();
         }
 

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -428,7 +428,8 @@ class MMR920C04 {
     mmr920C04::FilterSetting filter_setting =
         mmr920C04::FilterSetting::LOW_PASS_FILTER;
 
-    static constexpr std::array<float, 4> MeasurementTimings{3.1, 6.1, 12.2, 24.3};  // in msec
+    static constexpr std::array<float, 4> MeasurementTimings{3.1, 6.1, 12.2,
+                                                             24.3};  // in msec
     static constexpr float DEFAULT_DELAY_BUFFER =
         1.0;  // in msec (TODO might need to change to fit in uint16_t)
     static constexpr uint16_t STOP_DELAY = 0;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -267,8 +267,6 @@ class MMR920C04 {
     auto handle_ongoing_response(i2c::messages::TransactionResponse &m)
         -> void {
         auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
-        std::cout << "echoing" << echoing << "\n";
-        std::cout << "binding" << bind_sync << "\n";
         if (!bind_sync && !echoing) {
             stop_continuous_polling(m.id.transaction_index,
                                     static_cast<uint8_t>(reg_id));
@@ -297,10 +295,7 @@ class MMR920C04 {
         if (bind_sync && pressure_read) {
             auto pressure = mmr920C04::PressureResult::to_pressure(
                 _registers.pressure_result.reading);
-            auto signed_pressure =
-                mmr920C04::PressureResult::to_pressure(signed_data_store);
-            std::cout << "I'm in bind sync and pressure is" << pressure << "\n";
-            std::cout << "but signed data is" << signed_pressure << "\n";
+
             if (std::fabs(pressure) - std::fabs(current_pressure_baseline_pa) >
                 threshold_pascals) {
                 hardware.set_sync();
@@ -351,14 +346,11 @@ class MMR920C04 {
             reg_id == mmr920C04::Registers::PRESSURE_READ;
         auto temperature_read =
             reg_id == mmr920C04::Registers::TEMPERATURE_READ;
-        std::cout << "pressure totale before add " << pressure_running_total
-                  << "\n";
+
         if (pressure_read) {
             auto pressure =
                 mmr920C04::PressureResult::to_pressure(signed_data_store);
             pressure_running_total += pressure;
-            std::cout << "pressure totale after add " << pressure_running_total
-                      << "\n";
         }
         if (temperature_read) {
             auto temperature =
@@ -370,14 +362,12 @@ class MMR920C04 {
         }
         reset_readings();
 
-        std::cout << "baseline reads " << total_baseline_reads << "\n";
         if (pressure_read) {
             auto current_pressure_baseline_pa =
                 pressure_running_total / total_baseline_reads;
             auto pressure_fixed_point =
                 mmr920C04::reading_to_fixed_point(current_pressure_baseline_pa);
-            std::cout << "averaged pressure " << current_pressure_baseline_pa
-                      << "\n";
+
             // FIXME This should be tied to the set threshold
             // command so we can completely remove the base line sensor
             // request from all sensors!

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -58,10 +58,19 @@ class PressureMessageHandler {
         // may not be routed to baseline function like we suspect
         if (utils::tag_in_token(m.id.token,
                                 utils::ResponseTag::POLL_IS_CONTINUOUS)) {
-            driver.handle_ongoing_response(m);
+            if (reg_id == mmr920C04::Registers::TEMPERATURE_READ) {
+                driver.handle_ongoing_temperature_response(m);
+            } else {
+                driver.handle_ongoing_pressure_response(m);
+            }
             LOG("continuous transaction response");
         } else {
-            driver.handle_baseline_response(m);
+            if (reg_id == mmr920C04::Registers::TEMPERATURE_READ) {
+                driver.handle_baseline_temperature_response(m);
+            } else {
+                driver.handle_baseline_pressure_response(m);
+            }
+
             LOG("limited transaction response");
         }
     }

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iostream>
-
 #include "can/core/ids.hpp"
 #include "common/core/bit_utils.hpp"
 #include "common/core/logging.h"
@@ -60,11 +58,9 @@ class PressureMessageHandler {
         // may not be routed to baseline function like we suspect
         if (utils::tag_in_token(m.id.token,
                                 utils::ResponseTag::POLL_IS_CONTINUOUS)) {
-            std::cout << "handling ongoing response\n";
             driver.handle_ongoing_response(m);
             LOG("continuous transaction response");
         } else {
-            std::cout << "handling baseline response\n";
             driver.handle_baseline_response(m);
             LOG("limited transaction response");
         }

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -47,28 +47,39 @@ class PressureMessageHandler {
   private:
     void visit(const std::monostate &) {}
 
-    void visit(const i2c::messages::TransactionResponse &m) {
-        driver.handle_response(m);
+    void visit(i2c::messages::TransactionResponse &m) {
+        auto reg_id = utils::reg_from_id<mmr920C04::Registers>(m.id.token);
+        if ((reg_id != mmr920C04::Registers::LOW_PASS_PRESSURE_READ) &&
+            (reg_id != mmr920C04::Registers::PRESSURE_READ) && 
+            (reg_id != mmr920C04::Registers::TEMPERATURE_READ) &&
+            (reg_id != mmr920C04::Registers::STATUS)) {
+            return;
+        }
+
+        if (utils::tag_in_token(m.id.token,
+                                utils::ResponseTag::POLL_IS_CONTINUOUS)) {
+            driver.handle_ongoing_response(m);
+            LOG("continuous transaction response");
+        } else {
+            driver.handle_baseline_response(m);
+            LOG("limited transaction response");
+        }
     }
 
     void visit(const can::messages::ReadFromSensorRequest &m) {
         LOG("Received request to read from %d sensor\n", m.sensor);
         if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.set_sync_bind(can::ids::SensorOutputBinding::report);
-            driver.set_limited_poll(true);
+            driver.reset_limited();
             driver.set_number_of_reads(1);
-            if (!driver.get_pressure()) {
-                LOG("Could not send read pressure command");
-            }
-        } else {
-            if (can::ids::SensorType(m.sensor) ==
+            auto tags_as_int = 1;
+            driver.poll_limited_pressure(1, tags_as_int);
+        }
+        if (can::ids::SensorType(m.sensor) ==
                 can::ids::SensorType::pressure_temperature) {
-                driver.set_sync_bind(can::ids::SensorOutputBinding::report);
-                driver.set_limited_poll(true);
-                if (!driver.get_temperature()) {
-                    LOG("Could not send read temperature command");
-                }
-            }
+            driver.reset_limited();
+            driver.set_number_of_reads(1);
+            auto tags_as_int = 1;
+            driver.poll_limited_temperature(1, tags_as_int);
         }
     }
 
@@ -83,20 +94,41 @@ class PressureMessageHandler {
     }
 
     void visit(const can::messages::SetSensorThresholdRequest &m) {
-        LOG("Received request to set threshold to %d from %d sensor\n",
+        LOG("Received request to set threshold to %d from %d sensor",
             m.threshold, m.sensor);
-        driver.set_threshold(m.threshold);
-        driver.send_threshold(m.message_index);
+        // NOTE this function only supports pressure reads right now.
+        if (m.mode == can::ids::SensorThresholdMode::absolute) {
+            driver.set_threshold(
+                fixed_point_to_float(m.threshold, S15Q16_RADIX), m.mode,
+                m.message_index);
+        } else {
+            driver.reset_limited();
+            driver.set_number_of_reads(10);
+            std::array tags{utils::ResponseTag::IS_PART_OF_POLL,
+                            utils::ResponseTag::IS_BASELINE,
+                            utils::ResponseTag::IS_THRESHOLD_SENSE};
+            auto tags_as_int = utils::byte_from_tags(tags);
+            driver.prime_autothreshold(
+                fixed_point_to_float(m.threshold, S15Q16_RADIX));
+            driver.poll_limited_pressure(
+                10, static_cast<can::ids::SensorId>(m.sensor_id), tags_as_int);
+        }
     }
 
     void visit(const can::messages::BindSensorOutputRequest &m) {
-        LOG("received bind request");
-        static_cast<void>(m);
-        if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.set_sync_bind(
-                static_cast<can::ids::SensorOutputBinding>(m.binding));
-            driver.set_limited_poll(false);
-            driver.get_pressure();
+        driver.set_echoing(
+            m.binding &
+            static_cast<uint8_t>(can::ids::SensorOutputBinding::report));
+        driver.set_bind_sync(
+            m.binding &
+            static_cast<uint8_t>(can::ids::SensorOutputBinding::sync));
+        std::array tags{utils::ResponseTag::IS_PART_OF_POLL,
+                        utils::ResponseTag::POLL_IS_CONTINUOUS};
+        auto tags_as_int = utils::byte_from_tags(tags);
+        if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure_temperature) {
+            driver.poll_continuous_temperature(tags_as_int);
+        } else {
+            driver.poll_continuous_pressure(tags_as_int);
         }
         driver.get_can_client().send_can_message(
             can::ids::NodeId::host, can::messages::ack_from_request(m));
@@ -106,13 +138,14 @@ class PressureMessageHandler {
         LOG("received baseline request");
         static_cast<void>(m);
         driver.set_sync_bind(can::ids::SensorOutputBinding::none);
-        driver.set_limited_poll(true);
-        driver.set_number_of_reads(m.number_of_reads);
-        if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure) {
-            driver.get_pressure();
-        } else if (can::ids::SensorType(m.sensor) ==
-                   can::ids::SensorType::temperature) {
-            driver.get_temperature();
+        std::array tags{utils::ResponseTag::IS_PART_OF_POLL,
+                utils::ResponseTag::IS_BASELINE,
+                utils::ResponseTag::IS_THRESHOLD_SENSE};
+        auto tags_as_int = utils::byte_from_tags(tags);
+        if (can::ids::SensorType(m.sensor) == can::ids::SensorType::pressure_temperature) {
+            driver.poll_limited_temperature(tags_as_int);
+        } else {
+            driver.poll_limited_pressure(tags_as_int);
         }
         driver.get_can_client().send_can_message(
             can::ids::NodeId::host, can::messages::ack_from_request(m));

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -19,32 +19,9 @@ class SensorHardware : public SensorHardwareBase {
         }
         return false;
     }
-    // TODO: change data_ready's input parameter to an std::map object, so that
-    //  the function being called is definitely the callback corresponding to
-    //  the correct GPIO interrupt
-    auto data_ready() -> void {
-        for (auto &callback_function : data_ready_callbacks) {
-            if (callback_function) {
-                callback_function();
-            }
-        }
-    }
 
     sensors::hardware::SensorHardwareConfiguration hardware;
 
-    std::array<std::function<void()>, 5> data_ready_callbacks = {};
-
-    auto add_data_ready_callback(std::function<void()> callback)
-        -> bool override {
-        for (auto &callback_function : data_ready_callbacks) {
-            if (callback_function) {
-                continue;
-            }
-            callback_function = callback;
-            return true;
-        }
-        return false;
-    }
 };
 };  // namespace hardware
 };  // namespace sensors

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -21,7 +21,6 @@ class SensorHardware : public SensorHardwareBase {
     }
 
     sensors::hardware::SensorHardwareConfiguration hardware;
-
 };
 };  // namespace hardware
 };  // namespace sensors

--- a/include/sensors/simulation/mmr920C04.hpp
+++ b/include/sensors/simulation/mmr920C04.hpp
@@ -11,37 +11,18 @@ using namespace i2c::hardware;
 
 class MMR920C04 : public I2CRegisterMap<uint8_t, uint32_t> {
   public:
-    MMR920C04(sim_mocks::MockSensorHardware &mock_sensor_hw)
-        : I2CRegisterMap{mmr920C04::ADDRESS,
-                         {{static_cast<uint8_t>(mmr920C04::Registers::STATUS),
-                           0xED},
-                          {static_cast<uint8_t>(
-                               mmr920C04::Registers::MEASURE_MODE_1),
-                           0},
-                          {static_cast<uint8_t>(
-                               mmr920C04::Registers::PRESSURE_READ),
-                           6000},
-                          {static_cast<uint8_t>(
-                               mmr920C04::Registers::LOW_PASS_PRESSURE_READ),
-                           6000},
-                          {static_cast<uint8_t>(
-                               mmr920C04::Registers::TEMPERATURE_READ),
-                           3200}}},
-          mock_sensor_hardware{mock_sensor_hw} {}
-
-    auto handle_write(const uint8_t *data, uint16_t size) -> bool {
-        auto result =
-            I2CRegisterMap<uint8_t, uint32_t>::handle_write(data, size);
-        uint8_t curr_reg = static_cast<uint8_t>(
-            I2CRegisterMap<uint8_t, uint32_t>::get_current_register());
-        if (curr_reg ==
-            static_cast<uint8_t>(mmr920C04::Registers::MEASURE_MODE_4)) {
-            mock_sensor_hardware.data_ready();
-        }
-        return result;
-    }
-
-    sim_mocks::MockSensorHardware &mock_sensor_hardware;
+    MMR920C04()
+        : I2CRegisterMap(
+              mmr920C04::ADDRESS,
+              {{static_cast<uint8_t>(mmr920C04::Registers::STATUS), 0xED},
+               {static_cast<uint8_t>(mmr920C04::Registers::MEASURE_MODE_1), 0},
+               {static_cast<uint8_t>(mmr920C04::Registers::PRESSURE_READ),
+                6000},
+               {static_cast<uint8_t>(
+                    mmr920C04::Registers::LOW_PASS_PRESSURE_READ),
+                6000},
+               {static_cast<uint8_t>(mmr920C04::Registers::TEMPERATURE_READ),
+                3200}}) {}
 };
 
 };  // namespace mmr920C04_simulator

--- a/include/sensors/simulation/mock_hardware.hpp
+++ b/include/sensors/simulation/mock_hardware.hpp
@@ -22,26 +22,6 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
         }
     }
     auto check_tip_presence() -> bool override { return false; }
-    std::array<std::function<void()>, 5> data_ready_callbacks = {};
-    auto add_data_ready_callback(std::function<void()> callback)
-        -> bool override {
-        for (auto &callback_function : data_ready_callbacks) {
-            if (callback_function) {
-                continue;
-            }
-            callback_function = callback;
-            return true;
-        }
-        return false;
-    }
-
-    auto data_ready() -> void {
-        for (auto &callback_function : data_ready_callbacks) {
-            if (callback_function) {
-                callback_function();
-            }
-        }
-    }
 
     void provide_state_manager(StateManagerHandle handle) {
         _state_manager = handle;

--- a/include/sensors/tests/mock_hardware.hpp
+++ b/include/sensors/tests/mock_hardware.hpp
@@ -13,26 +13,6 @@ class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
         sync_reset_calls++;
     }
     auto check_tip_presence() -> bool override { return false; }
-    std::array<std::function<void()>, 5> data_ready_callbacks = {};
-    auto add_data_ready_callback(std::function<void()> callback)
-        -> bool override {
-        for (auto &callback_function : data_ready_callbacks) {
-            if (callback_function) {
-                continue;
-            }
-            callback_function = callback;
-            return true;
-        }
-        return false;
-    }
-
-    auto data_ready() -> void {
-        for (auto &callback_function : data_ready_callbacks) {
-            if (callback_function) {
-                callback_function();
-            }
-        }
-    }
 
     auto get_sync_state_mock() const -> bool { return sync_state; }
     auto get_sync_set_calls() const -> uint32_t { return sync_set_calls; }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -126,11 +126,10 @@ static auto pins_for_sensor =
 static auto sensor_hardware_container =
     utility_configs::get_sensor_hardware_container(pins_for_sensor);
 
-static auto data_ready_gpio_primary =
-    pins_for_sensor.primary.data_ready.value();
+
 static auto ok_for_secondary =
     pins_for_sensor.secondary.has_value() &&
-    pins_for_sensor.secondary.value().data_ready.has_value();
+    pins_for_sensor.secondary.value().tip_sense.has_value();
 static auto tip_sense_gpio_primary = pins_for_sensor.primary.tip_sense.value();
 
 static auto& sensor_queue_client = sensor_tasks::get_queues();
@@ -138,27 +137,18 @@ static auto& sensor_queue_client = sensor_tasks::get_queues();
 static auto tail_accessor =
     eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
 
-#if PCBA_PRIMARY_REVISION == 'c' && PCBA_SECONDARY_REVISION == '2' && \
-    PIPETTE_TYPE != NINETY_SIX_CHANNEL
-static constexpr bool pressure_sensor_available = false;
-#else
-static constexpr bool pressure_sensor_available = true;
-#endif
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == data_ready_gpio_primary.pin && pressure_sensor_available) {
-        sensor_hardware_container.primary.data_ready();
-    } else if (GPIO_Pin == tip_sense_gpio_primary.pin) {
+    if (GPIO_Pin == tip_sense_gpio_primary.pin) {
         static_cast<void>(
             sensor_queue_client.tip_notification_queue->try_write_isr(
                 sensors::tip_presence::TipStatusChangeDetected{}));
     } else if (ok_for_secondary &&
                GPIO_Pin ==
-                   pins_for_sensor.secondary.value().data_ready.value().pin &&
-               pressure_sensor_available) {
-        if (sensor_hardware_container.secondary.has_value()) {
-            sensor_hardware_container.secondary.value().data_ready();
-        }
+                   pins_for_sensor.secondary.value().tip_sense.value().pin) {
+        static_cast<void>(
+            sensor_queue_client.tip_notification_queue->try_write_isr(
+                sensors::tip_presence::TipStatusChangeDetected{}));
     }
 }
 

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -126,7 +126,6 @@ static auto pins_for_sensor =
 static auto sensor_hardware_container =
     utility_configs::get_sensor_hardware_container(pins_for_sensor);
 
-
 static auto ok_for_secondary =
     pins_for_sensor.secondary.has_value() &&
     pins_for_sensor.secondary.value().tip_sense.has_value();
@@ -136,7 +135,6 @@ static auto& sensor_queue_client = sensor_tasks::get_queues();
 
 static auto tail_accessor =
     eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
-
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     if (GPIO_Pin == tip_sense_gpio_primary.pin) {

--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -118,27 +118,13 @@ void DebugMon_Handler(void) {}
 /*  file (startup_stm32g4xxxx.s).                                             */
 /******************************************************************************/
 
-void EXTI1_IRQHandler(void) {
-    __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_1);
-    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_1);
-}
-
 void EXTI2_IRQHandler(void) {
     __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_2);
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
 }
 
-void EXTI3_IRQHandler(void) {
-    __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_3);
-    HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
-}
-
 void EXTI9_5_IRQHandler(void) {
-    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_6)) {
-        // clear pending
-        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_6);
-        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_6);
-    } else if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_7)) {
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_7)) {
         // clear pending
         __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_7);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7); 
@@ -150,9 +136,6 @@ void EXTI15_10_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_12)) {
         __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_12);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
-    } else if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_11)) {
-        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_11);
-        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_11);
     }
 }
 

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -4,11 +4,6 @@
 #include "pipettes/core/pipette_type.h"
 #include "stm32g4xx_hal_gpio.h"
 
-// temporary workaround until we permanently disable
-// the data ready line interrupts and rely on a software
-// timer instead.
-
-static const int enable_96_chan_interrupts = 0;
 
 static void enable_gpio_port(void* port) {
     if (port == GPIOA) {
@@ -56,34 +51,23 @@ static void tip_sense_gpio_init() {
 static void nvic_priority_enable_init() {
     PipetteType pipette_type = get_pipette_type();
 
-    if (pipette_type == NINETY_SIX_CHANNEL && enable_96_chan_interrupts) {
+    if (pipette_type == NINETY_SIX_CHANNEL) {
         IRQn_Type block_9_5 = get_interrupt_line(gpio_block_9_5);
         IRQn_Type block_15_10 = get_interrupt_line(gpio_block_15_10);
-        /* EXTI interrupt init data ready/tip sense rear*/
+        /* EXTI interrupt init tip sense rear*/
         HAL_NVIC_SetPriority(block_9_5, 10, 0);
         HAL_NVIC_EnableIRQ(block_9_5);
 
-        /* EXTI interrupt init data ready/tip sense front*/
+        /* EXTI interrupt init tip sense front*/
         HAL_NVIC_SetPriority(block_15_10, 10, 0);
         HAL_NVIC_EnableIRQ(block_15_10);
     } else {
-        IRQn_Type block_3 = get_interrupt_line(gpio_block_3);
         IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
         /* EXTI interrupt init block tip sense*/
         HAL_NVIC_SetPriority(block_2, 10, 0);
         HAL_NVIC_EnableIRQ(block_2);
 
-        /* EXTI interrupt init data ready*/
-        HAL_NVIC_SetPriority(block_3, 10, 0);
-        HAL_NVIC_EnableIRQ(block_3);
     }
-    if (pipette_type == EIGHT_CHANNEL) {
-        IRQn_Type block_1 = get_interrupt_line(gpio_block_1);
-        /* EXTI interrupt init block tip sense*/
-        HAL_NVIC_SetPriority(block_1, 10, 0);
-        HAL_NVIC_EnableIRQ(block_1);
-    }
-
 
 }
 
@@ -212,7 +196,7 @@ static void data_ready_gpio_init() {
         /*Configure GPIO pin*/
         GPIO_InitTypeDef GPIO_InitStruct = {0};
         GPIO_InitStruct.Pin = hardware_front.pin;
-        GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
+        GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
         GPIO_InitStruct.Pull = GPIO_PULLUP;
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
         HAL_GPIO_Init(hardware_front.port, &GPIO_InitStruct);
@@ -222,7 +206,7 @@ static void data_ready_gpio_init() {
     /*Configure GPIO pin*/
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     GPIO_InitStruct.Pin = hardware.pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
+    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
     GPIO_InitStruct.Pull = GPIO_PULLUP;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(hardware.port, &GPIO_InitStruct);

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -307,12 +307,10 @@ int main(int argc, char** argv) {
     auto fake_sensor_hw_secondary =
         std::make_shared<sim_mocks::MockSensorHardware>();
     fake_sensor_hw_secondary->provide_state_manager(state_manager_connection);
-    auto pressuresensor_i2c1 = std::make_shared<mmr920C04_simulator::MMR920C04>(
-        get_pipette_type() == EIGHT_CHANNEL ? *fake_sensor_hw_primary
-                                            : *fake_sensor_hw_secondary);
-    auto pressuresensor_i2c3 = std::make_shared<mmr920C04_simulator::MMR920C04>(
-        get_pipette_type() == EIGHT_CHANNEL ? *fake_sensor_hw_secondary
-                                            : *fake_sensor_hw_primary);
+    auto pressuresensor_i2c1 =
+        std::make_shared<mmr920C04_simulator::MMR920C04>();
+    auto pressuresensor_i2c3 =
+        std::make_shared<mmr920C04_simulator::MMR920C04>();
     i2c::hardware::SimI2C::DeviceMap sensor_map_i2c1 = {
         {hdcsensor->get_address(), *hdcsensor},
         {pressuresensor_i2c1->get_address(), *pressuresensor_i2c1}};

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -1,5 +1,4 @@
 #include <concepts>
-#include <iostream>
 
 #include "can/core/messages.hpp"
 #include "catch2/catch.hpp"
@@ -127,7 +126,7 @@ SCENARIO("Testing the pressure sensor driver") {
                     std::get<can::messages::ReadFromSensorResponse>(
                         empty_can_msg.message);
                 float check_data_pascals =
-                    fixed_point_to_float(response_msg.sensor_data, 16);
+                    signed_fixed_point_to_float(response_msg.sensor_data, 16);
                 float expected_pascals = -490.3325;
                 REQUIRE(check_data_pascals == Approx(expected_pascals));
             }

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -98,7 +98,7 @@ SCENARIO("Testing the pressure sensor driver") {
             }
         }
         WHEN("A response is sent to the handle baseline function") {
-            driver.handle_baseline_response(message);
+            driver.handle_baseline_pressure_response(message);
             THEN(
                 "A ReadFromSensorResponse is sent to the CAN queue and it's "
                 "the expected value") {
@@ -119,7 +119,7 @@ SCENARIO("Testing the pressure sensor driver") {
         }
         WHEN("The response data is a negative value") {
             message.read_buffer = {0xF8, 0x5E, 0xE0};  // -5 cmH20
-            driver.handle_baseline_response(message);
+            driver.handle_baseline_pressure_response(message);
             THEN("We get the expected negative pressure read") {
                 can_queue.try_read(&empty_can_msg);
                 auto response_msg =
@@ -152,7 +152,7 @@ SCENARIO("Testing the pressure sensor driver") {
             .bytes_read = 3,
             .read_buffer = {0x3D, 0x09, 0x00}};  // 40 cmH20
         WHEN("a completed poll is sent to handle baseline response") {
-            driver.handle_baseline_response(message);
+            driver.handle_baseline_pressure_response(message);
             THEN("the i2c queue is populated with a RESET command") {
                 REQUIRE(i2c_queue.get_size() == 1);
                 auto reset_command =
@@ -212,7 +212,7 @@ SCENARIO("Testing the pressure sensor driver") {
                 .transaction_index = static_cast<uint8_t>(0)};
             auto sensor_response = i2c::messages::TransactionResponse{
                 .id = id, .bytes_read = 3, .read_buffer = {0x7F, 0xFF, 0xFF}};
-            driver.handle_ongoing_response(sensor_response);
+            driver.handle_ongoing_pressure_response(sensor_response);
             THEN(
                 "no data is sent via the CAN bus, and the sync pin is "
                 "set") {
@@ -264,7 +264,7 @@ SCENARIO("Testing the pressure sensor driver") {
                 .transaction_index = static_cast<uint8_t>(0)};
             auto sensor_response = i2c::messages::TransactionResponse{
                 .id = id, .bytes_read = 3, .read_buffer = {0xFF, 0xFF, 0xFF}};
-            driver.handle_baseline_response(sensor_response);
+            driver.handle_baseline_pressure_response(sensor_response);
             THEN("a RESET command is sent") {
                 auto reset_command =
                     get_message<i2c::messages::Transact>(i2c_queue);
@@ -299,7 +299,7 @@ SCENARIO("Testing the pressure sensor driver") {
                     .bytes_read = 3,
                     .read_buffer = {0x0, 0x54, 0x0, 0x00, 0x0, 0x0, 0x0, 0x0,
                                     0x0}};
-                driver.handle_baseline_response(sensor_response);
+                driver.handle_baseline_pressure_response(sensor_response);
             }
             for (int i = 0; i < 4; i++) {
                 auto sensor_response = i2c::messages::TransactionResponse{
@@ -307,7 +307,7 @@ SCENARIO("Testing the pressure sensor driver") {
                     .bytes_read = 3,
                     .read_buffer = {0x00, 0x9B, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                     0x0}};
-                driver.handle_baseline_response(sensor_response);
+                driver.handle_baseline_pressure_response(sensor_response);
             }
             // complete the auto zero so the baseline message will be sent
             id.is_completed_poll = true;
@@ -315,7 +315,7 @@ SCENARIO("Testing the pressure sensor driver") {
                 .id = id,
                 .bytes_read = 3,
                 .read_buffer = {0x00, 0x9B, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
-            driver.handle_baseline_response(sensor_response);
+            driver.handle_baseline_pressure_response(sensor_response);
             THEN(
                 "a BaselineSensorResponse is sent with the correct calculated "
                 "average") {

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -1,4 +1,5 @@
 #include <concepts>
+#include <iostream>
 
 #include "can/core/messages.hpp"
 #include "catch2/catch.hpp"
@@ -38,7 +39,7 @@ auto get_message(Queue& q) -> Message {
 constexpr auto sensor_id = can::ids::SensorId::S0;
 constexpr uint8_t sensor_id_int = 0x0;
 
-SCENARIO("Read pressure sensor values") {
+SCENARIO("Testing the pressure sensor driver") {
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
     test_mocks::MockMessageQueue<i2c::poller::TaskMessage> i2c_poll_queue{};
     test_mocks::MockMessageQueue<can::message_writer_task::TaskMessage>
@@ -60,272 +61,237 @@ SCENARIO("Read pressure sensor values") {
     sensors::tasks::MMR920C04 driver(writer, poller, queue_client,
                                      pressure_queue, hardware, sensor_id);
 
-    GIVEN("A single read of the pressure sensor, with output set to report") {
-        driver.set_sync_bind(can::ids::SensorOutputBinding::report);
-        driver.set_limited_poll(true);
-        driver.set_number_of_reads(1);
-        WHEN("the sensor_callback function is called") {
-            driver.sensor_callback();
+    can::message_writer_task::TaskMessage empty_can_msg{};
+
+    GIVEN("A single read request the pressure sensor") {
+        const uint8_t tags_as_int = 0x1;
+        i2c::messages::TransactionResponse message{
+            .id =
+                i2c::messages::TransactionIdentifier{
+                    .token = sensors::utils::build_id(
+                        sensors::mmr920C04::ADDRESS,
+                        static_cast<uint8_t>(sensors::mmr920C04::Registers::
+                                                 LOW_PASS_PRESSURE_READ),
+                        0x1),
+                    .is_completed_poll = 1,
+                    .transaction_index = 0},
+            .bytes_read = 3,
+            .read_buffer = {0x3D, 0x09, 0x00}};  // 40 cmH20
+        WHEN("the the limited poll is initiated") {
+            driver.poll_limited_pressure(1, tags_as_int);
             THEN(
-                "the i2c queue is populated with a READ_PRESSURE command and a "
-                "RESET command") {
-                REQUIRE(i2c_queue.get_size() == 2);
-                auto read_command =
+                "the i2c queue is populated with a MEASURE_MODE command and "
+                "the poller queue is populated with a PRESSURE_READ") {
+                REQUIRE(i2c_queue.get_size() == 1);
+                REQUIRE(i2c_poll_queue.get_size() == 1);
+                auto mode_command =
                     get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(read_command.transaction.write_buffer[0] ==
+                auto poller_command =
+                    get_message<i2c::messages::SingleRegisterPollRead>(
+                        i2c_poll_queue);
+                REQUIRE(mode_command.transaction.write_buffer[0] ==
                         static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::PRESSURE_READ));
+                            sensors::mmr920C04::Registers::MEASURE_MODE_4));
+                REQUIRE(
+                    poller_command.first.write_buffer[0] ==
+                    static_cast<uint8_t>(
+                        sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ));
+            }
+        }
+        WHEN("A response is sent to the handle baseline function") {
+            driver.handle_baseline_response(message);
+            THEN(
+                "A ReadFromSensorResponse is sent to the CAN queue and it's "
+                "the expected value") {
+                can_queue.try_read(&empty_can_msg);
+                REQUIRE(std::holds_alternative<
+                        can::messages::ReadFromSensorResponse>(
+                    empty_can_msg.message));
+
+                auto response_msg =
+                    std::get<can::messages::ReadFromSensorResponse>(
+                        empty_can_msg.message);
+                float check_data_pascals =
+                    fixed_point_to_float(response_msg.sensor_data, 16);
+                float expected_pascals = 3922.66;
+                REQUIRE(check_data_pascals == Approx(expected_pascals));
+                REQUIRE(hardware.get_sync_state_mock() == false);
+            }
+        }
+        WHEN("The response data is a negative value") {
+            message.read_buffer = {0xF8, 0x5E, 0xE0};  // -5 cmH20
+            driver.handle_baseline_response(message);
+            THEN("We get the expected negative pressure read") {
+                can_queue.try_read(&empty_can_msg);
+                auto response_msg =
+                    std::get<can::messages::ReadFromSensorResponse>(
+                        empty_can_msg.message);
+                float check_data_pascals =
+                    fixed_point_to_float(response_msg.sensor_data, 16);
+                float expected_pascals = -490.3325;
+                REQUIRE(check_data_pascals == Approx(expected_pascals));
+            }
+        }
+    }
+
+    GIVEN("a completed limited poll message with a baseline tag") {
+        driver.set_echoing(true);
+
+        std::array tags_for_baseline{
+            sensors::utils::ResponseTag::IS_PART_OF_POLL,
+            sensors::utils::ResponseTag::IS_THRESHOLD_SENSE};
+        i2c::messages::TransactionResponse message{
+            .id =
+                i2c::messages::TransactionIdentifier{
+                    .token = sensors::utils::build_id(
+                        sensors::mmr920C04::ADDRESS,
+                        static_cast<uint8_t>(sensors::mmr920C04::Registers::
+                                                 LOW_PASS_PRESSURE_READ),
+                        sensors::utils::byte_from_tags(tags_for_baseline)),
+                    .is_completed_poll = 1,
+                    .transaction_index = 0},
+            .bytes_read = 3,
+            .read_buffer = {0x3D, 0x09, 0x00}};  // 40 cmH20
+        WHEN("a completed poll is sent to handle baseline response") {
+            driver.handle_baseline_response(message);
+            THEN("the i2c queue is populated with a RESET command") {
+                REQUIRE(i2c_queue.get_size() == 1);
                 auto reset_command =
                     get_message<i2c::messages::Transact>(i2c_queue);
                 REQUIRE(
                     reset_command.transaction.write_buffer[0] ==
                     static_cast<uint8_t>(sensors::mmr920C04::Registers::RESET));
             }
-            AND_WHEN("the driver receives a response") {
-                auto id = i2c::messages::TransactionIdentifier{
-                    .token = static_cast<uint32_t>(
-                        sensors::mmr920C04::Registers::PRESSURE_READ),
-                    .is_completed_poll = false,
-                    .transaction_index = static_cast<uint8_t>(0)};
-                auto sensor_response = i2c::messages::TransactionResponse{
-                    .id = id,
-                    .bytes_read = 3,
-                    .read_buffer = {0x0, 0x85, 0x96, 0x0, 0x0, 0x0, 0x0, 0x0,
-                                    0x0}};
-                driver.handle_response(sensor_response);
-                THEN(
-                    "the handle_message function sends the correct data via "
-                    "the CAN bus, and sync state is false") {
-                    can::message_writer_task::TaskMessage can_msg{};
-
-                    can_queue.try_read(&can_msg);
-                    auto response_msg =
-                        std::get<can::messages::ReadFromSensorResponse>(
-                            can_msg.message);
-                    float check_data =
-                        fixed_point_to_float(response_msg.sensor_data, 16);
-                    float expected = 33.53677;
-                    REQUIRE(check_data == Approx(expected));
-                    REQUIRE(hardware.get_sync_state_mock() == false);
-                }
+            THEN("the can queue is populated with a baseline sensor request") {
+                can_queue.try_read(&empty_can_msg);
+                REQUIRE(std::holds_alternative<
+                        can::messages::BaselineSensorResponse>(
+                    empty_can_msg.message));
             }
         }
     }
+
     GIVEN("An unlimited poll with sensor binding set to sync") {
-        can_queue.reset();
-        driver.set_limited_poll(false);
-        driver.set_threshold(convert_to_fixed_point(15.0F, S15Q16_RADIX));
-        driver.get_pressure();
-        driver.set_sync_bind(can::ids::SensorOutputBinding::sync);
-        WHEN("the sensor_callback function is called") {
-            driver.sensor_callback();
+        driver.set_threshold(15.0F, can::ids::SensorThresholdMode::absolute, 1,
+                             false);
+
+        driver.set_echoing(false);
+        driver.set_bind_sync(true);
+        std::array tags{sensors::utils::ResponseTag::IS_PART_OF_POLL,
+                        sensors::utils::ResponseTag::POLL_IS_CONTINUOUS};
+        auto tags_as_int = sensors::utils::byte_from_tags(tags);
+        WHEN("the continuous poll function is called") {
+            driver.poll_continuous_pressure(tags_as_int);
             THEN(
                 "the i2c queue is populated with a MEASURE_MODE_4 and "
                 "a READ_PRESSURE command only") {
-                REQUIRE(i2c_queue.get_size() == 2);
-                auto read_command =
+                REQUIRE(i2c_queue.get_size() == 1);
+                REQUIRE(i2c_poll_queue.get_size() == 1);
+                auto mode_command =
                     get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(read_command.transaction.write_buffer[0] ==
+                auto read_command = get_message<
+                    i2c::messages::ConfigureSingleRegisterContinuousPolling>(
+                    i2c_poll_queue);
+                REQUIRE(mode_command.transaction.write_buffer[0] ==
                         static_cast<uint8_t>(
                             sensors::mmr920C04::Registers::MEASURE_MODE_4));
+                ;
+                REQUIRE(
+                    read_command.first.write_buffer[0] ==
+                    static_cast<uint8_t>(
+                        sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ));
+            }
+        }
+        WHEN("the driver receives a response higher than the threshold") {
+            auto id = i2c::messages::TransactionIdentifier{
+                .token = sensors::utils::build_id(
+                    sensors::mmr920C04::ADDRESS,
+                    static_cast<uint8_t>(
+                        sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ),
+                    tags_as_int),
+                .is_completed_poll = false,
+                .transaction_index = static_cast<uint8_t>(0)};
+            auto sensor_response = i2c::messages::TransactionResponse{
+                .id = id, .bytes_read = 3, .read_buffer = {0x7F, 0xFF, 0xFF}};
+            driver.handle_ongoing_response(sensor_response);
+            THEN(
+                "no data is sent via the CAN bus, and the sync pin is "
+                "set") {
+                REQUIRE(i2c_queue.get_size() == 0);
+                REQUIRE(can_queue.get_size() == 0);
+
+                REQUIRE(hardware.get_sync_state_mock() == true);
+            }
+        }
+    }
+
+    GIVEN("output binding = report") {
+        driver.set_bind_sync(true);
+        std::array tags{sensors::utils::ResponseTag::IS_PART_OF_POLL,
+                        sensors::utils::ResponseTag::IS_BASELINE,
+                        sensors::utils::ResponseTag::IS_THRESHOLD_SENSE};
+        auto tags_as_int = sensors::utils::byte_from_tags(tags);
+        WHEN("a limited poll for 3 reads is set") {
+            driver.poll_limited_pressure(3, tags_as_int);
+            THEN(
+                "the i2c queue receives a MEASURE_MODE_4 command and a "
+                "pressure read poll") {
+                REQUIRE(i2c_queue.get_size() == 1);
+                REQUIRE(i2c_poll_queue.get_size() == 1);
+                auto mode_command =
+                    get_message<i2c::messages::Transact>(i2c_queue);
+                REQUIRE(mode_command.transaction.write_buffer[0] ==
+                        static_cast<uint8_t>(
+                            sensors::mmr920C04::Registers::MEASURE_MODE_4));
+                auto read_command =
+                    get_message<i2c::messages::SingleRegisterPollRead>(
+                        i2c_poll_queue);
+
+                REQUIRE(
+                    read_command.first.write_buffer[0] ==
+                    static_cast<uint8_t>(
+                        sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ));
+                REQUIRE(read_command.polling == 3);
+            }
+        }
+        WHEN("The limited finishes a RESET command is sent") {
+            auto id = i2c::messages::TransactionIdentifier{
+                .token = sensors::utils::build_id(
+                    sensors::mmr920C04::ADDRESS,
+                    static_cast<uint8_t>(
+                        sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ),
+                    tags_as_int),
+                .is_completed_poll = true,
+                .transaction_index = static_cast<uint8_t>(0)};
+            auto sensor_response = i2c::messages::TransactionResponse{
+                .id = id, .bytes_read = 3, .read_buffer = {0xFF, 0xFF, 0xFF}};
+            driver.handle_baseline_response(sensor_response);
+            THEN("a RESET command is sent") {
                 auto reset_command =
                     get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(reset_command.transaction.write_buffer[0] ==
-                        static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::PRESSURE_READ));
-            }
-            AND_WHEN(
-                "the driver receives a response higher than the threshold") {
-                auto id = i2c::messages::TransactionIdentifier{
-                    .token = static_cast<uint32_t>(
-                        sensors::mmr920C04::Registers::PRESSURE_READ),
-                    .is_completed_poll = false,
-                    .transaction_index = static_cast<uint8_t>(0)};
-                auto sensor_response = i2c::messages::TransactionResponse{
-                    .id = id,
-                    .bytes_read = 3,
-                    .read_buffer = {0x0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                                    0xFF, 0xFF}};
-                driver.handle_response(sensor_response);
-                THEN(
-                    "no data is sent via the CAN bus, and the sync pin is "
-                    "set") {
-                    REQUIRE(can_queue.get_size() == 0);
-
-                    REQUIRE(hardware.get_sync_state_mock() == true);
-                }
+                REQUIRE(
+                    reset_command.transaction.write_buffer[0] ==
+                    static_cast<uint8_t>(sensors::mmr920C04::Registers::RESET));
             }
         }
     }
-    GIVEN("output binding = report") {
-        driver.set_sync_bind(can::ids::SensorOutputBinding::report);
-        WHEN("a limited poll for 3 reads is set") {
-            i2c_queue.reset();
-            driver.set_number_of_reads(4);
-            driver.set_limited_poll(true);
-            driver.get_pressure();
-            THEN("the i2c queue receives a MEASURE_MODE_4 command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-                auto read_command =
-                    get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(read_command.transaction.write_buffer[0] ==
-                        static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::MEASURE_MODE_4));
-            }
-            THEN(
-                "for each read, the i2c queue receives a READ_PRESSURE "
-                "command, RESET is sent after poll finishes") {
-                for (int i = 0; i < 4; i++) {
-                    i2c_queue.reset();
-                    driver.sensor_callback();
-                    auto read_command =
-                        get_message<i2c::messages::Transact>(i2c_queue);
-                    REQUIRE(read_command.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::PRESSURE_READ));
-                }
-                AND_THEN("a reset command is sent when the poll is finished") {
-                    auto reset_command =
-                        get_message<i2c::messages::Transact>(i2c_queue);
-                    REQUIRE(reset_command.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::RESET));
-                }
-            }
-        }
-        WHEN("A single read command is sent") {
-            driver.set_limited_poll(true);
-            driver.set_number_of_reads(1);
-            driver.get_pressure();
-            THEN("the i2c queue receives a MEASURE_MODE_4 command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-                auto read_command =
-                    get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(read_command.transaction.write_buffer[0] ==
-                        static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::MEASURE_MODE_4));
-            }
-            AND_WHEN("the sensor callback ist triggered") {
-                i2c_queue.reset();
-                driver.sensor_callback();
-                THEN(
-                    "the i2c queue receives a PRESSURE_READ command, and a "
-                    "RESET command") {
-                    REQUIRE(i2c_queue.get_size() == 2);
-                    auto read_command =
-                        get_message<i2c::messages::Transact>(i2c_queue);
-                    REQUIRE(read_command.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::PRESSURE_READ));
-                    auto reset_command =
-                        get_message<i2c::messages::Transact>(i2c_queue);
-                    REQUIRE(reset_command.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::RESET));
-                }
-            }
-        }
-        WHEN("a continuous poll is requested") {
-            driver.set_sync_bind(can::ids::SensorOutputBinding::sync);
-            driver.set_limited_poll(false);
-            driver.get_pressure();
-            THEN(
-                "the i2c queue receives a MEASURE_MODE_4 command, and then "
-                "continuous PRESSURE_READ commands") {
-                REQUIRE(i2c_queue.get_size() == 1);
-                auto read_command =
-                    get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(read_command.transaction.write_buffer[0] ==
-                        static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::MEASURE_MODE_4));
-                AND_THEN(
-                    "continuous PRESSURE_READS commands are sent, with no "
-                    "RESET") {
-                    for (int i = 0; i < 10; i++) {
-                        driver.sensor_callback();
-                        REQUIRE(i2c_queue.get_size() == 1);
-                        auto read_command =
-                            get_message<i2c::messages::Transact>(i2c_queue);
-                        REQUIRE(
-                            read_command.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::PRESSURE_READ));
-                    }
-                }
-            }
-        }
 
-        WHEN(
-            "another single read is requested, and the sensor callback is "
-            "executed") {
-            driver.set_sync_bind(can::ids::SensorOutputBinding::report);
-            driver.set_limited_poll(true);
-            driver.set_number_of_reads(1);
-            driver.get_pressure();
-            driver.sensor_callback();
-            THEN(
-                "the i2c queue is populated with a MEASURE_MODE_4 and "
-                "a READ_PRESSURE command") {
-                REQUIRE(i2c_queue.get_size() == 3);
-                auto measure_command =
-                    get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(measure_command.transaction.write_buffer[0] ==
-                        static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::MEASURE_MODE_4));
-                auto read_command =
-                    get_message<i2c::messages::Transact>(i2c_queue);
-                REQUIRE(read_command.transaction.write_buffer[0] ==
-                        static_cast<uint8_t>(
-                            sensors::mmr920C04::Registers::PRESSURE_READ));
-                AND_THEN("A reset command is sent after the first read") {
-                    auto reset_command =
-                        get_message<i2c::messages::Transact>(i2c_queue);
-                    REQUIRE(reset_command.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::RESET));
-                }
-            }
-            AND_WHEN(
-                "the driver receives a response higher than the threshold") {
-                auto id = i2c::messages::TransactionIdentifier{
-                    .token = static_cast<uint32_t>(
-                        sensors::mmr920C04::Registers::PRESSURE_READ),
-                    .is_completed_poll = false,
-                    .transaction_index = static_cast<uint8_t>(0)};
-                auto sensor_response = i2c::messages::TransactionResponse{
-                    .id = id,
-                    .bytes_read = 3,
-                    .read_buffer = {0x0, 0x85, 0x96, 0x0, 0x0, 0x0, 0x0, 0x0,
-                                    0x0}};
-                driver.handle_response(sensor_response);
-                THEN(
-                    "the handle_message function sends the correct data via "
-                    "the CAN bus, and the sync pin is not set") {
-                    can::message_writer_task::TaskMessage can_msg{};
-
-                    can_queue.try_read(&can_msg);
-                    auto response_msg =
-                        std::get<can::messages::ReadFromSensorResponse>(
-                            can_msg.message);
-                    float check_data =
-                        fixed_point_to_float(response_msg.sensor_data, 16);
-                    float expected = 33.53677;
-                    REQUIRE(check_data == Approx(expected));
-                    REQUIRE(hardware.get_sync_state_mock() == false);
-                }
-            }
-        }
-    }
     GIVEN("a baseline sensor request with 10 reads is processed") {
-        int num_reads = 10;
-        driver.set_sync_bind(can::ids::SensorOutputBinding::none);
-        driver.set_limited_poll(true);
-        driver.set_number_of_reads(num_reads);
-        driver.get_pressure();
+        driver.set_echoing(false);
+        driver.set_bind_sync(false);
+
+        std::array tags{sensors::utils::ResponseTag::IS_PART_OF_POLL,
+                        sensors::utils::ResponseTag::IS_BASELINE,
+                        sensors::utils::ResponseTag::IS_THRESHOLD_SENSE};
+        auto tags_as_int = sensors::utils::byte_from_tags(tags);
+        driver.poll_limited_pressure(10, tags_as_int);
         WHEN("pressure driver receives the requested sensor readings") {
             auto id = i2c::messages::TransactionIdentifier{
-                .token = static_cast<uint32_t>(
-                    sensors::mmr920C04::Registers::PRESSURE_READ),
+                .token = sensors::utils::build_id(
+                    sensors::mmr920C04::ADDRESS,
+                    static_cast<uint8_t>(
+                        sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ),
+                    tags_as_int),
                 .is_completed_poll = false,
                 .transaction_index = static_cast<uint8_t>(0)};
             for (int i = 0; i < 5; i++) {
@@ -334,18 +300,23 @@ SCENARIO("Read pressure sensor values") {
                     .bytes_read = 3,
                     .read_buffer = {0x0, 0x54, 0x0, 0x00, 0x0, 0x0, 0x0, 0x0,
                                     0x0}};
-                driver.sensor_callback();
-                driver.handle_response(sensor_response);
+                driver.handle_baseline_response(sensor_response);
             }
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < 4; i++) {
                 auto sensor_response = i2c::messages::TransactionResponse{
                     .id = id,
                     .bytes_read = 3,
                     .read_buffer = {0x00, 0x9B, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                     0x0}};
-                driver.sensor_callback();
-                driver.handle_response(sensor_response);
+                driver.handle_baseline_response(sensor_response);
             }
+            // complete the auto zero so the baseline message will be sent
+            id.is_completed_poll = true;
+            auto sensor_response = i2c::messages::TransactionResponse{
+                .id = id,
+                .bytes_read = 3,
+                .read_buffer = {0x00, 0x9B, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}};
+            driver.handle_baseline_response(sensor_response);
             THEN(
                 "a BaselineSensorResponse is sent with the correct calculated "
                 "average") {

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -36,7 +36,7 @@ constexpr uint8_t pressure_temperature_id =
     static_cast<uint8_t>(can::ids::SensorType::pressure_temperature);
 constexpr uint8_t sensor_id_int = 0x0;
 
-SCENARIO("read pressure sensor values") {
+SCENARIO("Receiving messages through the pressure sensor message handler") {
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
     test_mocks::MockMessageQueue<i2c::poller::TaskMessage> i2c_poll_queue{};
     test_mocks::MockMessageQueue<can::message_writer_task::TaskMessage>
@@ -58,57 +58,145 @@ SCENARIO("read pressure sensor values") {
     auto sensor = sensors::tasks::PressureMessageHandler{
         writer, poller, queue_client, response_queue, mock_hw, sensor_id};
 
-    GIVEN("a request to take a single read of the pressure sensor") {
-        auto single_read =
-            sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
-                {}, 0xdeadbeef, pressure_id, sensor_id_int));
-        sensor.handle_message(single_read);
-        WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-            }
-            auto transact_message =
-                get_message<i2c::messages::Transact>(i2c_queue);
-            REQUIRE(transact_message.transaction.address ==
-                    sensors::mmr920C04::ADDRESS);
-        }
-    }
-    GIVEN("a request to take multiple reads of the pressure sensor") {
-        auto single_read =
-            sensors::utils::TaskMessage(can::messages::BaselineSensorRequest(
-                {}, 0xdeadbeef, pressure_id, sensor_id_int));
-        sensor.handle_message(single_read);
-        WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-            }
-            auto transact_message =
-                get_message<i2c::messages::Transact>(i2c_queue);
-            REQUIRE(transact_message.transaction.address ==
-                    sensors::mmr920C04::ADDRESS);
-        }
-    }
+    // GIVEN("a request to take a single read of the pressure sensor") {
+    //     auto single_read =
+    //         sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
+    //             {}, 0xdeadbeef, pressure_id, sensor_id_int));
+    //     sensor.handle_message(single_read);
+    //     WHEN("the handler function receives the message") {
+    //         THEN("the i2c queue is populated with a MEASURE MODE 4 command")
+    //         {
+    //             REQUIRE(i2c_queue.get_size() == 1);
+    //         }
+    //         auto transact_message =
+    //             get_message<i2c::messages::Transact>(i2c_queue);
+    //         REQUIRE(transact_message.transaction.address ==
+    //                 sensors::mmr920C04::ADDRESS);
+    //     }
+    // }
+    // GIVEN("a request to take multiple reads of the pressure sensor") {
+    //     auto single_read =
+    //         sensors::utils::TaskMessage(can::messages::BaselineSensorRequest(
+    //             {}, 0xdeadbeef, pressure_id, sensor_id_int));
+    //     sensor.handle_message(single_read);
+    //     WHEN("the handler function receives the message") {
+    //         THEN("the i2c queue is populated with a MEASURE MODE 4 command")
+    //         {
+    //             REQUIRE(i2c_queue.get_size() == 1);
+    //         }
+    //         auto transact_message =
+    //             get_message<i2c::messages::Transact>(i2c_queue);
+    //         REQUIRE(transact_message.transaction.address ==
+    //                 sensors::mmr920C04::ADDRESS);
+    //     }
+    // }
 
-    GIVEN("a request to take a single read of the temperature sensor") {
-        auto single_read =
-            sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
-                {}, 0xdeadbeef, pressure_temperature_id, sensor_id_int));
-        sensor.handle_message(single_read);
-        WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a transact command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-            }
-            AND_WHEN("we read the message from the queue") {
-                auto transact_message =
-                    get_message<i2c::messages::Transact>(i2c_queue);
+    // GIVEN("a request to take a single read of the temperature sensor") {
+    //     auto single_read =
+    //         sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
+    //             {}, 0xdeadbeef, pressure_temperature_id, sensor_id_int));
+    //     sensor.handle_message(single_read);
+    //     WHEN("the handler function receives the message") {
+    //         THEN("the i2c queue is populated with a transact command") {
+    //             REQUIRE(i2c_queue.get_size() == 1);
+    //         }
+    //         AND_WHEN("we read the message from the queue") {
+    //             auto transact_message =
+    //                 get_message<i2c::messages::Transact>(i2c_queue);
 
-                THEN("The command addresses are correct") {
-                    REQUIRE(transact_message.transaction.address ==
-                            sensors::mmr920C04::ADDRESS);
-                    REQUIRE(transact_message.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::MEASURE_MODE_4));
-                }
+    //             THEN("The command addresses are correct") {
+    //                 REQUIRE(transact_message.transaction.address ==
+    //                         sensors::mmr920C04::ADDRESS);
+    //                 REQUIRE(transact_message.transaction.write_buffer[0] ==
+    //                         static_cast<uint8_t>(
+    //                             sensors::mmr920C04::Registers::MEASURE_MODE_4));
+    //             }
+    //         }
+    //     }
+    // }
+
+    GIVEN("A TransactionResponse message") {
+        can_queue.reset();
+        i2c::messages::TransactionResponse response_details{
+            .id =
+                i2c::messages::TransactionIdentifier{
+                    .token = sensors::utils::build_id(
+                        sensors::mmr920C04::ADDRESS,
+                        static_cast<uint8_t>(sensors::mmr920C04::Registers::
+                                                 LOW_PASS_PRESSURE_READ),
+                        0x1),
+                    .is_completed_poll = 1,
+                    .transaction_index = 0},
+            .bytes_read = 3,
+            .read_buffer = {0x3D, 0x09, 0x00}};
+
+        can::message_writer_task::TaskMessage empty_can_msg{};
+        WHEN("the handler function receives a continuous poll response") {
+            // prep for continuous read request
+            auto bind_pressure = sensors::utils::TaskMessage(
+                can::messages::BindSensorOutputRequest(
+                    {}, 0xdeadbeef, can::ids::SensorType::pressure,
+                    can::ids::SensorId::S0, 2));
+            sensor.handle_message(bind_pressure);
+
+            std::array tags_for_continuous{
+                sensors::utils::ResponseTag::IS_PART_OF_POLL,
+                sensors::utils::ResponseTag::POLL_IS_CONTINUOUS};
+            response_details.id.token = sensors::utils::build_id(
+                sensors::mmr920C04::ADDRESS,
+                static_cast<uint8_t>(
+                    sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ),
+                sensors::utils::byte_from_tags(tags_for_continuous));
+            auto response_read = sensors::utils::TaskMessage(response_details);
+            sensor.handle_message(response_read);
+            THEN("there should be a ReadFromSensorResponse") {
+                REQUIRE(can_queue.has_message());
+                can_queue.try_read(&empty_can_msg);
+                REQUIRE(std::holds_alternative<
+                        can::messages::ReadFromSensorResponse>(
+                    empty_can_msg.message));
+            }
+        }
+
+        WHEN("the handler function receives a baseline poll response") {
+            // prep for baseline sensor request
+            auto single_read = sensors::utils::TaskMessage(
+                can::messages::BaselineSensorRequest(
+                    {}, 0xdeadbeef, pressure_id, sensor_id_int));
+            sensor.handle_message(single_read);
+
+            std::array tags_for_baseline{
+                sensors::utils::ResponseTag::IS_PART_OF_POLL,
+                sensors::utils::ResponseTag::IS_THRESHOLD_SENSE};
+            response_details.id.token = sensors::utils::build_id(
+                sensors::mmr920C04::ADDRESS,
+                static_cast<uint8_t>(
+                    sensors::mmr920C04::Registers::LOW_PASS_PRESSURE_READ),
+                sensors::utils::byte_from_tags(tags_for_baseline));
+            auto response_read = sensors::utils::TaskMessage(response_details);
+            sensor.handle_message(response_read);
+            THEN("there should be a BaselineSensorResponse") {
+                REQUIRE(can_queue.has_message());
+                can_queue.try_read(&empty_can_msg);
+                REQUIRE(std::holds_alternative<
+                        can::messages::BaselineSensorResponse>(
+                    empty_can_msg.message));
+            }
+        }
+
+        WHEN("the handler function receives an unsupported register response") {
+            std::array tags_for_baseline{
+                sensors::utils::ResponseTag::IS_PART_OF_POLL,
+                sensors::utils::ResponseTag::IS_THRESHOLD_SENSE};
+            response_details.id.token = sensors::utils::build_id(
+                sensors::mmr920C04::ADDRESS,
+                static_cast<uint8_t>(
+                    sensors::mmr920C04::Registers::MACRAM_WRITE),
+                sensors::utils::byte_from_tags(tags_for_baseline));
+            auto response_read = sensors::utils::TaskMessage(response_details);
+            sensor.handle_message(response_read);
+            THEN("there should be no response from the driver") {
+                REQUIRE(!can_queue.has_message());
             }
         }
     }

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -58,62 +58,62 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
     auto sensor = sensors::tasks::PressureMessageHandler{
         writer, poller, queue_client, response_queue, mock_hw, sensor_id};
 
-    // GIVEN("a request to take a single read of the pressure sensor") {
-    //     auto single_read =
-    //         sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
-    //             {}, 0xdeadbeef, pressure_id, sensor_id_int));
-    //     sensor.handle_message(single_read);
-    //     WHEN("the handler function receives the message") {
-    //         THEN("the i2c queue is populated with a MEASURE MODE 4 command")
-    //         {
-    //             REQUIRE(i2c_queue.get_size() == 1);
-    //         }
-    //         auto transact_message =
-    //             get_message<i2c::messages::Transact>(i2c_queue);
-    //         REQUIRE(transact_message.transaction.address ==
-    //                 sensors::mmr920C04::ADDRESS);
-    //     }
-    // }
-    // GIVEN("a request to take multiple reads of the pressure sensor") {
-    //     auto single_read =
-    //         sensors::utils::TaskMessage(can::messages::BaselineSensorRequest(
-    //             {}, 0xdeadbeef, pressure_id, sensor_id_int));
-    //     sensor.handle_message(single_read);
-    //     WHEN("the handler function receives the message") {
-    //         THEN("the i2c queue is populated with a MEASURE MODE 4 command")
-    //         {
-    //             REQUIRE(i2c_queue.get_size() == 1);
-    //         }
-    //         auto transact_message =
-    //             get_message<i2c::messages::Transact>(i2c_queue);
-    //         REQUIRE(transact_message.transaction.address ==
-    //                 sensors::mmr920C04::ADDRESS);
-    //     }
-    // }
+    GIVEN("a request to take a single read of the pressure sensor") {
+        auto single_read =
+            sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
+                {}, 0xdeadbeef, pressure_id, sensor_id_int));
+        sensor.handle_message(single_read);
+        WHEN("the handler function receives the message") {
+            THEN("the i2c queue is populated with a MEASURE MODE 4 command")
+            {
+                REQUIRE(i2c_queue.get_size() == 1);
+            }
+            auto transact_message =
+                get_message<i2c::messages::Transact>(i2c_queue);
+            REQUIRE(transact_message.transaction.address ==
+                    sensors::mmr920C04::ADDRESS);
+        }
+    }
+    GIVEN("a request to take multiple reads of the pressure sensor") {
+        auto single_read =
+            sensors::utils::TaskMessage(can::messages::BaselineSensorRequest(
+                {}, 0xdeadbeef, pressure_id, sensor_id_int));
+        sensor.handle_message(single_read);
+        WHEN("the handler function receives the message") {
+            THEN("the i2c queue is populated with a MEASURE MODE 4 command")
+            {
+                REQUIRE(i2c_queue.get_size() == 1);
+            }
+            auto transact_message =
+                get_message<i2c::messages::Transact>(i2c_queue);
+            REQUIRE(transact_message.transaction.address ==
+                    sensors::mmr920C04::ADDRESS);
+        }
+    }
 
-    // GIVEN("a request to take a single read of the temperature sensor") {
-    //     auto single_read =
-    //         sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
-    //             {}, 0xdeadbeef, pressure_temperature_id, sensor_id_int));
-    //     sensor.handle_message(single_read);
-    //     WHEN("the handler function receives the message") {
-    //         THEN("the i2c queue is populated with a transact command") {
-    //             REQUIRE(i2c_queue.get_size() == 1);
-    //         }
-    //         AND_WHEN("we read the message from the queue") {
-    //             auto transact_message =
-    //                 get_message<i2c::messages::Transact>(i2c_queue);
+    GIVEN("a request to take a single read of the temperature sensor") {
+        auto single_read =
+            sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
+                {}, 0xdeadbeef, pressure_temperature_id, sensor_id_int));
+        sensor.handle_message(single_read);
+        WHEN("the handler function receives the message") {
+            THEN("the i2c queue is populated with a transact command") {
+                REQUIRE(i2c_queue.get_size() == 1);
+            }
+            AND_WHEN("we read the message from the queue") {
+                auto transact_message =
+                    get_message<i2c::messages::Transact>(i2c_queue);
 
-    //             THEN("The command addresses are correct") {
-    //                 REQUIRE(transact_message.transaction.address ==
-    //                         sensors::mmr920C04::ADDRESS);
-    //                 REQUIRE(transact_message.transaction.write_buffer[0] ==
-    //                         static_cast<uint8_t>(
-    //                             sensors::mmr920C04::Registers::MEASURE_MODE_4));
-    //             }
-    //         }
-    //     }
-    // }
+                THEN("The command addresses are correct") {
+                    REQUIRE(transact_message.transaction.address ==
+                            sensors::mmr920C04::ADDRESS);
+                    REQUIRE(transact_message.transaction.write_buffer[0] ==
+                            static_cast<uint8_t>(
+                                sensors::mmr920C04::Registers::MEASURE_MODE_4));
+                }
+            }
+        }
+    }
 
     GIVEN("A TransactionResponse message") {
         can_queue.reset();
@@ -139,6 +139,8 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
                     can::ids::SensorId::S0, 2));
             sensor.handle_message(bind_pressure);
 
+            // discard the ack response
+            can_queue.reset();
             std::array tags_for_continuous{
                 sensors::utils::ResponseTag::IS_PART_OF_POLL,
                 sensors::utils::ResponseTag::POLL_IS_CONTINUOUS};
@@ -151,6 +153,7 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
             sensor.handle_message(response_read);
             THEN("there should be a ReadFromSensorResponse") {
                 REQUIRE(can_queue.has_message());
+                REQUIRE(can_queue.get_size() == 1);
                 can_queue.try_read(&empty_can_msg);
                 REQUIRE(std::holds_alternative<
                         can::messages::ReadFromSensorResponse>(
@@ -165,6 +168,8 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
                     {}, 0xdeadbeef, pressure_id, sensor_id_int));
             sensor.handle_message(single_read);
 
+            // discard the ack response
+            can_queue.reset();
             std::array tags_for_baseline{
                 sensors::utils::ResponseTag::IS_PART_OF_POLL,
                 sensors::utils::ResponseTag::IS_THRESHOLD_SENSE};
@@ -177,6 +182,7 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
             sensor.handle_message(response_read);
             THEN("there should be a BaselineSensorResponse") {
                 REQUIRE(can_queue.has_message());
+                REQUIRE(can_queue.get_size() == 1);
                 can_queue.try_read(&empty_can_msg);
                 REQUIRE(std::holds_alternative<
                         can::messages::BaselineSensorResponse>(

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -64,8 +64,7 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
                 {}, 0xdeadbeef, pressure_id, sensor_id_int));
         sensor.handle_message(single_read);
         WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a MEASURE MODE 4 command")
-            {
+            THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
                 REQUIRE(i2c_queue.get_size() == 1);
             }
             auto transact_message =
@@ -80,8 +79,7 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
                 {}, 0xdeadbeef, pressure_id, sensor_id_int));
         sensor.handle_message(single_read);
         WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a MEASURE MODE 4 command")
-            {
+            THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
                 REQUIRE(i2c_queue.get_size() == 1);
             }
             auto transact_message =


### PR DESCRIPTION
## Overview

We cannot rely on the data ready interrupt to tell us when data is ready for the pressure sensor. Instead, we will now use a software timer to poll the data from the pressure sensor. Thankfully all of the infrastructure was there to easily make this change, however, I also took the opportunity to refactor the pressure driver a little bit to (hopefully) make it a little cleaner/more clear.

It was also requested from EEs that we switch over to using the low pass filter built in on the sensor, so I made that change here as well.

## Tests

- [x] Verify liquid sensing still functions as expected
- [x] Verify values coming back from the pressure sensor match what we expect.