### PR TITLE
fix(motor-control): add delay to give enough time for ebrake to physically disengage.

### DIFF
--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -18,14 +18,14 @@ void MotorHardware::activate_motor() {
     gpio::set(pins.enable);
     if (pins.ebrake.has_value()) {
         gpio::reset(pins.ebrake.value());
+        motor_hardware_delay(20);
     }
 }
 void MotorHardware::deactivate_motor() {
     if (pins.ebrake.has_value()) {
         gpio::set(pins.ebrake.value());
-        motor_hardware_delay(10);
+        motor_hardware_delay(20);
     }
-    motor_hardware_delay(10);
     gpio::reset(pins.enable);
 }
 void MotorHardware::start_timer_interrupt() {


### PR DESCRIPTION
# Overview

We did not give enough time after enabling the motor and disabling the ebrake, this would cause a move complete without condition being met. So lets add a 20ms delay after engaging/disengaging the the ebrake so it can settle before attempting to perform a move.

Closes: [RQA-2565](https://opentrons.atlassian.net/browse/RQA-2565)

# Change Log

- Add 20ms delay after engaging/disengaging the ebrake

# Test Plan

- [x] Make sure that we can home the gantry after instrument calibration
- [x] Make sure that we can home the gantry after module calibration


# Review Requests

# Risk Assessment

Med, this affects homing,
Needs to be tested under typical homing conditions

[RQA-2565]: https://opentrons.atlassian.net/browse/RQA-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