### PR TITLE
fix(pipettes): increase sensor stack sizes

### DIFF
--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -8,26 +8,26 @@ static auto tasks = sensor_tasks::Tasks{};
 static auto queue_client = sensor_tasks::QueueClient{};
 
 static auto eeprom_task_builder =
-    freertos_task::TaskStarter<256, eeprom::task::EEPromTask>{};
+    freertos_task::TaskStarter<512, eeprom::task::EEPromTask>{};
 
 static auto environment_sensor_task_builder =
-    freertos_task::TaskStarter<256, sensors::tasks::EnvironmentSensorTask,
+    freertos_task::TaskStarter<512, sensors::tasks::EnvironmentSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto capacitive_sensor_task_builder_rear =
-    freertos_task::TaskStarter<256, sensors::tasks::CapacitiveSensorTask,
+    freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto capacitive_sensor_task_builder_front =
-    freertos_task::TaskStarter<256, sensors::tasks::CapacitiveSensorTask,
+    freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto pressure_sensor_task_builder_rear =
-    freertos_task::TaskStarter<256, sensors::tasks::PressureSensorTask,
+    freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S0);
 
 static auto pressure_sensor_task_builder_front =
-    freertos_task::TaskStarter<256, sensors::tasks::PressureSensorTask,
+    freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,
                                can::ids::SensorId>(can::ids::SensorId::S1);
 
 static auto tip_notification_task_builder_front =

--- a/pipettes/firmware/freertos_idle_timer_task.cpp
+++ b/pipettes/firmware/freertos_idle_timer_task.cpp
@@ -40,3 +40,15 @@ extern "C" void vApplicationGetTimerTaskMemory(
     *ppxTimerTaskStackBuffer = idle_timer_stack.data();
     *pulTimerTaskStackSize = idle_timer_stack.size();
 }
+
+// We are matching the definition of this function in FreeRTOS, and thus
+// keep the function signature the same
+extern "C" void vApplicationStackOverflowHook(
+    TaskHandle_t xTask,
+    // NOLINTNEXTLINE(readability-non-const-parameter)
+    signed char *pcTaskName) {
+    static_cast<void>(xTask);
+    static_cast<void>(pcTaskName);
+    // Lock the processor forever
+    configASSERT(0);
+}


### PR DESCRIPTION
I got a little too trigger happy with #682 with the sensor tasks. Some pipettes have been crashing when using the environmental or pressure sensors, and running one with a debugger + overflow detection enabled showed that the stack for the sensor task will overflow sometimes. The sensor tasks use their stack to maintain a parallel map of the register map of their respective sensor, so it kind of makes sense. We could (and maybe should) refactor the handlers to be statically allocated somehow to avoid throwing too much data on the stack, but for now we can just bump the stacks back up.

