### PR TITLE
fix(include): pressure-sensor max-value

### DIFF
--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -31,7 +31,7 @@ constexpr uint16_t ADDRESS = 0x67 << 1;
 
 // The pressure range is approximately 3922.0F. We shouldn't
 // need to ever exceed this value.
-constexpr float MAX_PRESSURE_READING = 3922.0F;
+constexpr float MAX_PRESSURE_READING = 392.2F;  // FIXME: 3922.0F
 
 enum class SensorStatus : uint8_t {
     SHUTDOWN = 0x0,

--- a/include/sensors/core/mmr920C04.hpp
+++ b/include/sensors/core/mmr920C04.hpp
@@ -29,9 +29,8 @@ namespace sensors {
 namespace mmr920C04 {
 constexpr uint16_t ADDRESS = 0x67 << 1;
 
-// The pressure range is approximately 3922.0F. We shouldn't
-// need to ever exceed this value.
-constexpr float MAX_PRESSURE_READING = 392.2F;  // FIXME: 3922.0F
+// Pressure cannot be measured beyond +/-8226.4F
+constexpr float MAX_PRESSURE_READING = 8226.4F;
 
 enum class SensorStatus : uint8_t {
     SHUTDOWN = 0x0,


### PR DESCRIPTION
This PR sets the pressure sensor's max value to 8.2kPa, which is the highest value possibly returned by the pressure sensor. Anything higher cannot be measured and will return as 8.2kPa.