### PR TITLE
feat(i2c): interrupt-based I2C communication

### DIFF
--- a/gantry/firmware/i2c_setup.c
+++ b/gantry/firmware/i2c_setup.c
@@ -30,6 +30,10 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
         &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     __HAL_RCC_I2C2_CLK_ENABLE();
+    HAL_NVIC_SetPriority(I2C2_EV_IRQn, 7, 0);
+    HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
+    HAL_NVIC_SetPriority(I2C2_ER_IRQn, 7, 0);
+    HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
 }
 
 HAL_I2C_HANDLE MX_I2C2_Init() {
@@ -94,4 +98,14 @@ void i2c_setup(I2CHandlerStruct* i2c_handles) {
 
     // write protect the eeprom.
     disable_eeprom_write();
+}
+
+void I2C2_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&hi2c2);
+}
+
+void I2C2_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&hi2c2);
 }

--- a/gripper/firmware/i2c_setup.c
+++ b/gripper/firmware/i2c_setup.c
@@ -31,6 +31,11 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
             GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
             &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
         __HAL_RCC_I2C2_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C2_EV_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C2_ER_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
     }
 
     if (hi2c->Instance == I2C3) {
@@ -45,6 +50,11 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
             GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
             &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
         __HAL_RCC_I2C3_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C3_EV_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C3_ER_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C3_ER_IRQn);
     }
 }
 
@@ -140,4 +150,24 @@ void i2c_setup(I2CHandlerStruct* i2c_handles) {
 
     // write protect the eeprom.
     disable_eeprom_write();
+}
+
+void I2C2_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&hi2c2);
+}
+
+void I2C2_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&hi2c2);
+}
+
+void I2C3_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&hi2c3);
+}
+
+void I2C3_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&hi2c3);
 }

--- a/head/firmware/i2c_setup.c
+++ b/head/firmware/i2c_setup.c
@@ -30,6 +30,11 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
         &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     __HAL_RCC_I2C3_CLK_ENABLE();
+
+    HAL_NVIC_SetPriority(I2C3_EV_IRQn, 7, 0);
+    HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+    HAL_NVIC_SetPriority(I2C3_ER_IRQn, 7, 0);
+    HAL_NVIC_EnableIRQ(I2C3_ER_IRQn);
 }
 
 HAL_I2C_HANDLE MX_I2C2_Init() {
@@ -94,4 +99,14 @@ void i2c_setup(I2CHandlerStruct* i2c_handles) {
 
     // write protect the eeprom.
     disable_eeprom_write();
+}
+
+void I2C3_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&hi2c3);
+}
+
+void I2C3_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&hi2c3);
 }

--- a/i2c/firmware/i2c.c
+++ b/i2c/firmware/i2c.c
@@ -2,21 +2,112 @@
 #include "platform_specific_hal.h"
 #include "i2c/firmware/i2c.h"
 
+#include <stdint.h>
+#include "FreeRTOS.h"
+#include "task.h"
+
+#define MAX_I2C_HANDLES (3)
+
+typedef struct {
+    I2C_HandleTypeDef *i2c_handle;
+    TaskHandle_t task_to_notify;
+} NotificationHandle_t;
+
+static NotificationHandle_t _notification_handles[MAX_I2C_HANDLES];
+
+static bool _initialized = false;
+
+/**
+ * @brief Get the notification handle based on the HAL I2C struct.
+ * Returns NULL if the handle is not found.
+ */
+static NotificationHandle_t* lookup_handle(I2C_HandleTypeDef *i2c_handle) {
+    for(size_t i = 0; i < MAX_I2C_HANDLES; ++i) {
+        if(_notification_handles[i].i2c_handle == i2c_handle) {
+            return &_notification_handles[i];
+        }
+    }
+    return NULL;
+}
+
+static void initialize_notification_handles() {
+    if(!_initialized) {
+        for(size_t i = 0; i < MAX_I2C_HANDLES; ++i) {
+            _notification_handles[i].i2c_handle = NULL;
+            _notification_handles[i].task_to_notify = NULL;
+        }
+        _initialized = true;
+    }
+}
+
+/**
+ * @brief Common handler for all I2C callbacks.
+ */
+static void handle_i2c_callback(I2C_HandleTypeDef *i2c_handle) {
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    NotificationHandle_t *instance = lookup_handle(i2c_handle);
+    if(instance == NULL) {
+        return;
+    }
+    if(instance->task_to_notify == NULL) {
+        return;
+    }
+
+    vTaskNotifyGiveFromISR(instance->task_to_notify, 
+                            &xHigherPriorityTaskWoken);
+    instance->task_to_notify = NULL;
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+bool i2c_register_handle(HAL_I2C_HANDLE handle) {
+    initialize_notification_handles();
+
+    I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)handle;
+    NotificationHandle_t *notif_handle = lookup_handle(i2c_handle);
+    if(notif_handle != NULL) {
+        // Already registered
+        return true;
+    }
+
+    // Now find an empty slot
+    notif_handle = lookup_handle(NULL);
+    if(notif_handle == NULL) {
+        // No empty slots
+        return false;
+    }
+    notif_handle->i2c_handle = i2c_handle;
+    return true;
+
+}
+
 
 /**
  * Wrapper around HAL_I2C_Master_Transmit
  */
 bool hal_i2c_master_transmit(HAL_I2C_HANDLE handle, uint16_t DevAddress, uint8_t *data, uint16_t size, uint32_t timeout)
 {
+    uint32_t notification_val = 0;
     I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)handle;
