### PR TITLE
fix(motor-control): atomically account for encoder overflows

### DIFF
--- a/gantry/firmware/interfaces_proto.cpp
+++ b/gantry/firmware/interfaces_proto.cpp
@@ -11,6 +11,7 @@
 #include "gantry/core/utils.hpp"
 #include "gantry/firmware/eeprom_keys.hpp"
 #include "motor-control/core/stepper_motor/motion_controller.hpp"
+#include "motor-control/core/stepper_motor/motor_encoder_background_timer.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/firmware/stepper_motor/motor_hardware.hpp"
 #include "spi/firmware/spi_comms.hpp"
@@ -234,6 +235,9 @@ static motor_handler::MotorInterruptHandler motor_interrupt(
     motor_queue, gantry::queues::get_queues(), motor_hardware_iface, stallcheck,
     update_position_queue);
 
+static auto encoder_background_timer =
+    motor_encoder::BackgroundTimer(motor_interrupt, motor_hardware_iface);
+
 /**
  * Timer callback.
  */
@@ -275,6 +279,8 @@ void interfaces::initialize() {
 
     // Start the can bus
     canbus.start(can_bit_timings);
+
+    encoder_background_timer.start();
 
     iWatchdog.start(6);
 }

--- a/gantry/firmware/interfaces_rev1.cpp
+++ b/gantry/firmware/interfaces_rev1.cpp
@@ -11,6 +11,7 @@
 #include "gantry/core/utils.hpp"
 #include "gantry/firmware/eeprom_keys.hpp"
 #include "motor-control/core/stepper_motor/motion_controller.hpp"
+#include "motor-control/core/stepper_motor/motor_encoder_background_timer.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/firmware/stepper_motor/motor_hardware.hpp"
 #include "spi/firmware/spi_comms.hpp"
@@ -259,6 +260,9 @@ static motor_handler::MotorInterruptHandler motor_interrupt(
     motor_queue, gantry::queues::get_queues(), motor_hardware_iface, stallcheck,
     update_position_queue);
 
+static auto encoder_background_timer =
+    motor_encoder::BackgroundTimer(motor_interrupt, motor_hardware_iface);
+
 /**
  * Timer callback.
  */
@@ -301,6 +305,8 @@ void interfaces::initialize() {
 
     // Start the can bus
     canbus.start(can_bit_timings);
+
+    encoder_background_timer.start();
 
     iWatchdog.start(6);
 }

--- a/gantry/firmware/motor_hardware.c
+++ b/gantry/firmware/motor_hardware.c
@@ -240,9 +240,6 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
     if (htim == &htim2) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM2_CLK_ENABLE();
-        /* TIM2 interrupt Init */
-        HAL_NVIC_SetPriority(TIM2_IRQn, 7, 0);
-        HAL_NVIC_EnableIRQ(TIM2_IRQn);
     }
 }
 

--- a/gantry/firmware/motor_hardware.c
+++ b/gantry/firmware/motor_hardware.c
@@ -219,6 +219,8 @@ void TIM2_Encoder_Init(void) {
     __HAL_TIM_ENABLE_IT(&htim2, TIM_IT_UPDATE);
     /* Set update event request source as: counter overflow */
     __HAL_TIM_URS_ENABLE(&htim2);
+    /* Enable UIFREMAP so the MSb of the count register reflects overflows */
+    __HAL_TIM_UIFREMAP_ENABLE(&htim2);
     /* Enable encoder interface */
     HAL_TIM_Encoder_Start_IT(&htim2, TIM_CHANNEL_ALL);
 }

--- a/gripper/firmware/interfaces_z_motor.cpp
+++ b/gripper/firmware/interfaces_z_motor.cpp
@@ -5,6 +5,7 @@
 #include "gripper/firmware/eeprom_keys.hpp"
 #include "gripper/firmware/utility_gpio.h"
 #include "motor-control/core/stepper_motor/motion_controller.hpp"
+#include "motor-control/core/stepper_motor/motor_encoder_background_timer.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/core/stepper_motor/tmc2130.hpp"
 #include "motor-control/core/tasks/motor_hardware_task.hpp"
