### PR TITLE
fix(motor-control): debounce stall detection

### DIFF
--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <cstdio>
+
 #include "motor-control/core/types.hpp"
 
 namespace stall_check {
@@ -96,7 +97,6 @@ class StallCheck {
             stall_state = new_state;
         }
         stall_state_bounce = new_state;
-        printf("state %d, bounce %d, new %d\n", stall_state, stall_state_bounce, new_state);
     }
     [[nodiscard]] auto stall_debounce_state() const -> bool {
         return stall_state;

--- a/include/motor-control/core/stall_check.hpp
+++ b/include/motor-control/core/stall_check.hpp
@@ -6,7 +6,7 @@
  */
 
 #pragma once
-
+#include <cstdio>
 #include "motor-control/core/types.hpp"
 
 namespace stall_check {
@@ -52,7 +52,7 @@ class StallCheck {
      * @return True if the motor position is OK, false if the encoder
      * indicates a stall occurred.
      */
-    [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) const -> bool
+    [[nodiscard]] auto check_stall_itr(int32_t encoder_steps) -> bool
         __attribute__((optimize(3)));
 
     [[nodiscard]] auto has_encoder() const -> bool;
@@ -89,6 +89,18 @@ class StallCheck {
 
     sq31_31 _next_threshold_positive = 0;
     sq31_31 _next_threshold_negative = 0;
+    bool stall_state = true;
+    bool stall_state_bounce = true;
+    auto stall_update(bool new_state) -> void {
+        if (new_state == stall_state_bounce) {
+            stall_state = new_state;
+        }
+        stall_state_bounce = new_state;
+        printf("state %d, bounce %d, new %d\n", stall_state, stall_state_bounce, new_state);
+    }
+    [[nodiscard]] auto stall_debounce_state() const -> bool {
+        return stall_state;
+    }
 };
 
 }  // namespace stall_check

--- a/motor-control/core/stall_check.cpp
+++ b/motor-control/core/stall_check.cpp
@@ -53,14 +53,14 @@ auto StallCheck::reset_itr_counts(int32_t stepper_steps) -> void {
     return false;
 }
 
-[[nodiscard]] auto StallCheck::check_stall_itr(int32_t encoder_steps) const
-    -> bool {
+[[nodiscard]] auto StallCheck::check_stall_itr(int32_t encoder_steps) -> bool {
     if (!has_encoder()) {
         return true;
     }
     sq31_31 diff = std::llabs(_encoder_ideal_counts -
                               (static_cast<sq31_31>(encoder_steps) << RADIX));
-    return diff <= _encoder_step_threshold;
+    stall_update(diff <= _encoder_step_threshold);
+    return stall_debounce_state();
 }
 
 [[nodiscard]] auto StallCheck::has_encoder() const -> bool {

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -43,7 +43,7 @@ SCENARIO("motor handler stall detection") {
     GIVEN("a linear move which is not expecting a stall") {
         auto cond = GENERATE(Stops::none, Stops::sync_line);
         auto msg1 = Move{.message_index = 101,
-                         .duration = 23,
+                         .duration = 33,
                          .velocity = default_velocity,
                          .stop_condition = static_cast<uint8_t>(cond)};
         auto msg2 = Move{.duration = 10, .velocity = default_velocity};
@@ -90,7 +90,7 @@ SCENARIO("motor handler stall detection") {
             static_cast<uint8_t>(GENERATE(Stops::none, Stops::sync_line));
         auto msg1 =
             Move{.message_index = 13,
-                 .duration = 26,
+                 .duration = 46,
                  .velocity = default_velocity,
                  .stop_condition = static_cast<uint8_t>(
                      static_cast<uint8_t>(Stops::ignore_stalls) ^ cond)};
@@ -104,7 +104,7 @@ SCENARIO("motor handler stall detection") {
         REQUIRE(test_objs.queue.get_size() == 2);
         test_objs.handler.update_move();
         WHEN("encoder doesn't update with the motor") {
-            for (int i = 0; i < 23; ++i) {
+            for (int i = 0; i < 33; ++i) {
                 test_objs.handler.run_interrupt();
             }
             THEN(
@@ -126,7 +126,7 @@ SCENARIO("motor handler stall detection") {
                 std::ignore = inc_error_count;
 
                 THEN("the move finishes") {
-                    for (int i = 22; i < (int)msg1.duration; i++) {
+                    for (int i = 32; i < (int)msg1.duration; i++) {
                         test_objs.handler.run_interrupt();
                     }
                     REQUIRE(test_objs.reporter.messages.size() == 3);
@@ -200,7 +200,7 @@ SCENARIO("motor handler stall detection") {
 
     GIVEN("a move with stall expected stop condition") {
         Move msg1 = Move{.message_index = 101,
-                         .duration = 23,
+                         .duration = 33,
                          .velocity = default_velocity,
                          .stop_condition = static_cast<uint8_t>(Stops::stall)};
         constexpr Move msg2 =
@@ -248,7 +248,7 @@ SCENARIO("motor handler stall detection") {
 
     GIVEN("a move with stall expected stop condition with ignore stalls flag") {
         Move msg1 = Move{.message_index = 102,
-                         .duration = 23,
+                         .duration = 33,
                          .velocity = default_velocity,
                          .stop_condition = static_cast<uint8_t>(
                              static_cast<uint8_t>(Stops::stall) ^
@@ -318,7 +318,7 @@ SCENARIO("motor handler stall detection") {
 
     GIVEN("a limit switch backoff move with a stall detected") {
         test_objs.hw.set_mock_lim_sw(true);
-        auto msg1 = Move{.duration = 23,
+        auto msg1 = Move{.duration = 33,
                          .velocity = default_velocity,
                          .stop_condition =
                              static_cast<uint8_t>(Stops::limit_switch_backoff)};

--- a/motor-control/tests/test_stall_check.cpp
+++ b/motor-control/tests/test_stall_check.cpp
@@ -12,6 +12,8 @@ TEST_CASE("stall itr check functionality") {
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(11, -11);
+                // do this once before the REQUIRE to clear debounce
+                std::ignore = subject.check_stall_itr(encoder_ticks);
                 REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
@@ -23,6 +25,8 @@ TEST_CASE("stall itr check functionality") {
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(112, 134);
+                // do this once before the REQUIRE to clear debounce
+                std::ignore = subject.check_stall_itr(encoder_ticks);
                 REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
@@ -37,6 +41,8 @@ TEST_CASE("stall itr check functionality") {
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(1, 23);
+                // do this once before the REQUIRE to clear debounce
+                std::ignore = subject.check_stall_itr(encoder_ticks);
                 REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
@@ -48,6 +54,8 @@ TEST_CASE("stall itr check functionality") {
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(112, 134);
+                // do this once before the REQUIRE to clear debounce
+                std::ignore = subject.check_stall_itr(encoder_ticks);
                 REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
@@ -62,6 +70,8 @@ TEST_CASE("stall itr check functionality") {
             }
             THEN("unacceptable encoder positions are stalls") {
                 int32_t encoder_ticks = GENERATE(1129, 1331);
+                // do this once before the REQUIRE to clear debounce
+                std::ignore = subject.check_stall_itr(encoder_ticks);
                 REQUIRE(!subject.check_stall_itr(encoder_ticks));
             }
         }
@@ -110,6 +120,9 @@ TEST_CASE("stall check isr step handling") {
                 }
                 THEN("invalid encoder position returns false") {
                     encoder_position += stall_threshold_um + 10;
+                    // do this once before the REQUIRE to clear debounce
+                    std::ignore = subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um));
                     REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
                         encoder_position * encoder_tick_per_um)));
                 }
@@ -135,6 +148,9 @@ TEST_CASE("stall check isr step handling") {
                 }
                 THEN("invalid encoder position returns false") {
                     encoder_position -= stall_threshold_um + 10;
+                    // do this once before the REQUIRE to clear debounce
+                    std::ignore = subject.check_stall_itr(static_cast<int32_t>(
+                        encoder_position * encoder_tick_per_um));
                     REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
                         encoder_position * encoder_tick_per_um)));
                 }
@@ -162,6 +178,9 @@ TEST_CASE("stall check isr step handling") {
                 float encoder_position = stepper_begin_um +
                                          (stall_threshold_um * stallchecks) +
                                          error;
+                // do this once before the REQUIRE to clear debounce
+                std::ignore = subject.check_stall_itr(static_cast<int32_t>(
+                    encoder_position * encoder_tick_per_um));
                 THEN("the position is not valid") {
                     REQUIRE(!subject.check_stall_itr(static_cast<int32_t>(
                         encoder_position * encoder_tick_per_um)));


### PR DESCRIPTION
Sometimes the motor interrupt and the encoder interrupt squash on each other for 1 cycle so this should fix that.