### PR TITLE
fix(motor-control): delay after enabling motor and before disengaging brake

### DIFF
--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -17,8 +17,10 @@ void MotorHardware::negative_direction() { gpio::reset(pins.direction); }
 void MotorHardware::activate_motor() {
     gpio::set(pins.enable);
     if (pins.ebrake.has_value()) {
-        gpio::reset(pins.ebrake.value());
+        // allow time for the motor current to stablize before releasing the
+        // brake
         motor_hardware_delay(20);
+        gpio::reset(pins.ebrake.value());
     }
 }
 void MotorHardware::deactivate_motor() {


### PR DESCRIPTION
The z-stages still drop sometimes when the motor first gets enabled (see [ticket](https://opentrons.atlassian.net/jira/servicedesk/projects/RESC/issues/RESC-328?jql=project%20%3D%20%22RESC%22%20ORDER%20BY%20created%20DESC)). I suspect the hold current hasn't had a chance to ramp up before the brake gets disengaged. This should fix most of the issues.

If motors are still dropping after this fix, we might want to consider temporarily increasing the hold current while the motor is being enabled to hold the motor in place. 