### PR TITLE
fix(motor-control): set encoder start position in motor ISR

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -342,6 +342,8 @@ class MotorInterruptHandler {
         has_active_move = move_queue.try_read_isr(&buffered_move);
         if (has_active_move) {
             hardware.enable_encoder();
+            buffered_move.start_encoder_position =
+                hardware.get_encoder_pulses();
         }
         if (set_direction_pin()) {
             hardware.positive_direction();

--- a/motor-control/tests/test_motor_interrupt_queue.cpp
+++ b/motor-control/tests/test_motor_interrupt_queue.cpp
@@ -45,6 +45,14 @@ TEST_CASE("motor interrupt handler queue functionality") {
                         REQUIRE(handler.has_move_messages() == false);
                     }
                 }
+                WHEN("a move is updated") {
+                    CHECK(msg1.start_encoder_position == 0);
+                    hardware.sim_set_encoder_pulses(300);
+                    THEN("the start encoder position should be updated to buffered move") {
+                        handler.update_move();
+                        REQUIRE(handler.get_buffered_move().start_encoder_position == 300);
+                    }
+                }
                 WHEN("a movement stalls") {
                     handler.run_interrupt();
                     handler.cancel_and_clear_moves(

--- a/motor-control/tests/test_motor_interrupt_queue.cpp
+++ b/motor-control/tests/test_motor_interrupt_queue.cpp
@@ -48,9 +48,12 @@ TEST_CASE("motor interrupt handler queue functionality") {
                 WHEN("a move is updated") {
                     CHECK(msg1.start_encoder_position == 0);
                     hardware.sim_set_encoder_pulses(300);
-                    THEN("the start encoder position should be updated to buffered move") {
+                    THEN(
+                        "the start encoder position should be updated to "
+                        "buffered move") {
                         handler.update_move();
-                        REQUIRE(handler.get_buffered_move().start_encoder_position == 300);
+                        REQUIRE(handler.get_buffered_move()
+                                    .start_encoder_position == 300);
                     }
                 }
                 WHEN("a movement stalls") {


### PR DESCRIPTION
We didn't actually set the encoder start position for stepper motor move message (except when we home) – this fixes it so we can track the distance traveled.