### PR TITLE
fix(sensors): don't send errors when queue is full

### DIFF
--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -370,13 +370,6 @@ class MMR920 {
             if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
                 (*p_buff).at(pressure_buffer_index) = pressure;
                 pressure_buffer_index++;
-            } else {
-                can_client.send_can_message(
-                    can::ids::NodeId::host,
-                    can::messages::ErrorMessage{
-                        .message_index = 0,
-                        .severity = can::ids::ErrorSeverity::warning,
-                        .error_code = can::ids::ErrorCode::stop_requested});
             }
 #else
             can_client.send_can_message(


### PR DESCRIPTION
When we send a bunch of errors because the queue is full it can cause the can bus to choke up with stop requests which are annoying and make the logs hard to read.

The new LLD script that uses this custom firmware now limits motion based on factors that include the buffer size of the pipettes so we can just get rid of this.