### PR TITLE
feat(sensors): add a new can message to batch read sensor data

### DIFF
--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -107,6 +107,7 @@ enum class MessageId {
     gear_read_motor_driver_request = 0x507,
     max_sensor_value_request = 0x70,
     max_sensor_value_response = 0x71,
+    batch_read_sensor_response = 0x81,
     read_sensor_request = 0x82,
     write_sensor_request = 0x83,
     baseline_sensor_request = 0x84,

--- a/include/can/core/message_writer.hpp
+++ b/include/can/core/message_writer.hpp
@@ -29,7 +29,8 @@ class MessageWriter {
      * @param message The message to send
      */
     template <message_core::CanResponseMessage ResponseMessage>
-    void send_can_message(can::ids::NodeId node, ResponseMessage&& message) {
+    auto send_can_message(can::ids::NodeId node, ResponseMessage&& message)
+        -> bool {
         auto arbitration_id = can::arbitration_id::ArbitrationId{};
         auto task_message = can::message_writer_task::TaskMessage{};
 
@@ -41,7 +42,7 @@ class MessageWriter {
         arbitration_id.originating_node_id(node_id);
         task_message.arbitration_id = arbitration_id;
         task_message.message = message;
-        queue->try_write(task_message);
+        return queue->try_write(task_message);
     }
 
     void set_queue(QueueType* q) { queue = q; }

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <span>
 #include <vector>
@@ -982,13 +983,17 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
         -> bool = default;
 };
 
+// Max len = (max size - uint32(message_index) - 3x uint8(sensor_type, sensor_id
+// and data_length))/uint32(data_element_size)
+constexpr size_t BATCH_SENSOR_MAX_LEN =
+    std::floor((can::message_core::MaxMessageSize - 4 - 1 - 1 - 1) / 4);
 struct BatchReadFromSensorResponse
     : BaseMessage<MessageId::batch_read_sensor_response> {
     uint32_t message_index = 0;
     can::ids::SensorType sensor{};
     can::ids::SensorId sensor_id{};
     uint8_t data_length = 0;
-    std::array<uint32_t, 14> sensor_data{};
+    std::array<uint32_t, BATCH_SENSOR_MAX_LEN> sensor_data{};
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -993,7 +993,7 @@ struct BatchReadFromSensorResponse
     can::ids::SensorType sensor{};
     can::ids::SensorId sensor_id{};
     uint8_t data_length = 0;
-    std::array<int32_t, BATCH_SENSOR_MAX_LEN> sensor_data;
+    std::array<int32_t, BATCH_SENSOR_MAX_LEN> sensor_data{};
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -982,6 +982,30 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
         -> bool = default;
 };
 
+struct BatchReadFromSensorResponse
+    : BaseMessage<MessageId::batch_read_sensor_response> {
+    uint32_t message_index = 0;
+    can::ids::SensorType sensor{};
+    can::ids::SensorId sensor_id{};
+    uint8_t data_length = 0;
+    std::array<uint32_t, 14> sensor_data{};
+
+    template <bit_utils::ByteIterator Output, typename Limit>
+    auto serialize(Output body, Limit limit) const -> uint8_t {
+        auto iter = bit_utils::int_to_bytes(message_index, body, limit);
+        iter =
+            bit_utils::int_to_bytes(static_cast<uint8_t>(sensor), iter, limit);
+        iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
+                                       limit);
+        for (auto i = 0; i < data_length; i++) {
+            iter = bit_utils::int_to_bytes(sensor_data[i], iter, limit);
+        }
+        return iter - body;
+    }
+    auto operator==(const BatchReadFromSensorResponse& other) const
+        -> bool = default;
+};
+
 struct SetSensorThresholdRequest
     : BaseMessage<MessageId::set_sensor_threshold_request> {
     uint32_t message_index;
@@ -1879,10 +1903,10 @@ using ResponseMessageType = std::variant<
     ReadMotorDriverRegisterResponse, ReadFromEEPromResponse, MoveCompleted,
     ReadPresenceSensingVoltageResponse, PushToolsDetectedNotification,
     ReadLimitSwitchResponse, MotorPositionResponse, ReadFromSensorResponse,
-    FirmwareUpdateStatusResponse, SensorThresholdResponse,
-    SensorDiagnosticResponse, TaskInfoResponse, PipetteInfoResponse,
-    BindSensorOutputResponse, GripperInfoResponse, TipActionResponse,
-    PeripheralStatusResponse, BrushedMotorConfResponse,
+    BatchReadFromSensorResponse, FirmwareUpdateStatusResponse,
+    SensorThresholdResponse, SensorDiagnosticResponse, TaskInfoResponse,
+    PipetteInfoResponse, BindSensorOutputResponse, GripperInfoResponse,
+    TipActionResponse, PeripheralStatusResponse, BrushedMotorConfResponse,
     UpdateMotorPositionEstimationResponse, BaselineSensorResponse,
     PushTipPresenceNotification, GetMotorUsageResponse, GripperJawStateResponse,
     GripperJawHoldoffResponse, HepaUVInfoResponse, GetHepaFanStateResponse,

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -993,7 +993,7 @@ struct BatchReadFromSensorResponse
     can::ids::SensorType sensor{};
     can::ids::SensorId sensor_id{};
     uint8_t data_length = 0;
-    std::array<uint32_t, BATCH_SENSOR_MAX_LEN> sensor_data{};
+    std::array<int32_t, BATCH_SENSOR_MAX_LEN> sensor_data;
 
     template <bit_utils::ByteIterator Output, typename Limit>
     auto serialize(Output body, Limit limit) const -> uint8_t {

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -986,7 +986,7 @@ struct ReadFromSensorResponse : BaseMessage<MessageId::read_sensor_response> {
 // Max len = (max size - uint32(message_index) - 3x uint8(sensor_type, sensor_id
 // and data_length))/uint32(data_element_size)
 constexpr size_t BATCH_SENSOR_MAX_LEN =
-    std::floor((can::message_core::MaxMessageSize - 4 - 1 - 1 - 1) / 4);
+    size_t((can::message_core::MaxMessageSize - 4 - 1 - 1 - 1) / 4);
 struct BatchReadFromSensorResponse
     : BaseMessage<MessageId::batch_read_sensor_response> {
     uint32_t message_index = 0;
@@ -1003,7 +1003,7 @@ struct BatchReadFromSensorResponse
         iter = bit_utils::int_to_bytes(static_cast<uint8_t>(sensor_id), iter,
                                        limit);
         for (auto i = 0; i < data_length; i++) {
-            iter = bit_utils::int_to_bytes(sensor_data[i], iter, limit);
+            iter = bit_utils::int_to_bytes(sensor_data.at(i), iter, limit);
         }
         return iter - body;
     }

--- a/include/common/tests/mock_message_writer.hpp
+++ b/include/common/tests/mock_message_writer.hpp
@@ -22,10 +22,10 @@ class MockMessageWriter {
      * @param message The message to send
      */
     template <can::message_core::CanResponseMessage ResponseMessage>
-    void send_can_message(can::ids::NodeId, ResponseMessage&& message) {
+    auto send_can_message(can::ids::NodeId, ResponseMessage&& message) -> bool {
         can::message_writer_task::TaskMessage task_msg{.arbitration_id = 0x1,
                                                        .message = message};
-        queue->try_write(task_msg);
+        return queue->try_write(task_msg);
     }
 
     void set_queue(QueueType* q) { queue = q; }

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -242,7 +242,7 @@ class FDC1004 {
     }
 
     auto try_send_next_chunk(uint32_t message_index) -> void {
-        std::array<uint32_t, can::messages::BATCH_SENSOR_MAX_LEN> data{};
+        std::array<int32_t, can::messages::BATCH_SENSOR_MAX_LEN> data{};
         auto count = get_buffer_count();
         auto data_len = std::min(uint8_t(count),
                                  uint8_t(can::messages::BATCH_SENSOR_MAX_LEN));

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -250,7 +250,9 @@ class FDC1004 {
             return;
         }
         for (uint8_t i = 0; i < data_len; i++) {
-            data.at(i) = convert_to_fixed_point((*sensor_buffer).at(sensor_buffer_index_start + i), S15Q16_RADIX);
+            data.at(i) = convert_to_fixed_point(
+                (*sensor_buffer).at(sensor_buffer_index_start + i),
+                S15Q16_RADIX);
         }
         auto response = can::messages::BatchReadFromSensorResponse{
             .message_index = message_index,

--- a/include/sensors/core/tasks/capacitive_driver.hpp
+++ b/include/sensors/core/tasks/capacitive_driver.hpp
@@ -251,7 +251,8 @@ class FDC1004 {
         }
         for (uint8_t i = 0; i < data_len; i++) {
             data.at(i) = convert_to_fixed_point(
-                (*sensor_buffer).at(sensor_buffer_index_start + i),
+                (*sensor_buffer)
+                    .at((sensor_buffer_index_start + i) % SENSOR_BUFFER_SIZE),
                 S15Q16_RADIX);
         }
         auto response = can::messages::BatchReadFromSensorResponse{

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -320,7 +320,7 @@ class MMR920 {
     }
 
     auto try_send_next_chunk(uint32_t message_index) -> void {
-        std::array<uint32_t, can::messages::BATCH_SENSOR_MAX_LEN> data{};
+        std::array<int32_t, can::messages::BATCH_SENSOR_MAX_LEN> data{};
         auto count = get_buffer_count();
         auto data_len = std::min(uint8_t(count),
                                  uint8_t(can::messages::BATCH_SENSOR_MAX_LEN));

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -329,7 +329,8 @@ class MMR920 {
         }
         for (uint8_t i = 0; i < data_len; i++) {
             data.at(i) = mmr920::reading_to_fixed_point(
-                (*sensor_buffer).at(sensor_buffer_index_start + i));
+                (*sensor_buffer)
+                    .at((sensor_buffer_index_start + i) % SENSOR_BUFFER_SIZE));
         }
         auto response = can::messages::BatchReadFromSensorResponse{
             .message_index = message_index,

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -455,17 +455,6 @@ class MMR920 {
                 response_pressure -= current_moving_pressure_baseline_pa;
             }
             sensor_buffer_log(response_pressure);
-            if (!enable_auto_baseline) {
-                // This preserves the old way of echoing continuous polls
-                can_client.send_can_message(
-                    can::ids::NodeId::host,
-                    can::messages::ReadFromSensorResponse{
-                        .message_index = 0,
-                        .sensor = can::ids::SensorType::pressure,
-                        .sensor_id = sensor_id,
-                        .sensor_data =
-                            mmr920::reading_to_fixed_point(response_pressure)});
-            }
 
             if (enable_auto_baseline &&
                 sensor_buffer_index == AUTO_BASELINE_END &&

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -328,7 +328,7 @@ class MMR920 {
             return;
         }
         for (uint8_t i = 0; i < data_len; i++) {
-            data[i] = mmr920::reading_to_fixed_point(
+            data.at(i) = mmr920::reading_to_fixed_point(
                 (*sensor_buffer).at(sensor_buffer_index_start + i));
         }
         auto response = can::messages::BatchReadFromSensorResponse{

--- a/sensors/tests/CMakeLists.txt
+++ b/sensors/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(sensors
         PROPERTIES
         CXX_STANDARD 20
         CXX_STANDARD_REQUIRED TRUE)
-
+target_compile_definitions(sensors PUBLIC SENSOR_BUFF_SIZE=300)
 target_compile_options(sensors
         PUBLIC
         -Wall

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -557,6 +557,7 @@ SCENARIO("read capacitance sensor values supporting shared CINs") {
             auto second = first;
             second.id.transaction_index = 1;
             second.read_buffer = buffer_b;
+            second.id.is_completed_poll=1;
             auto first_task_msg = sensors::utils::TaskMessage(first);
             auto second_task_msg = sensors::utils::TaskMessage(second);
             sensor_shared.handle_message(first_task_msg);
@@ -662,8 +663,9 @@ SCENARIO("capacitance driver tests no shared CINs") {
 
             THEN("it should forward the converted data via can") {
                 can_queue.try_read(&empty_msg);
-                auto sent = std::get<can::messages::BatchReadFromSensorResponse>(
-                    empty_msg.message);
+                auto sent =
+                    std::get<can::messages::BatchReadFromSensorResponse>(
+                        empty_msg.message);
                 REQUIRE(sent.sensor == can::ids::SensorType::capacitive);
                 // we're just checking that the data is faithfully represented,
                 // don't really care what it is

--- a/sensors/tests/test_capacitive_sensor.cpp
+++ b/sensors/tests/test_capacitive_sensor.cpp
@@ -557,7 +557,7 @@ SCENARIO("read capacitance sensor values supporting shared CINs") {
             auto second = first;
             second.id.transaction_index = 1;
             second.read_buffer = buffer_b;
-            second.id.is_completed_poll=1;
+            second.id.is_completed_poll = 1;
             auto first_task_msg = sensors::utils::TaskMessage(first);
             auto second_task_msg = sensors::utils::TaskMessage(second);
             sensor_shared.handle_message(first_task_msg);

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -307,7 +307,8 @@ SCENARIO("Testing the pressure sensor driver") {
             for (size_t i = 0; i <= SENSOR_BUFFER_SIZE + 1; i++) {
                 driver.handle_ongoing_pressure_response(sensor_response);
                 if (i > 0 && i % 14 == 0) {
-                    // Can queue here can't handle that many messages so just pop them off one at a time.
+                    // Can queue here can't handle that many messages so just
+                    // pop them off one at a time.
                     REQUIRE(can_queue.get_size() == 1);
                     can_queue.reset();
                 }

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -98,13 +98,17 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
                     sensors::mmr920::Registers::LOW_PASS_PRESSURE_READ),
                 sensors::utils::byte_from_tags(tags_for_continuous));
             auto response_read = sensors::utils::TaskMessage(response_details);
-            sensor.handle_message(response_read);
-            THEN("there should be a ReadFromSensorResponse") {
+            THEN(
+                "there should be a Batch read sensor response after 14 "
+                "messages") {
+                for (auto i = 0; i < 14; i++) {
+                    sensor.handle_message(response_read);
+                }
                 REQUIRE(can_queue.has_message());
                 REQUIRE(can_queue.get_size() == 1);
                 can_queue.try_read(&empty_can_msg);
                 REQUIRE(std::holds_alternative<
-                        can::messages::ReadFromSensorResponse>(
+                        can::messages::BatchReadFromSensorResponse>(
                     empty_can_msg.message));
             }
         }


### PR DESCRIPTION
In a first step to streamline tool_sensors.py we want to batch read sensor data, this will speed up the process and let us stream a lot better

This PR removes much of the complexity from tool sensors and puts creates a new log specifically for sensor data.

