### PR TITLE
feat(sensors): Self baselining during sensor moves

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -205,6 +205,7 @@ typedef enum {
     can_sensoroutputbinding_sync = 0x1,
     can_sensoroutputbinding_report = 0x2,
     can_sensoroutputbinding_max_threshold_sync = 0x4,
+    can_sensoroutputbinding_auto_baseline_report = 0x8,
 } CANSensorOutputBinding;
 
 /** How a sensor's threshold should be interpreted. */

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -215,6 +215,7 @@ enum class SensorOutputBinding {
     sync = 0x1,
     report = 0x2,
     max_threshold_sync = 0x4,
+    auto_baseline_report = 0x8,
 };
 
 /** How a sensor's threshold should be interpreted. */

--- a/include/common/core/hardware_delay.hpp
+++ b/include/common/core/hardware_delay.hpp
@@ -1,12 +1,17 @@
 #pragma once
 // Not my favorite way to check this, but if we don't have access
 // to vTaskDelay during host compilation so just dummy the function
+
+#ifdef ENABLE_CROSS_ONLY_HEADERS
+#include "FreeRTOS.h"
+#endif
+
 template <typename T>
 requires std::is_integral_v<T>
 static void vtask_hardware_delay(T ticks) {
-#ifndef INC_TASK_H
-    std::ignore = ticks;
-#else
+#ifdef ENABLE_CROSS_ONLY_HEADERS
     vTaskDelay(ticks);
+#else
+    std::ignore = ticks;
 #endif
 }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -411,8 +411,9 @@ class MotorInterruptHandler {
                 auto binding =
                     static_cast<uint8_t>(can::ids::SensorOutputBinding::sync) |
                     static_cast<uint8_t>(
-                        can::ids::SensorOutputBinding::report);  // sync and
-                                                                 // report
+                        can::ids::SensorOutputBinding::report) |
+                    static_cast<uint8_t>(
+                        can::ids::SensorOutputBinding::auto_baseline_report);
                 if (buffered_move.sensor_id == can::ids::SensorId::BOTH) {
                     send_bind_message(buffered_move.sensor_type,
                                       can::ids::SensorId::S0, binding);

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -408,7 +408,11 @@ class MotorInterruptHandler {
                 hardware.get_encoder_pulses();
 #ifdef USE_SENSOR_MOVE
             if (buffered_move.sensor_id != can::ids::SensorId::UNUSED) {
-                auto binding = static_cast<uint8_t>(0x3);  // sync and report
+                auto binding =
+                    static_cast<uint8_t>(can::ids::SensorOutputBinding::sync) |
+                    static_cast<uint8_t>(
+                        can::ids::SensorOutputBinding::report);  // sync and
+                                                                 // report
                 if (buffered_move.sensor_id == can::ids::SensorId::BOTH) {
                     send_bind_message(buffered_move.sensor_type,
                                       can::ids::SensorId::S0, binding);

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -506,21 +506,6 @@ class MotorInterruptHandler {
         tick_count = 0x0;
         stall_handled = false;
         build_and_send_ack(ack_msg_id);
-#ifdef USE_SENSOR_MOVE
-        if (buffered_move.sensor_id != can::ids::SensorId::UNUSED) {
-            auto binding = static_cast<uint8_t>(
-                can::ids::SensorOutputBinding::sync);  // make none?!
-            if (buffered_move.sensor_id == can::ids::SensorId::BOTH) {
-                send_bind_message(buffered_move.sensor_type,
-                                  can::ids::SensorId::S0, binding);
-                send_bind_message(buffered_move.sensor_type,
-                                  can::ids::SensorId::S1, binding);
-            } else {
-                send_bind_message(buffered_move.sensor_type,
-                                  buffered_move.sensor_id, binding);
-            }
-        }
-#endif
         set_buffered_move(MotorMoveMessage{});
         // update the stall check ideal encoder counts based on
         // last known location

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -2,25 +2,11 @@
 
 #include <array>
 
-#ifdef ENABLE_CROSS_ONLY_HEADERS
-// TODO(fps 7/12/2023): This is super hacky and I hate throwing #ifdefs
-// in our nicely host-independent code but for now we really just need
-// the vTaskDelay function and hopefully sometime in the near future I
-// can refactor this file with a nice templated sleep function.
-#include "FreeRTOS.h"
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define HACKY_TASK_SLEEP(___timeout___) vTaskDelay(___timeout___)
-
-#else
-
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define HACKY_TASK_SLEEP(___timeout___) (void)(___timeout___)
-#endif
-
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
 #include "common/core/bit_utils.hpp"
+#include "common/core/hardware_delay.hpp"
 #include "common/core/logging.h"
 #include "common/core/message_queue.hpp"
 #include "common/core/sensor_buffer.hpp"
@@ -63,11 +49,11 @@ class FDC1004 {
             // holding off for this PR.
 
             // Initial delay to avoid I2C bus traffic.
-            HACKY_TASK_SLEEP(100);
+            vtask_hardware_delay(100);
             update_capacitance_configuration();
             // Second delay to ensure IC is ready to start
             // readings (and also to avoid I2C bus traffic).
-            HACKY_TASK_SLEEP(100);
+            vtask_hardware_delay(100);
             set_sample_rate();
             _initialized = true;
         }

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -218,9 +218,8 @@ class FDC1004 {
             (*sensor_buffer).at(i) = 0;
         }
         can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::Acknowledgment{
-                    .message_index = message_index});
+            can::ids::NodeId::host,
+            can::messages::Acknowledgment{.message_index = message_index});
 #else
         std::ignore = message_index;
 #endif

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -217,6 +217,10 @@ class FDC1004 {
             }
             (*sensor_buffer).at(i) = 0;
         }
+        can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::Acknowledgment{
+                    .message_index = message_index});
 #else
         std::ignore = message_index;
 #endif

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -378,8 +378,8 @@ class MMR920 {
 
         if (echo_this_time) {
             auto response_pressure = pressure - current_pressure_baseline_pa;
-            // do we want pressure or response pressure
-            sensor_buffer_log(pressure);
+
+            sensor_buffer_log(response_pressure);
 
             if (sensor_buffer_index == 10) {
                 current_pressure_baseline_pa =

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -364,6 +364,8 @@ class MMR920 {
             if (std::fabs(pressure - current_pressure_baseline_pa) >
                 threshold_pascals) {
                 hardware.set_sync();
+                // force this to stay set long enough to debounce on other nodes
+                vTaskDelay(10);
             } else {
                 hardware.reset_sync();
             }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -421,7 +421,7 @@ class MMR920 {
                         sensor_buffer->begin() + AUTO_BASELINE_START,
                         sensor_buffer->begin() + AUTO_BASELINE_END, 0) /
                     (AUTO_BASELINE_END - AUTO_BASELINE_START);
-                for (auto i = sensor_buffer_index - AUTO_BASELINE_SAMPLES;
+                for (auto i = sensor_buffer_index - AUTO_BASELINE_END;
                      i < sensor_buffer_index; i++) {
                     // apply the moving baseline to older samples to so that
                     // data is in the same format as later samples, don't apply

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -385,15 +385,16 @@ class MMR920 {
                 // we always start a read at sensor_buffer_index = 0 so we don't need to
                 // account for it being a circular buffer here
                 current_pressure_baseline_pa =
-                    std::accumulate(p_buff->begin(), p_buff->begin()+10, 0) /
+                    std::accumulate(sensor_buffer->begin(), sensor_buffer->begin()+10, 0) /
                     10 + current_pressure_baseline_pa;
                 for (auto i = sensor_buffer_index - 10; i < sensor_buffer_index;
                      i++) {
-                    p_buff->at(sensor_buffer_index) =
-                        p_buff->at(sensor_buffer_index) -
+                    sensor_buffer->at(sensor_buffer_index) =
+                        sensor_buffer->at(sensor_buffer_index) -
                         current_pressure_baseline_pa;
                 }
             }
+        }
     }
 
     auto handle_ongoing_temperature_response(

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -320,7 +320,7 @@ class MMR920 {
                         (*sensor_buffer).at(current_index))});
             if (i % 10 == 0) {
                 // slow it down so the can buffer doesn't choke
-                vtask_hardware_delay(50);
+                vtask_hardware_delay(20);
             }
         }
         can_client.send_can_message(

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -337,309 +337,308 @@ class MMR920 {
             can::messages::Acknowledgment{.message_index = message_index});
     }
 
-    auto handle_ongoing_pressure_response(i2c::messages::TransactionResponse &m)
-        -> void {
-        if (!bind_sync && !echoing && !max_pressure_sync) {
-            auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
-            stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
+    auto compute_auto_baseline() -> void {
+        // this is the auto-base lining during a move.  It requires that
+        // a BaselineSensorRequest is sent prior to a move using the
+        // auto baseline. it works by taking several samples
+        // at the beginning of the move but after noise has stopped.
+        // and we haven't crossed the circular buffer barrier yet) it
+        // then takes the average of those samples to create a new
+        // baseline factor
+        current_moving_pressure_baseline_pa =
+            std::accumulate(sensor_buffer->begin() + AUTO_BASELINE_START,
+                            sensor_buffer->begin() + AUTO_BASELINE_END, 0.0) /
+            float(AUTO_BASELINE_END - AUTO_BASELINE_START);
+        for (auto i = sensor_buffer_index - AUTO_BASELINE_END;
+             i < sensor_buffer_index; i++) {
+            // apply the moving baseline to older samples to so that
+            // data is in the same format as later samples, don't apply
+            // the current_pressure_baseline_pa since it has already
+            // been applied
+            sensor_buffer->at(sensor_buffer_index) =
+                sensor_buffer->at(sensor_buffer_index) -
+                current_moving_pressure_baseline_pa;
         }
+    }
 
-        bool echo_this_time = echoing;
-
-        // Pressure is always a three-byte value
-        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
-                                                  m.read_buffer.cend(),
-                                                  temporary_data_store));
-
-        uint32_t shifted_data_store = temporary_data_store >> 8;
-
-        save_pressure(shifted_data_store);
-        auto pressure = mmr920::PressureResult::to_pressure(
-            _registers.pressure_result.reading, sensor_version);
-
-        if (max_pressure_sync) {
-            bool this_tick_over_threshold =
-                std::fabs(pressure - current_pressure_baseline_pa) >=
-                mmr920::get_max_pressure_reading(sensor_version);
-            bool over_threshold = false;
-            if (this_tick_over_threshold) {
-                max_pressure_consecutive_readings =
-                    std::min(max_pressure_consecutive_readings + 1,
-                             max_pressure_required_readings);
-                over_threshold = (max_pressure_consecutive_readings ==
-                                  max_pressure_required_readings);
-                echo_this_time = true;
-            } else {
-                max_pressure_consecutive_readings = 0;
-            }
-            if (over_threshold) {
+    auto handle_sync_threshold(float pressure) -> void {
+        if (enable_auto_baseline) {
+            if ((sensor_buffer_index > AUTO_BASELINE_END ||
+                 crossed_buffer_index) &&
+                (std::fabs(pressure - current_pressure_baseline_pa -
+                           current_moving_pressure_baseline_pa) >
+                 threshold_pascals)) {
                 hardware.set_sync();
-                can_client.send_can_message(
-                    can::ids::NodeId::host,
-                    can::messages::ErrorMessage{
-                        .message_index = m.message_index,
-                        .severity = can::ids::ErrorSeverity::unrecoverable,
-                        .error_code = can::ids::ErrorCode::over_pressure});
-            } else if (!bind_sync) {
-                // if we're not using bind sync turn off the sync line
-                // we don't do this during bind sync because if it's triggering
-                // the sync line on purpose this causes bouncing on the line
-                // that turns off the sync and then immediately turns it back on
-                // and this can cause disrupt the behavior
+            } else {
                 hardware.reset_sync();
             }
         }
-        if (bind_sync) {
-            if (enable_auto_baseline) {
-                if ((sensor_buffer_index > AUTO_BASELINE_END ||
-                     crossed_buffer_index)) {
-                    if (std::fabs(pressure - current_pressure_baseline_pa -
-                                  current_moving_pressure_baseline_pa) >
-                        threshold_pascals) {
-                        hardware.set_sync();
-                    } else {
-                        hardware.reset_sync();
-                    }
-                }
+        else {
+            if (std::fabs(pressure - current_pressure_baseline_pa) >
+                threshold_pascals) {
+                hardware.set_sync();
             } else {
-                if (std::fabs(pressure - current_pressure_baseline_pa) >
-                    threshold_pascals) {
-                    hardware.set_sync();
-                } else {
-                    hardware.reset_sync();
-                }
-            }
-        }
-
-        if (echo_this_time) {
-            auto response_pressure = pressure - current_pressure_baseline_pa;
-            if (enable_auto_baseline) {
-                // apply moving baseline if using
-                response_pressure -= current_moving_pressure_baseline_pa;
-            }
-
-            sensor_buffer_log(response_pressure);
-            if (!enable_auto_baseline) {
-                // This preserves the old way of echoing continuous polls
-                can_client.send_can_message(
-                    can::ids::NodeId::host,
-                    can::messages::ReadFromSensorResponse{
-                        .message_index = 0,
-                        .sensor = can::ids::SensorType::pressure,
-                        .sensor_id = sensor_id,
-                        .sensor_data =
-                            mmr920::reading_to_fixed_point(response_pressure)});
-            }
-
-            if (enable_auto_baseline &&
-                sensor_buffer_index == AUTO_BASELINE_END &&
-                !crossed_buffer_index) {
-                // this is the auto-base lining during a move.  It requires that
-                // a BaselineSensorRequest is sent prior to a move using the
-                // auto baseline. it works by taking several samples
-                // at the beginning of the move but after noise has stopped.
-                // and we haven't crossed the circular buffer barrier yet) it
-                // then takes the average of those samples to create a new
-                // baseline factor
-                current_moving_pressure_baseline_pa =
-                    std::accumulate(
-                        sensor_buffer->begin() + AUTO_BASELINE_START,
-                        sensor_buffer->begin() + AUTO_BASELINE_END, 0) /
-                    float(AUTO_BASELINE_END - AUTO_BASELINE_START);
-                for (auto i = sensor_buffer_index - AUTO_BASELINE_END;
-                     i < sensor_buffer_index; i++) {
-                    // apply the moving baseline to older samples to so that
-                    // data is in the same format as later samples, don't apply
-                    // the current_pressure_baseline_pa since it has already
-                    // been applied
-                    sensor_buffer->at(sensor_buffer_index) =
-                        sensor_buffer->at(sensor_buffer_index) -
-                        current_moving_pressure_baseline_pa;
-                }
+                hardware.reset_sync();
             }
         }
     }
 
-    auto handle_ongoing_temperature_response(
-        i2c::messages::TransactionResponse &m) -> void {
-        if (!bind_sync && !echoing) {
-            auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
-            stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
+    auto handle_ongoing_pressure_response(i2c::messages::TransactionResponse &m)
+        -> void {
+    if (!bind_sync && !echoing && !max_pressure_sync) {
+        auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
+        stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
+    }
+
+    bool echo_this_time = echoing;
+
+    // Pressure is always a three-byte value
+    static_cast<void>(bit_utils::bytes_to_int(
+        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
+
+    uint32_t shifted_data_store = temporary_data_store >> 8;
+
+    save_pressure(shifted_data_store);
+    auto pressure = mmr920::PressureResult::to_pressure(
+        _registers.pressure_result.reading, sensor_version);
+
+    if (max_pressure_sync) {
+        bool this_tick_over_threshold =
+            std::fabs(pressure - current_pressure_baseline_pa) >=
+            mmr920::get_max_pressure_reading(sensor_version);
+        bool over_threshold = false;
+        if (this_tick_over_threshold) {
+            max_pressure_consecutive_readings =
+                std::min(max_pressure_consecutive_readings + 1,
+                         max_pressure_required_readings);
+            over_threshold = (max_pressure_consecutive_readings ==
+                              max_pressure_required_readings);
+            echo_this_time = true;
+        } else {
+            max_pressure_consecutive_readings = 0;
         }
+        if (over_threshold) {
+            hardware.set_sync();
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::ErrorMessage{
+                    .message_index = m.message_index,
+                    .severity = can::ids::ErrorSeverity::unrecoverable,
+                    .error_code = can::ids::ErrorCode::over_pressure});
+        } else if (!bind_sync) {
+            // if we're not using bind sync turn off the sync line
+            // we don't do this during bind sync because if it's triggering
+            // the sync line on purpose this causes bouncing on the line
+            // that turns off the sync and then immediately turns it back on
+            // and this can cause disrupt the behavior
+            hardware.reset_sync();
+        }
+    }
+    if (bind_sync) {
+        handle_sync_threshold(pressure);
+    }
 
-        // Pressure is always a three-byte value
-        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
-                                                  m.read_buffer.cend(),
-                                                  temporary_data_store));
-
-        uint32_t shifted_data_store = temporary_data_store >> 8;
-
-        save_temperature(shifted_data_store);
-
-        if (echoing) {
-            auto temperature = mmr920::TemperatureResult::to_temperature(
-                _registers.temperature_result.reading);
+    if (echo_this_time) {
+        auto response_pressure = pressure - current_pressure_baseline_pa;
+        if (enable_auto_baseline) {
+            // apply moving baseline if using
+            response_pressure -= current_moving_pressure_baseline_pa;
+        }
+        sensor_buffer_log(response_pressure);
+        if (!enable_auto_baseline) {
+            // This preserves the old way of echoing continuous polls
             can_client.send_can_message(
                 can::ids::NodeId::host,
                 can::messages::ReadFromSensorResponse{
-                    .message_index = m.message_index,
-                    .sensor = can::ids::SensorType::pressure_temperature,
+                    .message_index = 0,
+                    .sensor = can::ids::SensorType::pressure,
                     .sensor_id = sensor_id,
                     .sensor_data =
-                        mmr920::reading_to_fixed_point(temperature)});
+                        mmr920::reading_to_fixed_point(response_pressure)});
+        }
+
+        if (enable_auto_baseline && sensor_buffer_index == AUTO_BASELINE_END &&
+            !crossed_buffer_index) {
+            compute_auto_baseline();
         }
     }
+}
 
-    auto handle_baseline_pressure_response(
-        i2c::messages::TransactionResponse &m) -> void {
-        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
-                                                  m.read_buffer.cend(),
-                                                  temporary_data_store));
+auto handle_ongoing_temperature_response(i2c::messages::TransactionResponse &m)
+    -> void {
+    if (!bind_sync && !echoing) {
+        auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
+        stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
+    }
 
-        uint32_t shifted_data_store = temporary_data_store >> 8;
+    // Pressure is always a three-byte value
+    static_cast<void>(bit_utils::bytes_to_int(
+        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
 
-        auto pressure = mmr920::PressureResult::to_pressure(shifted_data_store,
-                                                            sensor_version);
-        pressure_running_total += pressure;
+    uint32_t shifted_data_store = temporary_data_store >> 8;
 
-        if (!m.id.is_completed_poll) {
-            return;
-        }
+    save_temperature(shifted_data_store);
 
-        auto current_pressure_baseline_pa =
-            pressure_running_total / total_baseline_reads;
-        auto pressure_fixed_point =
-            mmr920::reading_to_fixed_point(current_pressure_baseline_pa);
-
-        // FIXME This should be tied to the set threshold
-        // command so we can completely remove the base line sensor
-        // request from all sensors!
-        if (utils::tag_in_token(m.id.token,
-                                utils::ResponseTag::IS_THRESHOLD_SENSE)) {
-            can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::BaselineSensorResponse{
-                    .message_index = m.message_index,
-                    .sensor = can::ids::SensorType::pressure,
-                    .offset_average = pressure_fixed_point});
-            set_threshold(current_pressure_baseline_pa,
-                          can::ids::SensorThresholdMode::auto_baseline,
-                          m.message_index, false);
-        } else {
-            auto message = can::messages::ReadFromSensorResponse{
+    if (echoing) {
+        auto temperature = mmr920::TemperatureResult::to_temperature(
+            _registers.temperature_result.reading);
+        can_client.send_can_message(
+            can::ids::NodeId::host,
+            can::messages::ReadFromSensorResponse{
                 .message_index = m.message_index,
-                .sensor = SensorType::pressure,
+                .sensor = can::ids::SensorType::pressure_temperature,
                 .sensor_id = sensor_id,
-                .sensor_data = pressure_fixed_point};
-            can_client.send_can_message(can::ids::NodeId::host, message);
-        }
-        pressure_running_total = 0x0;
+                .sensor_data = mmr920::reading_to_fixed_point(temperature)});
+    }
+}
+
+auto handle_baseline_pressure_response(i2c::messages::TransactionResponse &m)
+    -> void {
+    static_cast<void>(bit_utils::bytes_to_int(
+        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
+
+    uint32_t shifted_data_store = temporary_data_store >> 8;
+
+    auto pressure =
+        mmr920::PressureResult::to_pressure(shifted_data_store, sensor_version);
+    pressure_running_total += pressure;
+
+    if (!m.id.is_completed_poll) {
+        return;
     }
 
-    auto handle_baseline_temperature_response(
-        i2c::messages::TransactionResponse &m) -> void {
-        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
-                                                  m.read_buffer.cend(),
-                                                  temporary_data_store));
+    auto current_pressure_baseline_pa =
+        pressure_running_total / total_baseline_reads;
+    auto pressure_fixed_point =
+        mmr920::reading_to_fixed_point(current_pressure_baseline_pa);
 
-        uint32_t shifted_data_store = temporary_data_store >> 8;
+    // FIXME This should be tied to the set threshold
+    // command so we can completely remove the base line sensor
+    // request from all sensors!
+    if (utils::tag_in_token(m.id.token,
+                            utils::ResponseTag::IS_THRESHOLD_SENSE)) {
+        can_client.send_can_message(
+            can::ids::NodeId::host,
+            can::messages::BaselineSensorResponse{
+                .message_index = m.message_index,
+                .sensor = can::ids::SensorType::pressure,
+                .offset_average = pressure_fixed_point});
+        set_threshold(current_pressure_baseline_pa,
+                      can::ids::SensorThresholdMode::auto_baseline,
+                      m.message_index, false);
+    } else {
+        auto message = can::messages::ReadFromSensorResponse{
+            .message_index = m.message_index,
+            .sensor = SensorType::pressure,
+            .sensor_id = sensor_id,
+            .sensor_data = pressure_fixed_point};
+        can_client.send_can_message(can::ids::NodeId::host, message);
+    }
+    pressure_running_total = 0x0;
+}
 
-        auto temperature =
-            mmr920::TemperatureResult::to_temperature(shifted_data_store);
-        temperature_running_total += temperature;
+auto handle_baseline_temperature_response(i2c::messages::TransactionResponse &m)
+    -> void {
+    static_cast<void>(bit_utils::bytes_to_int(
+        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
 
-        if (!m.id.is_completed_poll) {
-            return;
-        }
+    uint32_t shifted_data_store = temporary_data_store >> 8;
 
-        auto current_temperature_baseline =
-            temperature_running_total / total_baseline_reads;
-        auto offset_fixed_point =
-            mmr920::reading_to_fixed_point(current_temperature_baseline);
-        if (echoing) {
-            can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::BaselineSensorResponse{
-                    .message_index = m.message_index,
-                    .sensor = can::ids::SensorType::pressure_temperature,
-                    .offset_average = offset_fixed_point});
-        }
-        temperature_running_total = 0x0;
+    auto temperature =
+        mmr920::TemperatureResult::to_temperature(shifted_data_store);
+    temperature_running_total += temperature;
+
+    if (!m.id.is_completed_poll) {
+        return;
     }
 
-    auto get_can_client() -> CanClient & { return can_client; }
-
-  private:
-    I2CQueueWriter &writer;
-    I2CQueuePoller &poller;
-    CanClient &can_client;
-    OwnQueue &own_queue;
-    hardware::SensorHardwareBase &hardware;
-    const can::ids::SensorId &sensor_id;
-    const sensors::mmr920::SensorVersion sensor_version;
-
-    mmr920::MMR920RegisterMap _registers{};
-    mmr920::FilterSetting filter_setting =
-        mmr920::FilterSetting::LOW_PASS_FILTER;
-
-    static constexpr std::array<float, 4> MeasurementTimings{0.405, 0.81, 1.62,
-                                                             3.24};  // in msec
-    static constexpr float DEFAULT_DELAY_BUFFER =
-        1.0;  // in msec (TODO might need to change to fit in uint16_t)
-    static constexpr uint16_t STOP_DELAY = 0;
-
-    /**
-     * Time required before raising a Max Pressure error. The pressure must
-     * exceed the threshold for the entirety of this period.
-     */
-    static constexpr uint16_t MAX_PRESSURE_TIME_MS = 200;
-    mmr920::MeasurementRate measurement_mode_rate =
-        mmr920::MeasurementRate::MEASURE_4;
-
-    bool _initialized = false;
-    bool echoing = false;
-    bool enable_auto_baseline = false;
-    bool bind_sync = false;
-    bool max_pressure_sync = false;
-
-    float pressure_running_total = 0;
-    float temperature_running_total = 0;
-    uint16_t total_baseline_reads = 1;
-
-    float current_pressure_baseline_pa = 0;
-    float current_moving_pressure_baseline_pa = 0;
-    float current_temperature_baseline = 0;
-
-    size_t max_pressure_consecutive_readings = 0;
-    size_t max_pressure_required_readings = 0;
-
-    // TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
-    // sure this is an arbitrarily large number to enable continuous reads.
-    float threshold_pascals = 100.0F;
-    float offset_average = 0;
-
-    uint32_t temporary_data_store = 0x0;
-
-    template <mmr920::MMR920CommandRegister Reg>
-    requires registers::WritableRegister<Reg>
-    auto build_register_command(Reg &reg) -> uint8_t {
-        return static_cast<uint8_t>(reg.address);
+    auto current_temperature_baseline =
+        temperature_running_total / total_baseline_reads;
+    auto offset_fixed_point =
+        mmr920::reading_to_fixed_point(current_temperature_baseline);
+    if (echoing) {
+        can_client.send_can_message(
+            can::ids::NodeId::host,
+            can::messages::BaselineSensorResponse{
+                .message_index = m.message_index,
+                .sensor = can::ids::SensorType::pressure_temperature,
+                .offset_average = offset_fixed_point});
     }
+    temperature_running_total = 0x0;
+}
 
-    template <mmr920::MMR920CommandRegister Reg>
-    requires registers::WritableRegister<Reg>
-    auto set_register(Reg &reg) -> bool {
-        auto value =
-            // Ignore the typical linter warning because we're only using
-            // this on __packed structures that mimic hardware registers
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            *reinterpret_cast<mmr920::RegisterSerializedTypeA *>(&reg);
-        value &= Reg::value_mask;
-        return write(Reg::address, value);
-    }
-    std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer;
-    uint16_t sensor_buffer_index = 0;
-    bool crossed_buffer_index = false;
+auto get_can_client() -> CanClient & { return can_client; }
+
+private:
+I2CQueueWriter &writer;
+I2CQueuePoller &poller;
+CanClient &can_client;
+OwnQueue &own_queue;
+hardware::SensorHardwareBase &hardware;
+const can::ids::SensorId &sensor_id;
+const sensors::mmr920::SensorVersion sensor_version;
+
+mmr920::MMR920RegisterMap _registers{};
+mmr920::FilterSetting filter_setting = mmr920::FilterSetting::LOW_PASS_FILTER;
+
+static constexpr std::array<float, 4> MeasurementTimings{0.405, 0.81, 1.62,
+                                                         3.24};  // in msec
+static constexpr float DEFAULT_DELAY_BUFFER =
+    1.0;  // in msec (TODO might need to change to fit in uint16_t)
+static constexpr uint16_t STOP_DELAY = 0;
+
+/**
+ * Time required before raising a Max Pressure error. The pressure must
+ * exceed the threshold for the entirety of this period.
+ */
+static constexpr uint16_t MAX_PRESSURE_TIME_MS = 200;
+mmr920::MeasurementRate measurement_mode_rate =
+    mmr920::MeasurementRate::MEASURE_4;
+
+bool _initialized = false;
+bool echoing = false;
+bool enable_auto_baseline = false;
+bool bind_sync = false;
+bool max_pressure_sync = false;
+
+float pressure_running_total = 0;
+float temperature_running_total = 0;
+uint16_t total_baseline_reads = 1;
+
+float current_pressure_baseline_pa = 0;
+float current_moving_pressure_baseline_pa = 0;
+float current_temperature_baseline = 0;
+
+size_t max_pressure_consecutive_readings = 0;
+size_t max_pressure_required_readings = 0;
+
+// TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
+// sure this is an arbitrarily large number to enable continuous reads.
+float threshold_pascals = 100.0F;
+float offset_average = 0;
+
+uint32_t temporary_data_store = 0x0;
+
+template <mmr920::MMR920CommandRegister Reg>
+requires registers::WritableRegister<Reg>
+auto build_register_command(Reg &reg) -> uint8_t {
+    return static_cast<uint8_t>(reg.address);
+}
+
+template <mmr920::MMR920CommandRegister Reg>
+requires registers::WritableRegister<Reg>
+auto set_register(Reg &reg) -> bool {
+    auto value =
+        // Ignore the typical linter warning because we're only using
+        // this on __packed structures that mimic hardware registers
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        *reinterpret_cast<mmr920::RegisterSerializedTypeA *>(&reg);
+    value &= Reg::value_mask;
+    return write(Reg::address, value);
+}
+std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer;
+uint16_t sensor_buffer_index = 0;
+bool crossed_buffer_index = false;
 };
 
 }  // namespace tasks

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -305,7 +305,7 @@ class MMR920 {
     void send_accumulated_sensor_data(uint32_t message_index) {
         auto start = 0;
         auto count = sensor_buffer_index;
-        if (crossed_buffer_index == true) {
+        if (crossed_buffer_index) {
             start = sensor_buffer_index;
             count = SENSOR_BUFFER_SIZE;
         }
@@ -420,7 +420,7 @@ class MMR920 {
                     std::accumulate(
                         sensor_buffer->begin() + AUTO_BASELINE_START,
                         sensor_buffer->begin() + AUTO_BASELINE_END, 0) /
-                    (AUTO_BASELINE_END - AUTO_BASELINE_START);
+                    float(AUTO_BASELINE_END - AUTO_BASELINE_START);
                 for (auto i = sensor_buffer_index - AUTO_BASELINE_END;
                      i < sensor_buffer_index; i++) {
                     // apply the moving baseline to older samples to so that

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -383,7 +383,7 @@ class MMR920 {
 
             if (sensor_buffer_index == 10) {
                 current_pressure_baseline_pa =
-                    std::accumulate(std::begin(*p_buff), std::end(*p_buff), 0) /
+                    std::accumulate(p_buff->begin(), p_buff->begin()+10, 0) /
                     10;
                 for (auto i = sensor_buffer_index - 10; i < sensor_buffer_index;
                      i++) {

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <numeric>
 
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
@@ -372,6 +373,13 @@ class MMR920 {
             auto response_pressure = pressure - current_pressure_baseline_pa;
             // do we want pressure or response pressure
             sensor_buffer_log(pressure);
+
+            if (sensor_buffer_index == 10) {
+                current_pressure_baseline_pa =
+                    std::accumulate(std::begin(*p_buff), std::end(*p_buff), 0) /
+                    10;
+            }
+
             can_client.send_can_message(
                 can::ids::NodeId::host,
                 can::messages::ReadFromSensorResponse{

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -383,12 +383,12 @@ class MMR920 {
                 hardware.reset_sync();
             }
         }
-        if (bind_sync) {
+        if (bind_sync &&
+            (sensor_buffer_index > AUTO_BASELINE_END || crossed_buffer_index)) {
             if (std::fabs(pressure - current_pressure_baseline_pa -
                           current_moving_pressure_baseline_pa) >
                 threshold_pascals) {
                 hardware.set_sync();
-                // force this to stay set long enough to debounce on other nodes
             } else {
                 hardware.reset_sync();
             }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -382,9 +382,11 @@ class MMR920 {
             sensor_buffer_log(response_pressure);
 
             if (sensor_buffer_index == 10) {
+                // we always start a read at sensor_buffer_index = 0 so we don't need to
+                // account for it being a circular buffer here
                 current_pressure_baseline_pa =
                     std::accumulate(p_buff->begin(), p_buff->begin()+10, 0) /
-                    10;
+                    10 + current_pressure_baseline_pa;
                 for (auto i = sensor_buffer_index - 10; i < sensor_buffer_index;
                      i++) {
                     p_buff->at(sensor_buffer_index) =
@@ -392,16 +394,6 @@ class MMR920 {
                         current_pressure_baseline_pa;
                 }
             }
-
-            can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::ReadFromSensorResponse{
-                    .message_index = m.message_index,
-                    .sensor = can::ids::SensorType::pressure,
-                    .sensor_id = sensor_id,
-                    .sensor_data =
-                        mmr920::reading_to_fixed_point(response_pressure)});
-        }
     }
 
     auto handle_ongoing_temperature_response(

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -560,13 +560,8 @@ class MMR920 {
      * exceed the threshold for the entirety of this period.
      */
     static constexpr uint16_t MAX_PRESSURE_TIME_MS = 200;
-#ifdef USE_PRESSURE_MOVE
-    mmr920::MeasurementRate measurement_mode_rate =
-        mmr920::MeasurementRate::MEASURE_2;
-#else
     mmr920::MeasurementRate measurement_mode_rate =
         mmr920::MeasurementRate::MEASURE_4;
-#endif
 
     bool _initialized = false;
     bool echoing = false;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -311,6 +311,10 @@ class MMR920 {
             }
             (*sensor_buffer).at(current_index) = 0;
         }
+        can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::Acknowledgment{
+                    .message_index = message_index});
     }
 
     auto handle_ongoing_pressure_response(i2c::messages::TransactionResponse &m)

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -372,8 +372,7 @@ class MMR920 {
             } else {
                 hardware.reset_sync();
             }
-        }
-        else {
+        } else {
             if (std::fabs(pressure - current_pressure_baseline_pa) >
                 threshold_pascals) {
                 hardware.set_sync();
@@ -385,260 +384,267 @@ class MMR920 {
 
     auto handle_ongoing_pressure_response(i2c::messages::TransactionResponse &m)
         -> void {
-    if (!bind_sync && !echoing && !max_pressure_sync) {
-        auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
-        stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
+        if (!bind_sync && !echoing && !max_pressure_sync) {
+            auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
+            stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
+        }
+
+        bool echo_this_time = echoing;
+
+        // Pressure is always a three-byte value
+        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
+                                                  m.read_buffer.cend(),
+                                                  temporary_data_store));
+
+        uint32_t shifted_data_store = temporary_data_store >> 8;
+
+        save_pressure(shifted_data_store);
+        auto pressure = mmr920::PressureResult::to_pressure(
+            _registers.pressure_result.reading, sensor_version);
+
+        if (max_pressure_sync) {
+            bool this_tick_over_threshold =
+                std::fabs(pressure - current_pressure_baseline_pa) >=
+                mmr920::get_max_pressure_reading(sensor_version);
+            bool over_threshold = false;
+            if (this_tick_over_threshold) {
+                max_pressure_consecutive_readings =
+                    std::min(max_pressure_consecutive_readings + 1,
+                             max_pressure_required_readings);
+                over_threshold = (max_pressure_consecutive_readings ==
+                                  max_pressure_required_readings);
+                echo_this_time = true;
+            } else {
+                max_pressure_consecutive_readings = 0;
+            }
+            if (over_threshold) {
+                hardware.set_sync();
+                can_client.send_can_message(
+                    can::ids::NodeId::host,
+                    can::messages::ErrorMessage{
+                        .message_index = m.message_index,
+                        .severity = can::ids::ErrorSeverity::unrecoverable,
+                        .error_code = can::ids::ErrorCode::over_pressure});
+            } else if (!bind_sync) {
+                // if we're not using bind sync turn off the sync line
+                // we don't do this during bind sync because if it's triggering
+                // the sync line on purpose this causes bouncing on the line
+                // that turns off the sync and then immediately turns it back on
+                // and this can cause disrupt the behavior
+                hardware.reset_sync();
+            }
+        }
+        if (bind_sync) {
+            handle_sync_threshold(pressure);
+        }
+
+        if (echo_this_time) {
+            auto response_pressure = pressure - current_pressure_baseline_pa;
+            if (enable_auto_baseline) {
+                // apply moving baseline if using
+                response_pressure -= current_moving_pressure_baseline_pa;
+            }
+            sensor_buffer_log(response_pressure);
+            if (!enable_auto_baseline) {
+                // This preserves the old way of echoing continuous polls
+                can_client.send_can_message(
+                    can::ids::NodeId::host,
+                    can::messages::ReadFromSensorResponse{
+                        .message_index = 0,
+                        .sensor = can::ids::SensorType::pressure,
+                        .sensor_id = sensor_id,
+                        .sensor_data =
+                            mmr920::reading_to_fixed_point(response_pressure)});
+            }
+
+            if (enable_auto_baseline &&
+                sensor_buffer_index == AUTO_BASELINE_END &&
+                !crossed_buffer_index) {
+                compute_auto_baseline();
+            }
+        }
     }
 
-    bool echo_this_time = echoing;
-
-    // Pressure is always a three-byte value
-    static_cast<void>(bit_utils::bytes_to_int(
-        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
-
-    uint32_t shifted_data_store = temporary_data_store >> 8;
-
-    save_pressure(shifted_data_store);
-    auto pressure = mmr920::PressureResult::to_pressure(
-        _registers.pressure_result.reading, sensor_version);
-
-    if (max_pressure_sync) {
-        bool this_tick_over_threshold =
-            std::fabs(pressure - current_pressure_baseline_pa) >=
-            mmr920::get_max_pressure_reading(sensor_version);
-        bool over_threshold = false;
-        if (this_tick_over_threshold) {
-            max_pressure_consecutive_readings =
-                std::min(max_pressure_consecutive_readings + 1,
-                         max_pressure_required_readings);
-            over_threshold = (max_pressure_consecutive_readings ==
-                              max_pressure_required_readings);
-            echo_this_time = true;
-        } else {
-            max_pressure_consecutive_readings = 0;
+    auto handle_ongoing_temperature_response(
+        i2c::messages::TransactionResponse &m) -> void {
+        if (!bind_sync && !echoing) {
+            auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
+            stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
         }
-        if (over_threshold) {
-            hardware.set_sync();
-            can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::ErrorMessage{
-                    .message_index = m.message_index,
-                    .severity = can::ids::ErrorSeverity::unrecoverable,
-                    .error_code = can::ids::ErrorCode::over_pressure});
-        } else if (!bind_sync) {
-            // if we're not using bind sync turn off the sync line
-            // we don't do this during bind sync because if it's triggering
-            // the sync line on purpose this causes bouncing on the line
-            // that turns off the sync and then immediately turns it back on
-            // and this can cause disrupt the behavior
-            hardware.reset_sync();
-        }
-    }
-    if (bind_sync) {
-        handle_sync_threshold(pressure);
-    }
 
-    if (echo_this_time) {
-        auto response_pressure = pressure - current_pressure_baseline_pa;
-        if (enable_auto_baseline) {
-            // apply moving baseline if using
-            response_pressure -= current_moving_pressure_baseline_pa;
-        }
-        sensor_buffer_log(response_pressure);
-        if (!enable_auto_baseline) {
-            // This preserves the old way of echoing continuous polls
+        // Pressure is always a three-byte value
+        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
+                                                  m.read_buffer.cend(),
+                                                  temporary_data_store));
+
+        uint32_t shifted_data_store = temporary_data_store >> 8;
+
+        save_temperature(shifted_data_store);
+
+        if (echoing) {
+            auto temperature = mmr920::TemperatureResult::to_temperature(
+                _registers.temperature_result.reading);
             can_client.send_can_message(
                 can::ids::NodeId::host,
                 can::messages::ReadFromSensorResponse{
-                    .message_index = 0,
-                    .sensor = can::ids::SensorType::pressure,
+                    .message_index = m.message_index,
+                    .sensor = can::ids::SensorType::pressure_temperature,
                     .sensor_id = sensor_id,
                     .sensor_data =
-                        mmr920::reading_to_fixed_point(response_pressure)});
-        }
-
-        if (enable_auto_baseline && sensor_buffer_index == AUTO_BASELINE_END &&
-            !crossed_buffer_index) {
-            compute_auto_baseline();
+                        mmr920::reading_to_fixed_point(temperature)});
         }
     }
-}
 
-auto handle_ongoing_temperature_response(i2c::messages::TransactionResponse &m)
-    -> void {
-    if (!bind_sync && !echoing) {
-        auto reg_id = utils::reg_from_id<mmr920::Registers>(m.id.token);
-        stop_continuous_polling(m.id.token, static_cast<uint8_t>(reg_id));
-    }
+    auto handle_baseline_pressure_response(
+        i2c::messages::TransactionResponse &m) -> void {
+        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
+                                                  m.read_buffer.cend(),
+                                                  temporary_data_store));
 
-    // Pressure is always a three-byte value
-    static_cast<void>(bit_utils::bytes_to_int(
-        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
+        uint32_t shifted_data_store = temporary_data_store >> 8;
 
-    uint32_t shifted_data_store = temporary_data_store >> 8;
+        auto pressure = mmr920::PressureResult::to_pressure(shifted_data_store,
+                                                            sensor_version);
+        pressure_running_total += pressure;
 
-    save_temperature(shifted_data_store);
+        if (!m.id.is_completed_poll) {
+            return;
+        }
 
-    if (echoing) {
-        auto temperature = mmr920::TemperatureResult::to_temperature(
-            _registers.temperature_result.reading);
-        can_client.send_can_message(
-            can::ids::NodeId::host,
-            can::messages::ReadFromSensorResponse{
+        auto current_pressure_baseline_pa =
+            pressure_running_total / total_baseline_reads;
+        auto pressure_fixed_point =
+            mmr920::reading_to_fixed_point(current_pressure_baseline_pa);
+
+        // FIXME This should be tied to the set threshold
+        // command so we can completely remove the base line sensor
+        // request from all sensors!
+        if (utils::tag_in_token(m.id.token,
+                                utils::ResponseTag::IS_THRESHOLD_SENSE)) {
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::BaselineSensorResponse{
+                    .message_index = m.message_index,
+                    .sensor = can::ids::SensorType::pressure,
+                    .offset_average = pressure_fixed_point});
+            set_threshold(current_pressure_baseline_pa,
+                          can::ids::SensorThresholdMode::auto_baseline,
+                          m.message_index, false);
+        } else {
+            auto message = can::messages::ReadFromSensorResponse{
                 .message_index = m.message_index,
-                .sensor = can::ids::SensorType::pressure_temperature,
+                .sensor = SensorType::pressure,
                 .sensor_id = sensor_id,
-                .sensor_data = mmr920::reading_to_fixed_point(temperature)});
-    }
-}
-
-auto handle_baseline_pressure_response(i2c::messages::TransactionResponse &m)
-    -> void {
-    static_cast<void>(bit_utils::bytes_to_int(
-        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
-
-    uint32_t shifted_data_store = temporary_data_store >> 8;
-
-    auto pressure =
-        mmr920::PressureResult::to_pressure(shifted_data_store, sensor_version);
-    pressure_running_total += pressure;
-
-    if (!m.id.is_completed_poll) {
-        return;
+                .sensor_data = pressure_fixed_point};
+            can_client.send_can_message(can::ids::NodeId::host, message);
+        }
+        pressure_running_total = 0x0;
     }
 
-    auto current_pressure_baseline_pa =
-        pressure_running_total / total_baseline_reads;
-    auto pressure_fixed_point =
-        mmr920::reading_to_fixed_point(current_pressure_baseline_pa);
+    auto handle_baseline_temperature_response(
+        i2c::messages::TransactionResponse &m) -> void {
+        static_cast<void>(bit_utils::bytes_to_int(m.read_buffer.cbegin(),
+                                                  m.read_buffer.cend(),
+                                                  temporary_data_store));
 
-    // FIXME This should be tied to the set threshold
-    // command so we can completely remove the base line sensor
-    // request from all sensors!
-    if (utils::tag_in_token(m.id.token,
-                            utils::ResponseTag::IS_THRESHOLD_SENSE)) {
-        can_client.send_can_message(
-            can::ids::NodeId::host,
-            can::messages::BaselineSensorResponse{
-                .message_index = m.message_index,
-                .sensor = can::ids::SensorType::pressure,
-                .offset_average = pressure_fixed_point});
-        set_threshold(current_pressure_baseline_pa,
-                      can::ids::SensorThresholdMode::auto_baseline,
-                      m.message_index, false);
-    } else {
-        auto message = can::messages::ReadFromSensorResponse{
-            .message_index = m.message_index,
-            .sensor = SensorType::pressure,
-            .sensor_id = sensor_id,
-            .sensor_data = pressure_fixed_point};
-        can_client.send_can_message(can::ids::NodeId::host, message);
-    }
-    pressure_running_total = 0x0;
-}
+        uint32_t shifted_data_store = temporary_data_store >> 8;
 
-auto handle_baseline_temperature_response(i2c::messages::TransactionResponse &m)
-    -> void {
-    static_cast<void>(bit_utils::bytes_to_int(
-        m.read_buffer.cbegin(), m.read_buffer.cend(), temporary_data_store));
+        auto temperature =
+            mmr920::TemperatureResult::to_temperature(shifted_data_store);
+        temperature_running_total += temperature;
 
-    uint32_t shifted_data_store = temporary_data_store >> 8;
+        if (!m.id.is_completed_poll) {
+            return;
+        }
 
-    auto temperature =
-        mmr920::TemperatureResult::to_temperature(shifted_data_store);
-    temperature_running_total += temperature;
-
-    if (!m.id.is_completed_poll) {
-        return;
+        auto current_temperature_baseline =
+            temperature_running_total / total_baseline_reads;
+        auto offset_fixed_point =
+            mmr920::reading_to_fixed_point(current_temperature_baseline);
+        if (echoing) {
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::BaselineSensorResponse{
+                    .message_index = m.message_index,
+                    .sensor = can::ids::SensorType::pressure_temperature,
+                    .offset_average = offset_fixed_point});
+        }
+        temperature_running_total = 0x0;
     }
 
-    auto current_temperature_baseline =
-        temperature_running_total / total_baseline_reads;
-    auto offset_fixed_point =
-        mmr920::reading_to_fixed_point(current_temperature_baseline);
-    if (echoing) {
-        can_client.send_can_message(
-            can::ids::NodeId::host,
-            can::messages::BaselineSensorResponse{
-                .message_index = m.message_index,
-                .sensor = can::ids::SensorType::pressure_temperature,
-                .offset_average = offset_fixed_point});
+    auto get_can_client() -> CanClient & { return can_client; }
+
+  private:
+    I2CQueueWriter &writer;
+    I2CQueuePoller &poller;
+    CanClient &can_client;
+    OwnQueue &own_queue;
+    hardware::SensorHardwareBase &hardware;
+    const can::ids::SensorId &sensor_id;
+    const sensors::mmr920::SensorVersion sensor_version;
+
+    mmr920::MMR920RegisterMap _registers{};
+    mmr920::FilterSetting filter_setting =
+        mmr920::FilterSetting::LOW_PASS_FILTER;
+
+    static constexpr std::array<float, 4> MeasurementTimings{0.405, 0.81, 1.62,
+                                                             3.24};  // in msec
+    static constexpr float DEFAULT_DELAY_BUFFER =
+        1.0;  // in msec (TODO might need to change to fit in uint16_t)
+    static constexpr uint16_t STOP_DELAY = 0;
+
+    /**
+     * Time required before raising a Max Pressure error. The pressure must
+     * exceed the threshold for the entirety of this period.
+     */
+    static constexpr uint16_t MAX_PRESSURE_TIME_MS = 200;
+    mmr920::MeasurementRate measurement_mode_rate =
+        mmr920::MeasurementRate::MEASURE_4;
+
+    bool _initialized = false;
+    bool echoing = false;
+    bool enable_auto_baseline = false;
+    bool bind_sync = false;
+    bool max_pressure_sync = false;
+
+    float pressure_running_total = 0;
+    float temperature_running_total = 0;
+    uint16_t total_baseline_reads = 1;
+
+    float current_pressure_baseline_pa = 0;
+    float current_moving_pressure_baseline_pa = 0;
+    float current_temperature_baseline = 0;
+
+    size_t max_pressure_consecutive_readings = 0;
+    size_t max_pressure_required_readings = 0;
+
+    // TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
+    // sure this is an arbitrarily large number to enable continuous reads.
+    float threshold_pascals = 100.0F;
+    float offset_average = 0;
+
+    uint32_t temporary_data_store = 0x0;
+
+    template <mmr920::MMR920CommandRegister Reg>
+    requires registers::WritableRegister<Reg>
+    auto build_register_command(Reg &reg) -> uint8_t {
+        return static_cast<uint8_t>(reg.address);
     }
-    temperature_running_total = 0x0;
-}
 
-auto get_can_client() -> CanClient & { return can_client; }
-
-private:
-I2CQueueWriter &writer;
-I2CQueuePoller &poller;
-CanClient &can_client;
-OwnQueue &own_queue;
-hardware::SensorHardwareBase &hardware;
-const can::ids::SensorId &sensor_id;
-const sensors::mmr920::SensorVersion sensor_version;
-
-mmr920::MMR920RegisterMap _registers{};
-mmr920::FilterSetting filter_setting = mmr920::FilterSetting::LOW_PASS_FILTER;
-
-static constexpr std::array<float, 4> MeasurementTimings{0.405, 0.81, 1.62,
-                                                         3.24};  // in msec
-static constexpr float DEFAULT_DELAY_BUFFER =
-    1.0;  // in msec (TODO might need to change to fit in uint16_t)
-static constexpr uint16_t STOP_DELAY = 0;
-
-/**
- * Time required before raising a Max Pressure error. The pressure must
- * exceed the threshold for the entirety of this period.
- */
-static constexpr uint16_t MAX_PRESSURE_TIME_MS = 200;
-mmr920::MeasurementRate measurement_mode_rate =
-    mmr920::MeasurementRate::MEASURE_4;
-
-bool _initialized = false;
-bool echoing = false;
-bool enable_auto_baseline = false;
-bool bind_sync = false;
-bool max_pressure_sync = false;
-
-float pressure_running_total = 0;
-float temperature_running_total = 0;
-uint16_t total_baseline_reads = 1;
-
-float current_pressure_baseline_pa = 0;
-float current_moving_pressure_baseline_pa = 0;
-float current_temperature_baseline = 0;
-
-size_t max_pressure_consecutive_readings = 0;
-size_t max_pressure_required_readings = 0;
-
-// TODO(fs, 2022-11-11): Need to figure out a realistic threshold. Pretty
-// sure this is an arbitrarily large number to enable continuous reads.
-float threshold_pascals = 100.0F;
-float offset_average = 0;
-
-uint32_t temporary_data_store = 0x0;
-
-template <mmr920::MMR920CommandRegister Reg>
-requires registers::WritableRegister<Reg>
-auto build_register_command(Reg &reg) -> uint8_t {
-    return static_cast<uint8_t>(reg.address);
-}
-
-template <mmr920::MMR920CommandRegister Reg>
-requires registers::WritableRegister<Reg>
-auto set_register(Reg &reg) -> bool {
-    auto value =
-        // Ignore the typical linter warning because we're only using
-        // this on __packed structures that mimic hardware registers
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        *reinterpret_cast<mmr920::RegisterSerializedTypeA *>(&reg);
-    value &= Reg::value_mask;
-    return write(Reg::address, value);
-}
-std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer;
-uint16_t sensor_buffer_index = 0;
-bool crossed_buffer_index = false;
+    template <mmr920::MMR920CommandRegister Reg>
+    requires registers::WritableRegister<Reg>
+    auto set_register(Reg &reg) -> bool {
+        auto value =
+            // Ignore the typical linter warning because we're only using
+            // this on __packed structures that mimic hardware registers
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            *reinterpret_cast<mmr920::RegisterSerializedTypeA *>(&reg);
+        value &= Reg::value_mask;
+        return write(Reg::address, value);
+    }
+    std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer;
+    uint16_t sensor_buffer_index = 0;
+    bool crossed_buffer_index = false;
 };
 
 }  // namespace tasks

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -386,7 +386,6 @@ class MMR920 {
                 threshold_pascals) {
                 hardware.set_sync();
                 // force this to stay set long enough to debounce on other nodes
-                vTaskDelay(10);
             } else {
                 hardware.reset_sync();
             }

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -71,7 +71,7 @@ class MMR920 {
         echoing = should_echo;
         if (should_echo) {
             sensor_buffer_index = 0;  // reset buffer index
-            crossed_buffer_index=false;
+            crossed_buffer_index = false;
             sensor_buffer->fill(0.0);
         }
     }
@@ -237,7 +237,7 @@ class MMR920 {
         sensor_buffer_index++;
         if (sensor_buffer_index == SENSOR_BUFFER_SIZE) {
             sensor_buffer_index = 0;
-            crossed_buffer_index=true;
+            crossed_buffer_index = true;
         }
     }
 
@@ -301,14 +301,13 @@ class MMR920 {
         }
 
         can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::Acknowledgment{
-                    .message_index = count});
+            can::ids::NodeId::host,
+            can::messages::Acknowledgment{.message_index = count});
         for (int i = 0; i < count; i++) {
             // send over buffer and then clear buffer values
             // NOLINTNEXTLINE(div-by-zero)
-            int current_index = (i + start) %
-                                static_cast<int>(SENSOR_BUFFER_SIZE);
+            int current_index =
+                (i + start) % static_cast<int>(SENSOR_BUFFER_SIZE);
 
             can_client.send_can_message(
                 can::ids::NodeId::host,
@@ -324,9 +323,8 @@ class MMR920 {
             }
         }
         can_client.send_can_message(
-                can::ids::NodeId::host,
-                can::messages::Acknowledgment{
-                    .message_index = message_index});
+            can::ids::NodeId::host,
+            can::messages::Acknowledgment{.message_index = message_index});
     }
 
     auto handle_ongoing_pressure_response(i2c::messages::TransactionResponse &m)
@@ -397,10 +395,11 @@ class MMR920 {
             sensor_buffer_log(response_pressure);
 
             if (sensor_buffer_index == 10 && !crossed_buffer_index) {
-
                 current_pressure_baseline_pa =
-                    std::accumulate(sensor_buffer->begin(), sensor_buffer->begin()+10, 0) /
-                    10 + current_pressure_baseline_pa;
+                    std::accumulate(sensor_buffer->begin(),
+                                    sensor_buffer->begin() + 10, 0) /
+                        10 +
+                    current_pressure_baseline_pa;
                 for (auto i = sensor_buffer_index - 10; i < sensor_buffer_index;
                      i++) {
                     sensor_buffer->at(sensor_buffer_index) =
@@ -546,7 +545,7 @@ class MMR920 {
     static constexpr uint16_t MAX_PRESSURE_TIME_MS = 200;
 #ifdef USE_PRESSURE_MOVE
     mmr920::MeasurementRate measurement_mode_rate =
-        mmr920::MeasurementRate::MEASURE_1;
+        mmr920::MeasurementRate::MEASURE_2;
 #else
     mmr920::MeasurementRate measurement_mode_rate =
         mmr920::MeasurementRate::MEASURE_4;

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -81,7 +81,6 @@ class PressureMessageHandler {
 
     void visit(const can::messages::SendAccumulatedSensorDataRequest &m) {
         LOG("Received request to dump pressure data buffer");
-
         driver.send_accumulated_sensor_data(m.message_index);
     }
 

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -136,6 +136,10 @@ class PressureMessageHandler {
         driver.set_max_bind_sync(
             m.binding & static_cast<uint8_t>(
                             can::ids::SensorOutputBinding::max_threshold_sync));
+        driver.set_auto_baseline_report(
+            m.binding &
+            static_cast<uint8_t>(
+                can::ids::SensorOutputBinding::auto_baseline_report));
         std::array tags{utils::ResponseTag::IS_PART_OF_POLL,
                         utils::ResponseTag::POLL_IS_CONTINUOUS};
         auto tags_as_int = utils::byte_from_tags(tags);


### PR DESCRIPTION
We baseline the sensor reading during moves so that we can compensate better for different tips having a different baseline pressure differential when the plunger is moving