### PR TITLE
feat(gripper): Use ccram for gripper

### DIFF
--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -177,6 +177,7 @@ void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim) {
     }
 }
 
+__attribute__((section(".ccmram")))
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim) {
     // Check which version of the timer triggered this callback
     if (htim == &htim7 && timer_callback) {

--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -65,7 +65,7 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM4_CLK_ENABLE();
         /* TIM4 interrupt Init */
-        HAL_NVIC_SetPriority(TIM4_IRQn, 6, 0);
+        HAL_NVIC_SetPriority(TIM4_IRQn, 7, 0);
         HAL_NVIC_EnableIRQ(TIM4_IRQn);
 
     } else if (htim == &htim15) {

--- a/gripper/firmware/stm32g4xx_it.c
+++ b/gripper/firmware/stm32g4xx_it.c
@@ -56,6 +56,9 @@ extern TIM_HandleTypeDef htim4;
 extern TIM_HandleTypeDef htim8;
 extern TIM_HandleTypeDef htim15;
 
+extern void call_brushed_motor_handler();
+extern void call_motor_handler();
+
 /******************************************************************************/
 /*            Cortex-M4 Processor Exceptions Handlers                         */
 /******************************************************************************/
@@ -146,7 +149,14 @@ void FDCAN1_IT0_IRQHandler(void) {
  * @brief This function handles TIM1 update interrupt and TIM16 global
  * interrupt.
  */
-void TIM1_UP_TIM16_IRQHandler(void) { HAL_TIM_IRQHandler(&htim1); }
+ __attribute__((section(".ccmram")))
+void TIM1_UP_TIM16_IRQHandler(void) {
+    // We ONLY ever enable the Update interrupt, so for a small efficiency gain
+    // we always make the assumption that this interrupt was triggered by the
+    // TIM_IT_UPDATE source.
+    __HAL_TIM_CLEAR_IT(&htim1, TIM_IT_UPDATE);
+    call_brushed_motor_handler();
+ }
 
 /**
  * @brief This function handles TIM1 capture/compare interrupt.
@@ -169,7 +179,14 @@ void TIM8_UP_IRQHandler(void) { HAL_TIM_IRQHandler(&htim8); }
 /**
  * @brief This function handles TIM7 global interrupt.
  */
-void TIM7_IRQHandler(void) { HAL_TIM_IRQHandler(&htim7); }
+__attribute__((section(".ccmram")))
+void TIM7_IRQHandler(void) {
+    // We ONLY ever enable the Update interrupt, so for a small efficiency gain
+    // we always make the assumption that this interrupt was triggered by the
+    // TIM_IT_UPDATE source.
+    __HAL_TIM_CLEAR_IT(&htim7, TIM_IT_UPDATE);
+    call_motor_handler();
+}
 
 extern void xPortSysTickHandler(void);
 void SysTick_Handler(void) {

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -50,7 +50,9 @@ class MotionController {
             .seq_id = can_msg.seq_id,
             .stop_condition = MoveStopCondition::none,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
-        enable_motor();
+        if (!enabled) {
+            enable_motor();
+        }
         queue.try_write(msg);
     }
 

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -159,9 +159,9 @@ class BrushedMotorInterruptHandler {
         } else if (motor_state == ControlState::FORCE_CONTROLLING ||
                    motor_state == ControlState::FORCE_CONTROLLING_HOME) {
             auto pulses = hardware.get_encoder_pulses();
-            if (!is_idle && pulses >= 0 && std::abs(pulses -
-                                     hold_encoder_position) >
-                                error_conf.unwanted_movement_threshold) {
+            if (!is_idle && pulses >= 0 &&
+                std::abs(pulses - hold_encoder_position) >
+                    error_conf.unwanted_movement_threshold) {
                 // we have likely dropped a labware or had a collision
                 auto err = motor_state == ControlState::FORCE_CONTROLLING
                                ? can::ids::ErrorCode::labware_dropped

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -158,7 +158,8 @@ class BrushedMotorInterruptHandler {
             }
         } else if (motor_state == ControlState::FORCE_CONTROLLING ||
                    motor_state == ControlState::FORCE_CONTROLLING_HOME) {
-            if (!is_idle && std::abs(hardware.get_encoder_pulses() -
+            auto pulses = hardware.get_encoder_pulses();
+            if (!is_idle && pulses >= 0 && std::abs(pulses -
                                      hold_encoder_position) >
                                 error_conf.unwanted_movement_threshold) {
                 // we have likely dropped a labware or had a collision


### PR DESCRIPTION
So before putting the gripper interrupts in ccram we were getting encoder overflow timing errors on the gripper jaw pretty frequently (~10 min of constant use) after doing the ccram stuff we drastically reduced the errors but it was still happening on avg every ~1.5 hours of constant use. So this throws the interrupts into ccram, and it also drops the priority of the motor usage timer to prevent it squashing over the interrupts.

As a final kind of guard against the encoder being -0xFFFF occasionally I threw in a check that the encoder is >=0 before reporting a stall