### PR TITLE
fix(hepa-uv): remove hepa-uv simulators so they don't block CI.

### DIFF
--- a/.github/workflows/build-simulators.yaml
+++ b/.github/workflows/build-simulators.yaml
@@ -24,7 +24,6 @@ jobs:
           gantry-y,
           gripper,
           head,
-          hepa-uv,
           pipettes-single,
           pipettes-multi,
           pipettes-96,

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -241,8 +241,7 @@
         "pipettes-single-simulator",
         "pipettes-multi-simulator",
         "pipettes-96-simulator",
-        "gripper-simulator",
-        "hepa-uv-simulator"
+        "gripper-simulator"
       ]
     },
     {
@@ -260,8 +259,7 @@
         "pipettes-single-simulator",
         "pipettes-multi-simulator",
         "pipettes-96-simulator",
-        "gripper-simulator",
-        "hepa-uv-simulator"
+        "gripper-simulator"
       ]
     }
   ]

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1237,8 +1237,8 @@ using TipStatusQueryRequest = Empty<MessageId::get_tip_status_request>;
 
 struct PushTipPresenceNotification
     : BaseMessage<MessageId::tip_presence_notification> {
-    uint32_t message_index;
-    uint8_t ejector_flag_status;
+    uint32_t message_index = 0;
+    uint8_t ejector_flag_status = 0;
     can::ids::SensorId sensor_id{};
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -1476,8 +1476,8 @@ using GetMotorUsageRequest = Empty<MessageId::get_motor_usage_request>;
 
 struct GetMotorUsageResponse
     : BaseMessage<MessageId::get_motor_usage_response> {
-    uint32_t message_index;
-    uint8_t num_keys;
+    uint32_t message_index = 0;
+    uint8_t num_keys = 0;
     struct __attribute__((__packed__)) UsageValueField {
         uint16_t key;
         uint16_t len;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1235,10 +1235,11 @@ struct BindSensorOutputResponse
 
 using TipStatusQueryRequest = Empty<MessageId::get_tip_status_request>;
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct PushTipPresenceNotification
     : BaseMessage<MessageId::tip_presence_notification> {
-    uint32_t message_index = 0;
-    uint8_t ejector_flag_status = 0;
+    uint32_t message_index;
+    uint8_t ejector_flag_status;
     can::ids::SensorId sensor_id{};
 
     template <bit_utils::ByteIterator Output, typename Limit>
@@ -1474,10 +1475,11 @@ struct SetGripperErrorToleranceRequest
 
 using GetMotorUsageRequest = Empty<MessageId::get_motor_usage_request>;
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct GetMotorUsageResponse
     : BaseMessage<MessageId::get_motor_usage_response> {
-    uint32_t message_index = 0;
-    uint8_t num_keys = 0;
+    uint32_t message_index;
+    uint8_t num_keys;
     struct __attribute__((__packed__)) UsageValueField {
         uint16_t key;
         uint16_t len;


### PR DESCRIPTION
The functionality for the HEPA/UV module is not complete yet, so let's remove the simulator build so it does not stop other simulators from building. This will be re-added in a future PR.