### PR TITLE
fix(can): parse the binding flag and pass to sensor move message

### DIFF
--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1744,6 +1744,7 @@ struct AddSensorMoveRequest : BaseMessage<MessageId::add_sensor_move_request> {
     uint8_t request_stop_condition;
     can::ids::SensorId sensor_id{};
     can::ids::SensorType sensor_type{};
+    uint8_t binding_flags;
 
     template <bit_utils::ByteIterator Input, typename Limit>
     static auto parse(Input body, Limit limit) -> AddSensorMoveRequest {
@@ -1756,6 +1757,7 @@ struct AddSensorMoveRequest : BaseMessage<MessageId::add_sensor_move_request> {
         uint32_t msg_ind = 0;
         uint8_t sensor_id = 0;
         uint8_t sensor_type = 0;
+        uint8_t binding_flags = 0;
 
         body = bit_utils::bytes_to_int(body, limit, msg_ind);
         body = bit_utils::bytes_to_int(body, limit, group_id);
@@ -1766,6 +1768,7 @@ struct AddSensorMoveRequest : BaseMessage<MessageId::add_sensor_move_request> {
         body = bit_utils::bytes_to_int(body, limit, request_stop_condition);
         body = bit_utils::bytes_to_int(body, limit, sensor_id);
         body = bit_utils::bytes_to_int(body, limit, sensor_type);
+        body = bit_utils::bytes_to_int(body, limit, binding_flags);
         return AddSensorMoveRequest{
             .message_index = msg_ind,
             .group_id = group_id,
@@ -1776,6 +1779,7 @@ struct AddSensorMoveRequest : BaseMessage<MessageId::add_sensor_move_request> {
             .request_stop_condition = request_stop_condition,
             .sensor_id = static_cast<can::ids::SensorId>(sensor_id),
             .sensor_type = static_cast<can::ids::SensorType>(sensor_type),
+            .binding_flags=binding_flags,
         };
     }
 

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -1779,7 +1779,7 @@ struct AddSensorMoveRequest : BaseMessage<MessageId::add_sensor_move_request> {
             .request_stop_condition = request_stop_condition,
             .sensor_id = static_cast<can::ids::SensorId>(sensor_id),
             .sensor_type = static_cast<can::ids::SensorType>(sensor_type),
-            .binding_flags=binding_flags,
+            .binding_flags = binding_flags,
         };
     }
 

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -80,7 +80,8 @@ class MotionController {
             0,
             hardware.get_usage_eeprom_config().get_distance_key(),
             can_msg.sensor_id,
-            can_msg.sensor_type};
+            can_msg.sensor_type,
+            can_msg.binding_flags};
         if (!enabled) {
             enable_motor();
         }
@@ -102,7 +103,8 @@ class MotionController {
             .stop_condition = can_msg.request_stop_condition,
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key(),
             .sensor_id = can::ids::SensorId::UNUSED,
-            .sensor_type = can::ids::SensorType::UNUSED};
+            .sensor_type = can::ids::SensorType::UNUSED,
+            .binding_flags = 0};
         if (!enabled) {
             enable_motor();
         }
@@ -123,7 +125,8 @@ class MotionController {
                 static_cast<uint8_t>(MoveStopCondition::limit_switch),
             .usage_key = hardware.get_usage_eeprom_config().get_distance_key(),
             .sensor_id = can::ids::SensorId::UNUSED,
-            .sensor_type = can::ids::SensorType::UNUSED};
+            .sensor_type = can::ids::SensorType::UNUSED,
+            .binding_flags = 0};
         if (!enabled) {
             enable_motor();
         }


### PR DESCRIPTION
We added it on the python side without doing all the parsing correctly in the c++ code