### PR TITLE
chore: handle internal-release tags

### DIFF
--- a/.github/workflows/release_bundle.yaml
+++ b/.github/workflows/release_bundle.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - '*'
     tags:
-      - '*'
+      - 'v*'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
by not posting releases for them