### PR TITLE
fix(motor-control): monitor encoder during empty moves

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
+++ b/include/motor-control/core/stepper_motor/motor_encoder_background_timer.hpp
@@ -32,7 +32,7 @@ class BackgroundTimer {
     auto callback() -> void {
         auto critical_section =
             freertos_synchronization::FreeRTOSCriticalSectionRAII();
-        if (!_interrupt_handler.has_active_move()) {
+        if (!_interrupt_handler.is_moving()) {
             // Refresh the overflow counter if nothing else is doing it
             // and update position flag if needed
             std::ignore = _interrupt_handler.check_for_stall();

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -586,6 +586,14 @@ class MotorInterruptHandler {
 
     auto has_active_move() -> bool { return _has_active_move.load(); }
 
+    /**
+     * @brief Returns whether the motor has an active move *and*
+     * the velocity is nonzero.
+     */
+    auto is_moving() -> bool {
+        return has_active_move() && buffered_move.velocity != 0;
+    }
+
   private:
     void update_hardware_step_tracker() {
         hardware.set_step_tracker(


### PR DESCRIPTION
RQA-1812, and possibly some other ABR failures, seems like it may be a result of an axis encoder overflowing multiple times during an empty move. We have an encoder background timer that runs when the interrupt handler doesn't have an active move, but that doesn't account for the fact that we often set up motor axes with empty moves (no acceleration & no velocity) matching the duration of the move groups for active axes. 

To fix this edge case, we should also check the velocity of the buffered move when the encoder timer is determining whether it should read the encoder. This PR adds a new function in the interrupt handler to return whether 1) there is a buffered move 2) the buffered move's velocity is not 0.

We only access the function in a critical section so I don't think it matters that the velocity isn't fully atomic.

Uploaded to Flexy. Threw the gantry around with the Estop on and was able to rehome fine, tried backdriving various axes while they were idle during other movements, everything seemed to get detected fine (rehoming would fast-home to the right place). Pretty confident this isn't introducing any _new_ issues, but I think the only way to really test if this is a fix is to put it on the ABR bots that have had this problem.