### PR TITLE
fix(hepa-uv): add hepa-uv to firmware manifest json file.

### DIFF
--- a/scripts/subsystem_versions.py
+++ b/scripts/subsystem_versions.py
@@ -17,6 +17,7 @@ SUBSYSTEMS = [
     "pipettes-single",
     "pipettes-multi",
     "pipettes-96",
+    "hepa-uv",
 ]
 USB_SUBSYSTEMS = [
     "rear-panel",


### PR DESCRIPTION
This is required to add the hepa-uv entry to the `opentrons-firmware.json` manifest file used by the Flex to perform firmware updates.