@@ -192,6 +193,9 @@ static motor_handler::MotorInterruptHandler motor_interrupt(
     motor_queue, gripper_tasks::z_tasks::get_queues(), motor_hardware_iface,
     stallcheck, update_position_queue);
 
+static auto encoder_background_timer =
+    motor_encoder::BackgroundTimer(motor_interrupt, motor_hardware_iface);
+
 /**
  * Timer callback.
  */
@@ -206,6 +210,7 @@ void z_motor_iface::initialize() {
     }
     initialize_hardware_z();
     set_z_motor_timer_callback(call_motor_handler, call_enc_handler);
+    encoder_background_timer.start();
 }
 
 auto z_motor_iface::get_spi() -> spi::hardware::SpiDeviceBase& {

--- a/gripper/firmware/motor_hardware_g.c
+++ b/gripper/firmware/motor_hardware_g.c
@@ -242,6 +242,8 @@ static void TIM2_EncoderG_Init(void) {
     __HAL_TIM_ENABLE_IT(&htim2, TIM_IT_UPDATE);
     /* Set update event request source as: counter overflow */
     __HAL_TIM_URS_ENABLE(&htim2);
+    /* Enable UIFREMAP so the MSb of the count register reflects overflows */
+    __HAL_TIM_UIFREMAP_ENABLE(&htim2);
     /* Enable encoder interface */
     HAL_TIM_Encoder_Start_IT(&htim2, TIM_CHANNEL_ALL);
 }

--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -136,9 +136,6 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
         GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
         HAL_GPIO_Init(G_MOT_ENC_PORT, &GPIO_InitStruct);
 
-        /* TIM2 interrupt Init */
-        HAL_NVIC_SetPriority(TIM2_IRQn, 7, 0);
-        HAL_NVIC_EnableIRQ(TIM2_IRQn);
     } else if (htim == &htim8) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM8_CLK_ENABLE();
@@ -155,9 +152,7 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
         GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
         GPIO_InitStruct.Alternate = GPIO_AF4_TIM8;
         HAL_GPIO_Init(Z_MOT_ENC_AB_PORT, &GPIO_InitStruct);
-
-        HAL_NVIC_SetPriority(TIM8_UP_IRQn, 7, 0);
-        HAL_NVIC_EnableIRQ(TIM8_UP_IRQn);
+        
     }
 }
 

--- a/gripper/firmware/motor_hardware_shared.c
+++ b/gripper/firmware/motor_hardware_shared.c
@@ -136,6 +136,9 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
         GPIO_InitStruct.Alternate = GPIO_AF1_TIM2;
         HAL_GPIO_Init(G_MOT_ENC_PORT, &GPIO_InitStruct);
 
+        /* TIM2 interrupt Init */
+        HAL_NVIC_SetPriority(TIM2_IRQn, 7, 0);
+        HAL_NVIC_EnableIRQ(TIM2_IRQn);
     } else if (htim == &htim8) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM8_CLK_ENABLE();

--- a/gripper/firmware/motor_hardware_z.c
+++ b/gripper/firmware/motor_hardware_z.c
@@ -72,6 +72,8 @@ inline static void TIM8_EncoderZ_Init(void)
     __HAL_TIM_ENABLE_IT(&htim8, TIM_IT_UPDATE);
     /* Set update event request source as: counter overflow */
     __HAL_TIM_URS_ENABLE(&htim8);
+    /* Enable UIFREMAP so the MSb of the count register reflects overflows */
+    __HAL_TIM_UIFREMAP_ENABLE(&htim8);
     /* Enable encoder interface */
     HAL_TIM_Encoder_Start_IT(&htim8, TIM_CHANNEL_ALL);
 }

--- a/head/firmware/main_rev1.cpp
+++ b/head/firmware/main_rev1.cpp
@@ -32,6 +32,7 @@
 #include "i2c/firmware/i2c_comms.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/stepper_motor/motor.hpp"
+#include "motor-control/core/stepper_motor/motor_encoder_background_timer.hpp"
 #include "motor-control/core/stepper_motor/motor_interrupt_handler.hpp"
 #include "motor-control/core/stepper_motor/tmc2160.hpp"
 #include "motor-control/firmware/stepper_motor/motor_hardware.hpp"
