### PR TITLE
fix(hepa-uv): fix issue when turning on UV after re-seating the hepa/uv on the flex.

### DIFF
--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -160,7 +160,8 @@ class UVMessageHandler {
             };
             can_client.send_can_message(can::ids::NodeId::host, msg);
             led_control_client.send_led_control_message(
-            led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 0, 50, 0));
+                led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 0, 50,
+                                                         0));
 
             uv_light_on = false;
             return;
@@ -187,7 +188,7 @@ class UVMessageHandler {
             led_control_client.send_led_control_message(
                 led_control_task_messages::PushButtonLED(UV_BUTTON, 0, 0, 0,
                                                          50));
-            }
+        }
 
         // wait 10ms for safety relay, then update the states
         ot_utils::freertos_sleep::sleep(100);

--- a/include/hepa-uv/core/uv_task.hpp
+++ b/include/hepa-uv/core/uv_task.hpp
@@ -149,6 +149,9 @@ class UVMessageHandler {
             return;
         }
 
+        // The safety relay needs to be active (Door Closed, Reed Switch set, and
+        // Push Button pressed) in order to turn on the UV Light. So Send an
+        // error if the safety relay is not active when trying to turn on the light.
         update_safety_relay_state();
         if (light_on && !safety_relay_active) {
             if (_timer.is_running()) _timer.stop();


### PR DESCRIPTION
# Overview

When the door is closed, the reed switch is set, and the UV push button is pressed, the UV light turns on as expected.
However, if you then lift the back of the Hepa/UV and unset the reed switch, then set it back down setting the reed switch again. When you press the UV push button the safety relay pin will NOT be active even though the door is closed, and reed is set. The only way to activate the safety relay pin again is to open, and close the Flex door, and THEN press the UV push button again. This is by design per the hardware team as a way to make sure the user understands the intention when turning ON the UV light again.

Closes: [RQA-2872](https://opentrons.atlassian.net/browse/RQA-2872)

# Changelog

- Check safety relay is not set before attempting to change the UV light state.

# Test Plan

- [x] Make sure that the UV light turns on when the door is closed, reed switch is set, and uv push button is pressed
- [x] Make sure that the UV light turns OFF and the push button LED is set to blue when the door is opened.
- [x] Make sure that the UV light turns OFF and the push button LED is set to blue when the reed switch is not set.
- [x] Make sure that after re-setting the reed switch that the UV light does not turn on and UV push button turns blue.
- [x] Make sure that after re-setting the reed switch that the UV light ONLY turns ON AFTER opening/closing the door.

[RQA-2872]: https://opentrons.atlassian.net/browse/RQA-2872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