### PR TITLE
fix(motor-control): reset itr count after finish move 

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -276,9 +276,6 @@ class MotorInterruptHandler {
                         return true;
                     }
                 }
-                // update the stall check ideal encoder counts based on
-                // last known location
-                stall_checker.reset_itr_counts(hardware.get_step_tracker());
                 return false;
             }
         } else {
@@ -461,6 +458,11 @@ class MotorInterruptHandler {
         stall_handled = false;
         build_and_send_ack(ack_msg_id);
         set_buffered_move(MotorMoveMessage{});
+        // update the stall check ideal encoder counts based on
+        // last known location
+        if (!has_move_messages()) {
+            stall_checker.reset_itr_counts(hardware.get_step_tracker());
+        }
     }
 
     void reset() {


### PR DESCRIPTION
The way we refreshed the stall threshold in #705 actually only fixes moves when they complete without meeting any condition. If the move has a stop condition such as sync_line or limit switch, etc, we don't reach that piece of code.

Moving the reset to the end of `finish_current_move` should fix this problem. 

Fixes this ticket: https://opentrons.atlassian.net/browse/RQA-1135