### PR TITLE
feat(hepa-uv): Add CAN messages to control the Hepa/UV filter.

### DIFF
--- a/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
+++ b/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
@@ -6,8 +6,13 @@
 #include "task.h"
 #include "timers.h"
 
-#define ROUNDED_DIV(A, B) (((A) + ((B) / 2)) / (B))
-#define TICKS_TO_MS(TICKS) (uint32_t)ROUNDED_DIV((TICKS) * 1000, configTICK_RATE_HZ)
+constexpr auto ROUNDED_DIV(uint32_t A, uint32_t B) noexcept -> uint32_t {
+    return (((A) + ((B) / 2)) / (B));
+}
+
+constexpr auto TICKS_TO_MS(uint32_t ticks) noexcept -> uint32_t {
+    return (uint32_t)ROUNDED_DIV((ticks) * 1000, (uint32_t)configTICK_RATE_HZ);
+}
 
 namespace ot_utils {
 namespace freertos_timer {
@@ -57,11 +62,11 @@ class FreeRTOSTimer {
         }
     }
 
-    uint32_t get_remaining_time() {
+    auto get_remaining_time() -> uint32_t {
         /*
         The time in ms remaining before this timer expires and the callback is executed.
         */
-        if (!is_running()) return uint32_t(0);
+        if (!is_running()) { return uint32_t(0); }
         return TICKS_TO_MS(xTimerGetExpiryTime( timer ) - xTaskGetTickCount());
     }
 

--- a/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
+++ b/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
@@ -7,7 +7,7 @@
 #include "timers.h"
 
 #define ROUNDED_DIV(A, B) (((A) + ((B) / 2)) / (B))
-#define PASSED_MS(TICKS) (uint32_t)ROUNDED_DIV((TICKS) * 1000, configTICK_RATE_HZ)
+#define TICKS_TO_MS(TICKS) (uint32_t)ROUNDED_DIV((TICKS) * 1000, configTICK_RATE_HZ)
 
 namespace ot_utils {
 namespace freertos_timer {
@@ -62,7 +62,7 @@ class FreeRTOSTimer {
         The time in ms remaining before this timer expires and the callback is executed.
         */
         if (!is_running()) return uint32_t(0);
-        return PASSED_MS(xTimerGetExpiryTime( timer ) - xTaskGetTickCount());
+        return TICKS_TO_MS(xTimerGetExpiryTime( timer ) - xTaskGetTickCount());
     }
 
     void start() { xTimerStart(timer, 1); }

--- a/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
+++ b/cpp-utils/include/ot_utils/freertos/freertos_timer.hpp
@@ -6,6 +6,9 @@
 #include "task.h"
 #include "timers.h"
 
+#define ROUNDED_DIV(A, B) (((A) + ((B) / 2)) / (B))
+#define PASSED_MS(TICKS) (uint32_t)ROUNDED_DIV((TICKS) * 1000, configTICK_RATE_HZ)
+
 namespace ot_utils {
 namespace freertos_timer {
 
@@ -52,6 +55,14 @@ class FreeRTOSTimer {
             stop();
             vTaskDelay(1);
         }
+    }
+
+    uint32_t get_remaining_time() {
+        /*
+        The time in ms remaining before this timer expires and the callback is executed.
+        */
+        if (!is_running()) return uint32_t(0);
+        return PASSED_MS(xTimerGetExpiryTime( timer ) - xTaskGetTickCount());
     }
 
     void start() { xTimerStart(timer, 1); }

--- a/hepa-uv/core/can_tasks.cpp
+++ b/hepa-uv/core/can_tasks.cpp
@@ -18,6 +18,7 @@ static auto hepauv_info_handler =
     hepauv_info::HepaUVInfoMessageHandler{main_queues, main_queues};
 
 static auto hepa_fan_handler = hepa::message_handler::HepaHandler{main_queues};
+static auto uv_light_handler = uv::message_handler::UVHandler{main_queues};
 
 /** Handler of system messages. */
 static auto system_message_handler =
@@ -47,6 +48,8 @@ static auto hepauv_info_dispatch_target =
 static auto hepa_dispatch_target =
     can_task::HepaDispatchTarget{hepa_fan_handler};
 
+static auto uv_dispatch_target = can_task::UVDispatchTarget{uv_light_handler};
+
 struct CheckForNodeId {
     can::ids::NodeId node_id;
     auto operator()(uint32_t arbitration_id) const {
@@ -67,7 +70,7 @@ static auto main_dispatcher = can::dispatch::Dispatcher(
                 (node_id == can::ids::NodeId::hepa_uv));
     },
     system_dispatch_target, hepauv_info_dispatch_target, eeprom_dispatch_target,
-    hepa_dispatch_target);
+    hepa_dispatch_target, uv_dispatch_target);
 
 auto static reader_message_buffer =
     freertos_message_buffer::FreeRTOSMessageBuffer<1024>{};

--- a/hepa-uv/core/can_tasks.cpp
+++ b/hepa-uv/core/can_tasks.cpp
@@ -2,7 +2,9 @@
 
 #include "eeprom/core/message_handler.hpp"
 #include "hepa-uv/core/can_task.hpp"
+#include "hepa-uv/core/hepa_task.hpp"
 #include "hepa-uv/core/hepauv_info.hpp"
+#include "hepa-uv/core/message_handler.hpp"
 
 using namespace can::dispatch;
 
@@ -15,6 +17,8 @@ auto can_sender_queue = freertos_message_queue::FreeRTOSMessageQueue<
 static auto hepauv_info_handler =
     hepauv_info::HepaUVInfoMessageHandler{main_queues, main_queues};
 
+static auto hepa_fan_handler = hepa::message_handler::HepaHandler{main_queues};
+
 /** Handler of system messages. */
 static auto system_message_handler =
     can::message_handlers::system::SystemMessageHandler{
@@ -25,6 +29,8 @@ static auto system_message_handler =
                   std::cend(version_get()->sha)),
         revision_get()->primary,
         revision_get()->secondary};
+static auto system_dispatch_target =
+    can_task::SystemDispatchTarget{system_message_handler};
 
 /** Handler for eeprom messages.*/
 static auto eeprom_message_handler =
@@ -35,11 +41,11 @@ static auto eeprom_dispatch_target =
                                        can::messages::ReadFromEEPromRequest>{
         eeprom_message_handler};
 
-static auto system_dispatch_target =
-    can_task::SystemDispatchTarget{system_message_handler};
-
 static auto hepauv_info_dispatch_target =
     can_task::HepaUVInfoDispatchTarget{hepauv_info_handler};
+
+static auto hepa_dispatch_target =
+    can_task::HepaDispatchTarget{hepa_fan_handler};
 
 struct CheckForNodeId {
     can::ids::NodeId node_id;
@@ -60,8 +66,8 @@ static auto main_dispatcher = can::dispatch::Dispatcher(
         return ((node_id == can::ids::NodeId::broadcast) ||
                 (node_id == can::ids::NodeId::hepa_uv));
     },
-    system_dispatch_target, hepauv_info_dispatch_target,
-    eeprom_dispatch_target);
+    system_dispatch_target, hepauv_info_dispatch_target, eeprom_dispatch_target,
+    hepa_dispatch_target);
 
 auto static reader_message_buffer =
     freertos_message_buffer::FreeRTOSMessageBuffer<1024>{};

--- a/hepa-uv/core/tasks.cpp
+++ b/hepa-uv/core/tasks.cpp
@@ -73,7 +73,7 @@ void hepauv_tasks::start_tasks(
     auto& hepa_task = hepa_task_builder.start(5, "hepa_fan", gpio_drive_pins,
                                               hepa_hardware, queues, queues);
     auto& uv_task =
-        uv_task_builder.start(5, "uv_ballast", gpio_drive_pins, queues);
+        uv_task_builder.start(5, "uv_ballast", gpio_drive_pins, queues, queues);
     auto& led_control_task =
         led_control_task_builder.start(5, "push_button_leds", led_hardware);
 

--- a/hepa-uv/core/tasks.cpp
+++ b/hepa-uv/core/tasks.cpp
@@ -71,7 +71,7 @@ void hepauv_tasks::start_tasks(
                                                   eeprom_hw_iface);
 
     auto& hepa_task = hepa_task_builder.start(5, "hepa_fan", gpio_drive_pins,
-                                              hepa_hardware, queues);
+                                              hepa_hardware, queues, queues);
     auto& uv_task =
         uv_task_builder.start(5, "uv_ballast", gpio_drive_pins, queues);
     auto& led_control_task =

--- a/hepa-uv/firmware/main_rev1.cpp
+++ b/hepa-uv/firmware/main_rev1.cpp
@@ -135,13 +135,11 @@ extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
         case UV_NO_MCU_PIN:
             if (hepauv_queues.hepa_queue != nullptr) {
                 static_cast<void>(hepauv_queues.hepa_queue->try_write_isr(
-                    interrupt_task_messages::GPIOInterruptChanged{
-                        .pin = GPIO_Pin}));
+                    GPIOInterruptChanged{.pin = GPIO_Pin}));
             }
             if (hepauv_queues.uv_queue != nullptr) {
                 static_cast<void>(hepauv_queues.uv_queue->try_write_isr(
-                    interrupt_task_messages::GPIOInterruptChanged{
-                        .pin = GPIO_Pin}));
+                    GPIOInterruptChanged{.pin = GPIO_Pin}));
             }
             break;
         default:

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -112,6 +112,12 @@ typedef enum {
     can_messageid_peripheral_status_request = 0x8c,
     can_messageid_peripheral_status_response = 0x8d,
     can_messageid_baseline_sensor_response = 0x8e,
+    can_messageid_set_hepa_fan_state_request = 0x90,
+    can_messageid_get_hepa_fan_state_request = 0x91,
+    can_messageid_get_hepa_fan_state_response = 0x92,
+    can_messageid_set_hepa_uv_state_request = 0x93,
+    can_messageid_get_hepa_uv_state_request = 0x94,
+    can_messageid_get_hepa_uv_state_response = 0x95,
 } CANMessageId;
 
 /** Can bus arbitration id node id. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -114,6 +114,12 @@ enum class MessageId {
     peripheral_status_request = 0x8c,
     peripheral_status_response = 0x8d,
     baseline_sensor_response = 0x8e,
+    set_hepa_fan_state_request = 0x90,
+    get_hepa_fan_state_request = 0x91,
+    get_hepa_fan_state_response = 0x92,
+    set_hepa_uv_state_request = 0x93,
+    get_hepa_uv_state_request = 0x94,
+    get_hepa_uv_state_response = 0x95,
 };
 
 /** Can bus arbitration id node id. */

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1581,6 +1581,51 @@ struct HepaUVInfoResponse : BaseMessage<MessageId::hepauv_info_response> {
     auto operator==(const HepaUVInfoResponse& other) const -> bool = default;
 };
 
