### PR TITLE
feat(motor-control): limit switch backoff move for stepper motors

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -218,6 +218,7 @@ typedef enum {
     can_movestopcondition_gripper_force = 0x8,
     can_movestopcondition_stall = 0x10,
     can_movestopcondition_ignore_stalls = 0x20,
+    can_movestopcondition_limit_switch_backoff = 0x30,
 } CANMoveStopCondition;
 
 /** A bit field of the arbitration id parts. */

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -218,7 +218,7 @@ typedef enum {
     can_movestopcondition_gripper_force = 0x8,
     can_movestopcondition_stall = 0x10,
     can_movestopcondition_ignore_stalls = 0x20,
-    can_movestopcondition_limit_switch_backoff = 0x30,
+    can_movestopcondition_limit_switch_backoff = 0x40,
 } CANMoveStopCondition;
 
 /** A bit field of the arbitration id parts. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -227,6 +227,7 @@ enum class MoveStopCondition {
     gripper_force = 0x8,
     stall = 0x10,
     ignore_stalls = 0x20,
+    limit_switch_backoff = 0x30,
 };
 
 /** High-level type of pipette. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -227,7 +227,7 @@ enum class MoveStopCondition {
     gripper_force = 0x8,
     stall = 0x10,
     ignore_stalls = 0x20,
-    limit_switch_backoff = 0x30,
+    limit_switch_backoff = 0x40,
 };
 
 /** High-level type of pipette. */

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -135,6 +135,7 @@ class BrushedMotorInterruptHandler {
                 }
                 break;
             case MoveStopCondition::ignore_stalls:
+            case MoveStopCondition::limit_switch_backoff:
             case MoveStopCondition::sync_line:
                 // TODO write cap sensor move code
                 break;
@@ -281,6 +282,7 @@ class BrushedMotorInterruptHandler {
                 break;
             case MoveStopCondition::sync_line:
             case MoveStopCondition::ignore_stalls:
+            case MoveStopCondition::limit_switch_backoff:
                 // this is an unused move stop condition for the brushed motor
                 // just return with no condition
                 // TODO creat can bus error messages and send that instead

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -281,7 +281,6 @@ class MotorInterruptHandler {
         if (limit_switch_triggered()) {
             position_tracker = 0;
             hardware.reset_step_tracker();
-//            hardware.reset_encoder_pulses();
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
         }
@@ -380,6 +379,8 @@ class MotorInterruptHandler {
                 MoveStopCondition::limit_switch)) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
             update_hardware_step_tracker();
+            hardware.position_flags.clear_flag(
+                    can::ids::MotorPositionFlags::stepper_position_ok);
         }
     }
 

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -281,6 +281,7 @@ class MotorInterruptHandler {
         if (limit_switch_triggered()) {
             position_tracker = 0;
             hardware.reset_step_tracker();
+//            hardware.reset_encoder_pulses();
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
         }
@@ -376,11 +377,7 @@ class MotorInterruptHandler {
         }
         if (has_active_move &&
             buffered_move.check_stop_condition(
-                MoveStopCondition::limit_switch) &&
-            !hardware.position_flags.check_flag(
-                MotorPositionStatus::Flags::stepper_position_ok)) {
-            // if stepper position is unreliable when home (i.e. first home
-            // after boot), update position to a large positive value
+                MoveStopCondition::limit_switch)) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
             update_hardware_step_tracker();
         }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -218,8 +218,7 @@ class MotorInterruptHandler {
             backed_off()) {
             return true;
         }
