### PR TITLE
fix(sensors): mitigate cap sensor configuration issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if (${CMAKE_CROSSCOMPILING})
     find_package(CrossGCC)
     find_package(OpenOCD)
 
-    add_compile_definitions(ENABLE_CCMRAM)
+    add_compile_definitions(ENABLE_CCMRAM, ENABLE_CROSS_ONLY_HEADERS)
 
     configure_file(common/firmware/platform_specific_hal_conf.h.in ${CMAKE_BINARY_DIR}/generated/platform_specific_hal_conf.h)
     configure_file(common/firmware/platform_specific_hal.h.in ${CMAKE_BINARY_DIR}/generated/platform_specific_hal.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,9 @@ if (${CMAKE_CROSSCOMPILING})
     find_package(CrossGCC)
     find_package(OpenOCD)
 
-    add_compile_definitions(ENABLE_CCMRAM, ENABLE_CROSS_ONLY_HEADERS)
+    add_compile_definitions(ENABLE_CCMRAM)
+
+    add_compile_definitions(ENABLE_CROSS_ONLY_HEADERS)
 
     configure_file(common/firmware/platform_specific_hal_conf.h.in ${CMAKE_BINARY_DIR}/generated/platform_specific_hal_conf.h)
     configure_file(common/firmware/platform_specific_hal.h.in ${CMAKE_BINARY_DIR}/generated/platform_specific_hal.h)

--- a/include/sensors/core/fdc1004.hpp
+++ b/include/sensors/core/fdc1004.hpp
@@ -129,7 +129,7 @@ template <typename Reg>
 // This is used to mask the value before writing it to the sensor.
 concept FDC1004Register =
     std::same_as<std::remove_cvref_t<decltype(Reg::address)>,
-                 std::remove_cvref_t<Registers&>> &&
+                 std::remove_cvref_t<Registers &>> &&
     std::integral<decltype(Reg::value_mask)>;
 
 template <typename Reg>
@@ -559,5 +559,21 @@ inline auto update_offset(float capacitance_pf, float current_offset_pf)
 
     return static_cast<float>(capdac) * CAPDAC_PF_PER_LSB;
 }
+
+inline auto measurement_ready(fdc1004::FDCConf &fdc,
+                              fdc1004::MeasureConfigMode mode) -> bool {
+    switch (mode) {
+        case fdc1004::MeasureConfigMode::ONE:
+            return fdc.measure_mode_1_status;
+        case fdc1004::MeasureConfigMode::TWO:
+            return fdc.measure_mode_2_status;
+        case fdc1004::MeasureConfigMode::THREE:
+            return fdc.measure_mode_3_status;
+        case fdc1004::MeasureConfigMode::FOUR:
+            return fdc.measure_mode_4_status;
+    }
+    return false;
+}
+
 }  // namespace fdc1004_utils
 };  // namespace sensors

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -8,10 +8,12 @@
 // the vTaskDelay function and hopefully sometime in the near future I
 // can refactor this file with a nice templated sleep function.
 #include "FreeRTOS.h"
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define HACKY_TASK_SLEEP(___timeout___) vTaskDelay(___timeout___)
 
 #else
 
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define HACKY_TASK_SLEEP(___timeout___) (void)(___timeout___)
 #endif
 
@@ -204,7 +206,7 @@ class FDC1004 {
     }
 
     void handle_fdc_response(i2c::messages::TransactionResponse &m) {
-        uint16_t reg_int;
+        uint16_t reg_int = 0;
         static_cast<void>(bit_utils::bytes_to_int(
             m.read_buffer.cbegin(), m.read_buffer.cend(), reg_int));
         auto fdc = read_register<fdc1004::FDCConf>(reg_int).value();

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -44,8 +44,14 @@ class CapacitiveMessageHandler {
 
     void visit(i2c::messages::TransactionResponse &m) {
         auto reg_id = utils::reg_from_id<uint8_t>(m.id.token);
+        if (reg_id == static_cast<uint8_t>(fdc1004::Registers::FDC_CONF)) {
+            driver.handle_fdc_response(m);
+            return;
+        }
         if ((reg_id != static_cast<uint8_t>(fdc1004::Registers::MEAS1_MSB)) &&
-            (reg_id != static_cast<uint8_t>(fdc1004::Registers::MEAS2_MSB))) {
+            (reg_id != static_cast<uint8_t>(fdc1004::Registers::MEAS2_MSB)) &&
+            (reg_id != static_cast<uint8_t>(fdc1004::Registers::MEAS1_LSB)) &&
+            (reg_id != static_cast<uint8_t>(fdc1004::Registers::MEAS2_LSB))) {
             return;
         }
 

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -70,6 +70,10 @@ template <std::ranges::range Tags>
     return bool(token & (1 << static_cast<size_t>(tag)));
 }
 
+[[nodiscard]] inline constexpr auto tags_from_token(uint32_t token) -> uint8_t {
+    return static_cast<uint8_t>(token & 0xff);
+}
+
 [[nodiscard]] inline constexpr auto build_id(uint16_t address, uint8_t reg,
                                              uint8_t tags = 0) -> uint32_t {
     return (static_cast<uint32_t>(address) << 16) |

--- a/include/sensors/simulation/fdc1004.hpp
+++ b/include/sensors/simulation/fdc1004.hpp
@@ -13,9 +13,12 @@ class FDC1004 : public I2CRegisterMap<uint8_t, uint16_t> {
         : I2CRegisterMap(
               fdc1004::ADDRESS,
               {{static_cast<uint8_t>(fdc1004::Registers::CONF_MEAS1), 0},
-               {static_cast<uint8_t>(fdc1004::Registers::FDC_CONF), 0},
+               // Mock out the Read Ready bits as set
+               {static_cast<uint8_t>(fdc1004::Registers::FDC_CONF), 0x000F},
                {static_cast<uint8_t>(fdc1004::Registers::MEAS1_MSB), 100},
                {static_cast<uint8_t>(fdc1004::Registers::MEAS1_LSB), 0},
+               {static_cast<uint8_t>(fdc1004::Registers::MEAS2_MSB), 100},
+               {static_cast<uint8_t>(fdc1004::Registers::MEAS2_LSB), 0},
                {static_cast<uint8_t>(fdc1004::Registers::DEVICE_ID),
                 fdc1004_utils::DEVICE_ID}}) {}
 };


### PR DESCRIPTION
The capacitive sensor seems to be having issues that stem from the initial register configuration. One issue seems to be that we are enabling a single channel at a time, but doing it twice in a row on startup. We may also be losing I2C messages in the flurry of bus traffic on startup, which may be exacerbated by the I2C tasks now releasing the CPU during transactions and therefore allowing other tasks to try to write more messages.

This PR does a couple of things which, in conjunction, seem to fix the issue of bad capacitive sensor data:
- Instead of directly polling the data registers, check the Reading Ready flags in the FDC register first.
- Always enable readings from both Reading 1 and Reading 2, and let them just run continuously forever
- Only configure one channel's readings at a time
- Add some `vTaskDelay` calls during startup to both 1) avoid I2C queue overflow 2) maybe give the sensor enough time to initialize?
- Removed the SMA filter, which had a few problems with fixed point conversions and also seems unnecessary with these fixes

Todo:

- [x] Test on single channel
- [x] Test on 96 channel
- [x] Test on gripper
- [x] Fix the capacitive sensor tests