### PR TITLE
fix(motion-control): Don't clear stepper-ok in stop request (#813)

### DIFF
--- a/include/motor-control/core/stepper_motor/motion_controller.hpp
+++ b/include/motor-control/core/stepper_motor/motion_controller.hpp
@@ -189,7 +189,8 @@ class MotionController {
         if (hardware.is_timer_interrupt_running()) {
             hardware.request_cancel();
         }
-        disable_motor();
+        hardware.deactivate_motor();
+        hardware.activate_motor();
     }
 
     auto read_limit_switch() -> bool { return hardware.check_limit_switch(); }


### PR DESCRIPTION
* We don't need to clear the stepper ok field when we get a stop message.

* Ok i was wrong about how this worked. We don't want to leave the motor enable false we just want to turn the brake on for a bit then turn it back off to leave the motor enabled.