### PR TITLE
fix(motor-control): refresh the stall thresholds after finish the last move in the queue

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -276,6 +276,9 @@ class MotorInterruptHandler {
                         return true;
                     }
                 }
+                // update the stall check ideal encoder counts based on
+                // last known location
+                stall_checker.reset_itr_counts(hardware.get_step_tracker());
                 return false;
             }
         } else {


### PR DESCRIPTION
The stall checker sometimes falsely reported that a stall has been detected even though the stepper and encoder values are within the acceptable threshold. 

This is because the `check_stall_itr()` function we use to check for stall is optimized for high-speed interrupts – we store a cache for the ideal encoder count and update it _only_ after the motor position has surpassed the current threshold. Now that we're checking for stall in the background timer, we're always comparing the current encoder value against the ideal count that was set from a previous move.

Instead, we should refresh the ideal count based on the current stepper count whenever the motor interrupt handler finishes the last move in a sequence (only when no new moves are in the queue). 
