### PR TITLE
chore: add revisions for PVT boards

### DIFF
--- a/bootloader/firmware/stm32G4/CMakeLists.txt
+++ b/bootloader/firmware/stm32G4/CMakeLists.txt
@@ -93,8 +93,8 @@ endmacro()
 foreach_revision(
     PROJECT_NAME bootloader-gripper
     CALL_FOREACH_REV gripper_bootloader_loop
-    REVISIONS a1 b1 c1
-    SOURCES gripper_sources gripper_sources gripper_sources
+    REVISIONS a1 b1 c1 c2
+    SOURCES gripper_sources gripper_sources gripper_sources gripper_sources
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
     )

--- a/bootloader/firmware/stm32G4/CMakeLists.txt
+++ b/bootloader/firmware/stm32G4/CMakeLists.txt
@@ -64,8 +64,8 @@ endmacro()
 foreach_revision(
     PROJECT_NAME bootloader-gantry-x
     CALL_FOREACH_REV gantry_x_bootloader_loop
-    REVISIONS a1 b1 c1
-    SOURCES _g4_sources _g4_sources _g4_sources
+    REVISIONS a1 b1 c1 c2
+    SOURCES _g4_sources _g4_sources _g4_sources _g4_sources
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
     )
@@ -73,8 +73,8 @@ foreach_revision(
 foreach_revision(
     PROJECT_NAME bootloader-gantry-y
     CALL_FOREACH_REV gantry_y_bootloader_loop
-    REVISIONS a1 b1 c1
-    SOURCES _g4_sources _g4_sources _g4_sources
+    REVISIONS a1 b1 c1 c2
+    SOURCES _g4_sources _g4_sources _g4_sources _g4_sources
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
     )
@@ -132,8 +132,8 @@ set(_pipette_sources ${_g4_sources} ./pipette_handle_messages.c)
 foreach_revision(
     PROJECT_NAME bootloader-pipettes-single
     CALL_FOREACH_REV pipettes_single_bootloader_loop
-    REVISIONS b1 c2
-    SOURCES _pipette_sources _pipette_sources
+    REVISIONS b1 c2 d1
+    SOURCES _pipette_sources _pipette_sources _pipette_sources
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
     )
@@ -141,8 +141,8 @@ foreach_revision(
 foreach_revision(
     PROJECT_NAME bootloader-pipettes-multi
     CALL_FOREACH_REV pipettes_multi_bootloader_loop
-    SOURCES _pipette_sources _pipette_sources
-    REVISIONS b1 c2
+    SOURCES _pipette_sources _pipette_sources _pipette_sources
+    REVISIONS b1 c2 d1
     NO_CREATE_IMAGE_HEX
     NO_CREATE_INSTALL_RULES
     )

--- a/gantry/firmware/CMakeLists.txt
+++ b/gantry/firmware/CMakeLists.txt
@@ -53,6 +53,7 @@ set(GANTRY_X_B1_SRCS
     ${CMAKE_SOURCE_DIR}/gantry/firmware/axis_x_rev1_hardware_config.c
 )
 set(GANTRY_X_C1_SRCS ${GANTRY_X_B1_SRCS})
+set(GANTRY_X_C2_SRCS ${GANTRY_X_C1_SRCS})
 
 set(GANTRY_Y_A1_SRCS
     ${GANTRY_BASE_SOURCES}
@@ -65,6 +66,7 @@ set(GANTRY_Y_B1_SRCS
     ${CMAKE_SOURCE_DIR}/gantry/firmware/axis_y_rev1_hardware_config.c
 )
 set(GANTRY_Y_C1_SRCS ${GANTRY_Y_B1_SRCS})
+set(GANTRY_Y_C2_SRCS ${GANTRY_Y_C1_SRCS})
 
 macro(gantry_loop_internal)
     set(_gli_options)
@@ -122,14 +124,14 @@ endmacro()
 foreach_revision(
     PROJECT_NAME gantry-x
     CALL_FOREACH_REV gantry_loop_internal_x
-    REVISIONS a1 b1 c1
-    SOURCES GANTRY_X_A1_SRCS GANTRY_X_B1_SRCS GANTRY_X_C1_SRCS
+    REVISIONS a1 b1 c1 c2
+    SOURCES GANTRY_X_A1_SRCS GANTRY_X_B1_SRCS GANTRY_X_C1_SRCS GANTRY_X_C2_SRCS
     )
 foreach_revision(
     PROJECT_NAME gantry-y
     CALL_FOREACH_REV gantry_loop_internal_y
-    REVISIONS a1 b1 c1
-    SOURCES GANTRY_Y_A1_SRCS GANTRY_Y_B1_SRCS GANTRY_Y_C1_SRCS
+    REVISIONS a1 b1 c1 c2
+    SOURCES GANTRY_Y_A1_SRCS GANTRY_Y_B1_SRCS GANTRY_Y_C1_SRCS GANTRY_Y_C2_SRCS
     )
 
 

--- a/gripper/firmware/CMakeLists.txt
+++ b/gripper/firmware/CMakeLists.txt
@@ -49,6 +49,7 @@ set(GRIPPER_SRCS_B1
         ${CMAKE_CURRENT_SOURCE_DIR}/main_rev1.cpp
 )
 set(GRIPPER_SRCS_C1 ${GRIPPER_SRCS_B1})
+set(GRIPPER_SRCS_C2 ${GRIPPER_SRCS_C1})
 
 macro(gripper_loop)
     set(_driver_suffix ${PROJECT_NAME}_${REVISION})
@@ -88,8 +89,8 @@ endmacro()
 
 foreach_revision(
     PROJECT_NAME gripper
-    REVISIONS a1 b1 c1
-    SOURCES GRIPPER_SRCS_A1 GRIPPER_SRCS_B1 GRIPPER_SRCS_C1
+    REVISIONS a1 b1 c1 c2
+    SOURCES GRIPPER_SRCS_A1 GRIPPER_SRCS_B1 GRIPPER_SRCS_C1 GRIPPER_SRCS_C2
     CALL_FOREACH_REV gripper_loop)
 
 alias_for_revision(PROJECT_NAME gripper REVISION a1 REVISION_ALIAS proto)

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -97,16 +97,16 @@ set(pipette_srcs ${PIPETTE_FW_LINTABLE_SRCS}
 
 foreach_revision(
     PROJECT_NAME pipettes-single
-    REVISIONS b1 c2
-    SOURCES pipette_srcs pipette_srcs
+    REVISIONS b1 c2 d1
+    SOURCES pipette_srcs pipette_srcs pipette_srcs
     CALL_FOREACH_REV pipettes_single_loop
     )
 
 foreach_revision(
     PROJECT_NAME pipettes-multi
-    REVISIONS b1 c2
+    REVISIONS b1 c2 d1
     CALL_FOREACH_REV pipettes_multi_loop
-    SOURCES pipette_srcs pipette_srcs
+    SOURCES pipette_srcs pipette_srcs pipette_srcs
     )
 
 foreach_revision(

--- a/rear-panel/firmware/CMakeLists.txt
+++ b/rear-panel/firmware/CMakeLists.txt
@@ -250,8 +250,8 @@ macro(rearpanel_loop)
 endmacro()
 
 foreach_revision(PROJECT_NAME rear-panel
-  REVISIONS b1 b2
-  SOURCES rearpanel_b1_srcs rearpanel_b1_srcs
+  REVISIONS b1 b2 c1
+  SOURCES rearpanel_b1_srcs rearpanel_b1_srcs rearpanel_b1_srcs
   CALL_FOREACH_REV rearpanel_loop
   NO_CREATE_IMAGE_HEX
   NO_CREATE_APPLICATION_HEX


### PR DESCRIPTION
Add revision handling for the variants:
- Gantry C2
- Rear-panel C1 (B2 did not actually exist, keeping it just in case)
- LT pipette D1
- Gripper C2

Head got a bump from C2.0 to C2.1, which we don't track; SOM got a bump but we don't track that; 96 hasn't gotten its bump yet.

These changes are to enter PVT.

## Risk
Medium I guess. These are going to be flashed to real boards and used in real ways, but there's no code changes before and after this, so I don't know.

## Testing
- [x] Put it on each and every one of these boards and boot it
- [x]  check that it reports correctly from bootloader
- [x] check that appropriate entries in the firmware manifest cause automated updates
- [x] check that the updated firmware preserves the revision