### PR TITLE
fix(pipettes): remove encoder handle from gear motor hardware

### DIFF
--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -77,12 +77,18 @@ void MotorHardware::reset_encoder_pulses() {
 
 void MotorHardware::enable_encoder() {
     LOG("Starting encoder interrupt")
+    if (!enc_handle) {
+        return;
+    }
     if (!motor_hardware_encoder_running(enc_handle)) {
         reset_encoder_pulses();
         motor_hardware_start_encoder(enc_handle);
     }
 }
 void MotorHardware::disable_encoder() {
+    if (!enc_handle) {
+        return;
+    }
     motor_hardware_stop_encoder(enc_handle);
 }
 

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -186,9 +186,9 @@ auto gear_motor::get_motor_hardware(
     -> gear_motor::GearHardware {
     return gear_motor::GearHardware{
         .left = motor_hardware::MotorHardware(pins.left_gear_motor, &htim6,
-                                              &htim2, gear_left_usage_config),
+                                              nullptr, gear_left_usage_config),
         .right = motor_hardware::MotorHardware(
-            pins.right_gear_motor, &htim6, &htim2, gear_right_usage_config)};
+            pins.right_gear_motor, &htim6, nullptr, gear_right_usage_config)};
 }
 
 auto gear_motor::get_motor_hardware_tasks(gear_motor::UnavailableGearHardware&)


### PR DESCRIPTION
remove the encoder handle from the gear motor hardware interfaces. they were resetting the plunger encoder when they did tip actions