### PR TITLE
feat(motor-control): report brushed motor state (jaw state)

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -67,6 +67,8 @@ typedef enum {
     can_messageid_brushed_motor_conf_request = 0x45,
     can_messageid_brushed_motor_conf_response = 0x46,
     can_messageid_set_gripper_error_tolerance = 0x47,
+    can_messageid_gripper_jaw_state_request = 0x48,
+    can_messageid_gripper_jaw_state_response = 0x49,
     can_messageid_acknowledgement = 0x50,
     can_messageid_read_presence_sensing_voltage_request = 0x600,
     can_messageid_read_presence_sensing_voltage_response = 0x601,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -69,6 +69,8 @@ enum class MessageId {
     brushed_motor_conf_request = 0x45,
     brushed_motor_conf_response = 0x46,
     set_gripper_error_tolerance = 0x47,
+    gripper_jaw_state_request = 0x48,
+    gripper_jaw_state_response = 0x49,
     acknowledgement = 0x50,
     read_presence_sensing_voltage_request = 0x600,
     read_presence_sensing_voltage_response = 0x601,

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1498,6 +1498,26 @@ struct GetMotorUsageResponse
 
     auto operator==(const GetMotorUsageResponse& other) const -> bool = default;
 };
+
+using GripperJawStateRequest = Empty<MessageId::gripper_jaw_state_request>;
+
+struct GripperJawStateResponse
+    : BaseMessage<MessageId::gripper_jaw_state_response> {
+    uint32_t message_index;
+    uint8_t jaw_state;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(message_index, body, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(jaw_state), iter,
+                                       limit);
+        return iter - body;
+    }
+
+    auto operator==(const GripperJawStateResponse& other) const
+        -> bool = default;
+};
+
 /**
  * A variant of all message types we might send..
  */
@@ -1513,6 +1533,7 @@ using ResponseMessageType = std::variant<
     BindSensorOutputResponse, GripperInfoResponse, TipActionResponse,
     PeripheralStatusResponse, BrushedMotorConfResponse,
     UpdateMotorPositionEstimationResponse, BaselineSensorResponse,
-    PushTipPresenceNotification, GetMotorUsageResponse>;
+    PushTipPresenceNotification, GetMotorUsageResponse,
+    GripperJawStateResponse>;
 
 }  // namespace can::messages

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -140,7 +140,9 @@ class MotionController {
         usage_client.send_usage_storage_queue(req);
     }
 
-    void get_jaw_state() {}
+    auto get_jaw_state() -> BrushedMotorState {
+        return hardware.get_motor_state;
+    }
 
   private:
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -141,7 +141,7 @@ class MotionController {
     }
 
     auto get_jaw_state() -> BrushedMotorState {
-        return hardware.get_motor_state;
+        return hardware.get_motor_state();
     }
 
   private:

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -140,6 +140,8 @@ class MotionController {
         usage_client.send_usage_storage_queue(req);
     }
 
+    void get_jaw_state() {}
+
   private:
     lms::LinearMotionSystemConfig<MEConfig> linear_motion_sys_config;
     BrushedMotorHardwareIface& hardware;

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -118,7 +118,8 @@ class BrushedMotorInterruptHandler {
                 controlled_move_to(move_delta);
                 if (std::abs(move_delta) <
                     error_conf.acceptable_position_error) {
-                    finish_current_move(true, AckMessageId::stopped_by_condition);
+                    finish_current_move(true,
+                                        AckMessageId::stopped_by_condition);
                 }
                 break;
             }
