### PR TITLE
fix(motor control): Use FreeRTOS delay instead of hardware delay

### DIFF
--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -133,7 +133,7 @@ uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t cle
 }
 
 void motor_hardware_delay(uint32_t delay) {
-    HAL_Delay(delay);
+    vTaskDelay(delay);
 }
 
 


### PR DESCRIPTION
We recently started adding a delay between engaging a head motor and starting the execution of a move. We were using a HAL delay to do this, and it turns out that this blocks FreeRTOS's task handling, and in certain edge cases causes a firmware crash. 

We should instead use FreeRTOS's built-in `vTaskDelay`