@@ -288,6 +289,9 @@ static motor_handler::MotorInterruptHandler motor_interrupt_right(
     motor_queue_right, head_tasks::get_right_queues(), motor_hardware_right,
     stallcheck_right, update_position_queue_right);
 
+static auto encoder_background_timer_right =
+    motor_encoder::BackgroundTimer(motor_interrupt_right, motor_hardware_right);
+
 // engaging motors on boot
 static motor_class::Motor motor_right{
     linear_config,
@@ -309,6 +313,9 @@ static motor_hardware::MotorHardware motor_hardware_left(
 static motor_handler::MotorInterruptHandler motor_interrupt_left(
     motor_queue_left, head_tasks::get_left_queues(), motor_hardware_left,
     stallcheck_left, update_position_queue_left);
+
+static auto encoder_background_timer_left =
+    motor_encoder::BackgroundTimer(motor_interrupt_left, motor_hardware_left);
 
 // engaging motors on boot
 static motor_class::Motor motor_left{
@@ -432,6 +439,9 @@ auto main() -> int {
                             i2c_comms3, eeprom_hw_iface);
 
     timer_for_notifier.start();
+
+    encoder_background_timer_left.start();
+    encoder_background_timer_right.start();
 
     iWatchdog.start(6);
 

--- a/head/firmware/motor_hardware_common.c
+++ b/head/firmware/motor_hardware_common.c
@@ -327,14 +327,10 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM2_CLK_ENABLE();
         /* TIM2 interrupt Init */
-        HAL_NVIC_SetPriority(TIM2_IRQn, 7, 0);
-        HAL_NVIC_EnableIRQ(TIM2_IRQn);
     } else if (htim == &htim3) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM3_CLK_ENABLE();
         /* TIM3 interrupt Init */
-        HAL_NVIC_SetPriority(TIM3_IRQn, 7, 0);
-        HAL_NVIC_EnableIRQ(TIM3_IRQn);
     }
 }
 

--- a/head/firmware/motor_hardware_common.c
+++ b/head/firmware/motor_hardware_common.c
@@ -267,6 +267,8 @@ void encoder_init(TIM_HandleTypeDef *htim) {
     __HAL_TIM_ENABLE_IT(htim, TIM_IT_UPDATE);
     /* Set update event request source as: counter overflow */
     __HAL_TIM_URS_ENABLE(htim);
+    /* Enable UIFREMAP so the MSb of the count register reflects overflows */
+    __HAL_TIM_UIFREMAP_ENABLE(htim);
     /* Enable encoder interface */
     HAL_TIM_Encoder_Start_IT(htim, TIM_CHANNEL_ALL);
 }

--- a/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
+++ b/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <concepts>
+#include <cstdint>
+#include <tuple>
+
+#include "motor-control/core/motor_hardware_interface.hpp"
+#include "ot_utils/freertos/freertos_timer.hpp"
+
+namespace motor_encoder {
+
+template <class T>
+concept InterruptHandler = requires(T handler) {
+    { handler.has_active_move() } -> std::same_as<bool>;
+};
+
+template <InterruptHandler Handler, typename MotorHardware>
+requires std::is_base_of_v<motor_hardware::MotorHardwareIface, MotorHardware>
+class BackgroundTimer {
+  public:
+    BackgroundTimer(Handler &interrupt_handler, MotorHardware &motor_hardware)
+        : _interrupt_handler(interrupt_handler),
+          _motor_hardware(motor_hardware),
+          _timer(
+              "encoder_timer", [this]() { this->callback(); }, PERIOD_MS) {}
+
+    auto start() -> void { _timer.start(); }
+
+    auto stop() -> void { _timer.stop(); }
+
+    auto callback() -> void {
+        if (!_interrupt_handler.has_active_move()) {
+            // Refresh the overflow counter if nothing else is doing it
+            std::ignore = _motor_hardware.get_encoder_pulses();
+        }
+    }
+
+  private:
+    static constexpr uint32_t PERIOD_MS = 10;
+
+    Handler &_interrupt_handler;
+    MotorHardware &_motor_hardware;
+    ot_utils::freertos_timer::FreeRTOSTimer _timer;
+};
+
+}  // namespace motor_encoder

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -20,8 +20,8 @@ bool motor_hardware_set_dac_value(void* dac_handle, uint32_t channel,
                                   uint32_t data_algn, uint32_t val);
 bool motor_hardware_start_pwm(void* tim_handle, uint32_t channel);
 bool motor_hardware_stop_pwm(void* tim_handle, uint32_t channel);