+struct SetHepaFanStateRequest
+    : BaseMessage<MessageId::set_hepa_fan_state_request> {
+    uint32_t message_index;
+    uint32_t duty_cycle;
+    uint8_t fan_on;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> SetHepaFanStateRequest {
+        uint8_t fan_on = 0;
+        uint32_t duty_cycle = 0;
+        uint32_t msg_ind = 0;
+
+        body = bit_utils::bytes_to_int(body, limit, msg_ind);
+        body = bit_utils::bytes_to_int(body, limit, duty_cycle);
+        body = bit_utils::bytes_to_int(body, limit, fan_on);
+        return SetHepaFanStateRequest{.message_index = msg_ind,
+                                         .duty_cycle = duty_cycle,
+                                         .fan_on = fan_on};
+    }
+
+    auto operator==(const SetHepaFanStateRequest& other) const
+        -> bool = default;
+};
+
+using GetHepaFanStateRequest = Empty<MessageId::get_hepa_fan_state_request>;
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct GetHepaFanStateResponse
+    : BaseMessage<MessageId::get_hepa_fan_state_response> {
+    uint32_t message_index;
+    uint32_t duty_cycle;
+    uint8_t fan_on;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(message_index, body, limit);
+        iter = bit_utils::int_to_bytes(duty_cycle, iter, limit);
+        iter = bit_utils::int_to_bytes(fan_on, iter, limit);
+        return iter - body;
+    }
+
+    auto operator==(const GetHepaFanStateResponse& other) const
+        -> bool = default;
+};
+
 /**
  * A variant of all message types we might send..
  */
