### PR TITLE
feat(all): allow for up to 12 steps in each move group

### DIFF
--- a/include/motor-control/core/tasks/brushed_move_group_task.hpp
+++ b/include/motor-control/core/tasks/brushed_move_group_task.hpp
@@ -13,7 +13,7 @@
 namespace brushed_move_group_task {
 
 constexpr std::size_t max_groups = 6;
-constexpr std::size_t max_moves_per_group = 5;
+constexpr std::size_t max_moves_per_group = 12;
 
 using MoveGroupType =
     move_group::MoveGroupManager<max_groups, max_moves_per_group,

--- a/include/motor-control/core/tasks/brushed_move_group_task.hpp
+++ b/include/motor-control/core/tasks/brushed_move_group_task.hpp
@@ -12,7 +12,7 @@
 
 namespace brushed_move_group_task {
 
-constexpr std::size_t max_groups = 6;
+constexpr std::size_t max_groups = 3;
 constexpr std::size_t max_moves_per_group = 12;
 
 using MoveGroupType =

--- a/include/motor-control/core/tasks/move_group_task.hpp
+++ b/include/motor-control/core/tasks/move_group_task.hpp
@@ -12,7 +12,7 @@
 
 namespace move_group_task {
 
-constexpr std::size_t max_groups = 6;
+constexpr std::size_t max_groups = 3;
 constexpr std::size_t max_moves_per_group = 12;
 
 using MoveGroupType =

--- a/include/motor-control/core/tasks/move_group_task.hpp
+++ b/include/motor-control/core/tasks/move_group_task.hpp
@@ -13,7 +13,7 @@
 namespace move_group_task {
 
 constexpr std::size_t max_groups = 6;
-constexpr std::size_t max_moves_per_group = 5;
+constexpr std::size_t max_moves_per_group = 12;
 
 using MoveGroupType =
     move_group::MoveGroupManager<max_groups, max_moves_per_group,

--- a/include/pipettes/core/tasks/move_group_task.hpp
+++ b/include/pipettes/core/tasks/move_group_task.hpp
@@ -16,7 +16,7 @@ namespace tasks {
 namespace move_group_task {
 
 constexpr std::size_t max_groups = 6;
-constexpr std::size_t max_moves_per_group = 5;
+constexpr std::size_t max_moves_per_group = 12;
 
 using MoveGroupType =
     move_group::MoveGroupManager<max_groups, max_moves_per_group,

--- a/include/pipettes/core/tasks/move_group_task.hpp
+++ b/include/pipettes/core/tasks/move_group_task.hpp
@@ -15,7 +15,7 @@ namespace tasks {
 
 namespace move_group_task {
 
-constexpr std::size_t max_groups = 6;
+constexpr std::size_t max_groups = 3;
 constexpr std::size_t max_moves_per_group = 12;
 
 using MoveGroupType =


### PR DESCRIPTION
In https://github.com/Opentrons/opentrons/pull/13451, we increase the maximum number of steps that may be generated in a move group. We need to be able to accept all of those steps on the firmware side.

The only real downside here is RAM usage. I was able to build everything locally, but we obviously need to make sure CI is able to link everything as well. If there are any problems I think the best thing to do is cut down on the total move groups, since in practice we only use a few of the allotted 6.