### PR TITLE
feat(gripper): add stay engaged param to grip message

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1005,6 +1005,8 @@ struct GripperGripRequest : BaseMessage<MessageId::gripper_grip_request> {
     uint8_t seq_id;
     brushed_timer_ticks duration;
     uint32_t duty_cycle;
+    int32_t encoder_position_um;
+    uint8_t stay_engaged;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> GripperGripRequest {
@@ -1012,6 +1014,8 @@ struct GripperGripRequest : BaseMessage<MessageId::gripper_grip_request> {
         uint8_t seq_id = 0;
         brushed_timer_ticks duration = 0;
         uint32_t duty_cycle = 0;
+        int32_t encoder_position_um = 0;
+        uint8_t stay_engaged = 0;
         uint32_t msg_ind = 0;
 
         body = bit_utils::bytes_to_int(body, limit, msg_ind);
@@ -1019,12 +1023,16 @@ struct GripperGripRequest : BaseMessage<MessageId::gripper_grip_request> {
         body = bit_utils::bytes_to_int(body, limit, seq_id);
         body = bit_utils::bytes_to_int(body, limit, duration);
         body = bit_utils::bytes_to_int(body, limit, duty_cycle);
+        body = bit_utils::bytes_to_int(body, limit, encoder_position_um);
+        body = bit_utils::bytes_to_int(body, limit, stay_engaged);
 
         return GripperGripRequest{.message_index = msg_ind,
                                   .group_id = group_id,
                                   .seq_id = seq_id,
                                   .duration = duration,
-                                  .duty_cycle = duty_cycle};
+                                  .duty_cycle = duty_cycle,
+                                  .encoder_position_um = encoder_position_um,
+                                  .stay_engaged = stay_engaged};
     }
 
     auto operator==(const GripperGripRequest& other) const -> bool = default;

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -48,6 +48,7 @@ class MotionController {
             .duty_cycle = can_msg.duty_cycle,
             .group_id = can_msg.group_id,
             .seq_id = can_msg.seq_id,
+            .stay_engaged = can_msg.stay_engaged,
             .stop_condition = MoveStopCondition::none,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
         if (!enabled) {

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -107,6 +107,7 @@ struct BrushedMove {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     uint8_t group_id;
     uint8_t seq_id;
     int32_t encoder_position;
+    uint8_t stay_engaged = 0;
     MoveStopCondition stop_condition = MoveStopCondition::none;
     int32_t start_encoder_position;
     uint16_t usage_key;


### PR DESCRIPTION
We want to be able to differentiate between an actual labware grip and a grip that closes the jaw to minimize the footprint of the gripper during gantry movement (we call this the idle position from the api). 

This will inform the firmware whether or not the jaw motor needs to stay engaged when we receive a stop request and prevent unexpected dropping of labware. And if the gripper was in the idle position, the jaw can simply disengage since it does not matter because it is not gripping anything.

The next step is to get gripper to report the real-time jaw state to the hardware controller API (so we don't have to rely soely on the gripper handler instance variable to keep track of the jaw state, which gets lost when the robot server stops).