@@ -1597,6 +1642,6 @@ using ResponseMessageType = std::variant<
     PeripheralStatusResponse, BrushedMotorConfResponse,
     UpdateMotorPositionEstimationResponse, BaselineSensorResponse,
     PushTipPresenceNotification, GetMotorUsageResponse, GripperJawStateResponse,
-    GripperJawHoldoffResponse, HepaUVInfoResponse>;
+    GripperJawHoldoffResponse, HepaUVInfoResponse, GetHepaFanStateResponse>;
 
 }  // namespace can::messages

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1626,6 +1626,53 @@ struct GetHepaFanStateResponse
         -> bool = default;
 };
 
+struct SetHepaUVStateRequest
+    : BaseMessage<MessageId::set_hepa_uv_state_request> {
+    uint32_t message_index;
+    uint32_t timeout_s;
+    uint8_t uv_light_on;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> SetHepaUVStateRequest {
+        uint8_t uv_light_on = 0;
+        uint32_t timeout_s = 0;
+        uint32_t msg_ind = 0;
+
+        body = bit_utils::bytes_to_int(body, limit, msg_ind);
+        body = bit_utils::bytes_to_int(body, limit, timeout_s);
+        body = bit_utils::bytes_to_int(body, limit, uv_light_on);
+        return SetHepaUVStateRequest{.message_index = msg_ind,
+                                         .timeout_s = timeout_s,
+                                         .uv_light_on = uv_light_on};
+    }
+
+    auto operator==(const SetHepaUVStateRequest& other) const
+        -> bool = default;
+};
+
+using GetHepaUVStateRequest = Empty<MessageId::get_hepa_uv_state_request>;
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+struct GetHepaUVStateResponse
+    : BaseMessage<MessageId::get_hepa_uv_state_response> {
+    uint32_t message_index;
+    uint32_t timeout_s;
+    uint8_t uv_light_on;
+    uint32_t remaining_time_s;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(message_index, body, limit);
+        iter = bit_utils::int_to_bytes(timeout_s, iter, limit);
+        iter = bit_utils::int_to_bytes(uv_light_on, iter, limit);
+        iter = bit_utils::int_to_bytes(remaining_time_s, iter, limit);
+        return iter - body;
+    }
+
+    auto operator==(const GetHepaUVStateResponse& other) const
+        -> bool = default;
+};
+
 /**
  * A variant of all message types we might send..
  */
@@ -1642,6 +1689,6 @@ using ResponseMessageType = std::variant<
     PeripheralStatusResponse, BrushedMotorConfResponse,
     UpdateMotorPositionEstimationResponse, BaselineSensorResponse,
     PushTipPresenceNotification, GetMotorUsageResponse, GripperJawStateResponse,
-    GripperJawHoldoffResponse, HepaUVInfoResponse, GetHepaFanStateResponse>;
+    GripperJawHoldoffResponse, HepaUVInfoResponse, GetHepaFanStateResponse, GetHepaUVStateResponse>;
 
 }  // namespace can::messages

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1597,8 +1597,8 @@ struct SetHepaFanStateRequest
         body = bit_utils::bytes_to_int(body, limit, duty_cycle);
         body = bit_utils::bytes_to_int(body, limit, fan_on);
         return SetHepaFanStateRequest{.message_index = msg_ind,
-                                         .duty_cycle = duty_cycle,
-                                         .fan_on = fan_on};
+                                      .duty_cycle = duty_cycle,
+                                      .fan_on = fan_on};
     }
 
     auto operator==(const SetHepaFanStateRequest& other) const
