### PR TITLE
fix(gripper): add GripperJawStateRequest to gripper can task & do not disable brushed motor if it was set to stay engaged

### DIFF
--- a/include/can/core/message_handlers/motion.hpp
+++ b/include/can/core/message_handlers/motion.hpp
@@ -48,7 +48,8 @@ class BrushedMotionHandler {
     using MessageType =
         std::variant<std::monostate, DisableMotorRequest, EnableMotorRequest,
                      ReadLimitSwitchRequest, MotorPositionRequest,
-                     SetGripperErrorToleranceRequest, GetMotorUsageRequest>;
+                     SetGripperErrorToleranceRequest, GetMotorUsageRequest,
+                     GripperJawStateRequest>;
 
     BrushedMotionHandler(BrushedMotionTaskClient &motion_client)
         : motion_client{motion_client} {}

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -48,7 +48,7 @@ using BrushedMotionDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::DisableMotorRequest, can::messages::EnableMotorRequest,
     can::messages::ReadLimitSwitchRequest, can::messages::MotorPositionRequest,
     can::messages::SetGripperErrorToleranceRequest,
-    can::messages::GetMotorUsageRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::GripperJawStateRequest>;
 using BrushedMoveGroupDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::move_group::BrushedMoveGroupHandler<
         g_tasks::QueueClient>,

--- a/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motion_controller.hpp
@@ -105,10 +105,9 @@ class MotionController {
         queue.reset();
         // if we're gripping something we need to flag this so we don't drop it
         if (!hardware.get_stay_enabled()) {
-            disable_motor();
-        }
-        if (hardware.is_timer_interrupt_running()) {
-            hardware.request_cancel();
+            if (hardware.is_timer_interrupt_running()) {
+                hardware.request_cancel();
+            }
         }
     }
 


### PR DESCRIPTION
Forgot to add this to the can task so we weren't getting any response back from the gripper. 

Testing is importante!