### PR TITLE
fix(motor-control): update position flag inside encoder background timer

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
+++ b/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
@@ -32,6 +32,8 @@ class BackgroundTimer {
         if (!_interrupt_handler.has_active_move()) {
             // Refresh the overflow counter if nothing else is doing it
             std::ignore = _motor_hardware.get_encoder_pulses();
+            // Update position flag if needed
+            std::ignore = _interrupt_handler.check_for_stall();
         }
     }
 

--- a/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
+++ b/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
@@ -31,8 +31,7 @@ class BackgroundTimer {
     auto callback() -> void {
         if (!_interrupt_handler.has_active_move()) {
             // Refresh the overflow counter if nothing else is doing it
-            std::ignore = _motor_hardware.get_encoder_pulses();
-            // Update position flag if needed
+            // and update position flag if needed
             std::ignore = _interrupt_handler.check_for_stall();
         }
     }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -78,14 +78,21 @@ class MotorInterruptHandler {
             hardware.step();
             update_hardware_step_tracker();
             if (stall_checker.step_itr(set_direction_pin())) {
-                if (stall_detected()) {
-                    hardware.position_flags.clear_flag(
-                        MotorPositionStatus::Flags::stepper_position_ok);
+                if (check_for_stall()) {
                     handle_stall_during_movement();
                 }
             }
             hardware.unstep();
         }
+    }
+
+    auto check_for_stall() -> bool {
+        if (stall_detected()) {
+            hardware.position_flags.clear_flag(
+                MotorPositionStatus::Flags::stepper_position_ok);
+            return true;
+        }
+        return false;
     }
 
     auto handle_stall_during_movement() -> void {


### PR DESCRIPTION
We should update the position flag whenever the encoder value is off from where we expect the motor to be, not just during an active move. We can do this in the encoder background timer so that we are re-evaluating the position flag every time we read the encoder pulses. 

