### PR TITLE
fix(pipettes): changes to enable the correct sync line ports for the 96-channel

### DIFF
--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -404,7 +404,7 @@ class MMR920C04 {
                     .offset_average = pressure_fixed_point});
             set_threshold(current_pressure_baseline_pa,
                           can::ids::SensorThresholdMode::auto_baseline,
-                          m.message_index, true);
+                          m.message_index, false);
         } else {
             auto message = can::messages::ReadFromSensorResponse{
                 .message_index = m.message_index,

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -404,7 +404,7 @@ class MMR920C04 {
                     .offset_average = pressure_fixed_point});
             set_threshold(current_pressure_baseline_pa,
                           can::ids::SensorThresholdMode::auto_baseline,
-                          m.message_index, false);
+                          m.message_index, true);
         } else {
             auto message = can::messages::ReadFromSensorResponse{
                 .message_index = m.message_index,

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -400,7 +400,7 @@ class MMR920C04 {
                 can::ids::NodeId::host,
                 can::messages::BaselineSensorResponse{
                     .message_index = m.message_index,
-                    .sensor = can::ids::SensorType::pressure_temperature,
+                    .sensor = can::ids::SensorType::pressure,
                     .offset_average = pressure_fixed_point});
             set_threshold(current_pressure_baseline_pa,
                           can::ids::SensorThresholdMode::auto_baseline,

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -12,6 +12,8 @@ static void enable_gpio_port(void* port) {
         __HAL_RCC_GPIOB_CLK_ENABLE();
     } else if (port == GPIOC) {
         __HAL_RCC_GPIOC_CLK_ENABLE();
+    } else if (port == GPIOD) {
+        __HAL_RCC_GPIOD_CLK_ENABLE();
     }
 }
 

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -156,7 +156,7 @@ static void sync_drive_gpio_init() {
     PipetteHardwarePin sync_in_hardware =
         pipette_hardware_get_gpio(pipette_type, pipette_hardware_device_sync_in);
     /* GPIO Ports Clock Enable */
-    enable_gpio_port(GPIOB);
+    enable_gpio_port(sync_in_hardware.port);
 
     /*Configure GPIO pin*/
     GPIO_InitTypeDef sync_in_init = {0};
@@ -168,7 +168,7 @@ static void sync_drive_gpio_init() {
     PipetteHardwarePin sync_out_hardware =
         pipette_hardware_get_gpio(pipette_type, pipette_hardware_device_sync_out);
 
-    enable_gpio_port(GPIOC);
+    enable_gpio_port(sync_out_hardware.port);
 
     GPIO_InitTypeDef sync_out_init = {0};
     sync_out_init.Pin = sync_out_hardware.pin;


### PR DESCRIPTION
The GPIO ports were wrong unfortunately. 