### PR TITLE
fix(sensors): send the pressure sensor response with the baseline applied

### DIFF
--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -364,8 +364,8 @@ class MMR920 {
         }
 
         if (echo_this_time) {
-            auto response_pressure =
-                std::fabs(pressure) - std::fabs(current_pressure_baseline_pa);
+            auto response_pressure = (pressure < 0 ? -1 : 1) * (
+                std::fabs(pressure) - std::fabs(current_pressure_baseline_pa));
 #ifdef USE_PRESSURE_MOVE
             if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
                 (*p_buff).at(pressure_buffer_index) = response_pressure;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -365,22 +365,21 @@ class MMR920 {
 
         if (echo_this_time) {
             auto response_pressure =
-                std::fabs(pressure) -
-                std::fabs(current_pressure_baseline_pa);
+                std::fabs(pressure) - std::fabs(current_pressure_baseline_pa);
 #ifdef USE_PRESSURE_MOVE
-                    if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
+            if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
                 (*p_buff).at(pressure_buffer_index) = response_pressure;
                 pressure_buffer_index++;
             }
 #else
-                    can_client.send_can_message(
-                        can::ids::NodeId::host,
-                        can::messages::ReadFromSensorResponse{
-                            .message_index = m.message_index,
-                            .sensor = can::ids::SensorType::pressure,
-                            .sensor_id = sensor_id,
-                            .sensor_data = mmr920::reading_to_fixed_point(
-                                response_pressure)});
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::ReadFromSensorResponse{
+                    .message_index = m.message_index,
+                    .sensor = can::ids::SensorType::pressure,
+                    .sensor_id = sensor_id,
+                    .sensor_data =
+                        mmr920::reading_to_fixed_point(response_pressure)});
 #endif
         }
     }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -366,7 +366,7 @@ class MMR920 {
         if (echo_this_time) {
             auto response_pressure =
                 std::fabs(pressure) -
-                std::fabs(current_pressure_baseline_pa)
+                std::fabs(current_pressure_baseline_pa);
 #ifdef USE_PRESSURE_MOVE
                     if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
                 (*p_buff).at(pressure_buffer_index) = response_pressure;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -364,21 +364,23 @@ class MMR920 {
         }
 
         if (echo_this_time) {
+            auto response_pressure =
+                std::fabs(pressure) -
+                std::fabs(current_pressure_baseline_pa)
 #ifdef USE_PRESSURE_MOVE
-            // send a response with 9999 to make an overload of the buffer
-            // visible
-            if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
-                (*p_buff).at(pressure_buffer_index) = pressure;
+                    if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
+                (*p_buff).at(pressure_buffer_index) = response_pressure;
                 pressure_buffer_index++;
             }
 #else
-            can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::ReadFromSensorResponse{
-                    .message_index = m.message_index,
-                    .sensor = can::ids::SensorType::pressure,
-                    .sensor_id = sensor_id,
-                    .sensor_data = mmr920::reading_to_fixed_point(pressure)});
+                    can_client.send_can_message(
+                        can::ids::NodeId::host,
+                        can::messages::ReadFromSensorResponse{
+                            .message_index = m.message_index,
+                            .sensor = can::ids::SensorType::pressure,
+                            .sensor_id = sensor_id,
+                            .sensor_data = mmr920::reading_to_fixed_point(
+                                response_pressure)});
 #endif
         }
     }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -355,7 +355,7 @@ class MMR920 {
             }
         }
         if (bind_sync) {
-            if (std::fabs(pressure) - std::fabs(current_pressure_baseline_pa) >
+            if (std::fabs(pressure - current_pressure_baseline_pa) >
                 threshold_pascals) {
                 hardware.set_sync();
             } else {
@@ -364,8 +364,7 @@ class MMR920 {
         }
 
         if (echo_this_time) {
-            auto response_pressure = (pressure < 0 ? -1 : 1) * (
-                std::fabs(pressure) - std::fabs(current_pressure_baseline_pa));
+            auto response_pressure = pressure - current_pressure_baseline_pa;
 #ifdef USE_PRESSURE_MOVE
             if (pressure_buffer_index < PRESSURE_SENSOR_BUFFER_SIZE) {
                 (*p_buff).at(pressure_buffer_index) = response_pressure;


### PR DESCRIPTION
Right now we send the raw sensor value instead of the corrected one, it will be better for lld development and just in general to get the corrected pressure data instead
