### PR TITLE
only autmomatically notify about low throughput tip changes

### DIFF
--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -138,11 +138,12 @@ static auto tail_accessor =
     eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == tip_sense_gpio_primary.pin &&
-        sensor_queue_client.tip_notification_queue_rear != nullptr) {
-        static_cast<void>(
-            sensor_queue_client.tip_notification_queue_rear->try_write_isr(
-                sensors::tip_presence::TipStatusChangeDetected{}));
+    if (GPIO_Pin == tip_sense_gpio_primary.pin) {
+        if (sensor_queue_client.tip_notification_queue_rear != nullptr) {
+            static_cast<void>(
+                sensor_queue_client.tip_notification_queue_rear->try_write_isr(
+                    sensors::tip_presence::TipStatusChangeDetected{}));
+        }
     }
 }
 

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -130,9 +130,6 @@ static auto pins_for_sensor =
 static auto sensor_hardware_container =
     utility_configs::get_sensor_hardware_container(pins_for_sensor);
 
-static auto ok_for_secondary =
-    pins_for_sensor.secondary.has_value() &&
-    pins_for_sensor.secondary.value().tip_sense.has_value();
 static auto tip_sense_gpio_primary = pins_for_sensor.primary.tip_sense.value();
 
 static auto& sensor_queue_client = sensor_tasks::get_queues();
@@ -141,12 +138,11 @@ static auto tail_accessor =
     eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == tip_sense_gpio_primary.pin) {
-        if (sensor_queue_client.tip_notification_queue_rear != nullptr) {
-            static_cast<void>(
-                sensor_queue_client.tip_notification_queue_rear->try_write_isr(
-                    sensors::tip_presence::TipStatusChangeDetected{}));
-        }
+    if (GPIO_Pin == tip_sense_gpio_primary.pin &&
+        sensor_queue_client.tip_notification_queue_rear != nullptr) {
+        static_cast<void>(
+            sensor_queue_client.tip_notification_queue_rear->try_write_isr(
+                sensors::tip_presence::TipStatusChangeDetected{}));
     }
 }
 

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -141,18 +141,10 @@ static auto tail_accessor =
     eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (GPIO_Pin == tip_sense_gpio_primary.pin) {
+    if (PIPETTE_TYPE != NINETY_SIX_CHANNEL) {
         if (sensor_queue_client.tip_notification_queue_rear != nullptr) {
             static_cast<void>(
                 sensor_queue_client.tip_notification_queue_rear->try_write_isr(
-                    sensors::tip_presence::TipStatusChangeDetected{}));
-        }
-    } else if (ok_for_secondary &&
-               GPIO_Pin ==
-                   pins_for_sensor.secondary.value().tip_sense.value().pin) {
-        if (sensor_queue_client.tip_notification_queue_front != nullptr) {
-            static_cast<void>(
-                sensor_queue_client.tip_notification_queue_front->try_write_isr(
                     sensors::tip_presence::TipStatusChangeDetected{}));
         }
     }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -141,7 +141,7 @@ static auto tail_accessor =
     eeprom::dev_data::DevDataTailAccessor{sensor_queue_client};
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
-    if (PIPETTE_TYPE != NINETY_SIX_CHANNEL) {
+    if (GPIO_Pin == tip_sense_gpio_primary.pin) {
         if (sensor_queue_client.tip_notification_queue_rear != nullptr) {
             static_cast<void>(
                 sensor_queue_client.tip_notification_queue_rear->try_write_isr(

--- a/pipettes/firmware/utility_configurations.cpp
+++ b/pipettes/firmware/utility_configurations.cpp
@@ -122,7 +122,7 @@ auto utility_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                         .port = GPIOC,
                         .pin = GPIO_PIN_7,
-                        .active_setting = GPIO_PIN_RESET}},
+                        .active_setting = GPIO_PIN_SET}},
         .secondary = sensors::hardware::SensorHardwareConfiguration{
             .sync_out =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -139,7 +139,7 @@ auto utility_configs::sensor_configurations<PipetteType::NINETY_SIX_CHANNEL>()
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .port = GPIOC,
                 .pin = GPIO_PIN_12,
-                .active_setting = GPIO_PIN_RESET}}};
+                .active_setting = GPIO_PIN_SET}}};
     return pins;
 }
 
@@ -166,7 +166,7 @@ auto utility_configs::sensor_configurations<
                         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                         .port = GPIOC,
                         .pin = GPIO_PIN_12,
