### PR TITLE
fix(sensors): send the result of baseline just like we do for pressure

### DIFF
--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -331,6 +331,12 @@ class FDC1004 {
             measurement, number_of_reads, current_offset_pf);
         if (utils::tag_in_token(m.id.token,
                                 utils::ResponseTag::IS_THRESHOLD_SENSE)) {
+            can_client.send_can_message(
+                can::ids::NodeId::host,
+                can::messages::BaselineSensorResponse{
+                    .message_index = m.message_index,
+                    .sensor = can::ids::SensorType::capacitive,
+                    .offset_average = capacitance});
             set_threshold(capacitance + next_autothreshold_pf,
                           can::ids::SensorThresholdMode::auto_baseline,
                           m.message_index);

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -336,7 +336,8 @@ class FDC1004 {
                 can::messages::BaselineSensorResponse{
                     .message_index = m.message_index,
                     .sensor = can::ids::SensorType::capacitive,
-                    .offset_average = capacitance});
+                    .offset_average =
+                        convert_to_fixed_point(capacitance, S15Q16_RADIX)});
             set_threshold(capacitance + next_autothreshold_pf,
                           can::ids::SensorThresholdMode::auto_baseline,
                           m.message_index);


### PR DESCRIPTION
Should help us debug future cap sensor early triggers by showing if there's bad baseline