### PR TITLE
feat(motor-control): report stepper & encoder position when stall occurs

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -409,13 +409,13 @@ class MotorInterruptHandler {
         if (has_active_move) {
             message_index = buffered_move.message_index;
         }
-        if (err_code == can::ids::ErrorCode::collision_detected) {
-            build_and_send_ack(AckMessageId::position_error);
-        }
         status_queue_client.send_move_status_reporter_queue(
             can::messages::ErrorMessage{.message_index = message_index,
                                         .severity = severity,
                                         .error_code = err_code});
+        if (err_code == can::ids::ErrorCode::collision_detected) {
+            build_and_send_ack(AckMessageId::position_error);
+        }
         status_queue_client.send_move_status_reporter_queue(
             usage_messages::IncreaseErrorCount{
                 .key =

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -61,20 +61,20 @@ SCENARIO("motor handler stall detection") {
             THEN("the stall is detected") {
                 REQUIRE(!test_objs.hw.position_flags.check_flag(
                     Flags::stepper_position_ok));
-                THEN("a move complete with position error ack is sent") {
-                    Ack ack_msg = std::get<Ack>(test_objs.reporter.messages[0]);
-                    REQUIRE(ack_msg.ack_id == AckMessageId::position_error);
-                    REQUIRE(ack_msg.message_index == 101);
-
-                    THEN("a unrecoverable collision error is raised") {
-                        can::messages::ErrorMessage err =
-                            std::get<can::messages::ErrorMessage>(
-                                test_objs.reporter.messages[1]);
-                        REQUIRE(err.message_index == 101);
-                        REQUIRE(err.error_code ==
-                                can::ids::ErrorCode::collision_detected);
-                        REQUIRE(err.severity ==
-                                can::ids::ErrorSeverity::unrecoverable);
+                THEN("a unrecoverable collision error is raised") {
+                    can::messages::ErrorMessage err =
+                        std::get<can::messages::ErrorMessage>(
+                            test_objs.reporter.messages[0]);
+                    REQUIRE(err.message_index == 101);
+                    REQUIRE(err.error_code ==
+                            can::ids::ErrorCode::collision_detected);
+                    REQUIRE(err.severity ==
+                            can::ids::ErrorSeverity::unrecoverable);
+                    THEN("a move complete with position error ack is sent") {
+                        Ack ack_msg =
+                            std::get<Ack>(test_objs.reporter.messages[1]);
+                        REQUIRE(ack_msg.ack_id == AckMessageId::position_error);
+                        REQUIRE(ack_msg.message_index == 101);
                         usage_messages::IncreaseErrorCount inc_error_count =
                             std::get<usage_messages::IncreaseErrorCount>(
                                 test_objs.reporter.messages[2]);


### PR DESCRIPTION
Send a MoveComplete message, on top of the error message, to report current stepper & encoder position when a stall happens during an active move.