### PR TITLE
fix(motor-control): do not disable encoder after homing

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -300,7 +300,6 @@ class MotorInterruptHandler {
                 hardware.get_encoder_pulses();
             hardware.reset_step_tracker();
             hardware.reset_encoder_pulses();
-            hardware.disable_encoder();
 
             stall_checker.reset_itr_counts(0);
             hardware.position_flags.set_flag(

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -21,7 +21,7 @@ bool motor_hardware_set_dac_value(void* dac_handle, uint32_t channel,
 bool motor_hardware_start_pwm(void* tim_handle, uint32_t channel);
 bool motor_hardware_stop_pwm(void* tim_handle, uint32_t channel);
 int32_t motor_hardware_encoder_pulse_count(void* encoder_handle);
-void motor_hardware_reset_encoder_count(void* encoder_handle);
+void motor_hardware_reset_encoder_count(void* encoder_handle, uint16_t reset_value);
 uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear);
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -71,6 +71,7 @@ class MotorHardware : public StepperMotorHardwareIface {
     debouncer::Debouncer estop = debouncer::Debouncer{};
     debouncer::Debouncer limit = debouncer::Debouncer{};
     debouncer::Debouncer sync = debouncer::Debouncer{};
+    static constexpr uint16_t encoder_reset_offset = 20;
     HardwareConfig pins;
     void* tim_handle;
     void* enc_handle;

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -77,7 +77,7 @@ void BrushedMotorHardware::reset_encoder_pulses() {
     if (!enc_handle) {
         return;
     }
-    motor_hardware_reset_encoder_count(enc_handle);
+    motor_hardware_reset_encoder_count(enc_handle, 0);
     motor_encoder_overflow_count = 0;
 }
 

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -106,9 +106,9 @@ int32_t motor_hardware_encoder_pulse_count(void* enc_htim) {
     return pulses;
 }
 
-void motor_hardware_reset_encoder_count(void* enc_htim) {
+void motor_hardware_reset_encoder_count(void* enc_htim, uint16_t reset_value) {
     __HAL_TIM_CLEAR_FLAG((TIM_HandleTypeDef*)enc_htim, TIM_FLAG_UPDATE);
-    __HAL_TIM_SET_COUNTER((TIM_HandleTypeDef*)enc_htim, 0);
+    __HAL_TIM_SET_COUNTER((TIM_HandleTypeDef*)enc_htim, reset_value);
 }
 
 uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear) {

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -64,14 +64,15 @@ int32_t MotorHardware::get_encoder_pulses() {
         return 0;
     }
     return (motor_encoder_overflow_count << 16) +
-           motor_hardware_encoder_pulse_count(enc_handle);
+           motor_hardware_encoder_pulse_count(enc_handle) -
+           static_cast<int32_t>(encoder_reset_offset);
 }
 
 void MotorHardware::reset_encoder_pulses() {
     if (!enc_handle) {
         return;
     }
-    motor_hardware_reset_encoder_count(enc_handle);
+    motor_hardware_reset_encoder_count(enc_handle, encoder_reset_offset);
     motor_encoder_overflow_count = 0;
 }
 


### PR DESCRIPTION
We really don't want the encoder to be disabled at any point because we want the motor controllers to be able to track any movements that happen while they're disabled. The encoder was originally disabled in order to deal with underflows after homing - this is seemingly due to the encoder being reset to 0 while there is some residual vibration on the motor shaft, resulting in the encoder ticking in the negative direction and underflowing the timer.

This PR changes the motor controllers to reset the encoder to a nonzero value, and does not disable the encoder after home movements.