### PR TITLE
fix(z-motors): should disegange Z motors at boot when motor controller task first starts

### DIFF
--- a/gripper/firmware/utility_gpio.c
+++ b/gripper/firmware/utility_gpio.c
@@ -131,7 +131,7 @@ inline static void ebrake_gpio_init(void) {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     HAL_GPIO_Init(EBRAKE_PORT, &GPIO_InitStruct);
 
-    HAL_GPIO_WritePin(EBRAKE_PORT, EBRAKE_PIN, GPIO_PIN_SET);
+    HAL_GPIO_WritePin(EBRAKE_PORT, EBRAKE_PIN, GPIO_PIN_RESET);
 }
 #endif
 

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -31,7 +31,7 @@ class MotionController {
                      StepperMotorHardwareIface& hardware_iface,
                      MotionConstraints constraints, GenericQueue& queue,
                      UpdatePositionQueue& update_queue,
-                     bool eng_on_strt = false)
+                     bool diseng_on_strt = false)
         : linear_motion_sys_config(lms_config),
           hardware(hardware_iface),
           motion_constraints(constraints),
@@ -45,7 +45,7 @@ class MotionController {
               linear_motion_sys_config.get_um_per_step(), 31)),
           um_per_encoder_pulse(convert_to_fixed_point_64_bit(
               linear_motion_sys_config.get_encoder_um_per_pulse(), 31)),
-          engage_at_startup(eng_on_strt) {}
+          disengage_at_startup(diseng_on_strt) {}
 
     auto operator=(const MotionController&) -> MotionController& = delete;
     auto operator=(MotionController&&) -> MotionController&& = delete;
@@ -179,7 +179,7 @@ class MotionController {
     bool enabled = false;
 
   public:
-    bool engage_at_startup;
+    bool disengage_at_startup;
 };
 
 }  // namespace motion_controller

--- a/include/motor-control/core/tasks/motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/motion_controller_task.hpp
@@ -175,8 +175,8 @@ class MotionControllerTask {
         TaskMessage message{};
         bool first_run = true;
         for (;;) {
-            if (first_run && controller->engage_at_startup) {
-                controller->enable_motor();
+            if (first_run && controller->disengage_at_startup) {
+                controller->disable_motor();
                 first_run = false;
             }
             if (queue.try_read(&message, queue.max_delay)) {


### PR DESCRIPTION
We've been mistakenly engaging the z motors during start up (this supposedly disables the ebrake and uses the start the motor interrupt handler, which is the exact opposite of what we did in hardware gpio init).

This PR makes sure the z motors stay disengaged until the host tells it to move later on.

Closes RQA-2301, RQA-2429