-                        .active_setting = GPIO_PIN_RESET}},
+                        .active_setting = GPIO_PIN_SET}},
         .secondary = sensors::hardware::SensorHardwareConfiguration{
             .sync_out =
                 {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -183,6 +183,6 @@ auto utility_configs::sensor_configurations<
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                 .port = GPIOC,
                 .pin = GPIO_PIN_7,
-                .active_setting = GPIO_PIN_RESET}}};
+                .active_setting = GPIO_PIN_SET}}};
     return pins;
 }

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -41,7 +41,6 @@ static void tip_sense_gpio_init() {
  * @retval None
  */
 static void nvic_priority_enable_init() {
-    PipetteType pipette_type = get_pipette_type();
     IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
     /* EXTI interrupt init block tip sense*/
     HAL_NVIC_SetPriority(block_2, 10, 0);

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -41,10 +41,12 @@ static void tip_sense_gpio_init() {
  * @retval None
  */
 static void nvic_priority_enable_init() {
-    IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
-    /* EXTI interrupt init block tip sense*/
-    HAL_NVIC_SetPriority(block_2, 10, 0);
-    HAL_NVIC_EnableIRQ(block_2);
+    if (pipette_type != NINETY_SIX_CHANNEL) {
+        IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
+        /* EXTI interrupt init block tip sense*/
+        HAL_NVIC_SetPriority(block_2, 10, 0);
+        HAL_NVIC_EnableIRQ(block_2);
+    }
 
 }
 

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -59,6 +59,7 @@ static void nvic_priority_enable_init() {
         /* EXTI interrupt init block tip sense*/
         HAL_NVIC_SetPriority(block_2, 10, 0);
         HAL_NVIC_EnableIRQ(block_2);
+    }
 }
 
 /**

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -26,12 +26,24 @@ static void tip_sense_gpio_init() {
     PipetteType pipette_type = get_pipette_type();
     
     GPIO_InitTypeDef GPIO_InitStruct = {0};
-    GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
     enable_gpio_port(GPIOC);
-    /*Configure GPIO pin : C2 */
-    GPIO_InitStruct.Pin = GPIO_PIN_2;
-    HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+    if (pipette_type == NINETY_SIX_CHANNEL) {
+        /*Configure GPIO pin :
+         * PC12, front tip sense
+         * PC7, rear tip sense
+         * */
+        GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_7;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+    } else {
+        /*Configure GPIO pin : C2 */
+        GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Pin = GPIO_PIN_2;
+        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
+    }
+
 }
 
 
@@ -41,11 +53,24 @@ static void tip_sense_gpio_init() {
  * @retval None
  */
 static void nvic_priority_enable_init() {
-    if (pipette_type != NINETY_SIX_CHANNEL) {
+    PipetteType pipette_type = get_pipette_type();
+
+    if (pipette_type == NINETY_SIX_CHANNEL) {
+        IRQn_Type block_9_5 = get_interrupt_line(gpio_block_9_5);
+        IRQn_Type block_15_10 = get_interrupt_line(gpio_block_15_10);
+        /* EXTI interrupt init tip sense rear*/
+        HAL_NVIC_SetPriority(block_9_5, 10, 0);
+        HAL_NVIC_EnableIRQ(block_9_5);
+
+        /* EXTI interrupt init tip sense front*/
+        HAL_NVIC_SetPriority(block_15_10, 10, 0);
+        HAL_NVIC_EnableIRQ(block_15_10);
+    } else {
         IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
         /* EXTI interrupt init block tip sense*/
         HAL_NVIC_SetPriority(block_2, 10, 0);
         HAL_NVIC_EnableIRQ(block_2);
+
     }
 
 }

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -29,19 +29,9 @@ static void tip_sense_gpio_init() {
     GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     enable_gpio_port(GPIOC);
-    if (pipette_type == NINETY_SIX_CHANNEL) {
-        /*Configure GPIO pin :
-         * PC12, front tip sense
-         * PC7, rear tip sense
-         * */
-        GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_7;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-    } else {
-        /*Configure GPIO pin : C2 */
-        GPIO_InitStruct.Pin = GPIO_PIN_2;
-        HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-    }
-
+    /*Configure GPIO pin : C2 */
+    GPIO_InitStruct.Pin = GPIO_PIN_2;
+    HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 }
 
 
@@ -52,24 +42,10 @@ static void tip_sense_gpio_init() {
  */
 static void nvic_priority_enable_init() {
     PipetteType pipette_type = get_pipette_type();
-
-    if (pipette_type == NINETY_SIX_CHANNEL) {
-        IRQn_Type block_9_5 = get_interrupt_line(gpio_block_9_5);
-        IRQn_Type block_15_10 = get_interrupt_line(gpio_block_15_10);
-        /* EXTI interrupt init tip sense rear*/
-        HAL_NVIC_SetPriority(block_9_5, 10, 0);
-        HAL_NVIC_EnableIRQ(block_9_5);
-
-        /* EXTI interrupt init tip sense front*/
-        HAL_NVIC_SetPriority(block_15_10, 10, 0);
-        HAL_NVIC_EnableIRQ(block_15_10);
-    } else {
-        IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
-        /* EXTI interrupt init block tip sense*/
-        HAL_NVIC_SetPriority(block_2, 10, 0);
-        HAL_NVIC_EnableIRQ(block_2);
-
-    }
+    IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
+    /* EXTI interrupt init block tip sense*/
+    HAL_NVIC_SetPriority(block_2, 10, 0);
+    HAL_NVIC_EnableIRQ(block_2);
 
 }
 

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -52,10 +52,13 @@ static void tip_sense_gpio_init() {
  * @retval None
  */
 static void nvic_priority_enable_init() {
-    IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
-    /* EXTI interrupt init block tip sense*/
-    HAL_NVIC_SetPriority(block_2, 10, 0);
-    HAL_NVIC_EnableIRQ(block_2);
+    PipetteType pipette_type = get_pipette_type();
+
+    if (pipette_type != NINETY_SIX_CHANNEL) {
+        IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
+        /* EXTI interrupt init block tip sense*/
+        HAL_NVIC_SetPriority(block_2, 10, 0);
+        HAL_NVIC_EnableIRQ(block_2);
 }
 
 /**

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -26,6 +26,7 @@ static void tip_sense_gpio_init() {
     PipetteType pipette_type = get_pipette_type();
     
     GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
     enable_gpio_port(GPIOC);
     if (pipette_type == NINETY_SIX_CHANNEL) {
         /*Configure GPIO pin :
@@ -33,13 +34,11 @@ static void tip_sense_gpio_init() {
          * PC7, rear tip sense
          * */
         GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Pin = GPIO_PIN_12 | GPIO_PIN_7;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     } else {
         /*Configure GPIO pin : C2 */
         GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
-        GPIO_InitStruct.Pull = GPIO_NOPULL;
         GPIO_InitStruct.Pin = GPIO_PIN_2;
         HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
     }

--- a/pipettes/firmware/utility_gpio.c
+++ b/pipettes/firmware/utility_gpio.c
@@ -52,26 +52,10 @@ static void tip_sense_gpio_init() {
  * @retval None
  */
 static void nvic_priority_enable_init() {
-    PipetteType pipette_type = get_pipette_type();
-
-    if (pipette_type == NINETY_SIX_CHANNEL) {
-        IRQn_Type block_9_5 = get_interrupt_line(gpio_block_9_5);
-        IRQn_Type block_15_10 = get_interrupt_line(gpio_block_15_10);
-        /* EXTI interrupt init tip sense rear*/
-        HAL_NVIC_SetPriority(block_9_5, 10, 0);
-        HAL_NVIC_EnableIRQ(block_9_5);
-
-        /* EXTI interrupt init tip sense front*/
-        HAL_NVIC_SetPriority(block_15_10, 10, 0);
-        HAL_NVIC_EnableIRQ(block_15_10);
-    } else {
-        IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
-        /* EXTI interrupt init block tip sense*/
-        HAL_NVIC_SetPriority(block_2, 10, 0);
-        HAL_NVIC_EnableIRQ(block_2);
-
-    }
-
+    IRQn_Type block_2 = get_interrupt_line(gpio_block_2);
+    /* EXTI interrupt init block tip sense*/
+    HAL_NVIC_SetPriority(block_2, 10, 0);
+    HAL_NVIC_EnableIRQ(block_2);
 }
 
 /**


### PR DESCRIPTION
## Overview
On the 96 channel pipette, readings of the tip presence sensor are only meaningful when the gear motors are moved down far enough to drop the shroud below the optical sensor. If tips are accidentally dropped during a protocol, we wouldn't actually know until we check by commanding the gear motors to move. Therefore, we don't need an interrupt for changes in the 96 channel's sensor status.

## Changelog
- Initialize the tip presence sensor for the 96 channel as a regular gpio input, and keep interrupt initialization for the single and 8 channel pipettes
- Remove the check in the interrupt's callback for whether the gpio pin is the `primary` or `secondary` sensor, as this only applies to the 96 channel
- Invert the active setting of the gpio pin only for the 96 channel, so the 96 channel's response logic matches the single and 8 channel's