### PR TITLE
feat(pipettes): require overpressure for 500ms before error

### DIFF
--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -275,6 +275,8 @@ class MMR920C04 {
             stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
         }
 
+        bool echo_this_time = echoing;
+
         // Pressure is always a three-byte value
         static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
                                                   m.read_buffer.cend(),
@@ -290,6 +292,7 @@ class MMR920C04 {
             if (std::fabs(pressure) - std::fabs(current_pressure_baseline_pa) >
                 mmr920C04::MAX_PRESSURE_READING) {
                 hardware.set_sync();
+                echo_this_time = true;
                 can_client.send_can_message(
                     can::ids::NodeId::host,
                     can::messages::ErrorMessage{
@@ -309,7 +312,7 @@ class MMR920C04 {
             }
         }
 
-        if (echoing) {
+        if (echo_this_time) {
             can_client.send_can_message(
                 can::ids::NodeId::host,
                 can::messages::ReadFromSensorResponse{


### PR DESCRIPTION
The intent of the overpressure warning is to avoid damage to the pressure sensor. The sensor will only give us a reading up to ~8kPa, but the actual pressure it can withstand is far higher. In an effort to avoid overeager protocol-ending errors, we are adding a requirement that the pressure remains over the threshold for at least 500MS before throwing an error.

This PR also adds reporting of any readings over the threshold.

Tested on Flexy by blocking the pipette nozzle while aspirating/dispensing. You can see in the can logs that you get a bunch of Pressure Reading responses before they start including error messages. Short aspiration/dispense distances don't have enough time to trigger the error.