-        if (buffered_move.check_stop_condition(
-                MoveStopCondition::sync_line) &&
+        if (buffered_move.check_stop_condition(MoveStopCondition::sync_line) &&
             sync_triggered()) {
             return true;
         }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -374,13 +374,12 @@ class MotorInterruptHandler {
         } else {
             hardware.negative_direction();
         }
-        if (has_active_move &&
-            buffered_move.check_stop_condition(
-                MoveStopCondition::limit_switch)) {
+        if (has_active_move && buffered_move.check_stop_condition(
+                                   MoveStopCondition::limit_switch)) {
             position_tracker = 0x7FFFFFFFFFFFFFFF;
             update_hardware_step_tracker();
             hardware.position_flags.clear_flag(
-                    can::ids::MotorPositionFlags::stepper_position_ok);
+                can::ids::MotorPositionFlags::stepper_position_ok);
         }
     }
 

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -279,6 +279,8 @@ class MotorInterruptHandler {
 
     auto homing_stopped() -> bool {
         if (limit_switch_triggered()) {
+            position_tracker = 0;
+            hardware.reset_step_tracker();
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
         }

--- a/motor-control/tests/CMakeLists.txt
+++ b/motor-control/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(motor-control
         test_fixed_point_utils.cpp
         test_motor_driver.cpp
         test_limit_switch.cpp
+        test_limit_switch_backoff.cpp
         test_move_status_handling.cpp
         test_sync_handling.cpp
         test_brushed_motor_interrupt_handler.cpp

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -1,4 +1,3 @@
-#include "can/core/ids.hpp"
 #include "catch2/catch.hpp"
 #include "common/tests/mock_message_queue.hpp"
 #include "motor-control/core/motor_messages.hpp"
@@ -58,7 +57,7 @@ SCENARIO("MoveStopCondition::limit_switch with the limit switch triggered") {
 
         THEN("stepper position flag is cleared") {
             REQUIRE(!test_objs.hw.position_flags.check_flag(
-                can::ids::MotorPositionFlags::stepper_position_ok));
+                MotorPositionStatus::Flags::stepper_position_ok));
         }
 
         AND_WHEN("the limit switch has been triggered") {
@@ -85,7 +84,7 @@ SCENARIO("MoveStopCondition::limit_switch with the limit switch triggered") {
 
             THEN("the stepper position flag is still cleared") {
                 REQUIRE(!test_objs.hw.position_flags.check_flag(
-                    can::ids::MotorPositionFlags::stepper_position_ok));
+                    MotorPositionStatus::Flags::stepper_position_ok));
             }
         }
     }
@@ -117,7 +116,7 @@ SCENARIO("MoveStopCondition::limit_switch and limit switch is not triggered") {
         }
         THEN("stepper position flag is cleared") {
             REQUIRE(!test_objs.hw.position_flags.check_flag(
-                can::ids::MotorPositionFlags::stepper_position_ok));
+                MotorPositionStatus::Flags::stepper_position_ok));
         }
 
         AND_WHEN("the limit switch has not been triggered") {

--- a/motor-control/tests/test_limit_switch_backoff.cpp
+++ b/motor-control/tests/test_limit_switch_backoff.cpp
@@ -75,6 +75,13 @@ SCENARIO(
                 THEN("position should be reset") {
                     REQUIRE(test_objs.handler.get_current_position() == 0);
                 }
+
+                THEN("both stepper and encoder position should be ok") {
+                    REQUIRE(test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::encoder_position_ok));
+                    REQUIRE(test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::stepper_position_ok));
+                }
             }
         }
     }
@@ -115,6 +122,13 @@ SCENARIO(
 
                 THEN("position should be reset") {
                     REQUIRE(test_objs.handler.get_current_position() == 0);
+                }
+
+                THEN("both stepper and encoder position should be ok") {
+                    REQUIRE(test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::encoder_position_ok));
+                    REQUIRE(test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::stepper_position_ok));
                 }
             }
         }
@@ -171,6 +185,15 @@ SCENARIO(
                 THEN("position should not be reset") {
                     REQUIRE(!test_objs.handler.get_current_position() == 0);
                 }
+
+                THEN(
+                    "both stepper and encoder position should still be not "
+                    "ok") {
+                    REQUIRE(!test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::encoder_position_ok));
+                    REQUIRE(!test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::stepper_position_ok));
+                }
             }
         }
     }
