### PR TITLE
fix(motor-control): critical section for encoders

### DIFF
--- a/include/common/core/freertos_synchronization.hpp
+++ b/include/common/core/freertos_synchronization.hpp
@@ -15,9 +15,11 @@ class FreeRTOSMutex {
 
     ~FreeRTOSMutex() { vSemaphoreDelete(handle); }
 
-    bool acquire() { return xSemaphoreTake(handle, portMAX_DELAY) == pdTRUE; }
+    auto acquire() -> bool {
+        return xSemaphoreTake(handle, portMAX_DELAY) == pdTRUE;
+    }
 
-    bool release() { return xSemaphoreGive(handle) == pdTRUE; }
+    auto release() -> bool { return xSemaphoreGive(handle) == pdTRUE; }
 
     auto get_count() -> int { return uxSemaphoreGetCount(handle); }
 

--- a/include/common/core/freertos_synchronization.hpp
+++ b/include/common/core/freertos_synchronization.hpp
@@ -69,10 +69,10 @@ class FreeRTOSCriticalSection {
   public:
     FreeRTOSCriticalSection() = default;
     FreeRTOSCriticalSection(const FreeRTOSCriticalSection &) = delete;
-    FreeRTOSCriticalSection(const FreeRTOSCriticalSection &&) = delete;
+    FreeRTOSCriticalSection(FreeRTOSCriticalSection &&) = delete;
     auto operator=(const FreeRTOSCriticalSection &)
         -> FreeRTOSCriticalSection & = delete;
-    auto operator=(const FreeRTOSCriticalSection &&)
+    auto operator=(FreeRTOSCriticalSection &&)
         -> FreeRTOSCriticalSection && = delete;
     ~FreeRTOSCriticalSection() = default;
 
@@ -81,6 +81,18 @@ class FreeRTOSCriticalSection {
 
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     void release() { taskEXIT_CRITICAL(); }
+};
+
+class FreeRTOSCriticalSectionRAII {
+  public:
+    FreeRTOSCriticalSectionRAII() { taskENTER_CRITICAL(); }
+    FreeRTOSCriticalSectionRAII(const FreeRTOSCriticalSectionRAII &) = delete;
+    FreeRTOSCriticalSectionRAII(FreeRTOSCriticalSectionRAII &&) = delete;
+    auto operator=(const FreeRTOSCriticalSectionRAII &)
+        -> FreeRTOSCriticalSectionRAII & = delete;
+    auto operator=(FreeRTOSCriticalSectionRAII &&)
+        -> FreeRTOSCriticalSectionRAII && = delete;
+    ~FreeRTOSCriticalSectionRAII() { taskEXIT_CRITICAL(); }
 };
 
 }  // namespace freertos_synchronization

--- a/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
+++ b/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
@@ -3,6 +3,7 @@
 #include <concepts>
 #include <cstdint>
 #include <tuple>
+
 #include "common/core/freertos_synchronization.hpp"
 #include "motor-control/core/motor_hardware_interface.hpp"
 #include "ot_utils/freertos/freertos_timer.hpp"

--- a/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
+++ b/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
@@ -3,7 +3,7 @@
 #include <concepts>
 #include <cstdint>
 #include <tuple>
-
+#include "common/core/freertos_synchronization.hpp"
 #include "motor-control/core/motor_hardware_interface.hpp"
 #include "ot_utils/freertos/freertos_timer.hpp"
 
@@ -29,6 +29,7 @@ class BackgroundTimer {
     auto stop() -> void { _timer.stop(); }
 
     auto callback() -> void {
+        freertos_synchronization::FreeRTOSCriticalSectionRAII();
         if (!_interrupt_handler.has_active_move()) {
             // Refresh the overflow counter if nothing else is doing it
             // and update position flag if needed

--- a/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
+++ b/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
@@ -30,7 +30,8 @@ class BackgroundTimer {
     auto stop() -> void { _timer.stop(); }
 
     auto callback() -> void {
-        freertos_synchronization::FreeRTOSCriticalSectionRAII();
+        auto critical_section =
+            freertos_synchronization::FreeRTOSCriticalSectionRAII();
         if (!_interrupt_handler.has_active_move()) {
             // Refresh the overflow counter if nothing else is doing it
             // and update position flag if needed


### PR DESCRIPTION
When we do the encoder polling timer we really want the motor interrupt to not be able to start in the middle of the timer code, so let's wrap it in a critical section.

## Testing
We saw this in a protocol that was moving the z up and down by 5mm over and over so let's run a protocol that just does that and see if it happens I guess? This is a bug that seems to have occurred once in hundreds or thousands of machine hours of testing so it's going to be tough to say for certain.

It did pass though.