@@ -146,24 +147,25 @@ class BrushedMotorInterruptHandler {
             // has not reported an error yet
             if (motor_state == ControlState::POSITION_CONTROLLING) {
                 int32_t move_delta =
-                        hardware.get_encoder_pulses() - hold_encoder_position;
+                    hardware.get_encoder_pulses() - hold_encoder_position;
                 controlled_move_to(move_delta);
-                // we use a value higher than the acceptable position here to allow
-                // the pid loop the opportunity to maintain small movements that
-                // occur from motion and vibration
+                // we use a value higher than the acceptable position here to
+                // allow the pid loop the opportunity to maintain small
+                // movements that occur from motion and vibration
                 if (move_delta > error_conf.unwanted_movement_threshold) {
-                    cancel_and_clear_moves(can::ids::ErrorCode::collision_detected);
+                    cancel_and_clear_moves(
+                        can::ids::ErrorCode::collision_detected);
                     error_handled = true;
                 }
             } else if (motor_state != ControlState::UNHOMED) {
                 auto pulses = hardware.get_encoder_pulses();
                 if (!is_idle && pulses >= 0 &&
                     std::abs(pulses - hold_encoder_position) >
-                    error_conf.unwanted_movement_threshold) {
+                        error_conf.unwanted_movement_threshold) {
                     // we have likely dropped a labware or had a collision
                     auto err = motor_state == ControlState::FORCE_CONTROLLING
-                               ? can::ids::ErrorCode::labware_dropped
-                               : can::ids::ErrorCode::collision_detected;
+                                   ? can::ids::ErrorCode::labware_dropped
+                                   : can::ids::ErrorCode::collision_detected;
                     cancel_and_clear_moves(err);
                     error_handled = true;
                 }
@@ -263,7 +265,8 @@ class BrushedMotorInterruptHandler {
         hardware.reset_control();
         timeout_ticks = 0;
         error_handled = false;
-        hardware.set_stay_enabled(static_cast<bool>(buffered_move.stay_engaged));
+        hardware.set_stay_enabled(
+            static_cast<bool>(buffered_move.stay_engaged));
         switch (buffered_move.stop_condition) {
             case MoveStopCondition::limit_switch:
                 motor_state = ControlState::FORCE_CONTROLLING_HOME;
@@ -276,7 +279,8 @@ class BrushedMotorInterruptHandler {
                     buffered_move.encoder_position) {
                     LOG("Attempting to add a gripper move to our current "
                         "position");
-                    finish_current_move(true, AckMessageId::stopped_by_condition);
+                    finish_current_move(true,
+                                        AckMessageId::stopped_by_condition);
                 }
                 break;
             case MoveStopCondition::none:
@@ -292,7 +296,8 @@ class BrushedMotorInterruptHandler {
                 // this is an unused move stop condition for the brushed motor
                 // just return with no condition
                 // TODO creat can bus error messages and send that instead
-                finish_current_move(false, AckMessageId::complete_without_condition);
+                finish_current_move(false,
+                                    AckMessageId::complete_without_condition);
                 break;
         }
     }
@@ -346,11 +351,12 @@ class BrushedMotorInterruptHandler {
 
         // only update hold position when the move is valid
         if (update_hold_position) {
-            // use the commanded move position as the hold position if posiiton controling
-            // otherwise, we can use the actual jaw encoder position
-            hold_encoder_position = motor_state == ControlState::POSITION_CONTROLLING
-                                    ? buffered_move.encoder_position
-                                    : hardware.get_encoder_pulses();
+            // use the commanded move position as the hold position if posiiton
+            // controling otherwise, we can use the actual jaw encoder position
+            hold_encoder_position =
+                motor_state == ControlState::POSITION_CONTROLLING
+                    ? buffered_move.encoder_position
+                    : hardware.get_encoder_pulses();
         }
 
         if (buffered_move.group_id != NO_GROUP) {

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -24,14 +24,11 @@ using namespace motor_messages;
  *
  */
 
-enum class ControlState {
-    FORCE_CONTROLLING_HOME,
-    FORCE_CONTROLLING,
-    POSITION_CONTROLLING,
-    IDLE,
-    ACTIVE,
-    ERROR,
-    ESTOP
+enum class ControlState : uint8_t {
+    UNHOMED = 0x0,
+    FORCE_CONTROLLING_HOME = 0x1,
+    FORCE_CONTROLLING = 0x2,
+    POSITION_CONTROLLING = 0x3
 };
 
 static constexpr uint32_t HOLDOFF_TICKS =

--- a/include/motor-control/core/motor_hardware_interface.hpp
+++ b/include/motor-control/core/motor_hardware_interface.hpp
@@ -145,5 +145,7 @@ class BrushedMotorHardwareIface : virtual public MotorHardwareIface {
     virtual void set_stay_enabled(bool state) = 0;
     virtual auto get_stay_enabled() -> bool = 0;
     virtual auto get_stopwatch_pulses(bool clear) -> uint16_t = 0;
+    virtual void set_motor_state(BrushedMotorState state) = 0;
+    virtual auto get_motor_state() -> BrushedMotorState = 0;
 };
 };  // namespace motor_hardware

--- a/include/motor-control/core/motor_messages.hpp
+++ b/include/motor-control/core/motor_messages.hpp
@@ -134,6 +134,11 @@ struct UpdatePositionResponse {
     uint8_t position_flags;
 };
 
+struct GripperJawStateResponse {
+    uint32_t message_index;
+    uint8_t jaw_state;
+};
+
 const uint8_t NO_GROUP = 0xff;
 
 constexpr const int RADIX = 31;

--- a/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
@@ -116,6 +116,15 @@ class MotionControllerMessageHandler {
         controller.send_usage_data(m.message_index, usage_client);
     }
 
+    void handle(const can::messages::GripperJawStateRequest& m) {
+        auto jaw_state = controller.get_jaw_state();
+        can_client.send_can_message(
+            can::ids::NodeId::host,
+            can::messages::GripperJawStateResponse msg{
+                .message_index = m.message_index,
+                .jaw_state = static_cast<uint8_t>(jaw_state)});
+    }
+
     brushed_motion_controller::MotionController<MEConfig>& controller;
     CanClient& can_client;
     UsageClient& usage_client;

--- a/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/brushed_motion_controller_task.hpp
@@ -118,11 +118,10 @@ class MotionControllerMessageHandler {
 
     void handle(const can::messages::GripperJawStateRequest& m) {
         auto jaw_state = controller.get_jaw_state();
-        can_client.send_can_message(
-            can::ids::NodeId::host,
-            can::messages::GripperJawStateResponse msg{
-                .message_index = m.message_index,
-                .jaw_state = static_cast<uint8_t>(jaw_state)});
+        can::messages::GripperJawStateResponse msg{
+            .message_index = m.message_index,
+            .jaw_state = static_cast<uint8_t>(jaw_state)};
+        can_client.send_can_message(can::ids::NodeId::host, msg);
     }
 
     brushed_motion_controller::MotionController<MEConfig>& controller;

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -31,7 +31,8 @@ using MoveGroupTaskMessage =
 using MoveStatusReporterTaskMessage = std::variant<
     std::monostate, motor_messages::Ack, motor_messages::UpdatePositionResponse,
     can::messages::ErrorMessage, can::messages::StopRequest,
-    usage_messages::IncreaseForceTimeUsage, usage_messages::IncreaseErrorCount>;
+    usage_messages::IncreaseForceTimeUsage, usage_messages::IncreaseErrorCount,
+    can::messages::GripperJawStateResponse>;
 
 using BrushedMotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,
@@ -45,7 +46,7 @@ using BrushedMotionControllerTaskMessage = std::variant<
     can::messages::AddBrushedLinearMoveRequest, can::messages::StopRequest,
     can::messages::ReadLimitSwitchRequest, can::messages::MotorPositionRequest,
     can::messages::SetGripperErrorToleranceRequest,
-    can::messages::GetMotorUsageRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::GripperJawStateRequest>;
 
 using BrushedMoveGroupTaskMessage = std::variant<
     std::monostate, can::messages::ClearAllMoveGroupsRequest,

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -31,8 +31,7 @@ using MoveGroupTaskMessage =
 using MoveStatusReporterTaskMessage = std::variant<
     std::monostate, motor_messages::Ack, motor_messages::UpdatePositionResponse,
     can::messages::ErrorMessage, can::messages::StopRequest,
-    usage_messages::IncreaseForceTimeUsage, usage_messages::IncreaseErrorCount,
-    can::messages::GripperJawStateResponse>;
+    usage_messages::IncreaseForceTimeUsage, usage_messages::IncreaseErrorCount>;
 
 using BrushedMotorDriverTaskMessage =
     std::variant<std::monostate, can::messages::SetBrushedMotorVrefRequest,

--- a/include/motor-control/core/types.hpp
+++ b/include/motor-control/core/types.hpp
@@ -39,3 +39,10 @@ struct __attribute__((__packed__)) UsageRequestSet {
     uint16_t type_key;
     uint16_t length;
 };
+
+enum class BrushedMotorState : uint8_t {
+    UNHOMED = 0x0,
+    FORCE_CONTROLLING_HOME = 0x1,
+    FORCE_CONTROLLING = 0x2,
+    POSITION_CONTROLLING = 0x3
+};

--- a/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
+++ b/include/motor-control/firmware/brushed_motor/brushed_motor_hardware.hpp
@@ -88,6 +88,9 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     void disable_encoder() final {}
     void enable_encoder() final {}
 
+    void set_motor_state(BrushedMotorState state) final { motor_state = state; }
+    auto get_motor_state() -> BrushedMotorState final { return motor_state; }
+
   private:
     bool stay_enabled = false;
     debouncer::Debouncer estop = debouncer::Debouncer{};
@@ -101,6 +104,7 @@ class BrushedMotorHardware : public BrushedMotorHardwareIface {
     std::atomic<bool> cancel_request = false;
     const UsageEEpromConfig& eeprom_config;
     void* stopwatch_handle;
+    BrushedMotorState motor_state = BrushedMotorState::UNHOMED;
 };
 
 };  // namespace motor_hardware

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -87,8 +87,12 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     void disable_encoder() final {}
     void enable_encoder() final {}
 
+    void set_motor_state(BrushedMotorState state) { motor_state = state; }
+    auto get_motor_state() -> BrushedMotorState { return motor_state; }
+
   private:
     bool stay_enabled = false;
+    BrushedMotorState motor_state = BrushedMotorState::UNHOMED;
     PWM_DIRECTION move_dir = PWM_DIRECTION::unset;
     int32_t motor_encoder_overflow_count = 0;
     bool ls_val = false;

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -107,25 +107,22 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     bool cancel_request = false;
     bool timer_interrupt_running = true;
     motor_hardware::UsageEEpromConfig eeprom_config =
-        motor_hardware::UsageEEpromConfig{
-            std::array<UsageRequestSet, 3>{
-                UsageRequestSet{
-                    .eeprom_key = 0x0,
-                    .type_key =
-                             uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
-                    .length = usage_storage_task::distance_data_usage_len},
-                UsageRequestSet{
-                    .eeprom_key = 0x1,
-                    .type_key = uint16_t(
-                            can::ids::MotorUsageValueType::force_application_time),
-                    .length = usage_storage_task::force_time_data_usage_len},
-                UsageRequestSet {
-                    .eeprom_key = 0x2,
-                    .type_key =
-                             uint16_t(can::ids::MotorUsageValueType::total_error_count),
-                    .length = usage_storage_task::error_count_usage_len
-                }}};
-
+        motor_hardware::UsageEEpromConfig{std::array<UsageRequestSet, 3>{
+            UsageRequestSet{
+                .eeprom_key = 0x0,
+                .type_key = uint16_t(
+                    can::ids::MotorUsageValueType::linear_motor_distance),
+                .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet{
+                .eeprom_key = 0x1,
+                .type_key = uint16_t(
+                    can::ids::MotorUsageValueType::force_application_time),
+                .length = usage_storage_task::force_time_data_usage_len},
+            UsageRequestSet{
+                .eeprom_key = 0x2,
+                .type_key =
+                    uint16_t(can::ids::MotorUsageValueType::total_error_count),
+                .length = usage_storage_task::error_count_usage_len}}};
 };
 
 class MockBrushedMotorDriverIface : public BrushedMotorDriverIface {

--- a/include/motor-control/tests/mock_brushed_motor_components.hpp
+++ b/include/motor-control/tests/mock_brushed_motor_components.hpp
@@ -108,11 +108,24 @@ class MockBrushedMotorHardware : public BrushedMotorHardwareIface {
     bool timer_interrupt_running = true;
     motor_hardware::UsageEEpromConfig eeprom_config =
         motor_hardware::UsageEEpromConfig{
-            std::array<UsageRequestSet, 1>{UsageRequestSet{
-                .eeprom_key = 0,
-                .type_key = uint16_t(
-                    can::ids::MotorUsageValueType::linear_motor_distance),
-                .length = usage_storage_task::distance_data_usage_len}}};
+            std::array<UsageRequestSet, 3>{
+                UsageRequestSet{
+                    .eeprom_key = 0x0,
+                    .type_key =
+                             uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
+                    .length = usage_storage_task::distance_data_usage_len},
+                UsageRequestSet{
+                    .eeprom_key = 0x1,
+                    .type_key = uint16_t(
+                            can::ids::MotorUsageValueType::force_application_time),
+                    .length = usage_storage_task::force_time_data_usage_len},
+                UsageRequestSet {
+                    .eeprom_key = 0x2,
+                    .type_key =
+                             uint16_t(can::ids::MotorUsageValueType::total_error_count),
+                    .length = usage_storage_task::error_count_usage_len
+                }}};
+
 };
 
 class MockBrushedMotorDriverIface : public BrushedMotorDriverIface {


### PR DESCRIPTION
This PR:
1. adds CAN messages to request and report gripper jaw state from the brushed motor hardware interface
2. simplifies the gripper jaw states to `unhomed`, `force controlling home`, `force controlling` and `position controlling`
3. includes a small refactor to the brushed motor interrupt handler