### PR TITLE
fix(can): modify TipActionResponse message order to match the expected order on python-side

### DIFF
--- a/can/tests/test_messages.cpp
+++ b/can/tests/test_messages.cpp
@@ -448,10 +448,10 @@ SCENARIO("message serializing works") {
                               .seq_id = 2,
                               .current_position_um = 0x3456789a,
                               .encoder_position_um = 0x05803931,
-                              .ack_id = 0x1,
-                              .success = 0x1,
-                              .action = can::ids::PipetteTipActionType::clamp,
                               .position_flags = 0x0,
+                              .ack_id = 0x1,
+                              .action = can::ids::PipetteTipActionType::clamp,
+                              .success = 0x1,
                               .gear_motor_id = can::ids::GearMotorId::left};
         auto arr = std::array<uint8_t, MESSAGE_SIZE + 5>{0, 0, 0, 0, 0, 0, 0, 0,
                                                          0, 0, 0, 0, 0, 0, 0, 0,
@@ -474,10 +474,10 @@ SCENARIO("message serializing works") {
                 REQUIRE(body.data()[11] == 0x80);
                 REQUIRE(body.data()[12] == 0x39);
                 REQUIRE(body.data()[13] == 0x31);
-                REQUIRE(body.data()[14] == 0x1);
+                REQUIRE(body.data()[14] == 0x0);
                 REQUIRE(body.data()[15] == 0x1);
                 REQUIRE(body.data()[16] == 0x0);
-                REQUIRE(body.data()[17] == 0x0);
+                REQUIRE(body.data()[17] == 0x1);
             }
             THEN("the total message size is the expected value") {
                 REQUIRE(size == MESSAGE_SIZE);

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1291,10 +1291,10 @@ struct TipActionResponse
     uint8_t seq_id;
     uint32_t current_position_um;
     int32_t encoder_position_um;
-    uint8_t ack_id;
-    uint8_t success;
-    can::ids::PipetteTipActionType action;
     uint8_t position_flags;
+    uint8_t ack_id;
+    can::ids::PipetteTipActionType action;
+    uint8_t success;
     can::ids::GearMotorId gear_motor_id;
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -1304,11 +1304,11 @@ struct TipActionResponse
         iter = bit_utils::int_to_bytes(seq_id, iter, limit);
         iter = bit_utils::int_to_bytes(current_position_um, iter, limit);
         iter = bit_utils::int_to_bytes(encoder_position_um, iter, limit);
+        iter = bit_utils::int_to_bytes(position_flags, iter, limit);
         iter = bit_utils::int_to_bytes(ack_id, iter, limit);
-        iter = bit_utils::int_to_bytes(success, iter, limit);
         iter =
             bit_utils::int_to_bytes(static_cast<uint8_t>(action), iter, limit);
-        iter = bit_utils::int_to_bytes(position_flags, iter, limit);
+        iter = bit_utils::int_to_bytes(success, iter, limit);
         iter = bit_utils::int_to_bytes(static_cast<uint8_t>(gear_motor_id),
                                        iter, limit);
         return iter - body;

--- a/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
+++ b/include/pipettes/core/tasks/gear_move_status_reporter_task.hpp
@@ -62,12 +62,12 @@ class MoveStatusMessageHandler {
             .seq_id = message.seq_id,
             .current_position_um = end_position,
             .encoder_position_um = 0,
+            .position_flags = 0,
             .ack_id = static_cast<uint8_t>(message.ack_id),
+            .action = message.action,
             // TODO: In a follow-up PR, tip sense reporting will
             // actually update this value to true or false.
             .success = static_cast<uint8_t>(true),
-            .action = message.action,
-            .position_flags = 0,
             .gear_motor_id = message.gear_motor_id};
         can_client.send_can_message(can::ids::NodeId::host, msg);
         int32_t distance_traveled_um =


### PR DESCRIPTION
## Overview

Unfortunately the ordering of the tip action response got messed up somewhere along the way. This caused the ack id to never return anyting other than the default state of 1 for the tip/gear motors.