### PR TITLE
chore(motor-control): put motor-control functions in ccmram

### DIFF
--- a/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
+++ b/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
@@ -73,6 +73,16 @@ SECTIONS
     _sccmram = .;       /* create a global symbol at ccmram start */
     *(.ccmram)
     *(.ccmram*)
+
+    /* NOTE ABOUT THE FOLLOWING SECTIONS
+    * 
+    * The CMAKE toolchain for cross-compilation MUST be configured
+    * with the option `-ffunction-sections` in order for this to work.
+    * This section matches the sections for the namespaces for motor
+    * functionality, and those namesapces are only broken out into
+    * individual linker sections if the function-sections option is enabled.
+    */
+
     *(.text.*motor_handler*) 
     *(.text.*motor_hardware*) 
     

--- a/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
+++ b/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
@@ -59,6 +59,27 @@ SECTIONS
     KEEP(*(.fw_update_flag_section))
   } > RAM
 
+  _siccmram = LOADADDR(.ccmram);
+  
+  /* CCM-RAM section 
+  * 
+  * IMPORTANT NOTE! 
+  * If initialized variables will be placed in this section,
+  * the startup code needs to be modified to copy the init-values.  
+  */
+  .ccmram :
+  {
+    . = ALIGN(4);
+    _sccmram = .;       /* create a global symbol at ccmram start */
+    *(.ccmram)
+    *(.ccmram*)
+    *(.text.*motor_handler*) 
+    *(.text.*motor_hardware*) 
+    
+    . = ALIGN(4);
+    _eccmram = .;       /* create a global symbol at ccmram end */
+  } >CCMRAM AT> ROM
+
   /* The program code and other data into "ROM" Rom type memory */
   .text :
   {
@@ -145,24 +166,6 @@ SECTIONS
     
   } >RAM AT> ROM
 
-  _siccmram = LOADADDR(.ccmram);
-  
-  /* CCM-RAM section 
-  * 
-  * IMPORTANT NOTE! 
-  * If initialized variables will be placed in this section,
-  * the startup code needs to be modified to copy the init-values.  
-  */
-  .ccmram :
-  {
-    . = ALIGN(4);
-    _sccmram = .;       /* create a global symbol at ccmram start */
-    *(.ccmram)
-    *(.ccmram*)
-    
-    . = ALIGN(4);
-    _eccmram = .;       /* create a global symbol at ccmram end */
-  } >CCMRAM AT> ROM
 
   /* Uninitialized data section into "RAM" Ram type memory */
   . = ALIGN(4);

--- a/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
+++ b/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
@@ -37,7 +37,7 @@ _Min_Stack_Size = 0x600;	/* required amount of stack */
 /* Memories definition */
 MEMORY
 {
-  CCMSRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 16K
+  CCMRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 16K
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 112K
   ROM    (rx)    : ORIGIN = 0x08008000,   LENGTH = 512K
 }
@@ -144,6 +144,25 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
     
   } >RAM AT> ROM
+
+  _siccmram = LOADADDR(.ccmram);
+  
+  /* CCM-RAM section 
+  * 
+  * IMPORTANT NOTE! 
+  * If initialized variables will be placed in this section,
+  * the startup code needs to be modified to copy the init-values.  
+  */
+  .ccmram :
+  {
+    . = ALIGN(4);
+    _sccmram = .;       /* create a global symbol at ccmram start */
+    *(.ccmram)
+    *(.ccmram*)
+    
+    . = ALIGN(4);
+    _eccmram = .;       /* create a global symbol at ccmram end */
+  } >CCMRAM AT> ROM
 
   /* Uninitialized data section into "RAM" Ram type memory */
   . = ALIGN(4);

--- a/common/firmware/STM32G491RETx/startup_stm32g491xx.s
+++ b/common/firmware/STM32G491RETx/startup_stm32g491xx.s
@@ -94,6 +94,25 @@ LoopFillZerobss:
   cmp r2, r4
   bcc FillZerobss
 
+InitCopyCCM:
+  movs r1, #0
+  ldr r2, =_sccmram
+  b LoopCopyCCM
+
+CopyCCM:
+  ldr r3, =_siccmram
+  ldr r3, [r3, r1]
+  str r3, [r0, r1]
+  adds	r1, r1, #4
+
+LoopCopyCCM:
+  ldr r0, =_sccmram 
+  ldr r3, =_eccmram 
+  adds r2, r0, r1 
+  cmp r2, r3 
+  bcc CopyCCM 
+
+
 /* Call the clock system intitialization function.*/
     bl  SystemInit
 /* Call static constructors */

