### PR TITLE
feat(sensors): support new pipette sensor board

### DIFF
--- a/gripper/firmware/main_proto.cpp
+++ b/gripper/firmware/main_proto.cpp
@@ -86,7 +86,8 @@ auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
                  .pin = GPIO_PIN_6,
                  .active_setting = GPIO_PIN_RESET}};
 
-auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins);
+auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins, version_wrapper);
 
 auto main() -> int {
     HardwareInit();

--- a/gripper/firmware/main_proto.cpp
+++ b/gripper/firmware/main_proto.cpp
@@ -87,7 +87,8 @@ auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
                  .active_setting = GPIO_PIN_RESET}};
 
 auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
-auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins, version_wrapper);
+auto sensor_hardware =
+    sensors::hardware::SensorHardware(sensor_pins, version_wrapper);
 
 auto main() -> int {
     HardwareInit();

--- a/gripper/firmware/main_rev1.cpp
+++ b/gripper/firmware/main_rev1.cpp
@@ -98,7 +98,8 @@ auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
                  .active_setting = GPIO_PIN_RESET}};
 
 auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
-auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins, version_wrapper);
+auto sensor_hardware =
+    sensors::hardware::SensorHardware(sensor_pins, version_wrapper);
 
 auto main() -> int {
     HardwareInit();

--- a/gripper/firmware/main_rev1.cpp
+++ b/gripper/firmware/main_rev1.cpp
@@ -97,7 +97,8 @@ auto sensor_pins = sensors::hardware::SensorHardwareConfiguration{
                  .pin = NSYNC_OUT_PIN,
                  .active_setting = GPIO_PIN_RESET}};
 
-auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins);
+auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+auto sensor_hardware = sensors::hardware::SensorHardware(sensor_pins, version_wrapper);
 
 auto main() -> int {
     HardwareInit();

--- a/gripper/simulator/main.cpp
+++ b/gripper/simulator/main.cpp
@@ -35,7 +35,8 @@ static auto sensor_map =
     i2c::hardware::SimI2C::DeviceMap{{capsensor.get_address(), capsensor}};
 static auto i2c2 = i2c::hardware::SimI2C{sensor_map};
 
-static sim_mocks::MockSensorHardware fake_sensor_hw{};
+static sensors::hardware::SensorHardwareVersionSingleton version_wrapper{};
+static sim_mocks::MockSensorHardware fake_sensor_hw{version_wrapper};
 
 static std::shared_ptr<state_manager::StateManagerConnection<
     freertos_synchronization::FreeRTOSCriticalSection>>

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -101,6 +101,8 @@ typedef enum {
     can_messageid_gear_set_current_request = 0x505,
     can_messageid_gear_write_motor_driver_request = 0x506,
     can_messageid_gear_read_motor_driver_request = 0x507,
+    can_messageid_max_sensor_value_request = 0x70,
+    can_messageid_max_sensor_value_response = 0x71,
     can_messageid_read_sensor_request = 0x82,
     can_messageid_write_sensor_request = 0x83,
     can_messageid_baseline_sensor_request = 0x84,

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -103,6 +103,8 @@ enum class MessageId {
     gear_set_current_request = 0x505,
     gear_write_motor_driver_request = 0x506,
     gear_read_motor_driver_request = 0x507,
+    max_sensor_value_request = 0x70,
+    max_sensor_value_response = 0x71,
     read_sensor_request = 0x82,
     write_sensor_request = 0x83,
     baseline_sensor_request = 0x84,

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -776,6 +776,53 @@ struct SendAccumulatedSensorDataRequest
         -> bool = default;
 };
 
+struct MaxSensorValueRequest : BaseMessage<MessageId::max_sensor_value_request> {
+    uint32_t message_index = 0;
+    uint8_t sensor = 0;
+    uint8_t sensor_id = 0;
+    uint8_t offset_reading = 0;
+
+    template <bit_utils::ByteIterator Input, typename Limit>
+    static auto parse(Input body, Limit limit) -> MaxSensorValueRequest {
+        uint8_t sensor = 0;
+        uint8_t sensor_id = 0;
+        uint8_t offset_reading = 0;
+        uint32_t msg_ind = 0;
+
+        body = bit_utils::bytes_to_int(body, limit, msg_ind);
+        body = bit_utils::bytes_to_int(body, limit, sensor);
+        body = bit_utils::bytes_to_int(body, limit, sensor_id);
+        body = bit_utils::bytes_to_int(body, limit, offset_reading);
+        return MaxSensorValueRequest{.message_index = msg_ind,
+                                     .sensor = sensor,
+                                     .sensor_id = sensor_id,
+                                     .offset_reading = offset_reading};
+    }
+
+    auto operator==(const MaxSensorValueRequest& other) const -> bool = default;
+};
+
+struct MaxSensorValueResponse
+    : BaseMessage<MessageId::max_sensor_value_response> {
+    uint32_t message_index = 0;
+    can::ids::SensorType sensor{};
+    can::ids::SensorId sensor_id{};
+    int32_t sensor_data = 0;
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(message_index, body, limit);
+        iter =
+            bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
+                                       limit);
+        iter = bit_utils::int_to_bytes(sensor_data, iter, limit);
+        return iter - body;
+    }
+    auto operator==(const MaxSensorValueResponse& other) const
+        -> bool = default;
+};
+
 struct ReadFromSensorRequest : BaseMessage<MessageId::read_sensor_request> {
     uint32_t message_index = 0;
     uint8_t sensor = 0;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -776,7 +776,8 @@ struct SendAccumulatedSensorDataRequest
         -> bool = default;
 };
 