+    NotificationHandle_t *notification_handle = lookup_handle(i2c_handle);
+
+    if(notification_handle == NULL) {
+        return false;
+    }
+
     uint32_t tickstart = HAL_GetTick();
     HAL_StatusTypeDef tx_result = HAL_OK;
     do {
-        tx_result = HAL_I2C_Master_Transmit(i2c_handle,
-                            DevAddress, data, size, timeout);
+        notification_handle->task_to_notify = xTaskGetCurrentTaskHandle();
+        tx_result = HAL_I2C_Master_Transmit_IT(i2c_handle,
+                            DevAddress, data, size);
+        notification_val = ulTaskNotifyTake(pdTRUE, timeout); // Wait for callback
         if (__HAL_I2C_GET_FLAG(i2c_handle, I2C_FLAG_AF)) {
             __HAL_I2C_CLEAR_FLAG(i2c_handle, I2C_FLAG_AF);
             tx_result = HAL_BUSY;
+        }
+        if(notification_val != 1) {
+            // Interrupt never fired
+            tx_result = HAL_TIMEOUT;
         }
         if (tx_result == HAL_OK) {
             break;
@@ -29,19 +120,53 @@ bool hal_i2c_master_transmit(HAL_I2C_HANDLE handle, uint16_t DevAddress, uint8_t
  * Wrapper around HAL_I2C_Master_Receive
  */
 bool hal_i2c_master_receive(HAL_I2C_HANDLE handle, uint16_t DevAddress, uint8_t *data, uint16_t size, uint32_t timeout){
+    uint32_t notification_val = 0;
     I2C_HandleTypeDef* i2c_handle = (I2C_HandleTypeDef*)handle;
+    NotificationHandle_t *notification_handle = lookup_handle(i2c_handle);
+
+    if(notification_handle == NULL) {
+        return false;
+    }
+
     uint32_t tickstart = HAL_GetTick();
     HAL_StatusTypeDef rx_result = HAL_OK;
     do {
-        rx_result = HAL_I2C_Master_Receive(i2c_handle, DevAddress, data, size,
-                                           timeout);
+        notification_handle->task_to_notify = xTaskGetCurrentTaskHandle();
+        rx_result = HAL_I2C_Master_Receive_IT(i2c_handle, DevAddress, data, size);
+        notification_val = ulTaskNotifyTake(pdTRUE, timeout); // Wait for callback
         if (__HAL_I2C_GET_FLAG(i2c_handle, I2C_FLAG_AF)){
             __HAL_I2C_CLEAR_FLAG(i2c_handle, I2C_FLAG_AF);
             rx_result = HAL_BUSY;
+        }
+        if(notification_val != 1) {
+            // Interrupt never fired
+            rx_result = HAL_TIMEOUT;
         }
         if (rx_result == HAL_OK) {
             break;
         }
     } while ((HAL_GetTick() - tickstart) < timeout);
     return rx_result == HAL_OK;
+}
+
+
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *i2c_handle){
+    handle_i2c_callback(i2c_handle);
+}
+
+void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *i2c_handle){
+    handle_i2c_callback(i2c_handle);
+}
+
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *i2c_handle) {
+    handle_i2c_callback(i2c_handle);
+}
+
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *i2c_handle) {
+    handle_i2c_callback(i2c_handle);
+}
+
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *i2c_handle)
+{
+    handle_i2c_callback(i2c_handle);
 }

--- a/i2c/firmware/i2c_comms.cpp
+++ b/i2c/firmware/i2c_comms.cpp
@@ -1,6 +1,5 @@
 #include "i2c/firmware/i2c_comms.hpp"
 
