### PR TITLE
fix(motor-control): do not disengage motor when a StopRequest is received

### DIFF
--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -109,7 +109,6 @@ class MotionController {
 
     void stop() {
         queue.reset();
-        disable_motor();
         if (hardware.is_timer_interrupt_running()) {
             hardware.request_cancel();
         }

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -260,7 +260,6 @@ class PipetteMotionController {
 
     void stop() {
         queue.reset();
-        disable_motor();
         // if the timer interrupt is running, cancel it. if it isn't running,
         // don't submit a cancel because then the cancel won't be read until
         // the timer starts the next time.


### PR DESCRIPTION
We should just let the DisengageMotorRequest handle that instead. 