### PR TITLE
fix(motion-control): Don't clear stepper-ok in stop request

### DIFF
--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -189,7 +189,8 @@ class MotionController {
         if (hardware.is_timer_interrupt_running()) {
             hardware.request_cancel();
         }
-        disable_motor();
+        hardware.deactivate_motor();
+        enabled = false;
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }

--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -190,7 +190,7 @@ class MotionController {
             hardware.request_cancel();
         }
         hardware.deactivate_motor();
-        enabled = false;
+        hardware.activate_motor();
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }


### PR DESCRIPTION
We added the disable motor in the stop request because that was the cause of some falling pipettes and we needed to turn the brake on. however disable clears the stepper ok flag and this isn't needed in this case.

So the new behavior is that it calls hardware disable_motor to turn the brake on, then it calls activate motor after to turn it back off and leaves the motor controller's 'enabled' flag true so the motion controller task has the option to call motor position update request.