### PR TITLE
feat(hepa-uv): add error code for door & reed state change during uv task

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -163,6 +163,8 @@ typedef enum {
     can_errorcode_motor_busy = 0xb,
     can_errorcode_stop_requested = 0xc,
     can_errorcode_over_pressure = 0xd,
+    can_errorcode_door_open = 0xe,
+    can_errorcode_reed_open = 0xf,
 } CANErrorCode;
 
 /** Tool types detected on Head. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -165,6 +165,8 @@ enum class ErrorCode {
     motor_busy = 0xb,
     stop_requested = 0xc,
     over_pressure = 0xd,
+    door_open = 0xe,
+    reed_open = 0xf,
 };
 
 /** Error Severity levels. */

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -98,12 +98,23 @@ class UVMessageHandler {
         // reset push button state if the door is opened or the reed switch is
         // not set
         if (!door_closed || !reed_switch_set) {
-            gpio::reset(drive_pins.uv_on_off);
-            // Set the push button LED's to user intervention (blue)
+            if (_timer.is_running()) {
+                gpio::reset(drive_pins.uv_on_off);
+                _timer.stop();
+                    // send error message when door/reed state change while uv
+                    // is on
+                    auto resp = can::messages::ErrorMessage{
+                    .message_index = 0,
+                    .severity = can::ids::ErrorSeverity::warning,
+                    .error_code = !door_closed ? can::ids::ErrorCode::door_open
+                                               : can::ids::ErrorCode::reed_open,
+                };
+                can_client.send_can_message(can::ids::NodeId::host, resp);
+            }
             led_control_client.send_led_control_message(
+                // Set the push button LED's to user intervention (blue)
                 led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 0, 50,
                                                          0));
-            if (_timer.is_running()) _timer.stop();
             uv_push_button = false;
             uv_light_on = false;
             return;

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -105,7 +105,7 @@ class UVMessageHandler {
                     // is on
                     auto resp = can::messages::ErrorMessage{
                     .message_index = 0,
-                    .severity = can::ids::ErrorSeverity::warning,
+                    .severity = can::ids::ErrorSeverity::unrecoverable,
                     .error_code = !door_closed ? can::ids::ErrorCode::door_open
                                                : can::ids::ErrorCode::reed_open,
                 };


### PR DESCRIPTION
This PR does two things:
1. Add error code for door & reed state change so the hepa uv can notify the server when the uv task gets interrupted by the hardware states
2. Only stops turns off the uv light if the hardware state changes if the uv task is running