### PR TITLE
fix(motor-control): Fix encoder underflow errors that happen directly after homes

### DIFF
--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -95,6 +95,8 @@ class MotorHardwareIface {
     virtual void start_timer_interrupt() = 0;
     virtual void stop_timer_interrupt() = 0;
     virtual auto is_timer_interrupt_running() -> bool = 0;
+    virtual void enable_encoder() = 0;
+    virtual void disable_encoder() = 0;
 
     virtual auto has_cancel_request() -> bool = 0;
     virtual void request_cancel() = 0;

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -72,6 +72,7 @@ class MotionController {
             .stop_condition =
                 static_cast<MoveStopCondition>(can_msg.request_stop_condition),
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
+        hardware.enable_encoder();
         if (!enabled) {
             enable_motor();
         }
@@ -90,6 +91,7 @@ class MotionController {
             .seq_id = can_msg.seq_id,
             .stop_condition = MoveStopCondition::limit_switch,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
+        hardware.enable_encoder();
         if (!enabled) {
             enable_motor();
         }
@@ -239,6 +241,8 @@ class PipetteMotionController {
             hardware.get_step_tracker(),
             can_msg.action,
             gear_motor_id};
+
+        hardware.enable_encoder();
         if (!enabled) {
             enable_motor();
         }

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -72,7 +72,6 @@ class MotionController {
             .stop_condition =
                 static_cast<MoveStopCondition>(can_msg.request_stop_condition),
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
-        hardware.enable_encoder();
         if (!enabled) {
             enable_motor();
         }
@@ -91,7 +90,6 @@ class MotionController {
             .seq_id = can_msg.seq_id,
             .stop_condition = MoveStopCondition::limit_switch,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
-        hardware.enable_encoder();
         if (!enabled) {
             enable_motor();
         }
@@ -242,7 +240,6 @@ class PipetteMotionController {
             can_msg.action,
             gear_motor_id};
 
-        hardware.enable_encoder();
         if (!enabled) {
             enable_motor();
         }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -242,6 +242,7 @@ class MotorInterruptHandler {
                 hardware.get_encoder_pulses();
             hardware.reset_step_tracker();
             hardware.reset_encoder_pulses();
+            hardware.disable_encoder();
             stall_checker.reset_itr_counts(0);
             hardware.position_flags.set_flag(
                 can::ids::MotorPositionFlags::stepper_position_ok);

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -305,6 +305,7 @@ class MotorInterruptHandler {
 
     void update_move() {
         has_active_move = move_queue.try_read_isr(&buffered_move);
+        hardware.enable_encoder();
         if (set_direction_pin()) {
             hardware.positive_direction();
         } else {

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -305,7 +305,9 @@ class MotorInterruptHandler {
 
     void update_move() {
         has_active_move = move_queue.try_read_isr(&buffered_move);
-        hardware.enable_encoder();
+        if (has_active_move) {
+            hardware.enable_encoder();
+        }
         if (set_direction_pin()) {
             hardware.positive_direction();
         } else {

--- a/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
@@ -85,6 +85,8 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     auto get_usage_eeprom_config() -> const UsageEEpromConfig& final {
         return eeprom_config;
     }
+    void disable_encoder() final {}
+    void enable_encoder() final {}
 
   private:
     bool stay_enabled = false;

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -10,6 +10,9 @@ extern "C" {
 #include <stdbool.h>
 void motor_hardware_start_timer(void* tim_handle);
 void motor_hardware_stop_timer(void* tim_handle);
+void motor_hardware_start_encoder(void* tim_handle);
+void motor_hardware_stop_encoder(void* tim_handle);
+bool motor_hardware_encoder_running(void* tim_handle);
 bool motor_hardware_timer_running(void* tim_handle);
 bool motor_hardware_start_dac(void* dac_handle, uint32_t channel);
 bool motor_hardware_stop_dac(void* dac_handle, uint32_t channel);

--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -56,6 +56,9 @@ class MotorHardware : public StepperMotorHardwareIface {
     auto has_cancel_request() -> bool final {
         return cancel_request.exchange(false);
     }
+    void disable_encoder() final;
+    void enable_encoder() final;
+
     void request_cancel() final { cancel_request.store(true); }
 
     auto get_usage_eeprom_config() -> const UsageEEpromConfig& final {

--- a/include/motor-control/simulation/sim_motor_hardware_iface.hpp
+++ b/include/motor-control/simulation/sim_motor_hardware_iface.hpp
@@ -95,6 +95,8 @@ class SimMotorHardwareIface : public motor_hardware::StepperMotorHardwareIface {
         -> motor_hardware::UsageEEpromConfig & final {
         return eeprom_config;
     }
+    void disable_encoder() final {}
+    void enable_encoder() final {}
 
   private:
     bool limit_switch_status = false;
@@ -179,6 +181,9 @@ class SimBrushedMotorHardwareIface
         return cancel_request.exchange(false);
     }
     void request_cancel() final { cancel_request.store(true); }
+
+    void disable_encoder() final {}
+    void enable_encoder() final {}
 
   private:
     bool stay_enabled = false;
@@ -267,6 +272,8 @@ class SimGearMotorHardwareIface
         -> motor_hardware::UsageEEpromConfig & final {
         return eeprom_config;
     }
+    void disable_encoder() final {}
+    void enable_encoder() final {}
 
   private:
     bool limit_switch_status = false;

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -84,6 +84,9 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
         return eeprom_config;
     }
 
+    void disable_encoder() final {}
+    void enable_encoder() final {}
+
   private:
     bool stay_enabled = false;
     PWM_DIRECTION move_dir = PWM_DIRECTION::unset;

--- a/include/motor-control/tests/mock_motor_hardware.hpp
+++ b/include/motor-control/tests/mock_motor_hardware.hpp
@@ -53,6 +53,9 @@ class MockMotorHardware : public motor_hardware::StepperMotorHardwareIface {
         return eeprom_config;
     }
 
+    void disable_encoder() final {}
+    void enable_encoder() final {}
+
   private:
     uint64_t steps = 0;
     bool mock_lim_sw_value = false;

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -54,7 +54,7 @@ bool motor_hardware_encoder_running(void* tim_handle) {
     if (!tim_handle) {
         return false;
     }
-    return HAL_TIM_Encoder_GetState(tim_handle) == HAL_TIM_STATE_BUSY;
+    return TIM_CHANNEL_STATE_GET((TIM_HandleTypeDef*)tim_handle, TIM_CHANNEL_1) == HAL_TIM_CHANNEL_STATE_BUSY;
 }
 
 void motor_hardware_stop_encoder(void* tim_handle) { HAL_TIM_Encoder_Stop_IT(tim_handle, TIM_CHANNEL_ALL); }

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -45,6 +45,20 @@ HAL_StatusTypeDef custom_stop_pwm_it(TIM_HandleTypeDef* htim,
     return HAL_OK;
 }
 
+
+void motor_hardware_start_encoder(void* tim_handle) {
+     HAL_TIM_Encoder_Start_IT(tim_handle, TIM_CHANNEL_ALL);
+}
+
+bool motor_hardware_encoder_running(void* tim_handle) {
+    if (!tim_handle) {
+        return false;
+    }
+    return HAL_TIM_Encoder_GetState(tim_handle) == HAL_TIM_STATE_BUSY;
+}
+
+void motor_hardware_stop_encoder(void* tim_handle) { HAL_TIM_Encoder_Stop_IT(tim_handle, TIM_CHANNEL_ALL); }
+
 void motor_hardware_start_timer(void* tim_handle) { HAL_TIM_Base_Start_IT(tim_handle); }
 
 void motor_hardware_stop_timer(void* tim_handle) { HAL_TIM_Base_Stop_IT(tim_handle); }

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -75,6 +75,18 @@ void MotorHardware::reset_encoder_pulses() {
     motor_encoder_overflow_count = 0;
 }
 
+
+void MotorHardware::enable_encoder() {
+    LOG("Starting encoder interrupt")
+    if (!motor_hardware_encoder_running(enc_handle)) {
+        reset_encoder_pulses();
+        motor_hardware_start_encoder(enc_handle);
+    }
+}
+void MotorHardware::disable_encoder() {
+    motor_hardware_stop_encoder(enc_handle);
+}
+
 void MotorHardware::encoder_overflow(int32_t direction) {
     // The overflow counter is a signed value that counts the net number
     // of overflows, positive or negative - i.e., if we overflow positive

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -75,7 +75,6 @@ void MotorHardware::reset_encoder_pulses() {
     motor_encoder_overflow_count = 0;
 }
 
-
 void MotorHardware::enable_encoder() {
     LOG("Starting encoder interrupt")
     if (!motor_hardware_encoder_running(enc_handle)) {


### PR DESCRIPTION
On several boards we noticed an issue where the encoder would be -2^16 off directly after a home and during the course of the investigation we found that the overflow interrupt is running multiple times in rapid succession when the encoder value is reset to 0. 
this solution turns it off when it finishes a home, and before any move makes sure that it is enabled again.