-
 using namespace i2c::hardware;
 
 /*
@@ -23,7 +22,7 @@ auto I2C::central_receive(uint8_t* data, uint16_t size, uint16_t dev_address,
     return hal_i2c_master_receive(handle, dev_address, data, size, timeout);
 }
 
-auto I2C::set_handle(HAL_I2C_HANDLE i2c_handle) -> void { 
-    handle = i2c_handle; 
+auto I2C::set_handle(HAL_I2C_HANDLE i2c_handle) -> void {
+    handle = i2c_handle;
     i2c_register_handle(handle);
 }

--- a/i2c/firmware/i2c_comms.cpp
+++ b/i2c/firmware/i2c_comms.cpp
@@ -1,7 +1,5 @@
 #include "i2c/firmware/i2c_comms.hpp"
 
-#include "FreeRTOS.h"
-#include "task.h"
 
 using namespace i2c::hardware;
 
@@ -25,4 +23,7 @@ auto I2C::central_receive(uint8_t* data, uint16_t size, uint16_t dev_address,
     return hal_i2c_master_receive(handle, dev_address, data, size, timeout);
 }
 
-auto I2C::set_handle(HAL_I2C_HANDLE i2c_handle) -> void { handle = i2c_handle; }
+auto I2C::set_handle(HAL_I2C_HANDLE i2c_handle) -> void { 
+    handle = i2c_handle; 
+    i2c_register_handle(handle);
+}

--- a/include/i2c/firmware/i2c.h
+++ b/include/i2c/firmware/i2c.h
@@ -9,7 +9,11 @@ extern "C" {
 
 typedef void * HAL_I2C_HANDLE;
 
-HAL_I2C_HANDLE MX_I2C_Init();
+/**
+ * @brief Before using an I2C struct, it should be "registered" so that
+ * the callbacks can be associated with the HAL I2C handles.
+ */
+bool i2c_register_handle(HAL_I2C_HANDLE handle);
 
 /**
  * Wrapper around HAL_I2C_Master_Transmit
@@ -20,10 +24,6 @@ bool hal_i2c_master_transmit(HAL_I2C_HANDLE handle, uint16_t dev_address, uint8_
  * Wrapper around HAL_I2C_Master_Receive
  */
 bool hal_i2c_master_receive(HAL_I2C_HANDLE handle, uint16_t dev_address, uint8_t *data, uint16_t size, uint32_t timeout);
-
-HAL_I2C_HANDLE MX_I2C1_Init();
-HAL_I2C_HANDLE MX_I2C3_Init();
-int data_ready();
 
 /**
  * enable writing to the eeprom.

--- a/pipettes/firmware/i2c_setup.c
+++ b/pipettes/firmware/i2c_setup.c
@@ -54,6 +54,11 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
             GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
             &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
         __HAL_RCC_I2C2_CLK_ENABLE();
+
+        HAL_NVIC_SetPriority(I2C2_EV_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C2_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C2_ER_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C2_ER_IRQn);
     } else if(hi2c->Instance==I2C3) {
         // PIN PC8 is SCL
         // PIN PC9 is SDA
@@ -68,6 +73,10 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
             &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
         __HAL_RCC_I2C3_CLK_ENABLE();
 
+        HAL_NVIC_SetPriority(I2C3_EV_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+        HAL_NVIC_SetPriority(I2C3_ER_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(I2C3_ER_IRQn);
     }
 
 }
@@ -167,4 +176,24 @@ void i2c_setup(I2CHandlerStruct* temp_struct) {
 
     // Write protect the eeprom
     disable_eeprom_write();
+}
+
+void I2C2_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&hi2c2);
+}
+
+void I2C2_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&hi2c2);
+}
+
+void I2C3_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&hi2c3);
+}
+
+void I2C3_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&hi2c3);
 }

--- a/rear-panel/firmware/i2c_setup.c
+++ b/rear-panel/firmware/i2c_setup.c
@@ -19,6 +19,11 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
         I2C3_PORT,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
         &GPIO_InitStruct);  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
     __HAL_RCC_I2C3_CLK_ENABLE();
+
+    HAL_NVIC_SetPriority(I2C3_EV_IRQn, 7, 0);
+    HAL_NVIC_EnableIRQ(I2C3_EV_IRQn);
+    HAL_NVIC_SetPriority(I2C3_ER_IRQn, 7, 0);
+    HAL_NVIC_EnableIRQ(I2C3_ER_IRQn);
 }
 
 HAL_I2C_HANDLE MX_I2C3_Init() {
@@ -84,4 +89,14 @@ void i2c_setup(I2CHandlerStruct* i2c_handles) {
 
     // write protect the eeprom.
     disable_eeprom_write();
+}
+
+void I2C3_EV_IRQHandler(void)
+{
+    HAL_I2C_EV_IRQHandler(&hi2c3);
+}
+
+void I2C3_ER_IRQHandler(void)
+{
+    HAL_I2C_ER_IRQHandler(&hi2c3);
 }


### PR DESCRIPTION
This PR changes the firmware's use of the HAL I2C API to be interrupt-based. The i2c task kicks off a read/write transmission and then releases the CPU until the I2C callback is called. This should release the CPU to run other FreeRTOS tasks during I2C transmissions, instead of spinning for the duration of the transmission. 

- When starting a new read/write, a handle associated with the HAL struct is loaded with a task-to-notify
- When the Tx/Rx complete callback is called, the task-to-notify is looked up via the HAL struct and, if it exists, that task is unblocked

This is the same implementation used on the Heater-Shaker and Thermocycler Gen2. 

Tested on FLEXY MCFLEXFACE by uploading firmware to the whole robot with a gripper, a 96 channel, and (after removing the 96) a single channel. Was able to read the serial number of all of the instruments & also calibrate them, and was able to dump the EEPROM from the other motor controllers without issues.