### PR TITLE
chore(cmake): Add sensor variant firmware ci

### DIFF
--- a/.github/workflows/build_sensor_fw.yaml
+++ b/.github/workflows/build_sensor_fw.yaml
@@ -32,7 +32,7 @@ jobs:
           cmake --preset=cross-sensor-buffer . -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: 'Build images'
         run: |
-          cmake --build --preset=firmware-g4-sensors --target firmware-applications
+          cmake --build --preset=firmware-g4-sensors --target firmware-applications firmware-images
       - name: 'Prep images for upload'
         run: |
           cmake --install ./build-cross-sensor

--- a/.github/workflows/build_sensor_fw.yaml
+++ b/.github/workflows/build_sensor_fw.yaml
@@ -1,0 +1,44 @@
+name: "Build firmware release bundles"
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  ci: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 20
+    steps:
+      - uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 0
+      - uses: "actions/cache@v3"
+        with:
+          path: "./stm32-tools"
+          key: ${{ runner.os }}-${{ hashFiles('**/cmake/*') }}-${{ secrets.CACHE_VERSION }}
+      - name: 'CMake configure'
+        run: |
+          cmake --preset=cross-sensor-buffer . -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - name: 'Build images'
+        run: |
+          cmake --build --preset=firmware-g4-sensors --target firmware-applications
+      - name: 'Prep images for upload'
+        run: |
+          cmake --install ./build-cross-sensor
+      - name: 'Upload application artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'firmware-applications-${{github.ref_name}}'
+          path: |
+            dist-sensor/applications/*

--- a/.github/workflows/build_sensor_fw.yaml
+++ b/.github/workflows/build_sensor_fw.yaml
@@ -1,4 +1,4 @@
-name: "Build firmware release bundles"
+name: "Build firmware sensor variant bundles"
 on:
   push:
     branches:

--- a/.github/workflows/cross-compile-special-sensors.yaml
+++ b/.github/workflows/cross-compile-special-sensors.yaml
@@ -1,4 +1,4 @@
-name: "cross-compile/format/lint all targets"
+name: "cross-compile-sensors/format/lint all targets"
 on:
   push:
     branches:
@@ -47,10 +47,10 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Configure
-        run: cmake --preset=cross . -DUSE_PRESSURE_MOVE=true
+        run: cmake --preset=cross-sensor-buffer .
 
       - name: Build all STM32G4 applications
-        run: cmake --build --preset=${{ matrix.target }} --target ${{ matrix.target }}-images ${{ matrix.target }}-applications
+        run: cmake --build ./build-cross-sensor --target ${{ matrix.target }}-images ${{ matrix.target }}-applications
 
   format:
     runs-on: "ubuntu-20.04"
@@ -76,10 +76,10 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Configure
-        run: cmake --preset=cross . -DUSE_PRESSURE_MOVE=true
+        run: cmake --preset=cross-sensor-buffer .
 
       - name: Format
-        run: cmake --build ./build-cross --target format-ci
+        run: cmake --build ./build-cross-sensor --target format-ci
 
   lint:
     runs-on: "ubuntu-20.04"
@@ -110,7 +110,7 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Configure
-        run: cmake --preset=cross . -DUSE_PRESSURE_MOVE=true
+        run: cmake --preset=cross-sensor-buffer .
 
       - name: Format
-        run: cmake --build ./build-cross --target ${{ matrix.target }}-lint
+        run: cmake --build ./build-cross-sensor --target ${{ matrix.target }}-lint

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ CMakeUserPresets.json
 *.pyc
 build-cross/
 build-cross-pipettes/
+build-cross-sensor/
 stm32-tools/
 build-host/
 cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ state_manager/coverage.xml
 state_manager/dist/
 state_manager/poetry.toml
 dist/
+dist-sensor/

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,6 +36,17 @@
       "inherits": "cross-no-directory-reqs"
     },
     {
+      "name": "cross-sensor-buffer",
+      "displayName": "STM32 G4 OT-3 cross-compilation with sensor data buffers",
+      "description": "Build application firmware for OT-3 systems that use STM32, for flashing onto boards",
+      "installDir": "${sourceDir}/dist-sensor",
+      "binaryDir": "${sourceDir}/build-cross-sensor",
+      "cacheVariables": {
+        "USE_PRESSURE_MOVE": true
+      },
+      "inherits": "cross"
+    },
+    {
       "name": "host",
       "displayName": "STM32 OT-3 host compilation for tests",
       "description": "Build libraries and test executables for OT-3 systems that use STM32",
@@ -82,6 +93,17 @@
       "displayName": "All G4 Firmwares",
       "description": "Environment to build all g4 firmware - see firmware-l5",
       "configurePreset": "cross",
+      "jobs": 4,
+      "targets": [
+        "firmware-applications",
+        "firmware-images"
+      ]
+    },
+    {
+      "name": "firmware-g4-sensors",
+      "displayName": "All G4 Firmwares With Sensor Data Buffers",
+      "description": "Environment to build all g4 firmware - see firmware-l5",
+      "configurePreset": "cross-sensor-buffer",
       "jobs": 4,
       "targets": [
         "firmware-applications",


### PR DESCRIPTION
This PR adds a new configure preset and build preset that builds the firmware with the "USE_PRESSURE_MOVE" define
This enables the special firmware that allows the system to buffer sensor data on the pipettes, and sync sensor tasks with movements.

The workflow file builds and uploads just the applications so that internal users can just pull the .zip file of them from CI instead of building them