### PR TITLE
chore: make firmware images contain refname

### DIFF
--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -42,6 +42,16 @@ jobs:
           name: 'firmware-applications-${{github.ref_name}}'
           path: |
             dist/applications/*
+      - name: 'Make images contain the refname'
+        run: |
+          for distpath in ./dist/*images ; do
+              pushd $distpath
+              for imagefile in ./*.hex ; do
+                  base=$(basename $imagefile .hex)
+                  mv $imagefile $base-${{github.ref_name}}.hex
+              done
+              popd
+          done
       - name: 'Upload all-images artifact'
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Request from hardware to make it easier to distribute images to the factory. Now we'll get names like gantry-x-c2-v13.hex.

- [x] images have the refname in them 
- [x] images still end in .hex
- [x] applications are unmodified