### PR TITLE
fix(motion-control): motor driver error surfacing

### DIFF
--- a/pipettes/firmware/motor_configurations.cpp
+++ b/pipettes/firmware/motor_configurations.cpp
@@ -207,6 +207,11 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                      .port = GPIOB,
                      .pin = GPIO_PIN_9,
                      .active_setting = GPIO_PIN_RESET},
+                .diag0 =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_6,
+                     .active_setting = GPIO_PIN_RESET},
             };
         case TMC2160PipetteAxis::left_gear_motor:
             return motor_hardware::HardwareConfig{
@@ -236,6 +241,11 @@ auto motor_configs::hardware_config_by_axis(TMC2160PipetteAxis which)
                     {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
                      .port = GPIOB,
                      .pin = GPIO_PIN_9,
+                     .active_setting = GPIO_PIN_RESET},
+                .diag0 =
+                    {// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+                     .port = GPIOB,
+                     .pin = GPIO_PIN_6,
                      .active_setting = GPIO_PIN_RESET},
             };
         case TMC2160PipetteAxis::linear_motor:


### PR DESCRIPTION
Fixes (motor driver false positive) error seen with 96-channel pipette. To test, successfully calibrated 96-channel pipette as well as gripper and then homed.