-struct MaxSensorValueRequest : BaseMessage<MessageId::max_sensor_value_request> {
+struct MaxSensorValueRequest
+    : BaseMessage<MessageId::max_sensor_value_request> {
     uint32_t message_index = 0;
     uint8_t sensor = 0;
     uint8_t sensor_id = 0;

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -79,7 +79,8 @@ using SensorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::WriteToSensorRequest, can::messages::BaselineSensorRequest,
     can::messages::SetSensorThresholdRequest,
     can::messages::BindSensorOutputRequest,
-    can::messages::PeripheralStatusRequest>;
+    can::messages::PeripheralStatusRequest,
+    can::messages::MaxSensorValueRequest>;
 
 auto constexpr reader_message_buffer_size = 1024;
 

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -96,7 +96,8 @@ using SensorDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::WriteToSensorRequest, can::messages::BaselineSensorRequest,
     can::messages::SetSensorThresholdRequest,
     can::messages::BindSensorOutputRequest,
-    can::messages::PeripheralStatusRequest>;
+    can::messages::PeripheralStatusRequest,
+    can::messages::MaxSensorValueRequest>;
 
 using PipetteInfoDispatchTarget = can::dispatch::DispatchParseTarget<
     pipette_info::PipetteInfoMessageHandler<central_tasks::QueueClient,

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -13,6 +13,7 @@
 #include "sensors/core/tasks/capacitive_sensor_task.hpp"
 #include "sensors/core/tasks/environmental_sensor_task.hpp"
 #include "sensors/core/tasks/pressure_sensor_task.hpp"
+#include "sensors/core/tasks/read_sensor_board_rev_task.hpp"
 #include "sensors/core/tasks/tip_presence_notification_task.hpp"
 
 /**
@@ -39,9 +40,9 @@ void start_tasks(CanWriterTask& can_writer, I2CClient& i2c3_task_client,
                  I2CClient& i2c1_task_client,
                  I2CPollerClient& i2c1_poller_client,
                  sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
+                 sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
                  can::ids::NodeId id,
-                 eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
-                 sensors::mmr920::SensorVersion sensor_version);
+                 eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware);
 
 void start_tasks(
     CanWriterTask& can_writer, I2CClient& i2c3_task_client,
@@ -49,9 +50,9 @@ void start_tasks(
     I2CPollerClient& i2c1_poller_client,
     sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
     sensors::hardware::SensorHardwareBase& sensor_hardware_secondary,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
     can::ids::NodeId id,
-    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
-    sensors::mmr920::SensorVersion sensor_version);
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware);
 
 /**
  * Access to all sensor/eeprom tasks. This will be a singleton.
@@ -80,6 +81,9 @@ struct Tasks {
     sensors::tasks::TipPresenceNotificationTask<
         freertos_message_queue::FreeRTOSMessageQueue>*
         tip_notification_task_front{nullptr};
+    sensors::tasks::ReadSenorBoardTask<
+        freertos_message_queue::FreeRTOSMessageQueue>*
+        read_sensor_board_task{nullptr};
 };
 
 /**

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -81,7 +81,7 @@ struct Tasks {
     sensors::tasks::TipPresenceNotificationTask<
         freertos_message_queue::FreeRTOSMessageQueue>*
         tip_notification_task_front{nullptr};
-    sensors::tasks::ReadSenorBoardTask<
+    sensors::tasks::ReadSensorBoardTask<
         freertos_message_queue::FreeRTOSMessageQueue>* read_sensor_board_task{
         nullptr};
 };

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -35,14 +35,14 @@ using I2CClient =
 using I2CPollerClient =
     i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>;
 
-void start_tasks(CanWriterTask& can_writer, I2CClient& i2c3_task_client,
-                 I2CPollerClient& i2c3_poller_client,
-                 I2CClient& i2c1_task_client,
-                 I2CPollerClient& i2c1_poller_client,
-                 sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
-                 sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
-                 can::ids::NodeId id,
-                 eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware);
+void start_tasks(
+    CanWriterTask& can_writer, I2CClient& i2c3_task_client,
+    I2CPollerClient& i2c3_poller_client, I2CClient& i2c1_task_client,
+    I2CPollerClient& i2c1_poller_client,
+    sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
+    can::ids::NodeId id,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware);
 
 void start_tasks(
     CanWriterTask& can_writer, I2CClient& i2c3_task_client,
@@ -82,8 +82,8 @@ struct Tasks {
         freertos_message_queue::FreeRTOSMessageQueue>*
         tip_notification_task_front{nullptr};
     sensors::tasks::ReadSenorBoardTask<
-        freertos_message_queue::FreeRTOSMessageQueue>*
-        read_sensor_board_task{nullptr};
+        freertos_message_queue::FreeRTOSMessageQueue>* read_sensor_board_task{
+        nullptr};
 };
 
 /**

--- a/include/pipettes/firmware/utility_configurations.hpp
+++ b/include/pipettes/firmware/utility_configurations.hpp
@@ -21,7 +21,9 @@ struct SensorHardwareContainer {
 
 auto led_gpio(PipetteType pipette_type) -> gpio::PinConfig;
 
-auto get_sensor_hardware_container(SensorHardwareGPIO pins, sensors::hardware::SensorHardwareVersionSingleton& version_wrapper)
+auto get_sensor_hardware_container(
+    SensorHardwareGPIO pins,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper)
     -> SensorHardwareContainer;
 
 template <PipetteType P>

--- a/include/pipettes/firmware/utility_configurations.hpp
+++ b/include/pipettes/firmware/utility_configurations.hpp
@@ -21,7 +21,7 @@ struct SensorHardwareContainer {
 
 auto led_gpio(PipetteType pipette_type) -> gpio::PinConfig;
 
-auto get_sensor_hardware_container(SensorHardwareGPIO pins)
+auto get_sensor_hardware_container(SensorHardwareGPIO pins, sensors::hardware::SensorHardwareVersionSingleton& version_wrapper)
     -> SensorHardwareContainer;
 
 template <PipetteType P>

--- a/include/sensors/core/message_handlers/sensors.hpp
+++ b/include/sensors/core/message_handlers/sensors.hpp
@@ -46,6 +46,11 @@ class SensorHandler {
                       can::ids::SensorId(m.sensor_id), m);
     }
 
+    void visit(const can::messages::MaxSensorValueRequest &m) {
+        send_to_queue(can::ids::SensorType(m.sensor),
+                      can::ids::SensorId(m.sensor_id), m);
+    }
+
     void visit(const can::messages::SendAccumulatedSensorDataRequest &m) {
         if (can::ids::SensorType(m.sensor_type) ==
             can::ids::SensorType::pressure) {

--- a/include/sensors/core/pie4ioe5.hpp
+++ b/include/sensors/core/pie4ioe5.hpp
@@ -28,9 +28,9 @@ enum class registers : uint8_t {
 };
 
 enum class version_responses : uint8_t {
-    // right now only version 1 responds
+    // right now only version D1.1 of the pipette sensor board responds
     // version 0 does not respond
-    VERSION_1 = 0x03,
+    VERSION_1 = 0x01, // Pipette_sensor board D1.1
 };
 
 }  // namespace pie4ioe4

--- a/include/sensors/core/pie4ioe5.hpp
+++ b/include/sensors/core/pie4ioe5.hpp
@@ -30,7 +30,7 @@ enum class registers : uint8_t {
 enum class version_responses : uint8_t {
     // right now only version D1.1 of the pipette sensor board responds
     // version 0 does not respond
-    VERSION_1 = 0x01, // Pipette_sensor board D1.1
+    VERSION_1 = 0x01,  // Pipette_sensor board D1.1
 };
 
 }  // namespace pie4ioe4

--- a/include/sensors/core/pie4ioe5.hpp
+++ b/include/sensors/core/pie4ioe5.hpp
@@ -1,0 +1,37 @@
+#pragma once
+namespace sensors {
+namespace pie4ioe4 {
+// https://www.diodes.com/assets/Datasheets/PI4IOE5V6408.pdf
+
+constexpr uint16_t ADDRESS = 0x43 << 1;
+
+enum class registers : uint8_t {
+    dev_id_and_ctl = 0x01,  // default 1010 0010
+    // reserved 0x02
+    io_direction = 0x03,  // default 0000 0000
+    // reserved 0x04
+    output_state = 0x05,  // default 0000 0000
+    // reserved 0x06
+    output_high_impedance = 0x07,  // default 1111 1111
+    // reserved 0x08
+    input_default_state = 0x09,  // default 0000 0000
+    // reserved 0x0A
+    pull_up_down_enable = 0x0B,  // default 1111 1111
+    // reserved 0x0C
+    pull_up_down_select = 0x0D,  // default 0000 0000
+    // reserved 0x0E
+    input_status = 0x0F,  // default xxxx xxxx
+    // reserved 0x10
+    interrupt_mask = 0x11,  // default 0000 0000
+    // reserved 0x12
+    interrupt_status = 0x13,  // default xxxx xxxx
+};
+
+enum class version_responses : uint8_t {
+    // right now only version 1 responds
+    // version 0 does not respond
+    VERSION_1 = 0x03,
+};
+
+}  // namespace pie4ioe4
+}  // namespace sensors

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -57,7 +57,7 @@ class SensorHardwareVersionSingleton {
 
     void set_board_rev(utils::SensorBoardRev rev) { b_revision = rev; }
 
-    utils::SensorBoardRev get_board_rev() { return b_revision; }
+    auto get_board_rev() -> utils::SensorBoardRev { return b_revision; }
 
   private:
     utils::SensorBoardRev b_revision = utils::SensorBoardRev::VERSION_0;
@@ -70,9 +70,9 @@ class SensorHardwareBase {
         : version_wrapper{version_wrapper} {}
     virtual ~SensorHardwareBase() = default;
     SensorHardwareBase(const SensorHardwareBase&) = default;
-    auto operator=(const SensorHardwareBase&) -> SensorHardwareBase& = default;
+    auto operator=(const SensorHardwareBase&) -> SensorHardwareBase& = delete;
     SensorHardwareBase(SensorHardwareBase&&) = default;
-    auto operator=(SensorHardwareBase&&) -> SensorHardwareBase& = default;
+    auto operator=(SensorHardwareBase&&) -> SensorHardwareBase& = delete;
 
     virtual auto set_sync() -> void = 0;
     virtual auto reset_sync() -> void = 0;
@@ -137,7 +137,7 @@ class SensorHardwareBase {
             reset_sync();
         }
     }
-    utils::SensorBoardRev get_board_rev() {
+    auto get_board_rev() -> utils::SensorBoardRev {
         return version_wrapper.get_board_rev();
     }
 

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -63,7 +63,8 @@ class SensorHardwareVersionSingleton {
 /** abstract sensor hardware device for a sync line */
 class SensorHardwareBase {
   public:
-    SensorHardwareBase() = default;
+    SensorHardwareBase(SensorHardwareVersionSingleton& version_wrapper) :
+        version_wrapper{version_wrapper} {}
     virtual ~SensorHardwareBase() = default;
     SensorHardwareBase(const SensorHardwareBase&) = default;
     auto operator=(const SensorHardwareBase&) -> SensorHardwareBase& = default;
@@ -133,11 +134,13 @@ class SensorHardwareBase {
             reset_sync();
         }
     }
+    utils::SensorBoardRev get_board_rev() { return version_wrapper.get_board_rev(); }
 
   private:
     uint8_t set_sync_required_mask = 0x00;
     uint8_t set_sync_enabled_mask = 0x00;
     uint8_t sync_state_mask = 0x00;
+    SensorHardwareVersionSingleton& version_wrapper;
 };
 
 struct SensorHardwareContainer {

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -5,6 +5,7 @@
 
 #include "can/core/ids.hpp"
 #include "common/firmware/gpio.hpp"
+#include "sensors/core/utils.hpp"
 
 namespace sensors {
 namespace hardware {
@@ -41,6 +42,24 @@ static auto get_mask_from_id(can::ids::SensorId sensor) -> uint8_t {
     }
     return static_cast<uint8_t>(mask_enum);
 }
+
+class SensorHardwareVersionSingleton {
+  public:
+    SensorHardwareVersionSingleton() = default;
+    virtual ~SensorHardwareVersionSingleton() = default;
+    SensorHardwareVersionSingleton(const SensorHardwareVersionSingleton&) = default;
+    auto operator=(const SensorHardwareVersionSingleton&) -> SensorHardwareVersionSingleton& = default;
+    SensorHardwareVersionSingleton(SensorHardwareVersionSingleton&&) = default;
+    auto operator=(SensorHardwareVersionSingleton&&) -> SensorHardwareVersionSingleton& = default;
+
+    void set_board_rev(utils::SensorBoardRev rev) { b_revision = rev; }
+
+    utils::SensorBoardRev get_board_rev() { return b_revision; }
+  private:
+    utils::SensorBoardRev b_revision = utils::SensorBoardRev::VERSION_0;
+};
+
+
 /** abstract sensor hardware device for a sync line */
 class SensorHardwareBase {
   public:

--- a/include/sensors/core/sensor_hardware_interface.hpp
+++ b/include/sensors/core/sensor_hardware_interface.hpp
@@ -47,24 +47,27 @@ class SensorHardwareVersionSingleton {
   public:
     SensorHardwareVersionSingleton() = default;
     virtual ~SensorHardwareVersionSingleton() = default;
-    SensorHardwareVersionSingleton(const SensorHardwareVersionSingleton&) = default;
-    auto operator=(const SensorHardwareVersionSingleton&) -> SensorHardwareVersionSingleton& = default;
+    SensorHardwareVersionSingleton(const SensorHardwareVersionSingleton&) =
+        default;
+    auto operator=(const SensorHardwareVersionSingleton&)
+        -> SensorHardwareVersionSingleton& = default;
     SensorHardwareVersionSingleton(SensorHardwareVersionSingleton&&) = default;
-    auto operator=(SensorHardwareVersionSingleton&&) -> SensorHardwareVersionSingleton& = default;
+    auto operator=(SensorHardwareVersionSingleton&&)
+        -> SensorHardwareVersionSingleton& = default;
 
     void set_board_rev(utils::SensorBoardRev rev) { b_revision = rev; }
 
     utils::SensorBoardRev get_board_rev() { return b_revision; }
+
   private:
     utils::SensorBoardRev b_revision = utils::SensorBoardRev::VERSION_0;
 };
 
-
 /** abstract sensor hardware device for a sync line */
 class SensorHardwareBase {
   public:
-    SensorHardwareBase(SensorHardwareVersionSingleton& version_wrapper) :
-        version_wrapper{version_wrapper} {}
+    SensorHardwareBase(SensorHardwareVersionSingleton& version_wrapper)
+        : version_wrapper{version_wrapper} {}
     virtual ~SensorHardwareBase() = default;
     SensorHardwareBase(const SensorHardwareBase&) = default;
     auto operator=(const SensorHardwareBase&) -> SensorHardwareBase& = default;
@@ -134,7 +137,9 @@ class SensorHardwareBase {
             reset_sync();
         }
     }
-    utils::SensorBoardRev get_board_rev() { return version_wrapper.get_board_rev(); }
+    utils::SensorBoardRev get_board_rev() {
+        return version_wrapper.get_board_rev();
+    }
 
   private:
     uint8_t set_sync_required_mask = 0x00;

--- a/include/sensors/core/tasks/capacitive_sensor_task.hpp
+++ b/include/sensors/core/tasks/capacitive_sensor_task.hpp
@@ -99,6 +99,10 @@ class CapacitiveMessageHandler {
         }
     }
 
+    void visit(const can::messages::MaxSensorValueRequest &m) {
+        std::ignore = m;
+    }
+
     void visit(can::messages::WriteToSensorRequest &m) {
         LOG("Received request to write data %d to %d sensor", m.data, m.sensor);
         // FIXME we should send a response message after a write request

--- a/include/sensors/core/tasks/environmental_sensor_task.hpp
+++ b/include/sensors/core/tasks/environmental_sensor_task.hpp
@@ -81,6 +81,10 @@ class EnvironmentSensorMessageHandler {
         std::ignore = m;
     }
 
+    void visit(const can::messages::MaxSensorValueRequest &m) {
+        std::ignore = m;
+    }
+
     void visit(const can::messages::BindSensorOutputRequest &m) {
         LOG("Received bind sensor output request from %d sensor", m.sensor);
         // sync doesn't quite mean the same thing here for us. We should

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -647,7 +647,7 @@ class MMR920 {
     uint16_t sensor_buffer_index = 0;
     bool crossed_buffer_index = false;
 
-    auto sensor_version() -> sensors::mmr920::SensorVersion{
+    auto sensor_version() -> sensors::mmr920::SensorVersion {
         utils::SensorBoardRev rev = hardware.get_board_rev();
         switch (rev) {
             case utils::SensorBoardRev::VERSION_1:

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -647,7 +647,7 @@ class MMR920 {
     uint16_t sensor_buffer_index = 0;
     bool crossed_buffer_index = false;
 
-    sensors::mmr920::SensorVersion sensor_version() {
+    auto sensor_version() -> sensors::mmr920::SensorVersion{
         utils::SensorBoardRev rev = hardware.get_board_rev();
         switch (rev) {
             case utils::SensorBoardRev::VERSION_1:

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -576,6 +576,17 @@ class MMR920 {
 
     auto get_can_client() -> CanClient & { return can_client; }
 
+    auto sensor_version() -> sensors::mmr920::SensorVersion {
+        utils::SensorBoardRev rev = hardware.get_board_rev();
+        switch (rev) {
+            case utils::SensorBoardRev::VERSION_1:
+                return sensors::mmr920::SensorVersion::mmr920c10;
+            case utils::SensorBoardRev::VERSION_0:
+            default:
+                return sensors::mmr920::SensorVersion::mmr920c04;
+        }
+    }
+
   private:
     I2CQueueWriter &writer;
     I2CQueuePoller &poller;
@@ -646,17 +657,6 @@ class MMR920 {
     std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer;
     uint16_t sensor_buffer_index = 0;
     bool crossed_buffer_index = false;
-
-    auto sensor_version() -> sensors::mmr920::SensorVersion {
-        utils::SensorBoardRev rev = hardware.get_board_rev();
-        switch (rev) {
-            case utils::SensorBoardRev::VERSION_1:
-                return sensors::mmr920::SensorVersion::mmr920c10;
-            case utils::SensorBoardRev::VERSION_0:
-            default:
-                return sensors::mmr920::SensorVersion::mmr920c04;
-        }
-    }
 };
 
 }  // namespace tasks

--- a/include/sensors/core/tasks/pressure_sensor_task.hpp
+++ b/include/sensors/core/tasks/pressure_sensor_task.hpp
@@ -23,10 +23,9 @@ class PressureMessageHandler {
         CanClient &can_client, OwnQueue &own_queue,
         sensors::hardware::SensorHardwareBase &hardware,
         const can::ids::SensorId &id,
-        const sensors::mmr920::SensorVersion &version,
         std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer)
-        : driver{i2c_writer, i2c_poller, can_client, own_queue,
-                 hardware,   id,         version,    sensor_buffer} {}
+        : driver{i2c_writer, i2c_poller, can_client,   own_queue,
+                 hardware,   id,         sensor_buffer} {}
     PressureMessageHandler(const PressureMessageHandler &) = delete;
     PressureMessageHandler(const PressureMessageHandler &&) = delete;
     auto operator=(const PressureMessageHandler &)
@@ -209,11 +208,10 @@ class PressureSensorTask {
         i2c::writer::Writer<QueueImpl> *writer,
         i2c::poller::Poller<QueueImpl> *poller, CanClient *can_client,
         sensors::hardware::SensorHardwareBase *hardware,
-        sensors::mmr920::SensorVersion *sensor_version,
         std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer) {
         auto handler = PressureMessageHandler{
-            *writer,   *poller,   *can_client,     get_queue(),
-            *hardware, sensor_id, *sensor_version, sensor_buffer};
+            *writer,   *poller,   *can_client,  get_queue(),
+            *hardware, sensor_id, sensor_buffer};
         handler.initialize();
         utils::TaskMessage message{};
         for (;;) {

--- a/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
+++ b/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
@@ -12,11 +12,14 @@ using TaskMessage =
 template <class I2CQueueWriter, class OwnQueue>
 class ReadSenorBoardHandler {
   public:
-    explicit ReadSenorBoardHandler(I2CQueueWriter &i2c_writer, OwnQueue &own_queue)
+    explicit ReadSenorBoardHandler(I2CQueueWriter &i2c_writer,
+                                   OwnQueue &own_queue)
         : i2c_writer{i2c_writer}, task_queue{own_queue} {
         // request gpio expander status register
-        i2c_writer->read(pie4ioe4::ADDRESS, static_cast<uint8_t>(pie4ioe4::registers::input_status), 1,
-                        task_queue);
+        i2c_writer->read(
+            pie4ioe4::ADDRESS,
+            static_cast<uint8_t>(pie4ioe4::registers::input_status), 1,
+            task_queue);
     }
     ReadSenorBoardHandler(const ReadSenorBoardHandler &) = delete;
     ReadSenorBoardHandler(const ReadSenorBoardHandler &&) = delete;
@@ -37,14 +40,15 @@ class ReadSenorBoardHandler {
 
     void visit(i2c::messages::TransactionResponse &m) {
         if (m.bytes_read == 1 &&
-            m.read_buffer[0] == static_cast<uint8_t>(pie4ioe4::version_responses::VERSION_1)) {
+            m.read_buffer[0] ==
+                static_cast<uint8_t>(pie4ioe4::version_responses::VERSION_1)) {
             rev = utils::SensorBoardRev::VERSION_1;
         }
     }
 
     utils::SensorBoardRev rev = utils::SensorBoardRev::VERSION_0;
     I2CQueueWriter &i2c_writer;
-    OwnQueue& task_queue;
+    OwnQueue &task_queue;
 };
 
 /**
@@ -56,8 +60,7 @@ class ReadSenorBoardTask {
   public:
     using Messages = TaskMessage;
     using QueueType = QueueImpl<TaskMessage>;
-    ReadSenorBoardTask(QueueType &queue)
-        : queue{queue} {}
+    ReadSenorBoardTask(QueueType &queue) : queue{queue} {}
     ReadSenorBoardTask(const ReadSenorBoardTask &c) = delete;
     ReadSenorBoardTask(const ReadSenorBoardTask &&c) = delete;
     auto operator=(const ReadSenorBoardTask &c) = delete;
@@ -69,7 +72,7 @@ class ReadSenorBoardTask {
      */
     void operator()(
         i2c::writer::Writer<QueueImpl> *writer,
-        sensors::hardware::SensorHardwareVersionSingleton* version_wrapper) {
+        sensors::hardware::SensorHardwareVersionSingleton *version_wrapper) {
         auto handler = ReadSenorBoardHandler(writer, get_queue());
 
         TaskMessage message{};
@@ -86,5 +89,5 @@ class ReadSenorBoardTask {
     QueueType &queue;
 };
 
-}  // namespace task
+}  // namespace tasks
 }  // namespace sensors

--- a/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
+++ b/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
@@ -27,13 +27,13 @@ class ReadSensorBoardHandler {
         -> ReadSensorBoardHandler & = delete;
     auto operator=(const ReadSensorBoardHandler &&)
         -> ReadSensorBoardHandler && = delete;
-    ~ReadSensorBoardHandler() {}
+    ~ReadSensorBoardHandler() = default;
 
     void handle_message(const TaskMessage &m) {
         std::visit([this](auto o) { this->visit(o); }, m);
     }
 
-    utils::SensorBoardRev get_rev() { return rev; }
+    auto get_rev() -> utils::SensorBoardRev { return rev; }
 
   private:
     void visit(const std::monostate &) {}

--- a/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
+++ b/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
@@ -10,9 +10,9 @@ using TaskMessage =
     std::variant<std::monostate, i2c::messages::TransactionResponse>;
 
 template <class I2CQueueWriter, class OwnQueue>
-class ReadSenorBoardHandler {
+class ReadSensorBoardHandler {
   public:
-    explicit ReadSenorBoardHandler(I2CQueueWriter &i2c_writer,
+    explicit ReadSensorBoardHandler(I2CQueueWriter &i2c_writer,
                                    OwnQueue &own_queue)
         : i2c_writer{i2c_writer}, task_queue{own_queue} {
         // request gpio expander status register
@@ -21,13 +21,13 @@ class ReadSenorBoardHandler {
             static_cast<uint8_t>(pie4ioe4::registers::input_status), 1,
             task_queue);
     }
-    ReadSenorBoardHandler(const ReadSenorBoardHandler &) = delete;
-    ReadSenorBoardHandler(const ReadSenorBoardHandler &&) = delete;
-    auto operator=(const ReadSenorBoardHandler &)
-        -> ReadSenorBoardHandler & = delete;
-    auto operator=(const ReadSenorBoardHandler &&)
-        -> ReadSenorBoardHandler && = delete;
-    ~ReadSenorBoardHandler() {}
+    ReadSensorBoardHandler(const ReadSensorBoardHandler &) = delete;
+    ReadSensorBoardHandler(const ReadSensorBoardHandler &&) = delete;
+    auto operator=(const ReadSensorBoardHandler &)
+        -> ReadSensorBoardHandler & = delete;
+    auto operator=(const ReadSensorBoardHandler &&)
+        -> ReadSensorBoardHandler && = delete;
+    ~ReadSensorBoardHandler() {}
 
     void handle_message(const TaskMessage &m) {
         std::visit([this](auto o) { this->visit(o); }, m);
@@ -56,16 +56,16 @@ class ReadSenorBoardHandler {
  */
 template <template <class> class QueueImpl>
 requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
-class ReadSenorBoardTask {
+class ReadSensorBoardTask {
   public:
     using Messages = TaskMessage;
     using QueueType = QueueImpl<TaskMessage>;
-    ReadSenorBoardTask(QueueType &queue) : queue{queue} {}
-    ReadSenorBoardTask(const ReadSenorBoardTask &c) = delete;
-    ReadSenorBoardTask(const ReadSenorBoardTask &&c) = delete;
-    auto operator=(const ReadSenorBoardTask &c) = delete;
-    auto operator=(const ReadSenorBoardTask &&c) = delete;
-    ~ReadSenorBoardTask() = default;
+    ReadSensorBoardTask(QueueType &queue) : queue{queue} {}
+    ReadSensorBoardTask(const ReadSensorBoardTask &c) = delete;
+    ReadSensorBoardTask(const ReadSensorBoardTask &&c) = delete;
+    auto operator=(const ReadSensorBoardTask &c) = delete;
+    auto operator=(const ReadSensorBoardTask &&c) = delete;
+    ~ReadSensorBoardTask() = default;
 
     /**
      * Task entry point.
@@ -73,7 +73,7 @@ class ReadSenorBoardTask {
     void operator()(
         i2c::writer::Writer<QueueImpl> *writer,
         sensors::hardware::SensorHardwareVersionSingleton *version_wrapper) {
-        auto handler = ReadSenorBoardHandler(writer, get_queue());
+        auto handler = ReadSensorBoardHandler(writer, get_queue());
 
         TaskMessage message{};
         if (queue.try_read(&message, 1000)) {

--- a/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
+++ b/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
@@ -13,7 +13,7 @@ template <class I2CQueueWriter, class OwnQueue>
 class ReadSensorBoardHandler {
   public:
     explicit ReadSensorBoardHandler(I2CQueueWriter &i2c_writer,
-                                   OwnQueue &own_queue)
+                                    OwnQueue &own_queue)
         : i2c_writer{i2c_writer}, task_queue{own_queue} {
         // request gpio expander status register
         i2c_writer->read(

--- a/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
+++ b/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
@@ -76,7 +76,7 @@ class ReadSensorBoardTask {
         auto handler = ReadSensorBoardHandler(writer, get_queue());
 
         TaskMessage message{};
-        if (queue.try_read(&message, 1000)) {
+        if (queue.try_read(&message, queue.max_delay)) {
             handler.handle_message(message);
         }
         version_wrapper->set_board_rev(handler.get_rev());

--- a/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
+++ b/include/sensors/core/tasks/read_sensor_board_rev_task.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "sensors/core/pie4ioe5.hpp"
+#include "sensors/core/utils.hpp"
+
+namespace sensors {
+namespace tasks {
+
+using TaskMessage =
+    std::variant<std::monostate, i2c::messages::TransactionResponse>;
+
+template <class I2CQueueWriter, class OwnQueue>
+class ReadSenorBoardHandler {
+  public:
+    explicit ReadSenorBoardHandler(I2CQueueWriter &i2c_writer, OwnQueue &own_queue)
+        : i2c_writer{i2c_writer}, task_queue{own_queue} {
+        // request gpio expander status register
+        i2c_writer->read(pie4ioe4::ADDRESS, static_cast<uint8_t>(pie4ioe4::registers::input_status), 1,
+                        task_queue);
+    }
+    ReadSenorBoardHandler(const ReadSenorBoardHandler &) = delete;
+    ReadSenorBoardHandler(const ReadSenorBoardHandler &&) = delete;
+    auto operator=(const ReadSenorBoardHandler &)
+        -> ReadSenorBoardHandler & = delete;
+    auto operator=(const ReadSenorBoardHandler &&)
+        -> ReadSenorBoardHandler && = delete;
+    ~ReadSenorBoardHandler() {}
+
+    void handle_message(const TaskMessage &m) {
+        std::visit([this](auto o) { this->visit(o); }, m);
+    }
+
+    utils::SensorBoardRev get_rev() { return rev; }
+
+  private:
+    void visit(const std::monostate &) {}
+
+    void visit(i2c::messages::TransactionResponse &m) {
+        if (m.bytes_read == 1 &&
+            m.read_buffer[0] == static_cast<uint8_t>(pie4ioe4::version_responses::VERSION_1)) {
+            rev = utils::SensorBoardRev::VERSION_1;
+        }
+    }
+
+    utils::SensorBoardRev rev = utils::SensorBoardRev::VERSION_0;
+    I2CQueueWriter &i2c_writer;
+    OwnQueue& task_queue;
+};
+
+/**
+ * The task type.
+ */
+template <template <class> class QueueImpl>
+requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
+class ReadSenorBoardTask {
+  public:
+    using Messages = TaskMessage;
+    using QueueType = QueueImpl<TaskMessage>;
+    ReadSenorBoardTask(QueueType &queue)
+        : queue{queue} {}
+    ReadSenorBoardTask(const ReadSenorBoardTask &c) = delete;
+    ReadSenorBoardTask(const ReadSenorBoardTask &&c) = delete;
+    auto operator=(const ReadSenorBoardTask &c) = delete;
+    auto operator=(const ReadSenorBoardTask &&c) = delete;
+    ~ReadSenorBoardTask() = default;
+
+    /**
+     * Task entry point.
+     */
+    void operator()(
+        i2c::writer::Writer<QueueImpl> *writer,
+        sensors::hardware::SensorHardwareVersionSingleton* version_wrapper) {
+        auto handler = ReadSenorBoardHandler(writer, get_queue());
+
+        TaskMessage message{};
+        if (queue.try_read(&message, 1000)) {
+            handler.handle_message(message);
+        }
+        version_wrapper->set_board_rev(handler.get_rev());
+        vTaskDelete(nullptr);
+    }
+
+    [[nodiscard]] auto get_queue() const -> QueueType & { return queue; }
+
+  private:
+    QueueType &queue;
+};
+
+}  // namespace task
+}  // namespace sensors

--- a/include/sensors/core/tasks/tip_presence_notification_task.hpp
+++ b/include/sensors/core/tasks/tip_presence_notification_task.hpp
@@ -85,7 +85,6 @@ class TipPresenceNotificationTask {
             }
         }
     }
-
     [[nodiscard]] auto get_queue() const -> QueueType & { return queue; }
 
   private:

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -54,6 +54,11 @@ enum class ResponseTag : size_t {
     IS_THRESHOLD_SENSE = 4,
 };
 
+enum class SensorBoardRev : uint32_t {
+    VERSION_0 = 0,
+    VERSION_1 = 1,
+};
+
 [[nodiscard]] constexpr auto byte_from_tag(ResponseTag tag) -> uint8_t {
     return (1 << static_cast<size_t>(tag));
 }

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -25,7 +25,8 @@ using CanMessageTuple =
                can::messages::BaselineSensorRequest,
                can::messages::SetSensorThresholdRequest,
                can::messages::BindSensorOutputRequest,
-               can::messages::PeripheralStatusRequest>;
+               can::messages::PeripheralStatusRequest,
+               can::messages::MaxSensorValueRequest>;
 using OtherTaskMessagesTuple = std::tuple<i2c::messages::TransactionResponse>;
 using CanMessageHandler = typename ::utils::TuplesToVariants<
     std::tuple<std::monostate, can::messages::TipStatusQueryRequest>,

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -9,8 +9,9 @@ namespace hardware {
 
 class SensorHardware : public SensorHardwareBase {
   public:
-    SensorHardware(sensors::hardware::SensorHardwareConfiguration hardware, SensorHardwareVersionSingleton& version_wrapper)
-        :  SensorHardwareBase(version_wrapper), hardware(hardware){}
+    SensorHardware(sensors::hardware::SensorHardwareConfiguration hardware,
+                   SensorHardwareVersionSingleton& version_wrapper)
+        : SensorHardwareBase(version_wrapper), hardware(hardware) {}
     auto set_sync() -> void override { gpio::set(hardware.sync_out); }
     auto reset_sync() -> void override { gpio::reset(hardware.sync_out); }
     auto check_tip_presence() -> bool override {

--- a/include/sensors/firmware/sensor_hardware.hpp
+++ b/include/sensors/firmware/sensor_hardware.hpp
@@ -9,8 +9,8 @@ namespace hardware {
 
 class SensorHardware : public SensorHardwareBase {
   public:
-    SensorHardware(sensors::hardware::SensorHardwareConfiguration hardware)
-        : hardware(hardware) {}
+    SensorHardware(sensors::hardware::SensorHardwareConfiguration hardware, SensorHardwareVersionSingleton& version_wrapper)
+        :  SensorHardwareBase(version_wrapper), hardware(hardware){}
     auto set_sync() -> void override { gpio::set(hardware.sync_out); }
     auto reset_sync() -> void override { gpio::reset(hardware.sync_out); }
     auto check_tip_presence() -> bool override {

--- a/include/sensors/simulation/mock_hardware.hpp
+++ b/include/sensors/simulation/mock_hardware.hpp
@@ -11,6 +11,9 @@ using StateManagerHandle = std::shared_ptr<StateManager>;
 namespace sim_mocks {
 class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
   public:
+    MockSensorHardware(
+        sensors::hardware::SensorHardwareVersionSingleton& version_wrapper)
+        : sensors::hardware::SensorHardwareBase{version_wrapper} {}
     auto set_sync() -> void override {
         if (_state_manager) {
             _state_manager->send_sync_msg(SyncPinState::HIGH);

--- a/include/sensors/tests/mock_hardware.hpp
+++ b/include/sensors/tests/mock_hardware.hpp
@@ -4,6 +4,9 @@
 namespace test_mocks {
 class MockSensorHardware : public sensors::hardware::SensorHardwareBase {
   public:
+    MockSensorHardware(
+        sensors::hardware::SensorHardwareVersionSingleton& version_wrapper)
+        : sensors::hardware::SensorHardwareBase{version_wrapper} {}
     auto set_sync() -> void override {
         sync_state = true;
         sync_set_calls++;

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -42,7 +42,7 @@ static auto tip_notification_task_builder_front =
                                can::ids::SensorId>(can::ids::SensorId::S1);
 
 static auto sensor_board_reader_task_builder =
-    freertos_task::TaskStarter<256, sensors::tasks::ReadSenorBoardTask>{};
+    freertos_task::TaskStarter<256, sensors::tasks::ReadSensorBoardTask>{};
 
 void sensor_tasks::start_tasks(
     sensor_tasks::CanWriterTask& can_writer,

--- a/pipettes/core/sensor_tasks.cpp
+++ b/pipettes/core/sensor_tasks.cpp
@@ -41,6 +41,9 @@ static auto tip_notification_task_builder_front =
     freertos_task::TaskStarter<256, sensors::tasks::TipPresenceNotificationTask,
                                can::ids::SensorId>(can::ids::SensorId::S1);
 
+static auto sensor_board_reader_task_builder =
+    freertos_task::TaskStarter<256, sensors::tasks::ReadSenorBoardTask>{};
+
 void sensor_tasks::start_tasks(
     sensor_tasks::CanWriterTask& can_writer,
     sensor_tasks::I2CClient& i2c3_task_client,
@@ -48,9 +51,9 @@ void sensor_tasks::start_tasks(
     sensor_tasks::I2CClient& i2c2_task_client,
     sensor_tasks::I2CPollerClient& i2c2_poller_client,
     sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
     can::ids::NodeId id,
-    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
-    sensors::mmr920::SensorVersion sensor_version) {
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware) {
     // Low throughput sensor task (single channel)
     queue_client.set_node_id(id);
     auto& queues = sensor_tasks::get_queues();
@@ -73,7 +76,7 @@ void sensor_tasks::start_tasks(
         5, "enviro sensor", i2c3_task_client, i2c3_poller_client, queues);
     auto& pressure_sensor_task_rear = pressure_sensor_task_builder_rear.start(
         5, "pressure sensor s0", pressure_i2c_client, pressure_i2c_poller,
-        queues, sensor_hardware_primary, sensor_version, sensor_buffer);
+        queues, sensor_hardware_primary, sensor_buffer);
     auto& capacitive_sensor_task_rear =
         capacitive_sensor_task_builder_rear.start(
             5, "capacitive sensor s0", i2c3_task_client, i2c3_poller_client,
@@ -81,11 +84,15 @@ void sensor_tasks::start_tasks(
     auto& tip_notification_task_rear = tip_notification_task_builder_rear.start(
         5, "tip notification sensor s0", queues, sensor_hardware_primary);
 
+    auto& read_sensor_board_task = sensor_board_reader_task_builder.start(
+        5, "read sensor board", i2c3_task_client, version_wrapper);
+
     tasks.eeprom_task = &eeprom_task;
     tasks.environment_sensor_task = &environment_sensor_task;
     tasks.capacitive_sensor_task_rear = &capacitive_sensor_task_rear;
     tasks.pressure_sensor_task_rear = &pressure_sensor_task_rear;
     tasks.tip_notification_task_rear = &tip_notification_task_rear;
+    tasks.read_sensor_board_task = &read_sensor_board_task;
 
     queues.set_queue(&can_writer.get_queue());
     queues.eeprom_queue = &eeprom_task.get_queue();
@@ -105,9 +112,9 @@ void sensor_tasks::start_tasks(
     sensor_tasks::I2CPollerClient& i2c2_poller_client,
     sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
     sensors::hardware::SensorHardwareBase& sensor_hardware_secondary,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
     can::ids::NodeId id,
-    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
-    sensors::mmr920::SensorVersion sensor_version) {
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware) {
     // High throughput sensor task (eight and ninety six channel)
     queue_client.set_node_id(id);
     auto& queues = sensor_tasks::get_queues();
@@ -139,11 +146,10 @@ void sensor_tasks::start_tasks(
     auto& pressure_sensor_task_rear = pressure_sensor_task_builder_rear.start(
         5, "pressure sensor s0", primary_pressure_i2c_client,
         primary_pressure_i2c_poller, queues, sensor_hardware_primary,
-        sensor_version, sensor_buffer);
+        sensor_buffer);
     auto& pressure_sensor_task_front = pressure_sensor_task_builder_front.start(
         5, "pressure sensor s1", secondary_pressure_i2c_client,
         secondary_pressure_i2c_poller, queues, sensor_hardware_secondary,
-        sensor_version,
 #ifdef USE_TWO_BUFFERS
         sensor_buffer_front);
 #else
@@ -159,12 +165,16 @@ void sensor_tasks::start_tasks(
     auto& tip_notification_task_rear = tip_notification_task_builder_rear.start(
         5, "tip notification sensor s0", queues, sensor_hardware_primary);
 
+    auto& read_sensor_board_task = sensor_board_reader_task_builder.start(
+        5, "read sensor board", i2c3_task_client, version_wrapper);
+
     tasks.eeprom_task = &eeprom_task;
     tasks.environment_sensor_task = &environment_sensor_task;
     tasks.pressure_sensor_task_rear = &pressure_sensor_task_rear;
     tasks.pressure_sensor_task_front = &pressure_sensor_task_front;
     tasks.tip_notification_task_rear = &tip_notification_task_rear;
     tasks.capacitive_sensor_task_rear = &capacitive_sensor_task_rear;
+    tasks.read_sensor_board_task = &read_sensor_board_task;
 
     queues.set_queue(&can_writer.get_queue());
     queues.eeprom_queue = &eeprom_task.get_queue();

--- a/pipettes/firmware/CMakeLists.txt
+++ b/pipettes/firmware/CMakeLists.txt
@@ -97,21 +97,21 @@ set(pipette_srcs ${PIPETTE_FW_LINTABLE_SRCS}
 
 foreach_revision(
     PROJECT_NAME pipettes-single
-    REVISIONS b1 c2 d1 e1
+    REVISIONS b1 c2 d1
     SOURCES pipette_srcs pipette_srcs pipette_srcs pipette_srcs
     CALL_FOREACH_REV pipettes_single_loop
     )
 
 foreach_revision(
     PROJECT_NAME pipettes-multi
-    REVISIONS b1 c2 d1 e1
+    REVISIONS b1 c2 d1
     CALL_FOREACH_REV pipettes_multi_loop
     SOURCES pipette_srcs pipette_srcs pipette_srcs pipette_srcs
     )
 
 foreach_revision(
     PROJECT_NAME pipettes-96
-    REVISIONS b1 c1 d2 e1
+    REVISIONS b1 c1 d2
     CALL_FOREACH_REV pipettes_96_loop
     SOURCES pipette_srcs pipette_srcs pipette_srcs pipette_srcs
     )

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -128,12 +128,13 @@ void encoder_callback(int32_t direction) {
                                                 direction);
 }
 
-static auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+static auto version_wrapper =
+    sensors::hardware::SensorHardwareVersionSingleton();
 static auto pins_for_sensor =
     utility_configs::sensor_configurations<PIPETTE_TYPE>();
 static auto sensor_hardware_container =
-    utility_configs::get_sensor_hardware_container(pins_for_sensor, version_wrapper);
-
+    utility_configs::get_sensor_hardware_container(pins_for_sensor,
+                                                   version_wrapper);
 
 static auto tip_sense_gpio_primary = pins_for_sensor.primary.tip_sense.value();
 
@@ -186,8 +187,7 @@ auto initialize_motor_tasks(
                               peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware_container.primary,
                               sensor_hardware_container.secondary.value(),
-                              version_wrapper, id,
-                              eeprom_hardware_iface);
+                              version_wrapper, id, eeprom_hardware_iface);
 
     initialize_linear_timer(plunger_callback);
     initialize_gear_timer(gear_callback_wrapper);
@@ -214,8 +214,7 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   sensor_hardware_container.primary,
                                   sensor_hardware_container.secondary.value(),
-                                  version_wrapper,
-                                  id, eeprom_hardware_iface);
+                                  version_wrapper, id, eeprom_hardware_iface);
     } else {
         sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                                   peripheral_tasks::get_i2c3_client(),
@@ -223,8 +222,7 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_client(),
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   sensor_hardware_container.primary,
-                                  version_wrapper, id,
-                                  eeprom_hardware_iface);
+                                  version_wrapper, id, eeprom_hardware_iface);
     }
 
     initialize_linear_timer(plunger_callback);

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -128,10 +128,12 @@ void encoder_callback(int32_t direction) {
                                                 direction);
 }
 
+static auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
 static auto pins_for_sensor =
     utility_configs::sensor_configurations<PIPETTE_TYPE>();
 static auto sensor_hardware_container =
-    utility_configs::get_sensor_hardware_container(pins_for_sensor);
+    utility_configs::get_sensor_hardware_container(pins_for_sensor, version_wrapper);
+
 
 static auto tip_sense_gpio_primary = pins_for_sensor.primary.tip_sense.value();
 
@@ -191,8 +193,9 @@ auto initialize_motor_tasks(
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware_container.primary,
-                              sensor_hardware_container.secondary.value(), id,
-                              eeprom_hardware_iface, pressure_sensor_version);
+                              sensor_hardware_container.secondary.value(),
+                              version_wrapper, id,
+                              eeprom_hardware_iface);
 
     initialize_linear_timer(plunger_callback);
     initialize_gear_timer(gear_callback_wrapper);
@@ -219,17 +222,17 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   sensor_hardware_container.primary,
                                   sensor_hardware_container.secondary.value(),
-                                  id, eeprom_hardware_iface,
-                                  pressure_sensor_version);
+                                  version_wrapper,
+                                  id, eeprom_hardware_iface);
     } else {
         sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                                   peripheral_tasks::get_i2c3_client(),
                                   peripheral_tasks::get_i2c3_poller_client(),
                                   peripheral_tasks::get_i2c1_client(),
                                   peripheral_tasks::get_i2c1_poller_client(),
-                                  sensor_hardware_container.primary, id,
-                                  eeprom_hardware_iface,
-                                  pressure_sensor_version);
+                                  sensor_hardware_container.primary,
+                                  version_wrapper, id,
+                                  eeprom_hardware_iface);
     }
 
     initialize_linear_timer(plunger_callback);

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -150,14 +150,6 @@ extern "C" void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     }
 }
 
-#if PCBA_PRIMARY_REVISION == 'e'
-static constexpr auto pressure_sensor_version =
-    sensors::mmr920::SensorVersion::mmr920c10;
-#else
-static constexpr auto pressure_sensor_version =
-    sensors::mmr920::SensorVersion::mmr920c04;
-#endif
-
 // Unfortunately, these numbers need to be literals or defines
 // to get the compile-time checks to work so we can't actually
 // correctly rely on the hal to get these numbers - they need

--- a/pipettes/firmware/utility_configurations.cpp
+++ b/pipettes/firmware/utility_configurations.cpp
@@ -32,12 +32,14 @@ auto utility_configs::get_sensor_hardware_container(
     -> utility_configs::SensorHardwareContainer {
     if (pins.secondary.has_value()) {
         return utility_configs::SensorHardwareContainer{
-            .primary = sensors::hardware::SensorHardware(pins.primary, version_wrapper),
-            .secondary =
-                sensors::hardware::SensorHardware(pins.secondary.value(), version_wrapper)};
+            .primary = sensors::hardware::SensorHardware(pins.primary,
+                                                         version_wrapper),
+            .secondary = sensors::hardware::SensorHardware(
+                pins.secondary.value(), version_wrapper)};
     }
     return utility_configs::SensorHardwareContainer{
-        .primary = sensors::hardware::SensorHardware(pins.primary, version_wrapper)};
+        .primary =
+            sensors::hardware::SensorHardware(pins.primary, version_wrapper)};
 }
 
 template <>

--- a/pipettes/firmware/utility_configurations.cpp
+++ b/pipettes/firmware/utility_configurations.cpp
@@ -27,16 +27,17 @@ auto utility_configs::led_gpio(PipetteType pipette_type) -> gpio::PinConfig {
 }
 
 auto utility_configs::get_sensor_hardware_container(
-    utility_configs::SensorHardwareGPIO pins)
+    utility_configs::SensorHardwareGPIO pins,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper)
     -> utility_configs::SensorHardwareContainer {
     if (pins.secondary.has_value()) {
         return utility_configs::SensorHardwareContainer{
-            .primary = sensors::hardware::SensorHardware(pins.primary),
+            .primary = sensors::hardware::SensorHardware(pins.primary, version_wrapper),
             .secondary =
-                sensors::hardware::SensorHardware(pins.secondary.value())};
+                sensors::hardware::SensorHardware(pins.secondary.value(), version_wrapper)};
     }
     return utility_configs::SensorHardwareContainer{
-        .primary = sensors::hardware::SensorHardware(pins.primary)};
+        .primary = sensors::hardware::SensorHardware(pins.primary, version_wrapper)};
 }
 
 template <>

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -33,7 +33,8 @@ constexpr uint8_t sensor_id_int = 0x0;
 static std::array<float, SENSOR_BUFFER_SIZE> sensor_buffer;
 
 SCENARIO("read capacitance sensor values without shared CINs") {
-    test_mocks::MockSensorHardware mock_hw{};
+    auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+    test_mocks::MockSensorHardware mock_hw(version_wrapper);
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
     test_mocks::MockMessageQueue<i2c::poller::TaskMessage> poller_queue{};
 
@@ -362,7 +363,8 @@ SCENARIO("read capacitance sensor values without shared CINs") {
 }
 
 SCENARIO("read capacitance sensor values supporting shared CINs") {
-    test_mocks::MockSensorHardware mock_hw{};
+    auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+    test_mocks::MockSensorHardware mock_hw{version_wrapper};
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
     test_mocks::MockMessageQueue<i2c::poller::TaskMessage> poller_queue{};
 
@@ -567,7 +569,8 @@ SCENARIO("read capacitance sensor values supporting shared CINs") {
 }
 
 SCENARIO("capacitance driver tests no shared CINs") {
-    test_mocks::MockSensorHardware mock_hw{};
+    auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+    test_mocks::MockSensorHardware mock_hw{version_wrapper};
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
     test_mocks::MockMessageQueue<i2c::poller::TaskMessage> poller_queue{};
 
@@ -752,7 +755,8 @@ SCENARIO("capacitance driver tests no shared CINs") {
 }
 
 SCENARIO("threshold configuration") {
-    test_mocks::MockSensorHardware mock_hw{};
+    auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+    test_mocks::MockSensorHardware mock_hw{version_wrapper};
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
     test_mocks::MockMessageQueue<i2c::poller::TaskMessage> poller_queue{};
 

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -47,21 +47,21 @@ SCENARIO("Testing the pressure sensor driver") {
         can_queue{};
     test_mocks::MockMessageQueue<sensors::utils::TaskMessage> pressure_queue{};
     test_mocks::MockI2CResponseQueue response_queue{};
-    test_mocks::MockSensorHardware mock_hw{};
+
+    auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
 
     i2c::writer::TaskMessage empty_msg{};
     i2c::poller::TaskMessage empty_poll_msg{};
     auto writer = i2c::writer::Writer<test_mocks::MockMessageQueue>{};
     auto poller = i2c::poller::Poller<test_mocks::MockMessageQueue>{};
-    test_mocks::MockSensorHardware hardware{};
+    test_mocks::MockSensorHardware hardware{version_wrapper};
     auto queue_client =
         mock_client::QueueClient{.pressure_sensor_queue = &pressure_queue};
     queue_client.set_queue(&can_queue);
     writer.set_queue(&i2c_queue);
     poller.set_queue(&i2c_poll_queue);
-    sensors::tasks::MMR920 driver(
-        writer, poller, queue_client, pressure_queue, hardware, sensor_id,
-        sensors::mmr920::SensorVersion::mmr920c04, &sensor_buffer);
+    sensors::tasks::MMR920 driver(writer, poller, queue_client, pressure_queue,
+                                  hardware, sensor_id, &sensor_buffer);
 
     can::message_writer_task::TaskMessage empty_can_msg{};
 

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -45,7 +45,8 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
         can_queue{};
     test_mocks::MockMessageQueue<sensors::utils::TaskMessage> pressure_queue{};
     test_mocks::MockI2CResponseQueue response_queue{};
-    test_mocks::MockSensorHardware mock_hw{};
+    auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
+    test_mocks::MockSensorHardware mock_hw{version_wrapper};
 
     i2c::writer::TaskMessage empty_msg{};
     i2c::poller::TaskMessage empty_poll_msg{};
@@ -58,14 +59,8 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
     poller.set_queue(&i2c_poll_queue);
 
     auto sensor = sensors::tasks::PressureMessageHandler{
-        writer,
-        poller,
-        queue_client,
-        response_queue,
-        mock_hw,
-        sensor_id,
-        sensors::mmr920::SensorVersion::mmr920c04,
-        &sensor_buffer};
+        writer,  poller,    queue_client,  response_queue,
+        mock_hw, sensor_id, &sensor_buffer};
 
     GIVEN("A TransactionResponse message") {
         can_queue.reset();

--- a/sensors/tests/test_sensor_hardware.cpp
+++ b/sensors/tests/test_sensor_hardware.cpp
@@ -5,11 +5,13 @@
 #include "sensors/core/sensor_hardware_interface.hpp"
 #include "sensors/tests/mock_hardware.hpp"
 
+auto version_wrapper = sensors::hardware::SensorHardwareVersionSingleton();
 constexpr auto sensor_id_primary = can::ids::SensorId::S0;
 constexpr auto sensor_id_secondary = can::ids::SensorId::S1;
 
 SCENARIO("Multiple Sensors connected") {
-    test_mocks::MockSensorHardware mock_hw = test_mocks::MockSensorHardware{};
+    test_mocks::MockSensorHardware mock_hw =
+        test_mocks::MockSensorHardware{version_wrapper};
     GIVEN("One Sensor In use") {
         WHEN("Sensor not enabled") {
             REQUIRE(mock_hw.get_sync_state_mock() == false);
@@ -103,7 +105,7 @@ SCENARIO("Multiple Sensors connected") {
 }
 
 SCENARIO("Controling multiple sensors at once") {
-    test_mocks::MockSensorHardware mock_hw{};
+    test_mocks::MockSensorHardware mock_hw{version_wrapper};
     GIVEN("Using the BOTH sensorid") {
         WHEN("BOTH sensors are enabled") {
             mock_hw.set_sync_enabled(can::ids::SensorId::BOTH, true);


### PR DESCRIPTION
The new sensor board adds a GPIO expander so that we can read the version of the board and adjust how we read the pressure sensor.

The way this works is that there is a SensorHardwareVersionSingleton that is in charge of holding the version of the board, and it defaults to the version before we had the ability to see the sensor board rev. This singleton is then shared via the SensorHardwareBase instance(s) and a new ReadBoardRevTask

The new task attempts to query the i2c bus at the address of our expander, if it receives a response it compares the bitmap to known versions and sets the version of the singleton.

Now any sensor that gets updated, can change their behavior by asking their SensorHardware instance what rev to use instead of relying on compiler defines.