-uint32_t motor_hardware_encoder_pulse_count(void* encoder_handle);
-uint32_t motor_hardware_encoder_pulse_count_with_overflow(void* encoder_handle, int8_t *overflows);
+uint16_t motor_hardware_encoder_pulse_count(void* encoder_handle);
+uint16_t motor_hardware_encoder_pulse_count_with_overflow(void* encoder_handle, int8_t *overflows);
 void motor_hardware_reset_encoder_count(void* encoder_handle, uint16_t reset_value);
 uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear);
 #ifdef __cplusplus

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -20,7 +20,8 @@ bool motor_hardware_set_dac_value(void* dac_handle, uint32_t channel,
                                   uint32_t data_algn, uint32_t val);
 bool motor_hardware_start_pwm(void* tim_handle, uint32_t channel);
 bool motor_hardware_stop_pwm(void* tim_handle, uint32_t channel);
-int32_t motor_hardware_encoder_pulse_count(void* encoder_handle);
+uint32_t motor_hardware_encoder_pulse_count(void* encoder_handle);
+bool motor_hardware_encoder_is_counting_down(void *encoder_handle);
 void motor_hardware_reset_encoder_count(void* encoder_handle, uint16_t reset_value);
 uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear);
 #ifdef __cplusplus

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -21,7 +21,7 @@ bool motor_hardware_set_dac_value(void* dac_handle, uint32_t channel,
 bool motor_hardware_start_pwm(void* tim_handle, uint32_t channel);
 bool motor_hardware_stop_pwm(void* tim_handle, uint32_t channel);
 uint32_t motor_hardware_encoder_pulse_count(void* encoder_handle);
-bool motor_hardware_encoder_is_counting_down(void *encoder_handle);
+uint32_t motor_hardware_encoder_pulse_count_with_overflow(void* encoder_handle, int8_t *overflows);
 void motor_hardware_reset_encoder_count(void* encoder_handle, uint16_t reset_value);
 uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear);
 #ifdef __cplusplus

--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -76,7 +76,7 @@ class MotorHardware : public StepperMotorHardwareIface {
     void* tim_handle;
     void* enc_handle;
     const UsageEEpromConfig& eeprom_config;
-    int32_t motor_encoder_overflow_count = 0;
+    std::atomic<int32_t> motor_encoder_overflow_count = 0;
     std::atomic<bool> cancel_request = false;
 };
 

--- a/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
+++ b/include/motor-control/firmware/stepper_motor/motor_hardware.hpp
@@ -78,6 +78,7 @@ class MotorHardware : public StepperMotorHardwareIface {
     const UsageEEpromConfig& eeprom_config;
     std::atomic<int32_t> motor_encoder_overflow_count = 0;
     std::atomic<bool> cancel_request = false;
+    static constexpr uint32_t ENCODER_OVERFLOW_PULSES_BIT = 0x1 << 31;
 };
 
 };  // namespace motor_hardware

--- a/include/motor-control/simulation/motor_interrupt_driver.hpp
+++ b/include/motor-control/simulation/motor_interrupt_driver.hpp
@@ -53,7 +53,7 @@ class MotorInterruptDriver {
                         }
                         handler.run_interrupt();
 
