### PR TITLE
fix(include): use the correct sampling rate for the pressure sensor

### DIFF
--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -50,10 +50,10 @@ enum class FilterSetting : uint8_t {
 };
 
 enum class MeasurementRate : int {
-    MEASURE_1 = 0,  // 3.1msec
-    MEASURE_2 = 1,  // 6.1msec
-    MEASURE_3 = 2,  // 12.2msec
-    MEASURE_4 = 3   // 24.3msec
+    MEASURE_1 = 0,  // 0.405msec
+    MEASURE_2 = 1,  // 0.810msec
+    MEASURE_3 = 2,  // 1.62msec
+    MEASURE_4 = 3   // 3.24msec
 };
 
 enum class Registers : uint8_t {

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -426,8 +426,8 @@ class MMR920C04 {
     mmr920C04::FilterSetting filter_setting =
         mmr920C04::FilterSetting::LOW_PASS_FILTER;
 
-    static constexpr std::array<float, 4> MeasurementTimings{3.1, 6.1, 12.2,
-                                                             24.3};  // in msec
+    static constexpr std::array<float, 4> MeasurementTimings{0.405, 0.81, 1.62,
+                                                             3.24};  // in msec
     static constexpr float DEFAULT_DELAY_BUFFER =
         1.0;  // in msec (TODO might need to change to fit in uint16_t)
     static constexpr uint16_t STOP_DELAY = 0;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -424,7 +424,7 @@ class MMR920C04 {
 
     mmr920C04::MMR920C04RegisterMap _registers{};
     mmr920C04::FilterSetting filter_setting =
-        mmr920C04::FilterSetting::NO_FILTER;
+        mmr920C04::FilterSetting::LOW_PASS_FILTER;
 
     static constexpr std::array<float, 4> MeasurementTimings{0.405, 0.81, 1.62,
                                                              3.24};  // in msec

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -424,7 +424,7 @@ class MMR920C04 {
 
     mmr920C04::MMR920C04RegisterMap _registers{};
     mmr920C04::FilterSetting filter_setting =
-        mmr920C04::FilterSetting::LOW_PASS_FILTER;
+        mmr920C04::FilterSetting::NO_FILTER;
 
     static constexpr std::array<float, 4> MeasurementTimings{0.405, 0.81, 1.62,
                                                              3.24};  // in msec


### PR DESCRIPTION
## Overview

This is technically still not right because we're ignoring the decimal place values of the sensor and the frequency of mode 1/2 will be indistinguishable. I made a [ticket](https://opentrons.atlassian.net/browse/RET-1358) to support decimal values for delays, but I think it will be a bit of a pain.