### PR TITLE
fix(gantry): disable passive fast decay on Y axis

### DIFF
--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -186,7 +186,7 @@ static tmc2160::configs::TMC2160DriverConfig motor_driver_config_y{
                                .tbl = 0x1,
                                .vhighfs = 1,
                                .vhighchm = 1,
-                               .tpfd = 0x4,
+                               .tpfd = 0x0,
                                .mres = 0x3},
                   .coolconf = {.sgt = 0x6},
                   .pwmconf = {.pwm_ofs = 30,


### PR DESCRIPTION
One of the ABR units was having a repeatable issue where the motor would seemingly skip a few steps (between 0.5 and 1 mm worth at a time) during a movement, causing the gantry to be severely unaligned. Tip pickups would fail and the pipettes would be visibly off-center from their LPC'd positions. The Gantry Y controller is able to detect this "skipping", and the `motor_position_ok` flag would be cleared after the event. There was also an audible noise during the acceleration phase of the movements, and in slow-motion videos the Y axis belt was bouncing severely at the time of the noise, as if it had been plucked.

Looking at the current to one of the motor windings showed a smooth sine wave at the start of a movement, and a relatively clean square wave during the full-stepping high velocity portion of a movement. During the transition phase where the motor controller switches from microstepping to full stepping, there was a distortion in the waveform that seemingly skipped a step.

The `TPFD` configuration option in the TMC2160 controls "passive fast decay time," and is intended to dampen mid-range resonance in the motor. This is generally tuned to the inductance of the motor being controlled. Notably, our gantry Y motor PN has changed since the main tuning for the motor controller was performed.

After disabling `TPFD` by setting it to 0, the motor waveform looked very clean during the transition from microstepping to fullstepping. The noise disappeared, we could not recreate the stall, and we could run a protocol that repeatedly picked up tips without any alignment issues.

This change may also be useful for the Gantry X controller, but we haven't seen the same issues on that axis (possibly due to the lower load on the X axis) so we will not make that change until some further testing.