### PR TITLE
feat(motor-control): do not debounce sync line

### DIFF
--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -46,7 +46,7 @@ class MotorHardware : public StepperMotorHardwareIface {
     auto is_timer_interrupt_running() -> bool final;
     auto check_limit_switch() -> bool final { return limit.debounce_state(); }
     auto check_estop_in() -> bool final { return estop.debounce_state(); }
-    auto check_sync_in() -> bool final { return sync.debounce_state(); }
+    auto check_sync_in() -> bool final { return sync; }
     void read_limit_switch() final;
     void read_estop_in() final;
     void read_sync_in() final;
@@ -70,7 +70,7 @@ class MotorHardware : public StepperMotorHardwareIface {
   private:
     debouncer::Debouncer estop = debouncer::Debouncer{};
     debouncer::Debouncer limit = debouncer::Debouncer{};
-    debouncer::Debouncer sync = debouncer::Debouncer{};
+    std::atomic_bool sync = false;
     static constexpr uint16_t encoder_reset_offset = 20;
     HardwareConfig pins;
     void* tim_handle;

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -44,9 +44,7 @@ void MotorHardware::read_estop_in() {
     estop.debounce_update(gpio::is_set(pins.estop_in));
 }
 
-void MotorHardware::read_sync_in() {
-    sync.debounce_update(gpio::is_set(pins.sync_in));
-}
+void MotorHardware::read_sync_in() { sync = gpio::is_set(pins.sync_in); }
 
 void MotorHardware::set_LED(bool status) {
     if (status) {


### PR DESCRIPTION
During liquid sensor repeatability testing, the z axis was occasionally crashing a tip into the bottom of a well and ignoring the top of the water. This seemed to be an issue with the head board not recognizing the change of state on the `sync` line because:
- The pipette would end its movement and send a move completion as soon as it hit the top of the water, as expected
- The head's move completion would indicate that it ended due to reading the sync line, but would come up to 4 seconds later than the pipette's

Getting rid of the debouncing for this pin seems to pose little-to-no risk because 
- It is driven digitally, rather than by a real switch
- There is no consequence if it experiences transient noise due to e.g. plugging in a pipette, so long as there isn't a movement going on that is using the sync line.

I think that the _ideal_ fix here (and an ideal change for the limit switch) is to use a GPIO interrupt to preemptively change the cached value of the pin. However, as a quick fix, this seems to get the test script working reliably. 

Before this fix, the test script had a MTTF of less than 10 tips. After this change, we were able to run the script successfully through 4 columns of tips. On each iteration, the head board seemed to detect the top of the liquid at the right time.