### PR TITLE
fix(motor-control): adding back the removed delay to allow ebrake to fully disegnage

### DIFF
--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -21,6 +21,7 @@ void MotorHardware::activate_motor() {
         // brake
         motor_hardware_delay(20);
         gpio::reset(pins.ebrake.value());
+        motor_hardware_delay(20);
     }
 }
 void MotorHardware::deactivate_motor() {


### PR DESCRIPTION
In an attempt to fix the z stage free-falling issue (see https://github.com/Opentrons/ot3-firmware/pull/804), I had moved the delay before the ebrake so that the motor current has a chance to ramp up. As a result, the ebrake now doesn't have enough time to disengage before the motor is commanded to move so now the z stage would stall occasionally. So I'm adding more delay - so now it delays after enabling the motor, and delays again after the brake is disengaged. 