### PR TITLE
fix(pipettes): use GPIO pin names rather than EXTI pin names for the interrupt

### DIFF
--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -119,22 +119,22 @@ void DebugMon_Handler(void) {}
 /******************************************************************************/
 
 void EXTI2_IRQHandler(void) {
-    __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_2);
+    __HAL_GPIO_EXTI_CLEAR_FLAG(GPIO_PIN_2);
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
 }
 
 void EXTI9_5_IRQHandler(void) {
-    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_7)) {
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_7)) {
         // clear pending
-        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_7);
+        __HAL_GPIO_EXTI_CLEAR_FLAG(GPIO_PIN_7);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7); 
     }
 }
 
 
 void EXTI15_10_IRQHandler(void) {
-    if (__HAL_GPIO_EXTI_GET_IT(EXTI_LINE_12)) {
-        __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_12);
+    if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_12)) {
+        __HAL_GPIO_EXTI_CLEAR_FLAG(GPIO_PIN_12);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
     }
 }


### PR DESCRIPTION
## Overview

Well apparently EXTI_LINE_X != the GPIO pin bitfield and it was crashing the 96 channel firmware every time the IT was called. This problem wasn't showing up on the single/eight channel because the EXTI_LINE_2 value happened to be correct for GPIO_PIN_2.