### PR TITLE
fix(scripts): accept multi-digit version tags

### DIFF
--- a/scripts/subsystem_versions.py
+++ b/scripts/subsystem_versions.py
@@ -8,7 +8,7 @@ import subprocess
 import os
 from itertools import chain
 
-VERSION_REGEX = re.compile("v([0-9])")
+VERSION_REGEX = re.compile("v([0-9]+)")
 SUBSYSTEMS = [
     "head",
     "gantry-x",


### PR DESCRIPTION
The regex for matching the version tag when generating the manifest was only matching the first digit. This PR lets it match multiple digits.