### PR TITLE
fix(pipettes): Convert back to EXTI for single and multi

### DIFF
--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -119,14 +119,11 @@ void DebugMon_Handler(void) {}
 /******************************************************************************/
 
 void EXTI2_IRQHandler(void) {
-    __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_2);
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
 }
 
 void EXTI9_5_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_7)) {
-        // clear pending
-        __HAL_GPIO_EXTI_CLEAR_FLAG(GPIO_PIN_7);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_7); 
     }
 }
@@ -134,7 +131,6 @@ void EXTI9_5_IRQHandler(void) {
 
 void EXTI15_10_IRQHandler(void) {
     if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_12)) {
-        __HAL_GPIO_EXTI_CLEAR_FLAG(GPIO_PIN_12);
         HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_12);
     }
 }

--- a/pipettes/firmware/stm32g4xx_it.c
+++ b/pipettes/firmware/stm32g4xx_it.c
@@ -119,7 +119,7 @@ void DebugMon_Handler(void) {}
 /******************************************************************************/
 
 void EXTI2_IRQHandler(void) {
-    __HAL_GPIO_EXTI_CLEAR_FLAG(GPIO_PIN_2);
+    __HAL_GPIO_EXTI_CLEAR_FLAG(EXTI_LINE_2);
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_2);
 }
 


### PR DESCRIPTION
## Overview

So, very confused and not sure if we also need to make this change for the 96 channel, BUT switching back only the clear flag to the EXTI value seems to fix the async notifications for tip sensing.