### PR TITLE
fix(gripper): capacitive sensor task should use correct sensor ID

### DIFF
--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -69,14 +69,19 @@ class FDC1004 {
     auto get_sensor_id() -> can::ids::SensorId { return sensor_id; }
 
     auto set_sensor_id(can::ids::SensorId _id) -> void {
-        if (using_both_sensors && sensor_id != _id) {
-            if (_id == can::ids::SensorId::S1) {
-                measure_mode = fdc1004::MeasureConfigMode::TWO;
-            } else {
-                measure_mode = fdc1004::MeasureConfigMode::ONE;
-            }
+        if (sensor_id != _id) {
+            // we should always update the sensor id
             sensor_id = _id;
-            update_capacitance_configuration();
+            if (shared_sensor) {
+                // if we're sharing the sensor, then we need to update
+                // the measure mode
+                if (_id == can::ids::SensorId::S1) {
+                    measure_mode = fdc1004::MeasureConfigMode::TWO;
+                } else {
+                    measure_mode = fdc1004::MeasureConfigMode::ONE;
+                }
+                update_capacitance_configuration();
+            }
         }
     }
 

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -72,7 +72,7 @@ class FDC1004 {
         if (sensor_id != _id) {
             // we should always update the sensor id
             sensor_id = _id;
-            if (shared_sensor) {
+            if (using_both_sensors) {
                 // if we're sharing the sensor, then we need to update
                 // the measure mode
                 if (_id == can::ids::SensorId::S1) {


### PR DESCRIPTION
The S1 sensor has been falsely using the wrong ID while responding to CAN messages. 

This is because the sensor ID for the driver is defaulted to S0, and we rely on `set_sensor_id()` to update the sensor. We've made these changes for the pipettes (https://github.com/Opentrons/ot3-firmware/pull/630). And since `shared_sensor` is always false for the gripper, we've never set the sensor ID for S1. 