--- a/common/firmware/gpio.c
+++ b/common/firmware/gpio.c
@@ -2,6 +2,7 @@
 #include "platform_specific_hal.h"
 #include <stdbool.h>
 
+__attribute__((section( ".ccmram" )))
 void gpio_set(void* port, uint16_t pin, uint8_t active_setting) {
     if (!port) {
         return;
@@ -9,6 +10,7 @@ void gpio_set(void* port, uint16_t pin, uint8_t active_setting) {
     HAL_GPIO_WritePin(port, pin, active_setting);
 }
 
+__attribute__((section( ".ccmram" )))
 static uint8_t invert_gpio_value(uint8_t setting) {
     switch (setting) {
         case GPIO_PIN_SET:
@@ -20,6 +22,7 @@ static uint8_t invert_gpio_value(uint8_t setting) {
     }
 }
 
+__attribute__((section( ".ccmram" )))
 void gpio_reset(void* port, uint16_t pin,
                 uint8_t active_setting) {
     if (!port) {
@@ -28,6 +31,7 @@ void gpio_reset(void* port, uint16_t pin,
     HAL_GPIO_WritePin(port, pin, invert_gpio_value(active_setting));
 }
 
+__attribute__((section( ".ccmram" )))
 bool gpio_is_set(void* port, uint16_t pin, uint8_t active_setting) {
     return HAL_GPIO_ReadPin(port, pin) == active_setting;
 }

--- a/common/firmware/gpio.cpp
+++ b/common/firmware/gpio.cpp
@@ -2,14 +2,17 @@
 
 #include "gpio.h"
 
+__attribute__((section( ".ccmram" )))
 auto gpio::set(const gpio::PinConfig& pc) -> void {
     return gpio_set(pc.port, pc.pin, pc.active_setting);
 }
 
+__attribute__((section( ".ccmram" )))
 auto gpio::reset(const gpio::PinConfig& pc) -> void {
     return gpio_reset(pc.port, pc.pin, pc.active_setting);
 }
 
+__attribute__((section( ".ccmram" )))
 auto gpio::is_set(const gpio::PinConfig& pc) -> bool {
     return gpio_is_set(pc.port, pc.pin, pc.active_setting);
 }

--- a/common/firmware/gpio.cpp
+++ b/common/firmware/gpio.cpp
@@ -2,17 +2,17 @@
 
 #include "gpio.h"
 
-__attribute__((section( ".ccmram" )))
-auto gpio::set(const gpio::PinConfig& pc) -> void {
+__attribute__((section(".ccmram"))) auto gpio::set(const gpio::PinConfig& pc)
+    -> void {
     return gpio_set(pc.port, pc.pin, pc.active_setting);
 }
 
-__attribute__((section( ".ccmram" )))
-auto gpio::reset(const gpio::PinConfig& pc) -> void {
+__attribute__((section(".ccmram"))) auto gpio::reset(const gpio::PinConfig& pc)
+    -> void {
     return gpio_reset(pc.port, pc.pin, pc.active_setting);
 }
 
-__attribute__((section( ".ccmram" )))
-auto gpio::is_set(const gpio::PinConfig& pc) -> bool {
+__attribute__((section(".ccmram"))) auto gpio::is_set(const gpio::PinConfig& pc)
+    -> bool {
     return gpio_is_set(pc.port, pc.pin, pc.active_setting);
 }

--- a/head/firmware/stm32g4xx_it.c
+++ b/head/firmware/stm32g4xx_it.c
@@ -147,6 +147,7 @@ void FDCAN1_IT0_IRQHandler(void) {
 /**
  * @brief This function handles TIM7 global interrupt.
  */
+__attribute__((section(".ccmram")))
 void TIM7_IRQHandler(void) { 
     // We ONLY ever enable the Update interrupt, so for a small efficiency gain
     // we always make the assumption that this interrupt was triggered by the

--- a/head/firmware/stm32g4xx_it.c
+++ b/head/firmware/stm32g4xx_it.c
@@ -48,6 +48,8 @@ DMA_HandleTypeDef hdma_spi1_rx;
 extern TIM_HandleTypeDef htim7;
 extern TIM_HandleTypeDef htim2;
 extern TIM_HandleTypeDef htim3;
+
+extern void motor_callback_glue();
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
 /******************************************************************************/
@@ -145,7 +147,13 @@ void FDCAN1_IT0_IRQHandler(void) {
 /**
  * @brief This function handles TIM7 global interrupt.
  */
-void TIM7_IRQHandler(void) { HAL_TIM_IRQHandler(&htim7); }
+void TIM7_IRQHandler(void) { 
+    // We ONLY ever enable the Update interrupt, so for a small efficiency gain
+    // we always make the assumption that this interrupt was triggered by the
+    // TIM_IT_UPDATE source.
+    __HAL_TIM_CLEAR_IT(&htim7, TIM_IT_UPDATE);
+    motor_callback_glue();
+ }
 
 /**
  * @brief This function handles TIM2 global interrupt.

--- a/motor-control/core/types.cpp
+++ b/motor-control/core/types.cpp
@@ -1,23 +1,22 @@
 #include "motor-control/core/types.hpp"
 
-__attribute__((section( ".ccmram" )))
-auto MotorPositionStatus::set_flag(MotorPositionStatus::Flags flag) -> void {
+__attribute__((section(".ccmram"))) auto MotorPositionStatus::set_flag(
+    MotorPositionStatus::Flags flag) -> void {
     backing.fetch_or(static_cast<uint8_t>(flag));
 }
 
-__attribute__((section( ".ccmram" )))
-auto MotorPositionStatus::clear_flag(MotorPositionStatus::Flags flag) -> void {
+__attribute__((section(".ccmram"))) auto MotorPositionStatus::clear_flag(
+    MotorPositionStatus::Flags flag) -> void {
     backing.fetch_and(~static_cast<uint8_t>(flag));
 }
 
-__attribute__((section( ".ccmram" )))
-[[nodiscard]] auto MotorPositionStatus::check_flag(
-    MotorPositionStatus::Flags flag) const -> bool {
+__attribute__((section(".ccmram"))) [[nodiscard]] auto
+MotorPositionStatus::check_flag(MotorPositionStatus::Flags flag) const -> bool {
     return (backing.load() & static_cast<uint8_t>(flag)) ==
            static_cast<uint8_t>(flag);
 }
 
-__attribute__((section( ".ccmram" )))
-[[nodiscard]] auto MotorPositionStatus::get_flags() const -> uint8_t {
+__attribute__((section(".ccmram"))) [[nodiscard]] auto
+MotorPositionStatus::get_flags() const -> uint8_t {
     return backing.load();
 }

--- a/motor-control/core/types.cpp
+++ b/motor-control/core/types.cpp
@@ -1,19 +1,23 @@
 #include "motor-control/core/types.hpp"
 
+__attribute__((section( ".ccmram" )))
 auto MotorPositionStatus::set_flag(MotorPositionStatus::Flags flag) -> void {
     backing.fetch_or(static_cast<uint8_t>(flag));
 }
 
+__attribute__((section( ".ccmram" )))
 auto MotorPositionStatus::clear_flag(MotorPositionStatus::Flags flag) -> void {
     backing.fetch_and(~static_cast<uint8_t>(flag));
 }
 
+__attribute__((section( ".ccmram" )))
 [[nodiscard]] auto MotorPositionStatus::check_flag(
     MotorPositionStatus::Flags flag) const -> bool {
     return (backing.load() & static_cast<uint8_t>(flag)) ==
            static_cast<uint8_t>(flag);
 }
 
+__attribute__((section( ".ccmram" )))
 [[nodiscard]] auto MotorPositionStatus::get_flags() const -> uint8_t {
     return backing.load();
 }


### PR DESCRIPTION
The motor interrupts are kind of slow. This PR is an attempt to speed them up, especially for the head controller.

* We add a section in the linker script to store function in the STM32 CCMRAM. 
  * This section is configured to grab every function in the `motor_handler` and `motor_hardware` namespaces
* We manually mark a few select functions to go in ccmram along with the specific motor controller stuff
* We add a section in the startup file to copy the ccmram functions from flash to ccmram, because the ccmram is volatile
* We also cut out the STM32 timer interrupt handler for the Head unit's motor control interrupt because it was taking up a lot of time with no real benefit

This seems to speed up the motors enough to let the head move both axes at the same time without crashing, which it couldn't do before. In the absence of any quantitative measurement of the interrupt latency, that feels like enough justification to make this change.
