### PR TITLE
fix(motor-control): catch falling 96 channel 

### DIFF
--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -195,6 +195,7 @@ class MotionController {
         if (hardware.is_timer_interrupt_running()) {
             hardware.set_cancel_request(error_severity, error_code);
         }
+        disable_motor();
     }
 
     void clear_cancel_request() { hardware.clear_cancel_request(); }

--- a/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
+++ b/include/motor-control/core/stepper_motor/motor_interrupt_handler.hpp
@@ -121,9 +121,8 @@ class MotorInterruptHandler {
             if ((buffered_move.start_encoder_position -
                  hardware.get_encoder_pulses()) > 10) {
                 return;
-            } else {
-                cancel_and_clear_moves(can::ids::ErrorCode::collision_detected);
             }
+            cancel_and_clear_moves(can::ids::ErrorCode::collision_detected);
         }
 
         if (buffered_move.check_stop_condition(MoveStopCondition::stall)) {

--- a/motor-control/tests/test_motor_stall_handling.cpp
+++ b/motor-control/tests/test_motor_stall_handling.cpp
@@ -308,11 +308,17 @@ SCENARIO("motor handler stall detection") {
                 REQUIRE(!test_objs.hw.position_flags.check_flag(
                     Flags::stepper_position_ok));
                 THEN("move completed and no error was raised") {
-                    REQUIRE(test_objs.reporter.messages.size() == 1);
-                    Ack ack_msg =
-                        std::get<Ack>(test_objs.reporter.messages.front());
-                    REQUIRE(ack_msg.ack_id ==
-                            AckMessageId::complete_without_condition);
+                    REQUIRE(test_objs.reporter.messages.size() == 6);
+                    for (auto& element : test_objs.reporter.messages) {
+                        printf("%ld\n", element.index());
+                    }
+                    can::messages::ErrorMessage err =
+                        std::get<can::messages::ErrorMessage>(
+                            test_objs.reporter.messages.front());
+                    REQUIRE(err.error_code ==
+                            can::ids::ErrorCode::collision_detected);
+                    REQUIRE(err.severity ==
+                            can::ids::ErrorSeverity::unrecoverable);
                 }
             }
         }


### PR DESCRIPTION
So from the various logs I have found 2 different cases where the 96 channel can fall down to the deck

1. During the first home after a boot up, the 96 sometimes falls, it's a little unclear on why this happens, there could be some static friction condition that happens when things are powered off.

2. If there is a Stop Request sent while the 96 is moving faster than the discontinuity speed in the downward direction, the steps immediately stop without acceleration and the momentum of the 96 overcomes the head motor, creates a resonate condition and falls.

This PR makes it a bit better by "catching" the pipette when this happens. First of all when a "stop request" is sent we will automatically call disable motor from the motion controller. This will activate the brake if there is one on that axis.

Second, specifically to address the first cause, this PR adds a new way of detecting when a fall is happening during a home by seeing if the axis starts moving in the wrong direction and triggering a collision detected. Since the python side already spits out a stop request immediately upon receipt of a collision detected this will trigger the brake.