### PR TITLE
feat(include): add error code for overpressure trigger

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -145,6 +145,7 @@ typedef enum {
     can_errorcode_estop_released = 0xa,
     can_errorcode_motor_busy = 0xb,
     can_errorcode_stop_requested = 0xc,
+    can_errorcode_over_pressure = 0xd,
 } CANErrorCode;
 
 /** Tool types detected on Head. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -147,6 +147,7 @@ enum class ErrorCode {
     estop_released = 0xa,
     motor_busy = 0xb,
     stop_requested = 0xc,
+    over_pressure = 0xd,
 };
 
 /** Error Severity levels. */

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -290,6 +290,13 @@ class MMR920C04 {
             if (std::fabs(pressure) - std::fabs(current_pressure_baseline_pa) >
                 mmr920C04::MAX_PRESSURE_READING) {
                 hardware.set_sync();
+                can_client.send_can_message(
+                    can::ids::NodeId::host,
+                    can::messages::ErrorMessage{
+                        .message_index = m.message_index,
+                        .severity = can::ids::ErrorSeverity::unrecoverable,
+                        .error_code = can::ids::ErrorCode::over_pressure
+                    });
             } else {
                 hardware.reset_sync();
             }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -295,8 +295,7 @@ class MMR920C04 {
                     can::messages::ErrorMessage{
                         .message_index = m.message_index,
                         .severity = can::ids::ErrorSeverity::unrecoverable,
-                        .error_code = can::ids::ErrorCode::over_pressure
-                    });
+                        .error_code = can::ids::ErrorCode::over_pressure});
             } else {
                 hardware.reset_sync();
             }


### PR DESCRIPTION
## Overview

We should throw an error message for the use-case of an overpressure spike being detected. Potentially we'll want to do some filtering at some point, but I think the chances of us getting into this value range is very low and thus it's OK to not do any type of signal processing.