@@ -209,6 +232,15 @@ SCENARIO(
                 }
                 THEN("position should not be reset") {
                     REQUIRE(!test_objs.handler.get_current_position() == 0);
+                }
+
+                THEN(
+                    "both stepper and encoder position should not have "
+                    "changed") {
+                    REQUIRE(test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::encoder_position_ok));
+                    REQUIRE(test_objs.hw.position_flags.check_flag(
+                        MotorPositionStatus::Flags::stepper_position_ok));
                 }
             }
         }

--- a/motor-control/tests/test_limit_switch_backoff.cpp
+++ b/motor-control/tests/test_limit_switch_backoff.cpp
@@ -23,23 +23,17 @@ struct HandlerContainer {
         handler{queue, reporter, hw, stall, update_position_queue};
 };
 
-static constexpr sq0_31 default_velocity =
-    0x1 << (TO_RADIX - 1);  // half a step per tick
-
-sq0_31 convert_velocity(float f) {
-    return sq0_31(f * static_cast<float>(1LL << TO_RADIX));
-}
-
 SCENARIO(
     "MoveStopCondition::limit_switch_backoff with the limit switch released") {
     HandlerContainer test_objs{};
-    Move msg1 = Move{.duration = 2,
-                     .velocity = convert_velocity(.5),
-                     .acceleration = 0,
-                     .group_id = 1,
-                     .seq_id = 0,
-                     .stop_condition = static_cast<uint8_t>(
-                         MoveStopCondition::limit_switch_backoff)};
+    Move msg1 =
+        Move{.duration = 2,
+             .velocity = int32_t(0.5 * static_cast<float>(1LL << TO_RADIX)),
+             .acceleration = 0,
+             .group_id = 1,
+             .seq_id = 0,
+             .stop_condition =
+                 static_cast<uint8_t>(MoveStopCondition::limit_switch_backoff)};
 
     test_objs.queue.try_write_isr(msg1);
     test_objs.handler.set_current_position(0x0);
@@ -131,13 +125,14 @@ SCENARIO(
     "MoveStopCondition::limit_switch_backoff and limit switch is not "
     "released") {
     HandlerContainer test_objs{};
-    Move msg1 = Move{.duration = 2,
-                     .velocity = convert_velocity(.5),
-                     .acceleration = 0,
-                     .group_id = 1,
-                     .seq_id = 0,
-                     .stop_condition = static_cast<uint8_t>(
-                         MoveStopCondition::limit_switch_backoff)};
+    Move msg1 =
+        Move{.duration = 2,
+             .velocity = int32_t(0.5 * static_cast<float>(1LL << TO_RADIX)),
+             .acceleration = 0,
+             .group_id = 1,
+             .seq_id = 0,
+             .stop_condition =
+                 static_cast<uint8_t>(MoveStopCondition::limit_switch_backoff)};
 
     test_objs.queue.try_write_isr(msg1);
     test_objs.handler.set_current_position(0x0);

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -327,6 +327,10 @@ TEST_CASE("Finishing a move") {
         test_objs.handler.set_current_position(set_position);
         test_objs.hw.sim_set_encoder_pulses(set_encoder_position);
         test_objs.hw.set_mock_lim_sw(true);
+        test_objs.hw.position_flags.clear_flag(
+            MotorPositionStatus::Flags::stepper_position_ok);
+        test_objs.hw.position_flags.clear_flag(
+            MotorPositionStatus::Flags::encoder_position_ok);
         REQUIRE(test_objs.handler.homing_stopped());
 
         THEN(
@@ -338,7 +342,7 @@ TEST_CASE("Finishing a move") {
             REQUIRE(msg.seq_id == move.seq_id);
             REQUIRE(msg.current_position_steps == 100);
             REQUIRE(msg.encoder_position == 200);
-            REQUIRE(msg.position_flags == 0x3);
+            REQUIRE(msg.position_flags == 0x0);
 
             AND_GIVEN("a backoff move") {
                 test_objs.reporter.messages.clear();

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -340,7 +340,7 @@ TEST_CASE("Finishing a move") {
             auto msg = std::get<Ack>(test_objs.reporter.messages[0]);
             REQUIRE(msg.group_id == move.group_id);
             REQUIRE(msg.seq_id == move.seq_id);
-            REQUIRE(msg.current_position_steps == 100);
+            REQUIRE(msg.current_position_steps == 0);
             REQUIRE(msg.encoder_position == 200);
             REQUIRE(msg.position_flags == 0x0);
 

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -336,19 +336,25 @@ TEST_CASE("Finishing a move") {
             auto msg = std::get<Ack>(test_objs.reporter.messages[0]);
             REQUIRE(msg.group_id == move.group_id);
             REQUIRE(msg.seq_id == move.seq_id);
-            REQUIRE(msg.current_position_steps == 0);
-            REQUIRE(msg.encoder_position == 0);
+            REQUIRE(msg.current_position_steps == 100);
+            REQUIRE(msg.encoder_position == 200);
             REQUIRE(msg.position_flags == 0x3);
 
-            AND_GIVEN("a followup move") {
+            AND_GIVEN("a backoff move") {
                 test_objs.reporter.messages.clear();
-                move = Move{.group_id = 1, .seq_id = 2};
+                move = Move{.group_id = 1,
+                            .seq_id = 3,
+                            .stop_condition = static_cast<uint8_t>(
+                                MoveStopCondition::limit_switch_backoff),
+                            .start_encoder_position =
+                                test_objs.hw.get_encoder_pulses()};
                 test_objs.handler.set_buffered_move(move);
-                uint64_t set_position = static_cast<uint64_t>(100) << 31;
-                uint32_t set_encoder_position = static_cast<uint32_t>(200);
+                uint64_t set_position = static_cast<uint64_t>(10) << 31;
+                uint32_t set_encoder_position = static_cast<uint32_t>(220);
                 test_objs.handler.set_current_position(set_position);
                 test_objs.hw.sim_set_encoder_pulses(set_encoder_position);
-                test_objs.handler.finish_current_move();
+                test_objs.hw.set_mock_lim_sw(false);
+                REQUIRE(test_objs.handler.backed_off());
 
                 THEN(
                     "the ack message should contain the correct information "
@@ -357,9 +363,35 @@ TEST_CASE("Finishing a move") {
                     auto msg = std::get<Ack>(test_objs.reporter.messages[0]);
                     REQUIRE(msg.group_id == move.group_id);
                     REQUIRE(msg.seq_id == move.seq_id);
-                    REQUIRE(msg.current_position_steps == 100);
-                    REQUIRE(msg.encoder_position == 200);
+                    REQUIRE(msg.current_position_steps == 0);
+                    REQUIRE(msg.encoder_position == 0);
                     REQUIRE(msg.position_flags == 0x3);
+                    REQUIRE(msg.start_encoder_position == -20);
+                }
+
+                AND_GIVEN("a subsequent move") {
+                    test_objs.reporter.messages.clear();
+                    move = Move{.group_id = 1, .seq_id = 2};
+                    test_objs.handler.set_buffered_move(move);
+                    uint64_t set_position = static_cast<uint64_t>(100) << 31;
+                    uint32_t set_encoder_position = static_cast<uint32_t>(200);
+                    test_objs.handler.set_current_position(set_position);
+                    test_objs.hw.sim_set_encoder_pulses(set_encoder_position);
+                    test_objs.handler.finish_current_move();
+
+                    THEN(
+                        "the ack message should contain the correct "
+                        "information "
+                        "when the move finishes") {
+                        REQUIRE(test_objs.reporter.messages.size() == 1);
+                        auto msg =
+                            std::get<Ack>(test_objs.reporter.messages[0]);
+                        REQUIRE(msg.group_id == move.group_id);
+                        REQUIRE(msg.seq_id == move.seq_id);
+                        REQUIRE(msg.current_position_steps == 100);
+                        REQUIRE(msg.encoder_position == 200);
+                        REQUIRE(msg.position_flags == 0x3);
+                    }
                 }
             }
         }

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -312,10 +312,10 @@ SCENARIO("motor handler stall detection") {
 
     GIVEN("a limit switch backoff move with a stall detected") {
         test_objs.hw.set_mock_lim_sw(true);
-        auto msg1 =
-            Move{.duration = 23,
-                 .velocity = default_velocity,
-                 .stop_condition = static_cast<uint8_t>(Stops::limit_switch_backoff)};
+        auto msg1 = Move{.duration = 23,
+                         .velocity = default_velocity,
+                         .stop_condition =
+                             static_cast<uint8_t>(Stops::limit_switch_backoff)};
         auto msg2 = Move{.duration = 10, .velocity = default_velocity};
         test_objs.queue.try_write(msg1);
         test_objs.queue.try_write(msg2);

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -274,11 +274,48 @@ SCENARIO("motor handler stall detection") {
         }
     }
 
-    GIVEN("a home move") {
+    GIVEN("a home move with a stall detected") {
+        test_objs.hw.set_mock_lim_sw(false);
+        test_objs.hw.position_flags.clear_flag(
+            MotorPositionStatus::Flags::encoder_position_ok);
+        test_objs.hw.position_flags.clear_flag(
+            MotorPositionStatus::Flags::stepper_position_ok);
         auto msg1 =
             Move{.duration = 23,
                  .velocity = -default_velocity,
                  .stop_condition = static_cast<uint8_t>(Stops::limit_switch)};
+        auto msg2 = Move{.duration = 10, .velocity = default_velocity};
+        test_objs.queue.try_write(msg1);
+        test_objs.queue.try_write(msg2);
+        REQUIRE(test_objs.queue.get_size() == 2);
+        test_objs.handler.update_move();
+
+        WHEN("encoder doesn't update with the motor") {
+            REQUIRE(test_objs.queue.get_size() == 1);
+            REQUIRE(test_objs.reporter.messages.size() == 0);
+            for (int i = 0; i < (int)msg1.duration; ++i) {
+                test_objs.handler.run_interrupt();
+            }
+            THEN("the stall is detected") {
+                REQUIRE(!test_objs.hw.position_flags.check_flag(
+                    Flags::stepper_position_ok));
+                THEN("move completed and no error was raised") {
+                    REQUIRE(test_objs.reporter.messages.size() == 1);
+                    Ack ack_msg =
+                        std::get<Ack>(test_objs.reporter.messages.front());
+                    REQUIRE(ack_msg.ack_id ==
+                            AckMessageId::complete_without_condition);
+                }
+            }
+        }
+    }
+
+    GIVEN("a limit switch backoff move with a stall detected") {
+        test_objs.hw.set_mock_lim_sw(true);
+        auto msg1 =
+            Move{.duration = 23,
+                 .velocity = default_velocity,
+                 .stop_condition = static_cast<uint8_t>(Stops::limit_switch_backoff)};
         auto msg2 = Move{.duration = 10, .velocity = default_velocity};
         test_objs.queue.try_write(msg1);
         test_objs.queue.try_write(msg2);


### PR DESCRIPTION
Ideally, the origin point of each axis should be the exact same point each time we command the axis to home. With level switches, there's a range of operating distance where the contacts are tripped. To improve precision, every time we home an axis and trigger a limit switch, we can slowly back away from the switch until the first instance the contacts are released. This way we can ensure the position of the axis origin to be roughly the same every time. 

Main changes:
1. Add a new move stop condition `MoveStopCondition::limit_switch_backoff`
2. Instead of resetting the stepper and encoder tracker after a HomeRequest, we're going to reset everything after the subsequent `limit_switch_backoff` move instead

Changes to the home & backoff behavior from last review:
1. Still setting stepper position to a large positive number at the beginning of a home_request (otherwise we'd run into negative position which we don't support)
2. Clearing stepper position flag when we begin to home
3. Resetting stepper position to 0 but not reset the status flag when limit switch is triggered
4. Only when backoff is completed we are resetting everything: stepper position, encoder position, motor status flags 

Required monorepo changes: https://github.com/Opentrons/opentrons/pull/12824

