### PR TITLE
fix(motor-control): do not enable motor when receives a zero-length move

### DIFF
--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -73,7 +73,7 @@ class MotionController {
             .seq_id = can_msg.seq_id,
             .stop_condition = can_msg.request_stop_condition,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
-        if (!enabled) {
+        if (!enabled && velocity_steps != 0) {
             enable_motor();
         }
         queue.try_write(msg);

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -73,7 +73,7 @@ class MotionController {
             .seq_id = can_msg.seq_id,
             .stop_condition = can_msg.request_stop_condition,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key()};
-        if (!enabled && velocity_steps != 0) {
+        if (!enabled && velocity_steps != 0 && acceleration_steps != 0) {
             enable_motor();
         }
         queue.try_write(msg);


### PR DESCRIPTION
We shouldn't need to to engage the motors when we're not planning on moving them. 

This might cause a lot of weird motor position errors so... gonna keep this as a draft as i do more testing and add more logic on the python side to handle this better.