### PR TITLE
fix(pipettes): handle ALL exti IRQS

### DIFF
--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -124,18 +124,63 @@ void EXTI2_IRQHandler(void) {
 }
 
 void EXTI9_5_IRQHandler(void) {
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_5)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_5);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_5);
+    }
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_6)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_6);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_6);
+    }
     if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_7)) {
         // clear pending
         __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_7);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7); 
     }
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_8)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_8);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_8);
+    }
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_9)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_9);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_9);
+    }
 }
 
 
 void EXTI15_10_IRQHandler(void) {
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_10)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_10);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_10);
+    }
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_11)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_11);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_11);
+    }
     if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_12)) {
         __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_12);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
+    }
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_13)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_13);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_13);
+    }
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_14)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_14);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_14);
+    }
+    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_15)) {
+        // clear pending
+        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_15);
+        HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_15);
     }
 }
 


### PR DESCRIPTION
The top level irq handlers for the EXTI fused
interrupts didn't actually check and clear all the possible EXTI interrupt sources for that NVIC interrupt.

Consider, for instance, EXTI9_5. This fuses the EXTI interrupt sources for gpio pins 9-5, inclusive. Any gpio on lin 9-5 configured MODE_IT_whatever will source an EXTI interrupt at that time on the same EXTI line as its pin number, which sets the pending bit for the line in the EXTI pend register. Then any time it gets any request - or really, any time a bit in its pend register is set - for lines 9-5,  the EXTI will send an NVIC IRQ on the EXTI9_5 line.

That means that if you get an NVIC irq on EXTI9_5, you better go and clear any pend bits _for all of those lines_ because otherwise you'll just get interrupted again immediately.

The top level ISRs did not do this; they only checked a couple of the lines. Now they check all of them.