### PR TITLE
fix(motor-control): enable motor before turning on the motor interrupt timer

### DIFF
--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -200,8 +200,8 @@ class MotionController {
     auto check_read_sync_line() -> bool { return hardware.check_sync_in(); }
 
     void enable_motor() {
-        hardware.start_timer_interrupt();
         hardware.activate_motor();
+        hardware.start_timer_interrupt();
         enabled = true;
     }
 


### PR DESCRIPTION
Recently we had to add a longer delay so that the brake had long enough to disable before the function returns. however the motor interrupt timer starts before we call enable motor. This swaps the order so that we know the motor is all the way enabled before we start the interrupt timer and try to move.