### PR TITLE
refactor(motor-control): use um/tick/tick for acceleration to increase resolution

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -20,7 +20,7 @@ using namespace can::ids;
 
 using stepper_timer_ticks = uint32_t;
 using brushed_timer_ticks = uint32_t;
-using um_per_tick = int32_t;
+using mm_per_tick = int32_t;
 using um_per_tick_sq = int32_t;
 
 /**
@@ -306,7 +306,7 @@ struct AddLinearMoveRequest : BaseMessage<MessageId::add_move_request> {
     uint8_t seq_id;
     stepper_timer_ticks duration;
     um_per_tick_sq acceleration;
-    um_per_tick velocity;
+    mm_per_tick velocity;
     uint8_t request_stop_condition;
 
     template <bit_utils::ByteIterator Input, typename Limit>
@@ -315,7 +315,7 @@ struct AddLinearMoveRequest : BaseMessage<MessageId::add_move_request> {
         uint8_t seq_id = 0;
         stepper_timer_ticks duration = 0;
         um_per_tick_sq acceleration = 0;
-        um_per_tick velocity = 0;
+        mm_per_tick velocity = 0;
         uint8_t request_stop_condition = 0;
         uint32_t msg_ind = 0;
 
@@ -345,14 +345,14 @@ struct HomeRequest : BaseMessage<MessageId::home_request> {
     uint8_t group_id;
     uint8_t seq_id;
     stepper_timer_ticks duration;
-    um_per_tick velocity;
+    mm_per_tick velocity;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> HomeRequest {
         uint8_t group_id = 0;
         uint8_t seq_id = 0;
         stepper_timer_ticks duration = 0;
-        um_per_tick velocity = 0;
+        mm_per_tick velocity = 0;
         uint32_t msg_ind = 0;
 
         body = bit_utils::bytes_to_int(body, limit, msg_ind);
@@ -502,15 +502,15 @@ struct UpdateMotorPositionEstimationResponse
 
 struct SetMotionConstraints : BaseMessage<MessageId::set_motion_constraints> {
     uint32_t message_index;
-    um_per_tick min_velocity;
-    um_per_tick max_velocity;
+    mm_per_tick min_velocity;
+    mm_per_tick max_velocity;
     um_per_tick_sq min_acceleration;
     um_per_tick_sq max_acceleration;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> SetMotionConstraints {
-        um_per_tick min_velocity = 0;
-        um_per_tick max_velocity = 0;
+        mm_per_tick min_velocity = 0;
+        mm_per_tick max_velocity = 0;
         um_per_tick_sq min_acceleration = 0;
         um_per_tick_sq max_acceleration = 0;
         uint32_t msg_ind = 0;
@@ -536,8 +536,8 @@ using GetMotionConstraintsRequest =
 struct GetMotionConstraintsResponse
     : BaseMessage<MessageId::get_motion_constraints_response> {
     uint32_t message_index;
-    um_per_tick min_velocity;
-    um_per_tick max_velocity;
+    mm_per_tick min_velocity;
+    mm_per_tick max_velocity;
     um_per_tick_sq min_acceleration;
     um_per_tick_sq max_acceleration;
 
@@ -1249,7 +1249,7 @@ struct TipActionRequest
     uint8_t group_id;
     uint8_t seq_id;
     stepper_timer_ticks duration;
-    um_per_tick velocity;
+    mm_per_tick velocity;
     can::ids::PipetteTipActionType action;
     uint8_t request_stop_condition;
 
@@ -1258,7 +1258,7 @@ struct TipActionRequest
         uint8_t group_id = 0;
         uint8_t seq_id = 0;
         stepper_timer_ticks duration = 0;
-        um_per_tick velocity = 0;
+        mm_per_tick velocity = 0;
         uint8_t _action = 0;
         uint8_t request_stop_condition = 0;
         uint32_t msg_ind = 0;

--- a/include/motor-control/core/linear_motion_system.hpp
+++ b/include/motor-control/core/linear_motion_system.hpp
@@ -45,7 +45,7 @@ struct LinearMotionSystemConfig {
         return (steps_per_rev * microstep) / (mech_config.get_mm_per_rev());
     }
     [[nodiscard]] constexpr auto get_usteps_per_um() const -> float {
-        return (steps_per_rev * microstep) / (mech_config.get_mm_per_rev()) * 1000.0;
+        return (steps_per_rev * microstep) / (mech_config.get_mm_per_rev() * 1000.0);
     }
     [[nodiscard]] constexpr auto get_um_per_step() const -> float {
         return (mech_config.get_mm_per_rev()) / (steps_per_rev * microstep) *

--- a/include/motor-control/core/linear_motion_system.hpp
+++ b/include/motor-control/core/linear_motion_system.hpp
@@ -44,6 +44,9 @@ struct LinearMotionSystemConfig {
     [[nodiscard]] constexpr auto get_usteps_per_mm() const -> float {
         return (steps_per_rev * microstep) / (mech_config.get_mm_per_rev());
     }
+    [[nodiscard]] constexpr auto get_usteps_per_um() const -> float {
+        return (steps_per_rev * microstep) / (mech_config.get_mm_per_rev()) * 1000.0;
+    }
     [[nodiscard]] constexpr auto get_um_per_step() const -> float {
         return (mech_config.get_mm_per_rev()) / (steps_per_rev * microstep) *
                1000;

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -8,12 +8,12 @@
 
 namespace motor_messages {
 
-using um_per_tick = can::messages::um_per_tick;
+using mm_per_tick = can::messages::mm_per_tick;
 using um_per_tick_sq = can::messages::um_per_tick_sq;
 
 struct MotionConstraints {
-    um_per_tick min_velocity;
-    um_per_tick max_velocity;
+    mm_per_tick min_velocity;
+    mm_per_tick max_velocity;
     um_per_tick_sq min_acceleration;
     um_per_tick_sq max_acceleration;
 };

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -39,6 +39,8 @@ class MotionController {
           update_queue(update_queue),
           steps_per_mm(convert_to_fixed_point_64_bit(
               linear_motion_sys_config.get_usteps_per_mm(), 31)),
+          steps_per_um(convert_to_fixed_point_64_bit(
+                  linear_motion_sys_config.get_usteps_per_um(), 31)),
           um_per_step(convert_to_fixed_point_64_bit(
               linear_motion_sys_config.get_um_per_step(), 31)),
           um_per_encoder_pulse(convert_to_fixed_point_64_bit(
@@ -61,7 +63,7 @@ class MotionController {
         steps_per_tick velocity_steps =
             fixed_point_multiply(steps_per_mm, can_msg.velocity);
         steps_per_tick_sq acceleration_steps =
-            fixed_point_multiply(steps_per_mm, can_msg.acceleration);
+            fixed_point_multiply(steps_per_um, can_msg.acceleration);
         Move msg{
             .message_index = can_msg.message_index,
             .duration = can_msg.duration,
@@ -172,6 +174,7 @@ class MotionController {
     GenericQueue& queue;
     UpdatePositionQueue& update_queue;
     sq31_31 steps_per_mm{0};
+    sq31_31 steps_per_um{0};
     sq31_31 um_per_step{0};
     sq31_31 um_per_encoder_pulse{0};
     bool enabled = false;


### PR DESCRIPTION
This PR changes the acceleration params we use in linear move request to use `um/tick/tick` instead of `mm/tick/tick` so we can work with lower accelerations.