### PR TITLE
fix(host): comment out .ccmram section for host builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ if (${CMAKE_CROSSCOMPILING})
     find_package(CrossGCC)
     find_package(OpenOCD)
 
+    add_compile_definitions(ENABLE_CCMRAM)
+
     configure_file(common/firmware/platform_specific_hal_conf.h.in ${CMAKE_BINARY_DIR}/generated/platform_specific_hal_conf.h)
     configure_file(common/firmware/platform_specific_hal.h.in ${CMAKE_BINARY_DIR}/generated/platform_specific_hal.h)
 

--- a/common/firmware/gpio.c
+++ b/common/firmware/gpio.c
@@ -2,7 +2,9 @@
 #include "platform_specific_hal.h"
 #include <stdbool.h>
 
+#ifdef ENABLE_CCMRAM
 __attribute__((section( ".ccmram" )))
+#endif
 void gpio_set(void* port, uint16_t pin, uint8_t active_setting) {
     if (!port) {
         return;
@@ -10,7 +12,9 @@ void gpio_set(void* port, uint16_t pin, uint8_t active_setting) {
     HAL_GPIO_WritePin(port, pin, active_setting);
 }
 
+#ifdef ENABLE_CCMRAM
 __attribute__((section( ".ccmram" )))
+#endif
 static uint8_t invert_gpio_value(uint8_t setting) {
     switch (setting) {
         case GPIO_PIN_SET:
@@ -22,7 +26,9 @@ static uint8_t invert_gpio_value(uint8_t setting) {
     }
 }
 
+#ifdef ENABLE_CCMRAM
 __attribute__((section( ".ccmram" )))
+#endif
 void gpio_reset(void* port, uint16_t pin,
                 uint8_t active_setting) {
     if (!port) {
@@ -31,7 +37,9 @@ void gpio_reset(void* port, uint16_t pin,
     HAL_GPIO_WritePin(port, pin, invert_gpio_value(active_setting));
 }
 
+#ifdef ENABLE_CCMRAM
 __attribute__((section( ".ccmram" )))
+#endif
 bool gpio_is_set(void* port, uint16_t pin, uint8_t active_setting) {
     return HAL_GPIO_ReadPin(port, pin) == active_setting;
 }

--- a/common/firmware/gpio.cpp
+++ b/common/firmware/gpio.cpp
@@ -2,17 +2,26 @@
 
 #include "gpio.h"
 
-__attribute__((section(".ccmram"))) auto gpio::set(const gpio::PinConfig& pc)
+#ifdef ENABLE_CCMRAM
+__attribute__((section( ".ccmram" )))
+#endif
+auto gpio::set(const gpio::PinConfig& pc)
     -> void {
     return gpio_set(pc.port, pc.pin, pc.active_setting);
 }
 
-__attribute__((section(".ccmram"))) auto gpio::reset(const gpio::PinConfig& pc)
+#ifdef ENABLE_CCMRAM
+__attribute__((section( ".ccmram" )))
+#endif
+auto gpio::reset(const gpio::PinConfig& pc)
     -> void {
     return gpio_reset(pc.port, pc.pin, pc.active_setting);
 }
 
-__attribute__((section(".ccmram"))) auto gpio::is_set(const gpio::PinConfig& pc)
+#ifdef ENABLE_CCMRAM
+__attribute__((section( ".ccmram" )))
+#endif
+auto gpio::is_set(const gpio::PinConfig& pc)
     -> bool {
     return gpio_is_set(pc.port, pc.pin, pc.active_setting);
 }

--- a/head/firmware/stm32g4xx_it.c
+++ b/head/firmware/stm32g4xx_it.c
@@ -147,7 +147,9 @@ void FDCAN1_IT0_IRQHandler(void) {
 /**
  * @brief This function handles TIM7 global interrupt.
  */
-__attribute__((section(".ccmram")))
+#ifdef ENABLE_CCMRAM
+__attribute__((section( ".ccmram" )))
+#endif
 void TIM7_IRQHandler(void) { 
     // We ONLY ever enable the Update interrupt, so for a small efficiency gain
     // we always make the assumption that this interrupt was triggered by the

--- a/motor-control/core/types.cpp
+++ b/motor-control/core/types.cpp
@@ -1,22 +1,34 @@
 #include "motor-control/core/types.hpp"
 
-__attribute__((section(".ccmram"))) auto MotorPositionStatus::set_flag(
+#ifdef ENABLE_CCMRAM
+__attribute__((section( ".ccmram" )))
+#endif
+auto MotorPositionStatus::set_flag(
     MotorPositionStatus::Flags flag) -> void {
     backing.fetch_or(static_cast<uint8_t>(flag));
 }
 
-__attribute__((section(".ccmram"))) auto MotorPositionStatus::clear_flag(
+#ifdef ENABLE_CCMRAM
+__attribute__((section( ".ccmram" )))
+#endif
+auto MotorPositionStatus::clear_flag(
     MotorPositionStatus::Flags flag) -> void {
     backing.fetch_and(~static_cast<uint8_t>(flag));
 }
 
-__attribute__((section(".ccmram"))) [[nodiscard]] auto
+#ifdef ENABLE_CCMRAM
+__attribute__((section(".ccmram")))
+#endif
+[[nodiscard]] auto
 MotorPositionStatus::check_flag(MotorPositionStatus::Flags flag) const -> bool {
     return (backing.load() & static_cast<uint8_t>(flag)) ==
            static_cast<uint8_t>(flag);
 }
 
-__attribute__((section(".ccmram"))) [[nodiscard]] auto
+#ifdef ENABLE_CCMRAM
+__attribute__((section(".ccmram")))
+#endif
+[[nodiscard]] auto
 MotorPositionStatus::get_flags() const -> uint8_t {
     return backing.load();
 }


### PR DESCRIPTION
If your host compiler is GCC, the .ccmram section attributes won't do anything because GCC silently ignores missing sections (whether that's good or bad is up for debate). If your host compiler is _not_ GCC, you might get compiler errors. This PR should eliminate those errors.