### PR TITLE
fix(pipettes): Assign front capacitive sensor task to s1

### DIFF
--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -20,7 +20,7 @@ static auto capacitive_sensor_task_builder_rear =
 
 static auto capacitive_sensor_task_builder_front =
     freertos_task::TaskStarter<512, sensors::tasks::CapacitiveSensorTask,
-                               can::ids::SensorId>(can::ids::SensorId::S0);
+                               can::ids::SensorId>(can::ids::SensorId::S1);
 
 static auto pressure_sensor_task_builder_rear =
     freertos_task::TaskStarter<512, sensors::tasks::PressureSensorTask,


### PR DESCRIPTION
In `sensor_tasks`, both the front and rear capacitive sensor task builders were assigned to sensor id S0. This fixes it so the rear one will be s0, and the front s1.