### PR TITLE
fix(sensors): revert measure mode rate change

### DIFF
--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -516,9 +516,13 @@ class MMR920 {
      * exceed the threshold for the entirety of this period.
      */
     static constexpr uint16_t MAX_PRESSURE_TIME_MS = 200;
-
+#ifdef USE_PRESSURE_MOVE
     mmr920::MeasurementRate measurement_mode_rate =
         mmr920::MeasurementRate::MEASURE_1;
+#else
+    mmr920::MeasurementRate measurement_mode_rate =
+        mmr920::MeasurementRate::MEASURE_4;
+#endif
 
     bool _initialized = false;
     bool echoing = false;


### PR DESCRIPTION
we increased the measure mode rate change for the LLD testing but it seems to cause false overpressure errors so this PR gates using the different rates behind the compile time flag that we use to build the LLD variant firmware
