### PR TITLE
feat(hepa-uv): Add a task to handle the UV Ballast state based on external input

### DIFF
--- a/hepa-uv/core/tasks.cpp
+++ b/hepa-uv/core/tasks.cpp
@@ -49,8 +49,7 @@ void hepauv_tasks::QueueClient::send_hepa_message(
     hepa_queue->try_write(m);
 }
 
-void hepauv_tasks::QueueClient::send_uv_message(
-    const uv_task::TaskMessage& m) {
+void hepauv_tasks::QueueClient::send_uv_message(const uv_task::TaskMessage& m) {
     uv_queue->try_write(m);
 }
 

--- a/hepa-uv/firmware/main_rev1.cpp
+++ b/hepa-uv/firmware/main_rev1.cpp
@@ -91,7 +91,7 @@ static auto gpio_drive_pins = gpio_drive_hardware::GpioDrivePins{
         .pin = UV_ON_OFF_MCU_PIN,
         .active_setting = UV_ON_OFF_AS}};
 
-static auto& hepa_queue_client = hepauv_tasks::get_main_queues();
+static auto& hepauv_queues = hepauv_tasks::get_main_queues();
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     switch (GPIO_Pin) {
@@ -99,12 +99,16 @@ extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
         case REED_SW_MCU_PIN:
         case HEPA_NO_MCU_PIN:
         case UV_NO_MCU_PIN:
-            if (hepa_queue_client.hepa_queue != nullptr) {
-                static_cast<void>(hepa_queue_client.hepa_queue->try_write_isr(
+            if (hepauv_queues.hepa_queue != nullptr) {
+                static_cast<void>(hepauv_queues.hepa_queue->try_write_isr(
                     interrupt_task_messages::GPIOInterruptChanged{
                         .pin = GPIO_Pin}));
             }
-            // send to uv queue here
+            if (hepauv_queues.uv_queue != nullptr) {
+                static_cast<void>(hepauv_queues.uv_queue->try_write_isr(
+                    interrupt_task_messages::GPIOInterruptChanged{
+                        .pin = GPIO_Pin}));
+            }
             break;
         default:
             break;

--- a/include/hepa-uv/core/hepa_task.hpp
+++ b/include/hepa-uv/core/hepa_task.hpp
@@ -15,7 +15,12 @@ using TaskMessage = interrupt_task_messages::TaskMessage;
 class HepaMessageHandler {
   public:
     explicit HepaMessageHandler(gpio_drive_hardware::GpioDrivePins &drive_pins)
-        : drive_pins{drive_pins} {}
+        : drive_pins{drive_pins} {
+        // get current state
+        hepa_push_button = gpio::is_set(drive_pins.hepa_push_button);
+        // turn off the HEPA fan
+        gpio::reset(drive_pins.hepa_on_off);
+    }
     HepaMessageHandler(const HepaMessageHandler &) = delete;
     HepaMessageHandler(const HepaMessageHandler &&) = delete;
     auto operator=(const HepaMessageHandler &) -> HepaMessageHandler & = delete;

--- a/include/hepa-uv/core/tasks.hpp
+++ b/include/hepa-uv/core/tasks.hpp
@@ -41,7 +41,6 @@ struct AllTask {
 
     uv_task::UVTask<freertos_message_queue::FreeRTOSMessageQueue>*
         uv_task_handler{nullptr};
-
 };
 
 /**

--- a/include/hepa-uv/core/tasks.hpp
+++ b/include/hepa-uv/core/tasks.hpp
@@ -2,6 +2,7 @@
 #include "can/core/message_writer.hpp"
 #include "common/core/freertos_timer.hpp"
 #include "hepa-uv/core/hepa_task.hpp"
+#include "hepa-uv/core/uv_task.hpp"
 #include "hepa-uv/firmware/gpio_drive_hardware.hpp"
 
 namespace hepauv_tasks {
@@ -18,10 +19,14 @@ void start_tasks(can::bus::CanBus& can_bus,
 struct QueueClient : can::message_writer::MessageWriter {
     QueueClient(can::ids::NodeId this_fw);
 
-    void send_interrupt_message(const hepa_task::TaskMessage& m);
+    void send_hepa_message(const hepa_task::TaskMessage& m);
+    void send_uv_message(const hepa_task::TaskMessage& m);
 
     freertos_message_queue::FreeRTOSMessageQueue<hepa_task::TaskMessage>*
         hepa_queue{nullptr};
+
+    freertos_message_queue::FreeRTOSMessageQueue<uv_task::TaskMessage>*
+        uv_queue{nullptr};
 };
 
 /**
@@ -33,6 +38,10 @@ struct AllTask {
 
     hepa_task::HepaTask<freertos_message_queue::FreeRTOSMessageQueue>*
         hepa_task_handler{nullptr};
+
+    uv_task::UVTask<freertos_message_queue::FreeRTOSMessageQueue>*
+        uv_task_handler{nullptr};
+
 };
 
 /**

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "can/core/ids.hpp"
+#include "common/core/bit_utils.hpp"
+#include "common/core/logging.h"
+#include "common/core/message_queue.hpp"
+#include "hepa-uv/firmware/gpio_drive_hardware.hpp"
+#include "messages.hpp"
+
+namespace uv_task {
+
+using TaskMessage = interrupt_task_messages::TaskMessage;
+
+class UVMessageHandler {
+  public:
+    explicit UVMessageHandler(gpio_drive_hardware::GpioDrivePins &drive_pins)
+        : drive_pins{drive_pins} {}
+    UVMessageHandler(const UVMessageHandler &) = delete;
+    UVMessageHandler(const UVMessageHandler &&) = delete;
+    auto operator=(const UVMessageHandler &) -> UVMessageHandler & = delete;
+    auto operator=(const UVMessageHandler &&)
+        -> UVMessageHandler && = delete;
+    ~UVMessageHandler() {}
+
+    void handle_message(const TaskMessage &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+  private:
+    void visit(const std::monostate &) {}
+
+    // Handle GPIO EXTI Interrupts here
+    void visit(const interrupt_task_messages::GPIOInterruptChanged &m) {
+        if (m.pin == drive_pins.uv_push_button.pin) {
+            uv_push_button = !uv_push_button;
+            // handle state changes here
+            if (uv_push_button) {
+                gpio::set(drive_pins.uv_on_off);
+            } else {
+                gpio::reset(drive_pins.uv_on_off);
+            }
+        }
+
+        // TODO: send CAN message to host
+    }
+
+    // state tracking variables
+    // TODO: add reed, door_open, etc
+    bool uv_push_button = false;
+    bool uv_fan_on = false;
+
+    gpio_drive_hardware::GpioDrivePins &drive_pins;
+};
+
+/**
+ * The task type.
+ */
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
+class UVTask {
+  public:
+    using Messages = TaskMessage;
+    using QueueType = QueueImpl<TaskMessage>;
+    UVTask(QueueType &queue) : queue{queue} {}
+    UVTask(const UVTask &c) = delete;
+    UVTask(const UVTask &&c) = delete;
+    auto operator=(const UVTask &c) = delete;
+    auto operator=(const UVTask &&c) = delete;
+    ~UVTask() = default;
+
+    /**
+     * Task entry point.
+     */
+    [[noreturn]] void operator()(
+        gpio_drive_hardware::GpioDrivePins *drive_pins) {
+        auto handler = UVMessageHandler{*drive_pins};
+        TaskMessage message{};
+        for (;;) {
+            if (queue.try_read(&message, queue.max_delay)) {
+                handler.handle_message(message);
+            }
+        }
+    }
+
+    [[nodiscard]] auto get_queue() const -> QueueType & { return queue; }
+
+  private:
+    QueueType &queue;
+};
+};  // namespace uv_task

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -73,11 +73,12 @@ class UVMessageHandler {
         if (door_closed && reed_switch_set && uv_push_button) {
             gpio::set(drive_pins.uv_on_off);
             // start the turn off timer
+            if (_timer.is_running()) _timer.stop();
             _timer.start();
             uv_fan_on = true;
         } else {
             gpio::reset(drive_pins.uv_on_off);
-            _timer.stop();
+            if (_timer.is_running()) _timer.stop();
             uv_fan_on = false;
         }
 

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -6,20 +6,33 @@
 #include "common/core/message_queue.hpp"
 #include "hepa-uv/firmware/gpio_drive_hardware.hpp"
 #include "messages.hpp"
+#include "ot_utils/freertos/freertos_timer.hpp"
 
 namespace uv_task {
+
+// How long to keep the UV light on in ms.
+static constexpr uint32_t DELAY_MS = 1000 * 60 * 15;  // 15 minutes
 
 using TaskMessage = interrupt_task_messages::TaskMessage;
 
 class UVMessageHandler {
   public:
     explicit UVMessageHandler(gpio_drive_hardware::GpioDrivePins &drive_pins)
-        : drive_pins{drive_pins} {}
+        : drive_pins{drive_pins},
+          _timer(
+              "UVTask", [ThisPtr = this] { ThisPtr->timer_callback(); },
+              DELAY_MS) {
+        // get current state
+        uv_push_button = gpio::is_set(drive_pins.uv_push_button);
+        door_closed = gpio::is_set(drive_pins.door_open);
+        reed_switch_set = gpio::is_set(drive_pins.reed_switch);
+        // turn off UV Ballast
+        gpio::reset(drive_pins.uv_on_off);
+    }
     UVMessageHandler(const UVMessageHandler &) = delete;
     UVMessageHandler(const UVMessageHandler &&) = delete;
     auto operator=(const UVMessageHandler &) -> UVMessageHandler & = delete;
-    auto operator=(const UVMessageHandler &&)
-        -> UVMessageHandler && = delete;
+    auto operator=(const UVMessageHandler &&) -> UVMessageHandler && = delete;
     ~UVMessageHandler() {}
 
     void handle_message(const TaskMessage &m) {
@@ -27,29 +40,58 @@ class UVMessageHandler {
     }
 
   private:
+    // call back to turn off the UV ballast
+    auto timer_callback() -> void {
+        gpio::reset(drive_pins.uv_on_off);
+        uv_push_button = false;
+        uv_fan_on = false;
+    }
+
     void visit(const std::monostate &) {}
 
     // Handle GPIO EXTI Interrupts here
     void visit(const interrupt_task_messages::GPIOInterruptChanged &m) {
+        if (m.pin == drive_pins.hepa_push_button.pin) {
+            // ignore hepa push button presses
+            return;
+        }
+
+        // update states
         if (m.pin == drive_pins.uv_push_button.pin) {
             uv_push_button = !uv_push_button;
-            // handle state changes here
-            if (uv_push_button) {
-                gpio::set(drive_pins.uv_on_off);
-            } else {
-                gpio::reset(drive_pins.uv_on_off);
-            }
+        } else if (m.pin == drive_pins.door_open.pin) {
+            door_closed = gpio::is_set(drive_pins.door_open);
+        } else if (m.pin == drive_pins.reed_switch.pin) {
+            reed_switch_set = gpio::is_set(drive_pins.reed_switch);
+        }
+
+        // reset push button state if the door is opened or the reed switch is
+        // not set
+        if (!door_closed || !reed_switch_set) uv_push_button = false;
+
+        // set the UV Ballast
+        if (door_closed && reed_switch_set && uv_push_button) {
+            gpio::set(drive_pins.uv_on_off);
+            // start the turn off timer
+            _timer.start();
+            uv_fan_on = true;
+        } else {
+            gpio::reset(drive_pins.uv_on_off);
+            _timer.stop();
+            uv_fan_on = false;
         }
 
         // TODO: send CAN message to host
     }
 
     // state tracking variables
-    // TODO: add reed, door_open, etc
+    bool door_closed = false;
+    bool reed_switch_set = false;
     bool uv_push_button = false;
     bool uv_fan_on = false;
 
     gpio_drive_hardware::GpioDrivePins &drive_pins;
+    ot_utils::freertos_timer::FreeRTOSTimer _timer;
 };
 
 /**


### PR DESCRIPTION
## Overview

The HEPA/UV has a UV Ballast that needs to turn on/off based on external input, this pr adds a a task that actuates the UV ballast based on these external inputs. It also adds a timer that turns off the UV ballast after 15m.

Closes: [RET-1402](https://opentrons.atlassian.net/browse/RET-1402)

## Changes

- Add a UVTask that listens for irq interrupts and turns on/off the UV Ballast accordingly
- Turn off the HEPA fan and UV Ballast on startup

## Review Requests

- Does this approach make sense?
- I'll have to go back in at some point to add a better interface instead of using gpio::set/reset directly
- Feedback is appreciated!

[RET-1402]: https://opentrons.atlassian.net/browse/RET-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