### PR TITLE
fix(motor-control): check for encoder overflow more often

### DIFF
--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -184,6 +184,7 @@ class MotorInterruptHandler {
 
     void run_interrupt() {
         // handle various error states
+        std::ignore = hardware.get_encoder_pulses();
         if (clear_queue_until_empty) {
             // If we were executing a move when estop asserted, and
             // what's in the queue is the remaining enqueued moves from


### PR DESCRIPTION
Currently we only check for encoder overflow when the motor is actively stepping. And if the motor velocity is very slow, we could potentially miss an overflow or two because of the encoder jitters. The fix here is to check for it more often. This will now allow our axes to move much more slowly.