### PR TITLE
fix(motor-control): clear encoder status flag when home fails

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -283,6 +283,10 @@ class MotorInterruptHandler {
         if (limit_switch_triggered()) {
             position_tracker = 0;
             hardware.reset_step_tracker();
+            if (stall_checker.has_encoder()) {
+                hardware.position_flags.set_flag(
+                    can::ids::MotorPositionFlags::encoder_position_ok);
+            }
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
         }
@@ -381,6 +385,8 @@ class MotorInterruptHandler {
             update_hardware_step_tracker();
             hardware.position_flags.clear_flag(
                 can::ids::MotorPositionFlags::stepper_position_ok);
+            hardware.position_flags.clear_flag(
+                can::ids::MotorPositionFlags::encoder_position_ok);
         }
     }
 

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -282,11 +282,6 @@ class MotorInterruptHandler {
     auto homing_stopped() -> bool {
         if (limit_switch_triggered()) {
             position_tracker = 0;
-            hardware.reset_step_tracker();
-            if (stall_checker.has_encoder()) {
-                hardware.position_flags.set_flag(
-                    can::ids::MotorPositionFlags::encoder_position_ok);
-            }
             finish_current_move(AckMessageId::stopped_by_condition);
             return true;
         }

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -55,9 +55,11 @@ SCENARIO("MoveStopCondition::limit_switch with the limit switch triggered") {
                     0x7FFFFFFFFFFFFFFF);
         }
 
-        THEN("stepper position flag is cleared") {
+        THEN("stepper and encoder position flags are cleared") {
             REQUIRE(!test_objs.hw.position_flags.check_flag(
                 MotorPositionStatus::Flags::stepper_position_ok));
+            REQUIRE(!test_objs.hw.position_flags.check_flag(
+                MotorPositionStatus::Flags::encoder_position_ok));
         }
 
         AND_WHEN("the limit switch has been triggered") {
@@ -70,6 +72,7 @@ SCENARIO("MoveStopCondition::limit_switch with the limit switch triggered") {
                 }
                 test_objs.handler.run_interrupt();
             }
+
             THEN(
                 "the move should be stopped with ack id = stopped "
                 "by "
@@ -81,7 +84,10 @@ SCENARIO("MoveStopCondition::limit_switch with the limit switch triggered") {
                 REQUIRE(read_ack.encoder_position == 50);
                 REQUIRE(read_ack.current_position_steps == 0);
             }
-
+            THEN("the encoder position flag should be set") {
+                REQUIRE(test_objs.hw.position_flags.check_flag(
+                    MotorPositionStatus::Flags::encoder_position_ok));
+            }
             THEN("the stepper position flag is still cleared") {
                 REQUIRE(!test_objs.hw.position_flags.check_flag(
                     MotorPositionStatus::Flags::stepper_position_ok));
@@ -114,9 +120,11 @@ SCENARIO("MoveStopCondition::limit_switch and limit switch is not triggered") {
             REQUIRE(test_objs.handler.get_current_position() ==
                     0x7FFFFFFFFFFFFFFF);
         }
-        THEN("stepper position flag is cleared") {
+        THEN("stepper and encoder position flags are cleared") {
             REQUIRE(!test_objs.hw.position_flags.check_flag(
                 MotorPositionStatus::Flags::stepper_position_ok));
+            REQUIRE(!test_objs.hw.position_flags.check_flag(
+                MotorPositionStatus::Flags::encoder_position_ok));
         }
 
         AND_WHEN("the limit switch has not been triggered") {
@@ -143,6 +151,12 @@ SCENARIO("MoveStopCondition::limit_switch and limit switch is not triggered") {
             }
             THEN("position should not be reset") {
                 REQUIRE(!test_objs.handler.get_current_position() == 0);
+            }
+            THEN("stepper and encoder position flags should remained cleared") {
+                REQUIRE(!test_objs.hw.position_flags.check_flag(
+                    MotorPositionStatus::Flags::stepper_position_ok));
+                REQUIRE(!test_objs.hw.position_flags.check_flag(
+                    MotorPositionStatus::Flags::encoder_position_ok));
             }
         }
     }

--- a/motor-control/tests/test_limit_switch.cpp
+++ b/motor-control/tests/test_limit_switch.cpp
@@ -82,15 +82,15 @@ SCENARIO("MoveStopCondition::limit_switch with the limit switch triggered") {
                     std::get<Ack>(test_objs.reporter.messages.back());
                 REQUIRE(read_ack.ack_id == AckMessageId::stopped_by_condition);
                 REQUIRE(read_ack.encoder_position == 50);
-                REQUIRE(read_ack.current_position_steps == 0);
+                REQUIRE(read_ack.current_position_steps == 350);
             }
-            THEN("the encoder position flag should be set") {
-                REQUIRE(test_objs.hw.position_flags.check_flag(
-                    MotorPositionStatus::Flags::encoder_position_ok));
-            }
-            THEN("the stepper position flag is still cleared") {
+            THEN(
+                "the stepper position flag and encoder position flags are "
+                "still cleared") {
                 REQUIRE(!test_objs.hw.position_flags.check_flag(
                     MotorPositionStatus::Flags::stepper_position_ok));
+                REQUIRE(!test_objs.hw.position_flags.check_flag(
+                    MotorPositionStatus::Flags::encoder_position_ok));
             }
         }
     }

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -340,9 +340,9 @@ TEST_CASE("Finishing a move") {
             auto msg = std::get<Ack>(test_objs.reporter.messages[0]);
             REQUIRE(msg.group_id == move.group_id);
             REQUIRE(msg.seq_id == move.seq_id);
-            REQUIRE(msg.current_position_steps == 0);
+            REQUIRE(msg.current_position_steps == 100);
             REQUIRE(msg.encoder_position == 200);
-            REQUIRE(msg.position_flags == 0x2);
+            REQUIRE(msg.position_flags == 0x0);
 
             AND_GIVEN("a backoff move") {
                 test_objs.reporter.messages.clear();

--- a/motor-control/tests/test_motor_pulse.cpp
+++ b/motor-control/tests/test_motor_pulse.cpp
@@ -342,7 +342,7 @@ TEST_CASE("Finishing a move") {
             REQUIRE(msg.seq_id == move.seq_id);
             REQUIRE(msg.current_position_steps == 0);
             REQUIRE(msg.encoder_position == 200);
-            REQUIRE(msg.position_flags == 0x0);
+            REQUIRE(msg.position_flags == 0x2);
 
             AND_GIVEN("a backoff move") {
                 test_objs.reporter.messages.clear();


### PR DESCRIPTION
If the limit switch is not triggered within a `HomeRequest`, this means that we can no longer trust the encoder value and we should just clear the flag. This will force the axis to do a proper home when it receives a `HomeRequest` again. 