-                    } while (handler.has_active_move);
+                    } while (handler.has_active_move());
                     LOG("Move completed. Stopping interrupt simulation..");
                 } else if (position_queue.has_message()) {
                     LOG("Running motor interrupt to update motor position from "

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -62,10 +62,7 @@ int32_t BrushedMotorHardware::get_encoder_pulses() {
     if (!enc_handle) {
         return 0;
     }
-    int8_t overflows = 0;
-    uint32_t pulses = motor_hardware_encoder_pulse_count_with_overflow(
-        enc_handle, &overflows);
-    motor_encoder_overflow_count += overflows;
+    uint32_t pulses = motor_hardware_encoder_pulse_count(enc_handle);
     return (motor_encoder_overflow_count << 16) + (0xFF & pulses);
 }
 

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -62,8 +62,11 @@ int32_t BrushedMotorHardware::get_encoder_pulses() {
     if (!enc_handle) {
         return 0;
     }
-    return (motor_encoder_overflow_count << 16) +
-           (0xFF & motor_hardware_encoder_pulse_count(enc_handle));
+    int8_t overflows = 0;
+    uint32_t pulses = motor_hardware_encoder_pulse_count_with_overflow(
+        enc_handle, &overflows);
+    motor_encoder_overflow_count += overflows;
+    return (motor_encoder_overflow_count << 16) + (0xFF & pulses);
 }
 
 uint16_t BrushedMotorHardware::get_stopwatch_pulses(bool clear) {

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -63,7 +63,7 @@ int32_t BrushedMotorHardware::get_encoder_pulses() {
         return 0;
     }
     return (motor_encoder_overflow_count << 16) +
-           motor_hardware_encoder_pulse_count(enc_handle);
+           (0xFF & motor_hardware_encoder_pulse_count(enc_handle));
 }
 
 uint16_t BrushedMotorHardware::get_stopwatch_pulses(bool clear) {

--- a/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
+++ b/motor-control/firmware/brushed_motor/brushed_motor_hardware.cpp
@@ -62,8 +62,8 @@ int32_t BrushedMotorHardware::get_encoder_pulses() {
     if (!enc_handle) {
         return 0;
     }
-    uint32_t pulses = motor_hardware_encoder_pulse_count(enc_handle);
-    return (motor_encoder_overflow_count << 16) + (0xFF & pulses);
+    return (motor_encoder_overflow_count << 16) +
+           (motor_hardware_encoder_pulse_count(enc_handle));
 }
 
 uint16_t BrushedMotorHardware::get_stopwatch_pulses(bool clear) {

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -94,16 +94,22 @@ bool motor_hardware_stop_pwm(void* htim, uint32_t channel) {
  * read a hal timer count value
  * if the timer is NULL return 0
  */
-uint16_t _get_hal_timer_count(void* htim) {
+uint32_t _get_hal_timer_count(void* htim) {
     if (htim != NULL) {
         return __HAL_TIM_GET_COUNTER((TIM_HandleTypeDef*)htim);
     }
     return 0;
 }
 
-int32_t motor_hardware_encoder_pulse_count(void* enc_htim) {
-    int32_t pulses = _get_hal_timer_count(enc_htim);
-    return pulses;
+uint32_t motor_hardware_encoder_pulse_count(void* enc_htim) {
+    return _get_hal_timer_count(enc_htim);;
+}
+
+bool motor_hardware_encoder_is_counting_down(void *encoder_handle) {
+    if(encoder_handle == NULL) {
+        return true;
+    }
+    return __HAL_TIM_IS_TIM_COUNTING_DOWN((TIM_HandleTypeDef*)encoder_handle);
 }
 
 void motor_hardware_reset_encoder_count(void* enc_htim, uint16_t reset_value) {

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -94,36 +94,28 @@ bool motor_hardware_stop_pwm(void* htim, uint32_t channel) {
  * read a hal timer count value
  * if the timer is NULL return 0
  */
-uint32_t _get_hal_timer_count(void* htim) {
+uint16_t _get_hal_timer_count(void* htim) {
     if (htim != NULL) {
         return __HAL_TIM_GET_COUNTER((TIM_HandleTypeDef*)htim);
     }
     return 0;
 }
 
-uint32_t motor_hardware_encoder_pulse_count(void* enc_htim) {
-    return _get_hal_timer_count(enc_htim) & 0xFFFF;
+uint16_t motor_hardware_encoder_pulse_count(void* enc_htim) {
+    return _get_hal_timer_count(enc_htim);
 }
 
-bool motor_hardware_encoder_is_counting_down(void *encoder_handle) {
-    if(encoder_handle == NULL) {
-        return true;
-    }
-    return __HAL_TIM_IS_TIM_COUNTING_DOWN((TIM_HandleTypeDef*)encoder_handle);
-}
-
-uint32_t motor_hardware_encoder_pulse_count_with_overflow(void* encoder_handle, int8_t *overflows) {
+uint16_t motor_hardware_encoder_pulse_count_with_overflow(void* encoder_handle, int8_t *overflows) {
     if(encoder_handle == NULL) {
         return 0;
     }
     TIM_HandleTypeDef *handle = encoder_handle;
     uint32_t pulses = __HAL_TIM_GET_COUNTER(handle);
     if( __HAL_TIM_GET_UIFCPY(pulses)) {
-        pulses &= 0xFFFF;
         __HAL_TIM_CLEAR_IT(handle, TIM_FLAG_UPDATE);
         *overflows = __HAL_TIM_IS_TIM_COUNTING_DOWN(handle) ? -1 : 1;
     }
-    return pulses;
+    return pulses & 0xFFFF;
 }
 
 void motor_hardware_reset_encoder_count(void* enc_htim, uint16_t reset_value) {

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -102,7 +102,7 @@ uint32_t _get_hal_timer_count(void* htim) {
 }
 
 uint32_t motor_hardware_encoder_pulse_count(void* enc_htim) {
-    return _get_hal_timer_count(enc_htim);;
+    return _get_hal_timer_count(enc_htim) & 0xFFFF;
 }
 
 bool motor_hardware_encoder_is_counting_down(void *encoder_handle) {
@@ -110,6 +110,20 @@ bool motor_hardware_encoder_is_counting_down(void *encoder_handle) {
         return true;
     }
     return __HAL_TIM_IS_TIM_COUNTING_DOWN((TIM_HandleTypeDef*)encoder_handle);
+}
+
+uint32_t motor_hardware_encoder_pulse_count_with_overflow(void* encoder_handle, int8_t *overflows) {
+    if(encoder_handle == NULL) {
+        return 0;
+    }
+    TIM_HandleTypeDef *handle = encoder_handle;
+    uint32_t pulses = __HAL_TIM_GET_COUNTER(handle);
+    if( __HAL_TIM_GET_UIFCPY(pulses)) {
+        pulses &= 0xFFFF;
+        __HAL_TIM_CLEAR_IT(handle, TIM_FLAG_UPDATE);
+        *overflows = __HAL_TIM_IS_TIM_COUNTING_DOWN(handle) ? -1 : 1;
+    }
+    return pulses;
 }
 
 void motor_hardware_reset_encoder_count(void* enc_htim, uint16_t reset_value) {

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -64,7 +64,7 @@ int32_t MotorHardware::get_encoder_pulses() {
         return 0;
     }
     int8_t overflows = 0;
-    uint32_t pulses = motor_hardware_encoder_pulse_count_with_overflow(
+    uint16_t pulses = motor_hardware_encoder_pulse_count_with_overflow(
         enc_handle, &overflows);
     motor_encoder_overflow_count += overflows;
     return (motor_encoder_overflow_count << 16) + static_cast<int32_t>(pulses) -

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -61,8 +61,14 @@ int32_t MotorHardware::get_encoder_pulses() {
     if (!enc_handle) {
         return 0;
     }
-    return (motor_encoder_overflow_count << 16) +
-           motor_hardware_encoder_pulse_count(enc_handle) -
+    uint32_t pulses = motor_hardware_encoder_pulse_count(enc_handle);
+    if (pulses & ENCODER_OVERFLOW_PULSES_BIT) {
+        pulses &= ~(ENCODER_OVERFLOW_PULSES_BIT);
+        pulses += motor_hardware_encoder_is_counting_down(enc_handle)
+                      ? -(1 << 16)
+                      : (1 << 16);
+    }
+    return (motor_encoder_overflow_count << 16) + static_cast<int32_t>(pulses) -
            static_cast<int32_t>(encoder_reset_offset);
 }
 

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -64,7 +64,8 @@ int32_t MotorHardware::get_encoder_pulses() {
         return 0;
     }
     int8_t overflows = 0;
-    uint32_t pulses = motor_hardware_encoder_pulse_count_with_overflow(enc_handle, &overflows);
+    uint32_t pulses = motor_hardware_encoder_pulse_count_with_overflow(
+        enc_handle, &overflows);
     motor_encoder_overflow_count += overflows;
     return (motor_encoder_overflow_count << 16) + static_cast<int32_t>(pulses) -
            static_cast<int32_t>(encoder_reset_offset);

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -48,7 +48,7 @@ SCENARIO("MoveStopCondition::limit_switch with the limit switch triggered") {
 
     WHEN("the move is loaded") {
         test_objs.handler.update_move();
-        REQUIRE(test_objs.handler.has_active_move);
+        REQUIRE(test_objs.handler.has_active_move());
 
         THEN("position gets set to large positive number") {
             REQUIRE(test_objs.handler.get_current_position() ==
@@ -108,7 +108,7 @@ SCENARIO("MoveStopCondition::limit_switch and limit switch is not triggered") {
 
     WHEN("the move is loaded") {
         test_objs.handler.update_move();
-        REQUIRE(test_objs.handler.has_active_move);
+        REQUIRE(test_objs.handler.has_active_move());
 
         THEN("position gets set to large positive number") {
             REQUIRE(test_objs.handler.get_current_position() ==

--- a/motor-control/tests/test_limit_switch_backoff.cpp
+++ b/motor-control/tests/test_limit_switch_backoff.cpp
@@ -47,7 +47,7 @@ SCENARIO(
 
         WHEN("the move is loaded") {
             test_objs.handler.update_move();
-            REQUIRE(test_objs.handler.has_active_move);
+            REQUIRE(test_objs.handler.has_active_move());
 
             THEN("the limit switch has been released") {
                 for (int i = 0; i < (int)msg1.duration; ++i) {
@@ -94,7 +94,7 @@ SCENARIO(
 
         WHEN("the move is loaded") {
             test_objs.handler.update_move();
-            REQUIRE(test_objs.handler.has_active_move);
+            REQUIRE(test_objs.handler.has_active_move());
 
             AND_WHEN("the limit switch has been released") {
                 for (int i = 0; i < (int)msg1.duration; ++i) {
@@ -159,7 +159,7 @@ SCENARIO(
             MotorPositionStatus::Flags::encoder_position_ok);
         WHEN("the move is loaded") {
             test_objs.handler.update_move();
-            REQUIRE(test_objs.handler.has_active_move);
+            REQUIRE(test_objs.handler.has_active_move());
 
             AND_WHEN("the limit switch has not been triggered") {
                 for (int i = 0; i < (int)msg1.duration; ++i) {
@@ -206,7 +206,7 @@ SCENARIO(
 
         WHEN("the move is loaded") {
             test_objs.handler.update_move();
-            REQUIRE(test_objs.handler.has_active_move);
+            REQUIRE(test_objs.handler.has_active_move());
 
             AND_WHEN("the limit switch has not been triggered") {
                 for (int i = 0; i < (int)msg1.duration; ++i) {

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -201,7 +201,7 @@ TEST_CASE("Compute move sequence") {
             THEN("we do not move") {
                 static_cast<void>(test_objs.handler.pulse());
                 REQUIRE(!test_objs.handler.can_step());
-                REQUIRE(!test_objs.handler.has_active_move);
+                REQUIRE(!test_objs.handler.has_active_move());
             }
         }
         WHEN("a move duration is up, and there is a move in the queue") {
@@ -215,7 +215,7 @@ TEST_CASE("Compute move sequence") {
             THEN("we immediately switch to the new move") {
                 static_cast<void>(test_objs.handler.pulse());
                 REQUIRE(test_objs.handler.can_step());
-                REQUIRE(test_objs.handler.has_active_move);
+                REQUIRE(test_objs.handler.has_active_move());
                 REQUIRE(test_objs.handler.get_buffered_move().velocity ==
                         msg2.velocity);
                 REQUIRE(test_objs.handler.get_buffered_move().duration ==
@@ -258,7 +258,7 @@ TEST_CASE("moves that result in out of range positions") {
                     current_position);
             AND_THEN("the move should be finished") {
                 static_cast<void>(test_objs.handler.pulse());
-                REQUIRE(test_objs.handler.has_active_move == false);
+                REQUIRE(test_objs.handler.has_active_move() == false);
             }
         }
     }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -18,6 +18,7 @@
 
 // todo check if needed
 #include "i2c/firmware/i2c_comms.hpp"
+#include "motor-control/core/stepper_motor/motor_encoder_background_timer.hpp"
 #include "pipettes/core/central_tasks.hpp"
 #include "pipettes/core/configs.hpp"
 #include "pipettes/core/gear_motor_tasks.hpp"
@@ -102,6 +103,9 @@ static auto plunger_interrupt = interfaces::linear_motor::get_interrupt(
 static auto linear_motion_control =
     interfaces::linear_motor::get_motion_control(linear_motor_hardware,
                                                  interrupt_queues);
+
+static auto encoder_background_timer =
+    motor_encoder::BackgroundTimer(plunger_interrupt, linear_motor_hardware);
 
 static auto gear_hardware =
     interfaces::gear_motor::get_motor_hardware(motor_config.hardware_pins);
@@ -272,8 +276,7 @@ auto main() -> int {
     peripheral_tasks::start_tasks(i2c_comms3, i2c_comms2, spi_comms);
     initialize_motor_tasks(id, motor_config.driver_configs, gear_motion_control,
                            lmh_tsk, gmh_tsks);
-
-    iWatchdog.start(6);
+    encoder_background_timer.start() iWatchdog.start(6);
 
     vTaskStartScheduler();
 }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -276,7 +276,8 @@ auto main() -> int {
     peripheral_tasks::start_tasks(i2c_comms3, i2c_comms2, spi_comms);
     initialize_motor_tasks(id, motor_config.driver_configs, gear_motion_control,
                            lmh_tsk, gmh_tsks);
-    encoder_background_timer.start() iWatchdog.start(6);
+    encoder_background_timer.start();
+    iWatchdog.start(6);
 
     vTaskStartScheduler();
 }

--- a/pipettes/firmware/motor_timer_hardware.c
+++ b/pipettes/firmware/motor_timer_hardware.c
@@ -136,9 +136,6 @@ void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim) {
     if (htim == &htim2) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM2_CLK_ENABLE();
-        /* TIM2 interrupt Init */
-        HAL_NVIC_SetPriority(TIM2_IRQn, 7, 0);
-        HAL_NVIC_EnableIRQ(TIM2_IRQn);
     }
 }
 

--- a/pipettes/firmware/motor_timer_hardware.c
+++ b/pipettes/firmware/motor_timer_hardware.c
@@ -55,6 +55,8 @@ void TIM2_Encoder_Init(void) {
     __HAL_TIM_ENABLE_IT(&htim2, TIM_IT_UPDATE);
     /* Set update event request source as: counter overflow */
     __HAL_TIM_URS_ENABLE(&htim2);
+    /* Enable UIFREMAP so the MSb of the count register reflects overflows */
+    __HAL_TIM_UIFREMAP_ENABLE(&htim2);
     /* Enable encoder interface */
     HAL_TIM_Encoder_Start_IT(&htim2, TIM_CHANNEL_ALL);
 }


### PR DESCRIPTION
## Overview

When one of the motor axes overflows its encoder, there's a not-uncommon race condition between the encoder timer's raw counter value and the variable capturing the number of timer overflows. If the motor interrupt controller tries to read the position between when the counter is updated but the overflows aren't updated, the encoder position will appear to be off by a considerable amount.

This PR enables the `UIFREMAP` bit for all of the encoders on the motor control boards. This bit effectively results in the MSb of the CNT register containing a flag for whether the encoder has a pending overflow. Instead of using the interrupt vector to determine when an overflow has occurred, we just check the UIFCPY bit in the CNT register. If an overflow has happened, the function getting the encoder pulses will clear the flag and return the direction in which the motor overflowed.

Because the encoder interrupts are disabled now, we have a new background timer that will periodically poll the encoder position. This is necessary because, if the position overflows twice while nothing is checking it, we would have no way to know how many times it overflowed.

## Testing

Tested by cycling the Z_L axis up and down such that the velocity reaches its peak value (this is important to overload the CPU with GPIO pulses) while it crosses the encoder overflow point. Without this change, there was a MTTF of maybe a dozen cycles. After the change I can run for 200 cycles with no issues.

Also disabled the gantry axes and dragged them across the deck and back, checking the encoder position from the REPL at a few points. The encoders were updating and the positions were consistent from edge to edge.