@@ -1642,12 +1642,11 @@ struct SetHepaUVStateRequest
         body = bit_utils::bytes_to_int(body, limit, timeout_s);
         body = bit_utils::bytes_to_int(body, limit, uv_light_on);
         return SetHepaUVStateRequest{.message_index = msg_ind,
-                                         .timeout_s = timeout_s,
-                                         .uv_light_on = uv_light_on};
+                                     .timeout_s = timeout_s,
+                                     .uv_light_on = uv_light_on};
     }
 
-    auto operator==(const SetHepaUVStateRequest& other) const
-        -> bool = default;
+    auto operator==(const SetHepaUVStateRequest& other) const -> bool = default;
 };
 
 using GetHepaUVStateRequest = Empty<MessageId::get_hepa_uv_state_request>;
@@ -1689,6 +1688,7 @@ using ResponseMessageType = std::variant<
     PeripheralStatusResponse, BrushedMotorConfResponse,
     UpdateMotorPositionEstimationResponse, BaselineSensorResponse,
     PushTipPresenceNotification, GetMotorUsageResponse, GripperJawStateResponse,
-    GripperJawHoldoffResponse, HepaUVInfoResponse, GetHepaFanStateResponse, GetHepaUVStateResponse>;
+    GripperJawHoldoffResponse, HepaUVInfoResponse, GetHepaFanStateResponse,
+    GetHepaUVStateResponse>;
 
 }  // namespace can::messages

--- a/include/hepa-uv/core/can_task.hpp
+++ b/include/hepa-uv/core/can_task.hpp
@@ -25,7 +25,12 @@ using HepaUVInfoDispatchTarget = can::dispatch::DispatchParseTarget<
 
 using HepaDispatchTarget = can::dispatch::DispatchParseTarget<
     hepa::message_handler::HepaHandler<hepauv_tasks::QueueClient>,
-    can::messages::SetHepaFanStateRequest, can::messages::GetHepaFanStateRequest>;
+    can::messages::SetHepaFanStateRequest,
+    can::messages::GetHepaFanStateRequest>;
+
+using UVDispatchTarget = can::dispatch::DispatchParseTarget<
+    uv::message_handler::UVHandler<hepauv_tasks::QueueClient>,
+    can::messages::SetHepaUVStateRequest, can::messages::GetHepaUVStateRequest>;
 
 auto constexpr reader_message_buffer_size = 1024;
 

--- a/include/hepa-uv/core/can_task.hpp
+++ b/include/hepa-uv/core/can_task.hpp
@@ -3,7 +3,9 @@
 #include "can/core/freertos_can_dispatch.hpp"
 #include "can/core/message_handlers/system.hpp"
 #include "common/core/freertos_message_queue.hpp"
+#include "hepa-uv/core/hepa_task.hpp"
 #include "hepa-uv/core/hepauv_info.hpp"
