### PR TITLE
fix(pipettes): don't use more RAM than allowed

### DIFF
--- a/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
+++ b/common/firmware/STM32G491RETx/STM32G491RETx_FLASH.ld
@@ -38,7 +38,7 @@ _Min_Stack_Size = 0x600;	/* required amount of stack */
 MEMORY
 {
   CCMRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 16K
-  RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 112K
+  RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 96K
   ROM    (rx)    : ORIGIN = 0x08008000,   LENGTH = 512K
 }
 

--- a/pipettes/core/can_task_high_throughput.cpp
+++ b/pipettes/core/can_task_high_throughput.cpp
@@ -149,10 +149,10 @@ auto static reader_task =
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask>{
+    freertos_task::FreeRTOSTask<256, can_task::CanMessageReaderTask>{
         reader_task};
 auto static writer_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask>{
+    freertos_task::FreeRTOSTask<256, can_task::CanMessageWriterTask>{
         writer_task};
 
 auto can_task::start_reader(can::bus::CanBus& canbus, can::ids::NodeId id)

--- a/pipettes/core/can_task_low_throughput.cpp
+++ b/pipettes/core/can_task_low_throughput.cpp
@@ -112,10 +112,10 @@ auto static reader_task =
 auto static writer_task = can_task::CanMessageWriterTask{can_sender_queue};
 
 auto static reader_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageReaderTask>{
+    freertos_task::FreeRTOSTask<256, can_task::CanMessageReaderTask>{
         reader_task};
 auto static writer_task_control =
-    freertos_task::FreeRTOSTask<512, can_task::CanMessageWriterTask>{
+    freertos_task::FreeRTOSTask<256, can_task::CanMessageWriterTask>{
         writer_task};
 
 auto can_task::start_reader(can::bus::CanBus& canbus, can::ids::NodeId id)

--- a/pipettes/core/gear_motor_tasks.cpp
+++ b/pipettes/core/gear_motor_tasks.cpp
@@ -13,29 +13,29 @@ static auto right_queue_client = gear_motor_tasks::QueueClient{};
 
 // left gear motor tasks
 static auto mc_task_builder_left = freertos_task::TaskStarter<
-    512, pipettes::tasks::motion_controller_task::MotionControllerTask>{};
+    256, pipettes::tasks::motion_controller_task::MotionControllerTask>{};
 static auto tmc2160_driver_task_builder_left =
-    freertos_task::TaskStarter<512, tmc2160::tasks::gear::MotorDriverTask>{};
+    freertos_task::TaskStarter<256, tmc2160::tasks::gear::MotorDriverTask>{};
 
 static auto move_group_task_builder_left = freertos_task::TaskStarter<
-    512, pipettes::tasks::move_group_task::MoveGroupTask>{};
+    256, pipettes::tasks::move_group_task::MoveGroupTask>{};
 static auto move_status_task_builder_left = freertos_task::TaskStarter<
-    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
+    256, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
 static auto right_usage_storage_task_builder =
-    freertos_task::TaskStarter<512, usage_storage_task::UsageStorageTask>{};
+    freertos_task::TaskStarter<256, usage_storage_task::UsageStorageTask>{};
 
 // right gear motor tasks
 static auto mc_task_builder_right = freertos_task::TaskStarter<
-    512, pipettes::tasks::motion_controller_task::MotionControllerTask>{};
+    256, pipettes::tasks::motion_controller_task::MotionControllerTask>{};
 static auto tmc2160_driver_task_builder_right =
-    freertos_task::TaskStarter<512, tmc2160::tasks::gear::MotorDriverTask>{};
+    freertos_task::TaskStarter<256, tmc2160::tasks::gear::MotorDriverTask>{};
 
 static auto move_group_task_builder_right = freertos_task::TaskStarter<
-    512, pipettes::tasks::move_group_task::MoveGroupTask>{};
+    256, pipettes::tasks::move_group_task::MoveGroupTask>{};
 static auto move_status_task_builder_right = freertos_task::TaskStarter<
-    512, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
+    256, pipettes::tasks::gear_move_status::MoveStatusReporterTask>{};
 static auto left_usage_storage_task_builder =
-    freertos_task::TaskStarter<512, usage_storage_task::UsageStorageTask>{};
+    freertos_task::TaskStarter<256, usage_storage_task::UsageStorageTask>{};
 
 void gear_motor_tasks::start_tasks(
     gear_motor_tasks::CanWriterTask& can_writer,

--- a/pipettes/core/linear_motor_tasks.cpp
+++ b/pipettes/core/linear_motor_tasks.cpp
@@ -16,20 +16,20 @@ static auto tmc2160_queue_client =
     linear_motor_tasks::tmc2160_driver::QueueClient{};
 
 static auto mc_task_builder =
-    freertos_task::TaskStarter<512,
+    freertos_task::TaskStarter<256,
                                motion_controller_task::MotionControllerTask>{};
 static auto tmc2130_driver_task_builder =
-    freertos_task::TaskStarter<512, tmc2130::tasks::MotorDriverTask>{};
+    freertos_task::TaskStarter<256, tmc2130::tasks::MotorDriverTask>{};
 static auto tmc2160_driver_task_builder =
-    freertos_task::TaskStarter<512, tmc2160::tasks::MotorDriverTask>{};
+    freertos_task::TaskStarter<256, tmc2160::tasks::MotorDriverTask>{};
 static auto move_group_task_builder =
-    freertos_task::TaskStarter<512, move_group_task::MoveGroupTask>{};
+    freertos_task::TaskStarter<256, move_group_task::MoveGroupTask>{};
 static auto move_status_task_builder = freertos_task::TaskStarter<
-    512, move_status_reporter_task::MoveStatusReporterTask>{};
+    256, move_status_reporter_task::MoveStatusReporterTask>{};
 static auto linear_usage_storage_task_builder =
-    freertos_task::TaskStarter<512, usage_storage_task::UsageStorageTask>{};
+    freertos_task::TaskStarter<256, usage_storage_task::UsageStorageTask>{};
 static auto eeprom_data_rev_update_builder =
-    freertos_task::TaskStarter<512, eeprom::data_rev_task::UpdateDataRevTask>{};
+    freertos_task::TaskStarter<256, eeprom::data_rev_task::UpdateDataRevTask>{};
 
 void linear_motor_tasks::start_tasks(
     linear_motor_tasks::CanWriterTask& can_writer,

--- a/pipettes/core/peripheral_tasks.cpp
+++ b/pipettes/core/peripheral_tasks.cpp
@@ -11,17 +11,17 @@ static auto i2c3_task_client =
     i2c::writer::Writer<freertos_message_queue::FreeRTOSMessageQueue>();
 
 static auto i2c1_task_builder =
-    freertos_task::TaskStarter<512, i2c::tasks::I2CTask>{};
+    freertos_task::TaskStarter<256, i2c::tasks::I2CTask>{};
 static auto i2c3_task_builder =
-    freertos_task::TaskStarter<512, i2c::tasks::I2CTask>{};
+    freertos_task::TaskStarter<256, i2c::tasks::I2CTask>{};
 template <template <typename> typename QueueImpl>
 using PollerWithTimer =
     i2c::tasks::I2CPollerTask<QueueImpl, freertos_timer::FreeRTOSTimer>;
 
 static auto i2c1_poll_task_builder =
-    freertos_task::TaskStarter<1024, PollerWithTimer>{};
+    freertos_task::TaskStarter<512, PollerWithTimer>{};
 static auto i2c3_poll_task_builder =
-    freertos_task::TaskStarter<1024, PollerWithTimer>{};
+    freertos_task::TaskStarter<512, PollerWithTimer>{};
 static auto i2c1_poll_client =
     i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>{};
 static auto i2c3_poll_client =
@@ -31,7 +31,7 @@ static auto spi_task_client =
     spi::writer::Writer<freertos_message_queue::FreeRTOSMessageQueue>();
 
 static auto spi_task_builder =
-    freertos_task::TaskStarter<512, spi::tasks::Task>{};
+    freertos_task::TaskStarter<256, spi::tasks::Task>{};
 
 void peripheral_tasks::start_tasks(i2c::hardware::I2CBase& i2c3_interface,
                                    i2c::hardware::I2CBase& i2c1_interface,

--- a/pipettes/core/peripheral_tasks.cpp
+++ b/pipettes/core/peripheral_tasks.cpp
@@ -19,9 +19,9 @@ using PollerWithTimer =
     i2c::tasks::I2CPollerTask<QueueImpl, freertos_timer::FreeRTOSTimer>;
 
 static auto i2c1_poll_task_builder =
-    freertos_task::TaskStarter<512, PollerWithTimer>{};
+    freertos_task::TaskStarter<1024, PollerWithTimer>{};
 static auto i2c3_poll_task_builder =
-    freertos_task::TaskStarter<512, PollerWithTimer>{};
+    freertos_task::TaskStarter<1024, PollerWithTimer>{};
 static auto i2c1_poll_client =
     i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>{};
 static auto i2c3_poll_client =

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -8,30 +8,30 @@ static auto tasks = sensor_tasks::Tasks{};
 static auto queue_client = sensor_tasks::QueueClient{};
 
 static auto eeprom_task_builder =
-    freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
+    freertos_task::TaskStarter<256, eeprom::task::EEPromTask>{};
 
 static auto environment_sensor_task_builder =
-    freertos_task::TaskStarter<512, sensors::tasks::EnvironmentSensorTask,
+    freertos_task::TaskStarter<256, sensors::tasks::EnvironmentSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto capacitive_sensor_task_builder_rear =
-    freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
+    freertos_task::TaskStarter<256, sensors::tasks::CapacitiveSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto capacitive_sensor_task_builder_front =
-    freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
+    freertos_task::TaskStarter<256, sensors::tasks::CapacitiveSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto pressure_sensor_task_builder_rear =
-    freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,
+    freertos_task::TaskStarter<256, sensors::tasks::PressureSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto pressure_sensor_task_builder_front =
-    freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,
+    freertos_task::TaskStarter<256, sensors::tasks::PressureSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S1);
 
 static auto tip_notification_task_builder_front =
-    freertos_task::TaskStarter<512,
+    freertos_task::TaskStarter<256,
                                sensors::tasks::TipPresenceNotificationTask>{};
 
 void sensor_tasks::start_tasks(


### PR DESCRIPTION
The linker file provided by STM is correct to say that the microcontroller has 112K RAM, but it _also_ separately defines the last 16K of that as the `CCMRAM` region. This means that, if the entire RAM is used by the program, variables will overlap into anything defined in ccmram and chaos will ensue.

The pipette firmware was all overflowing into ccmram, which the linker didn't complain about because it is unaware that the ccmram is aliased at the end of the normal SRAM address region.

The pipettes _also_ have a lot of tasks, and each of those tasks has a minimum stack size of 512 words (so 2048 bytes). This PR cuts all of the stack allocations in half.

Tested on a multichannel and a 96-channel. Able to calibrate, aspirate, dispense, pick up tips... seems good to go.

