### PR TITLE
fix(motor-control): only add a delay before disengaging motor if ebrake exists

### DIFF
--- a/head/firmware/motor_hardware_rev1.c
+++ b/head/firmware/motor_hardware_rev1.c
@@ -20,9 +20,7 @@ void initialize_rev_specific_pins() {
     HAL_GPIO_Init(GPIOC,  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
                   &GPIO_InitStruct);
 
-    // TODO: Handle brakes better, this just disengages
-    // them at boot
-    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_5 | GPIO_PIN_0, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(GPIOB, GPIO_PIN_5 | GPIO_PIN_0, GPIO_PIN_RESET);
 
     HAL_GPIO_WritePin(GPIOB, GPIO_PIN_11, GPIO_PIN_RESET);
     HAL_GPIO_WritePin(GPIOC, GPIO_PIN_4, GPIO_PIN_RESET);

--- a/include/motor-control/firmware/motor_control_hardware.h
+++ b/include/motor-control/firmware/motor_control_hardware.h
@@ -24,6 +24,7 @@ uint16_t motor_hardware_encoder_pulse_count(void* encoder_handle);
 uint16_t motor_hardware_encoder_pulse_count_with_overflow(void* encoder_handle, int8_t *overflows);
 void motor_hardware_reset_encoder_count(void* encoder_handle, uint16_t reset_value);
 uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t clear);
+void motor_hardware_delay(uint32_t delay);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -7,6 +7,7 @@
 #include "FreeRTOS.h"
 #include "platform_specific_hal_conf.h"
 #include "stm32g4xx_hal_tim.h"
+#include "stm32g4xx_hal.h"
 #include "task.h"
 
 HAL_StatusTypeDef custom_stop_pwm_it(TIM_HandleTypeDef* htim,
@@ -130,4 +131,9 @@ uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t cle
     }
     return count;
 }
+
+void motor_hardware_delay(uint32_t delay) {
+    HAL_Delay(delay);
+}
+
 

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -24,6 +24,7 @@ void MotorHardware::deactivate_motor() {
     if (pins.ebrake.has_value()) {
         gpio::set(pins.ebrake.value());
     }
+    motor_hardware_delay(10);
     gpio::reset(pins.enable);
 }
 void MotorHardware::start_timer_interrupt() {

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -23,8 +23,8 @@ void MotorHardware::activate_motor() {
 void MotorHardware::deactivate_motor() {
     if (pins.ebrake.has_value()) {
         gpio::set(pins.ebrake.value());
+        motor_hardware_delay(10);
     }
-    motor_hardware_delay(10);
     gpio::reset(pins.enable);
 }
 void MotorHardware::start_timer_interrupt() {


### PR DESCRIPTION
We shouldn't have added the delay if the ebrake doesn't exist. 

Also fixing an old commit message to actually show what it does.