### PR TITLE
refactor(include): reduce the amount the active mode command is sent to the pressure driver

### DIFF
--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -29,7 +29,7 @@ class PressureMessageHandler {
         -> PressureMessageHandler & = delete;
     auto operator=(const PressureMessageHandler &&)
         -> PressureMessageHandler && = delete;
-    ~PressureMessageHandler() = default;
+    ~PressureMessageHandler() { driver.reset_readings(); }
 
     void handle_message(const utils::TaskMessage &m) {
         std::visit([this](auto o) { this->visit(o); }, m);

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -58,61 +58,6 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
     auto sensor = sensors::tasks::PressureMessageHandler{
         writer, poller, queue_client, response_queue, mock_hw, sensor_id};
 
-    GIVEN("a request to take a single read of the pressure sensor") {
-        auto single_read =
-            sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
-                {}, 0xdeadbeef, pressure_id, sensor_id_int));
-        sensor.handle_message(single_read);
-        WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-            }
-            auto transact_message =
-                get_message<i2c::messages::Transact>(i2c_queue);
-            REQUIRE(transact_message.transaction.address ==
-                    sensors::mmr920C04::ADDRESS);
-        }
-    }
-    GIVEN("a request to take multiple reads of the pressure sensor") {
-        auto single_read =
-            sensors::utils::TaskMessage(can::messages::BaselineSensorRequest(
-                {}, 0xdeadbeef, pressure_id, sensor_id_int));
-        sensor.handle_message(single_read);
-        WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a MEASURE MODE 4 command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-            }
-            auto transact_message =
-                get_message<i2c::messages::Transact>(i2c_queue);
-            REQUIRE(transact_message.transaction.address ==
-                    sensors::mmr920C04::ADDRESS);
-        }
-    }
-
-    GIVEN("a request to take a single read of the temperature sensor") {
-        auto single_read =
-            sensors::utils::TaskMessage(can::messages::ReadFromSensorRequest(
-                {}, 0xdeadbeef, pressure_temperature_id, sensor_id_int));
-        sensor.handle_message(single_read);
-        WHEN("the handler function receives the message") {
-            THEN("the i2c queue is populated with a transact command") {
-                REQUIRE(i2c_queue.get_size() == 1);
-            }
-            AND_WHEN("we read the message from the queue") {
-                auto transact_message =
-                    get_message<i2c::messages::Transact>(i2c_queue);
-
-                THEN("The command addresses are correct") {
-                    REQUIRE(transact_message.transaction.address ==
-                            sensors::mmr920C04::ADDRESS);
-                    REQUIRE(transact_message.transaction.write_buffer[0] ==
-                            static_cast<uint8_t>(
-                                sensors::mmr920C04::Registers::MEASURE_MODE_4));
-                }
-            }
-        }
-    }
-
     GIVEN("A TransactionResponse message") {
         can_queue.reset();
         i2c::messages::TransactionResponse response_details{


### PR DESCRIPTION
## Overview

The data sheet doesn't appear to specify what happens if you set the active mode and reset the sensor in quick succession, but reducing the amount of active modes seems to reduce the frequency of the sensor borking.