+#include "hepa-uv/core/message_handler.hpp"
 #include "hepa-uv/core/tasks.hpp"
 
 namespace can_task {
@@ -15,10 +17,15 @@ using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
         hepauv_tasks::QueueClient>,
     can::messages::DeviceInfoRequest, can::messages::InitiateFirmwareUpdate,
     can::messages::FirmwareUpdateStatusRequest, can::messages::TaskInfoRequest>;
+
 using HepaUVInfoDispatchTarget = can::dispatch::DispatchParseTarget<
     hepauv_info::HepaUVInfoMessageHandler<hepauv_tasks::QueueClient,
                                           hepauv_tasks::QueueClient>,
     can::messages::InstrumentInfoRequest, can::messages::SetSerialNumber>;
+
+using HepaDispatchTarget = can::dispatch::DispatchParseTarget<
+    hepa::message_handler::HepaHandler<hepauv_tasks::QueueClient>,
+    can::messages::SetHepaFanStateRequest, can::messages::GetHepaFanStateRequest>;
 
 auto constexpr reader_message_buffer_size = 1024;
 

--- a/include/hepa-uv/core/hepa_task.hpp
+++ b/include/hepa-uv/core/hepa_task.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "common/core/bit_utils.hpp"
-#include "common/core/logging.h"
 #include "common/core/message_queue.hpp"
 #include "common/firmware/gpio.hpp"
 #include "hepa-uv/core/constants.h"
@@ -13,22 +13,24 @@
 
 namespace hepa_task {
 
-using TaskMessage = interrupt_task_messages::TaskMessage;
+const uint32_t DEFAULT_HEPA_PWM = 75;
 
-template <led_control_task::TaskClient LEDControlClient>
+using TaskMessage = hepa_task_messages::TaskMessage;
+
+template <led_control_task::TaskClient LEDControlClient,
+          can::message_writer_task::TaskClient CanClient>
 class HepaMessageHandler {
   public:
     explicit HepaMessageHandler(
         gpio_drive_hardware::GpioDrivePins &drive_pins,
         hepa_control_hardware::HepaControlHardware &hepa_hardware,
-        LEDControlClient &led_control_client)
+        LEDControlClient &led_control_client, CanClient &can_client)
         : drive_pins{drive_pins},
           hepa_hardware{hepa_hardware},
-          led_control_client{led_control_client} {
-        // get current state
-        hepa_push_button = gpio::is_set(drive_pins.hepa_push_button);
+          led_control_client{led_control_client},
+          can_client{can_client} {
         // turn off the HEPA fan
-        gpio::reset(drive_pins.hepa_on_off);
+        set_hepa_fan_state(false, 0);
     }
     HepaMessageHandler(const HepaMessageHandler &) = delete;
     HepaMessageHandler(const HepaMessageHandler &&) = delete;
@@ -45,35 +47,54 @@ class HepaMessageHandler {
     void visit(const std::monostate &) {}
 
     // Handle GPIO EXTI Interrupts here
-    void visit(const interrupt_task_messages::GPIOInterruptChanged &m) {
+    void visit(const GPIOInterruptChanged &m) {
         if (m.pin == drive_pins.hepa_push_button.pin) {
-            hepa_push_button = !hepa_push_button;
-            // handle state changes here
-            if (hepa_push_button) {
-                hepa_hardware.set_hepa_fan_speed(75);
-                gpio::set(drive_pins.hepa_on_off);
-                led_control_client.send_led_control_message(
-                    led_control_task_messages::PushButtonLED{HEPA_BUTTON, 0, 50,
-                                                             0, 0});
-            } else {
-                hepa_hardware.set_hepa_fan_speed(0);
-                gpio::reset(drive_pins.hepa_on_off);
-                led_control_client.send_led_control_message(
-                    led_control_task_messages::PushButtonLED{HEPA_BUTTON, 0, 0,
-                                                             0, 50});
-            }
+            hepa_fan_on = !hepa_fan_on;
+            set_hepa_fan_state(hepa_fan_on, hepa_fan_pwm);
         }
-
         // TODO: send CAN message to host
     }
 
-    // state tracking variables
-    bool hepa_push_button = false;
+    void visit(const can::messages::SetHepaFanStateRequest &m) {
+        hepa_fan_pwm = (static_cast<uint32_t>(
+            std::clamp(m.duty_cycle, uint32_t(0), uint32_t(100))));
+        set_hepa_fan_state(bool(m.fan_on), hepa_fan_pwm);
+        can_client.send_can_message(can::ids::NodeId::host,
+                                    can::messages::ack_from_request(m));
+    }
+
+    void visit(const can::messages::GetHepaFanStateRequest &m) {
+        auto resp = can::messages::GetHepaFanStateResponse{
+            .message_index = m.message_index,
+            .duty_cycle = hepa_fan_pwm,
+            .fan_on = hepa_fan_on};
+        can_client.send_can_message(can::ids::NodeId::host, resp);
+    }
+
+    void set_hepa_fan_state(bool turn_on = false,
+                            uint32_t duty_cycle = DEFAULT_HEPA_PWM) {
+        hepa_hardware.set_hepa_fan_speed(duty_cycle);
+        hepa_fan_on = (turn_on && duty_cycle > 0);
+        if (hepa_fan_on) {
+            gpio::set(drive_pins.hepa_on_off);
+            led_control_client.send_led_control_message(
+                led_control_task_messages::PushButtonLED{HEPA_BUTTON, 0, 50, 0,
+                                                         0});
+        } else {
+            gpio::reset(drive_pins.hepa_on_off);
+            led_control_client.send_led_control_message(
+                led_control_task_messages::PushButtonLED{HEPA_BUTTON, 0, 0, 0,
+                                                         50});
+        }
+    }
+
+    uint32_t hepa_fan_pwm = DEFAULT_HEPA_PWM;
     bool hepa_fan_on = false;
 
     gpio_drive_hardware::GpioDrivePins &drive_pins;
     hepa_control_hardware::HepaControlHardware &hepa_hardware;
     LEDControlClient &led_control_client;
+    CanClient &can_client;
 };
 
 /**
@@ -95,13 +116,14 @@ class HepaTask {
     /**
      * Task entry point.
      */
-    template <led_control_task::TaskClient LEDControlClient>
+    template <led_control_task::TaskClient LEDControlClient,
+              can::message_writer_task::TaskClient CanClient>
     [[noreturn]] void operator()(
         gpio_drive_hardware::GpioDrivePins *drive_pins,
         hepa_control_hardware::HepaControlHardware *hepa_hardware,
-        LEDControlClient *led_control_client) {
+        LEDControlClient *led_control_client, CanClient *can_client) {
         auto handler = HepaMessageHandler{*drive_pins, *hepa_hardware,
-                                          *led_control_client};
+                                          *led_control_client, *can_client};
         TaskMessage message{};
         for (;;) {
             if (queue.try_read(&message, queue.max_delay)) {
@@ -115,4 +137,14 @@ class HepaTask {
   private:
     QueueType &queue;
 };
+
+/**
+ * Concept describing a class that can message this task.
+ * @tparam Client
+ */
+template <typename Client>
+concept TaskClient = requires(Client client, const TaskMessage &m) {
+    {client.send_hepa_message(m)};
+};
+
 };  // namespace hepa_task

--- a/include/hepa-uv/core/hepauv_info.hpp
+++ b/include/hepa-uv/core/hepauv_info.hpp
@@ -50,8 +50,8 @@ class HepaUVInfoMessageHandler : eeprom::accessor::ReadListener {
         -> HepaUVInfoMessageHandler && = delete;
     ~HepaUVInfoMessageHandler() final = default;
 
-    using MessageType = std::variant<std::monostate, InstrumentInfoRequest,
-                                     SetSerialNumber>;
+    using MessageType =
+        std::variant<std::monostate, InstrumentInfoRequest, SetSerialNumber>;
 
     /**
      * Message handler

--- a/include/hepa-uv/core/hepauv_info.hpp
+++ b/include/hepa-uv/core/hepauv_info.hpp
@@ -50,8 +50,8 @@ class HepaUVInfoMessageHandler : eeprom::accessor::ReadListener {
         -> HepaUVInfoMessageHandler && = delete;
     ~HepaUVInfoMessageHandler() final = default;
 
-    using MessageType =
-        std::variant<std::monostate, InstrumentInfoRequest, SetSerialNumber>;
+    using MessageType = std::variant<std::monostate, InstrumentInfoRequest,
+                                     SetSerialNumber>;
 
     /**
      * Message handler

--- a/include/hepa-uv/core/interfaces.hpp
+++ b/include/hepa-uv/core/interfaces.hpp
@@ -31,6 +31,6 @@ class HepaControlInterface {
         -> HepaControlInterface& = delete;
     virtual ~HepaControlInterface() = default;
 
-    virtual void set_hepa_fan_speed(uint32_t duty_cycle);
+    virtual auto set_hepa_fan_speed(uint32_t duty_cycle) -> void = 0;
 };
 }  // namespace hepa_control

--- a/include/hepa-uv/core/message_handler.hpp
+++ b/include/hepa-uv/core/message_handler.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <variant>
+
+#include "hepa-uv/core/hepa_task.hpp"
+
+namespace hepa {
+namespace message_handler {
+
+using MessageType =
+    std::variant<std::monostate, can::messages::SetHepaFanStateRequest,
+                 can::messages::GetHepaFanStateRequest>;
+
+template <hepa_task::TaskClient HepaTaskClient>
+class HepaHandler {
+  public:
+    explicit HepaHandler(HepaTaskClient &hepa_client)
+        : hepa_client(hepa_client) {}
+    HepaHandler(const HepaHandler &) = delete;
+    HepaHandler(const HepaHandler &&) = delete;
+    auto operator=(const HepaHandler &) -> HepaHandler & = delete;
+    auto operator=(const HepaHandler &&) -> HepaHandler && = delete;
+    ~HepaHandler() = default;
+
+    void handle(MessageType &can_message) {
+        std::visit(
+            [this](auto &m) -> void { this->hepa_client.send_hepa_message(m); },
+            can_message);
+    }
+
+  private:
+    HepaTaskClient &hepa_client;
+};
+
+}  // namespace message_handler
+}  // namespace hepa

--- a/include/hepa-uv/core/messages.hpp
+++ b/include/hepa-uv/core/messages.hpp
@@ -28,14 +28,9 @@ Messages for the UV Task
 */
 namespace uv_task_messages {
 
-struct SetUVLightState {
-    uint8_t state;
-    uint32_t timeout;
-};
-
-using TaskMessage =
-    std::variant<std::monostate, GPIOInterruptChanged, SetUVLightState>;
-
+using TaskMessage = std::variant<std::monostate, GPIOInterruptChanged,
+                                 can::messages::GetHepaUVStateRequest,
+                                 can::messages::SetHepaUVStateRequest>;
 };  // namespace uv_task_messages
 
 namespace led_control_task_messages {

--- a/include/hepa-uv/core/messages.hpp
+++ b/include/hepa-uv/core/messages.hpp
@@ -4,8 +4,6 @@
 #include "hepa-uv/core/constants.h"
 #include "hepa-uv/firmware/gpio_drive_hardware.hpp"
 
-namespace interrupt_task_messages {
-
 /**
  * A message sent when external interurpts are triguered
  */
@@ -14,9 +12,31 @@ struct GPIOInterruptChanged {
     uint8_t state;
 };
 
-using TaskMessage = std::variant<std::monostate, GPIOInterruptChanged>;
+/*
+Messages for the Hepa Task
+*/
+namespace hepa_task_messages {
 
-}  // namespace interrupt_task_messages
+using TaskMessage = std::variant<std::monostate, GPIOInterruptChanged,
+                                 can::messages::GetHepaFanStateRequest,
+                                 can::messages::SetHepaFanStateRequest>;
+
+}  // namespace hepa_task_messages
+
+/*
+Messages for the UV Task
+*/
+namespace uv_task_messages {
+
+struct SetUVLightState {
+    uint8_t state;
+    uint32_t timeout;
+};
+
+using TaskMessage =
+    std::variant<std::monostate, GPIOInterruptChanged, SetUVLightState>;
+
+};  // namespace uv_task_messages
 
 namespace led_control_task_messages {
 

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "common/core/bit_utils.hpp"
-#include "common/core/logging.h"
 #include "common/core/message_queue.hpp"
 #include "hepa-uv/core/constants.h"
 #include "hepa-uv/core/led_control_task.hpp"
@@ -12,21 +12,26 @@
 
 namespace uv_task {
 
-// How long to keep the UV light on in ms.
-static constexpr uint32_t DELAY_MS = 1000 * 60 * 15;  // 15 minutes
+// How long to keep the UV light on in seconds.
+// static constexpr uint32_t DELAY_S = 60 * 15;      // 15 minutes
+static constexpr uint32_t DELAY_S = 5;            // 5s FOR TESTING
+static constexpr uint32_t MAX_DELAY_S = 60 * 60;  // 1hr max timeout
 
 using TaskMessage = uv_task_messages::TaskMessage;
 
-template <led_control_task::TaskClient LEDControlClient>
+template <led_control_task::TaskClient LEDControlClient,
+          can::message_writer_task::TaskClient CanClient>
 class UVMessageHandler {
   public:
     explicit UVMessageHandler(gpio_drive_hardware::GpioDrivePins &drive_pins,
-                              LEDControlClient &led_control_client)
+                              LEDControlClient &led_control_client,
+                              CanClient &can_client)
         : drive_pins{drive_pins},
           led_control_client{led_control_client},
+          can_client{can_client},
           _timer(
               "UVTask", [ThisPtr = this] { ThisPtr->timer_callback(); },
-              DELAY_MS) {
+              DELAY_S * 1000) {
         // get current state
         uv_push_button = gpio::is_set(drive_pins.uv_push_button);
         door_closed = gpio::is_set(drive_pins.door_open);
@@ -46,13 +51,9 @@ class UVMessageHandler {
 
   private:
     // call back to turn off the UV ballast
-    auto timer_callback() -> void {
-        gpio::reset(drive_pins.uv_on_off);
-        // Set the push button LED's to idle (white)
-        led_control_client.send_led_control_message(
-            led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 0, 0, 50));
+    void timer_callback() {
+        set_uv_light_state(false);
         uv_push_button = false;
-        uv_fan_on = false;
     }
 
     void visit(const std::monostate &) {}
@@ -73,30 +74,56 @@ class UVMessageHandler {
             reed_switch_set = gpio::is_set(drive_pins.reed_switch);
         }
 
+        // Drive the UV light
+        set_uv_light_state(uv_push_button, uv_off_timeout_s);
+    }
+
+    void visit(const can::messages::SetHepaUVStateRequest &m) {
+        uv_off_timeout_s = (static_cast<uint32_t>(
+            std::clamp(m.timeout_s, uint32_t(0), MAX_DELAY_S)));
+        can_client.send_can_message(can::ids::NodeId::host,
+                                    can::messages::ack_from_request(m));
+        set_uv_light_state(bool(m.uv_light_on), uv_off_timeout_s);
+    }
+
+    void visit(const can::messages::GetHepaUVStateRequest &m) {
+        auto resp = can::messages::GetHepaUVStateResponse{
+            .message_index = m.message_index,
+            .timeout_s = uv_off_timeout_s,
+            .uv_light_on = uv_light_on,
+            .remaining_time_s = (_timer.get_remaining_time() / 1000)};
+        can_client.send_can_message(can::ids::NodeId::host, resp);
+    }
+
+    void set_uv_light_state(bool uv_light_on, uint32_t timeout_s = DELAY_S) {
         // reset push button state if the door is opened or the reed switch is
         // not set
         if (!door_closed || !reed_switch_set) {
-            uv_push_button = false;
-            gpio::set(drive_pins.uv_on_off);
-            // TODO: Pulse this instead of solid blue
+            gpio::reset(drive_pins.uv_on_off);
             // Set the push button LED's to user intervention (blue)
             led_control_client.send_led_control_message(
                 led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 0, 50,
                                                          0));
             if (_timer.is_running()) _timer.stop();
+            uv_push_button = false;
+            uv_light_on = false;
             return;
         }
 
         // set the UV Ballast
-        if (uv_push_button) {
+        uv_light_on = uv_light_on && timeout_s > 0;
+        // update the push button state
+        uv_push_button = uv_light_on;
+        if (uv_light_on) {
             gpio::set(drive_pins.uv_on_off);
             // Set the push button LED's to running (green)
             led_control_client.send_led_control_message(
                 led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 50, 0,
                                                          0));
             if (_timer.is_running()) _timer.stop();
+            // Update the timer in ms
+            _timer.update_period(timeout_s * 1000);
             _timer.start();
-            uv_fan_on = true;
         } else {
             gpio::reset(drive_pins.uv_on_off);
             // Set the push button LED's to idle (white)
@@ -104,24 +131,21 @@ class UVMessageHandler {
                 led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 0, 0,
                                                          50));
             if (_timer.is_running()) _timer.stop();
-            uv_fan_on = false;
         }
 
-        // TODO: send CAN message to host
-    }
-
-    void visit(const uv_task_messages::SetUVLightState &m) {
-        printf("Set UV light state: %lu", m.timeout);
+        // TODO: send state change CAN message to host
     }
 
     // state tracking variables
     bool door_closed = false;
     bool reed_switch_set = false;
     bool uv_push_button = false;
-    bool uv_fan_on = false;
+    bool uv_light_on = false;
+    uint32_t uv_off_timeout_s = DELAY_S;
 
     gpio_drive_hardware::GpioDrivePins &drive_pins;
     LEDControlClient &led_control_client;
+    CanClient &can_client;
     ot_utils::freertos_timer::FreeRTOSTimer _timer;
 };
 
@@ -144,10 +168,13 @@ class UVTask {
     /**
      * Task entry point.
      */
-    template <led_control_task::TaskClient LEDControlClient>
+    template <led_control_task::TaskClient LEDControlClient,
+              can::message_writer_task::TaskClient CanClient>
     [[noreturn]] void operator()(gpio_drive_hardware::GpioDrivePins *drive_pins,
-                                 LEDControlClient *led_control_client) {
-        auto handler = UVMessageHandler{*drive_pins, *led_control_client};
+                                 LEDControlClient *led_control_client,
+                                 CanClient *can_client) {
+        auto handler =
+            UVMessageHandler{*drive_pins, *led_control_client, *can_client};
         TaskMessage message{};
         for (;;) {
             if (queue.try_read(&message, queue.max_delay)) {
@@ -161,4 +188,14 @@ class UVTask {
   private:
     QueueType &queue;
 };
+
+/**
+ * Concept describing a class that can message this task.
+ * @tparam Client
+ */
+template <typename Client>
+concept TaskClient = requires(Client client, const TaskMessage &m) {
+    {client.send_uv_message(m)};
+};
+
 };  // namespace uv_task

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -13,8 +13,7 @@
 namespace uv_task {
 
 // How long to keep the UV light on in seconds.
-// static constexpr uint32_t DELAY_S = 60 * 15;      // 15 minutes
-static constexpr uint32_t DELAY_S = 5;            // 5s FOR TESTING
+static constexpr uint32_t DELAY_S = 60 * 15;      // 15 minutes
 static constexpr uint32_t MAX_DELAY_S = 60 * 60;  // 1hr max timeout
 
 using TaskMessage = uv_task_messages::TaskMessage;

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -94,7 +94,7 @@ class UVMessageHandler {
         can_client.send_can_message(can::ids::NodeId::host, resp);
     }
 
-    void set_uv_light_state(bool uv_light_on, uint32_t timeout_s = DELAY_S) {
+    void set_uv_light_state(bool light_on, uint32_t timeout_s = DELAY_S) {
         // reset push button state if the door is opened or the reed switch is
         // not set
         if (!door_closed || !reed_switch_set) {
@@ -110,7 +110,7 @@ class UVMessageHandler {
         }
 
         // set the UV Ballast
-        uv_light_on = uv_light_on && timeout_s > 0;
+        uv_light_on = (light_on && timeout_s > 0);
         // update the push button state
         uv_push_button = uv_light_on;
         if (uv_light_on) {

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -15,7 +15,7 @@ namespace uv_task {
 // How long to keep the UV light on in ms.
 static constexpr uint32_t DELAY_MS = 1000 * 60 * 15;  // 15 minutes
 
-using TaskMessage = interrupt_task_messages::TaskMessage;
+using TaskMessage = uv_task_messages::TaskMessage;
 
 template <led_control_task::TaskClient LEDControlClient>
 class UVMessageHandler {
@@ -58,7 +58,7 @@ class UVMessageHandler {
     void visit(const std::monostate &) {}
 
     // Handle GPIO EXTI Interrupts here
-    void visit(const interrupt_task_messages::GPIOInterruptChanged &m) {
+    void visit(const GPIOInterruptChanged &m) {
         if (m.pin == drive_pins.hepa_push_button.pin) {
             // ignore hepa push button presses
             return;
@@ -108,6 +108,10 @@ class UVMessageHandler {
         }
 
         // TODO: send CAN message to host
+    }
+
+    void visit(const uv_task_messages::SetUVLightState &m) {
+        printf("Set UV light state: %lu", m.timeout);
     }
 
     // state tracking variables

--- a/include/hepa-uv/firmware/hepa_control_hardware.hpp
+++ b/include/hepa-uv/firmware/hepa_control_hardware.hpp
@@ -4,9 +4,7 @@
 
 namespace hepa_control_hardware {
 
-using namespace hepa_control;
-
-class HepaControlHardware : public HepaControlInterface {
+class HepaControlHardware : public hepa_control::HepaControlInterface {
   public:
     HepaControlHardware() = default;
     HepaControlHardware(const HepaControlHardware&) = delete;


### PR DESCRIPTION
# Overview

We need to control the Hepa/UV filter from the Flex for testing and eventual system integration, this PR implements the CAN messages required to make this happen. It also adds a new method to query the time remaining before a software timer expires. This PR coincides with [Opentrons/opentrons#14452](https://github.com/Opentrons/opentrons/pull/14452) PR.

Closes: [RET-1422](https://opentrons.atlassian.net/browse/RET-1422) [RET-1423](https://opentrons.atlassian.net/browse/RET-1423)

# Test Plan

- [x] Make sure the Hepa fan still turns on/off with the push button
- [x] Make sure the UV Ballast still turns on/off with the push button when the Flex door is closed and reed switch is set.
- [x] Make sure that we can set/get the Hepa fan state and duty cycle with the SetHepaFanStateRequest and GetHepaFanStateRequest messages.
- [x] Make sure that we can set/get the UV light state and timeout with the SetHepaUVStateRequest and GetHepaUVStateRequest messages.
- [x] Make sure that the UV light ONLY turns on via CAN message when the door is closed and reed switch is set.
- [x] Make sure that the UV light turns OFF when the door is opened
- [x] After turning ON the UV light via a CAN message, make sure we can turn off the light when the push button is pressed.

# Change Log

- Added implementation for CAN messages to set/get Hepa fan state/duty cycle
- Added implementation for CAN messages to set/get UV Light state/timeout in seconds
- Added a get_remaining_time method to the FreeRTOSTimer class to know the time in ms before the timer expires.
- Integrated the new CAN messages into their corresponding Hepa Task and UV Task
- Refactored the Hepa Task logic so it takes into account the CAN messages so we aren't duplicating code.
- Refactored the UV Task logic so it takes into account the CAN messages so we aren't duplicating code.

# Review Requests

- Does anything not make sense with the can messages?

# Risk Assessment

Low, unreleased



[RET-1422]: https://opentrons.atlassian.net/browse/RET-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RET-1423]: https://opentrons.atlassian.net/browse/RET-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