### PR TITLE
fix(gripper): add stopped state

### DIFF
--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -151,6 +151,7 @@ class BrushedMotorInterruptHandler {
                         can::ids::ErrorCode::collision_detected);
                     report_position(pulses);
                     error_handled = true;
+                    hardware.set_motor_state(BrushedMotorState::UNHOMED);
                 }
             } else if (motor_state != BrushedMotorState::UNHOMED) {
                 auto pulses = hardware.get_encoder_pulses();
@@ -166,6 +167,7 @@ class BrushedMotorInterruptHandler {
                         motor_state == BrushedMotorState::FORCE_CONTROLLING
                             ? can::ids::ErrorCode::labware_dropped
                             : can::ids::ErrorCode::collision_detected;
+                    hardware.set_motor_state(BrushedMotorState::UNHOMED);
                     cancel_and_clear_moves(err);
                     report_position(pulses);
                     error_handled = true;
@@ -197,8 +199,10 @@ class BrushedMotorInterruptHandler {
         } else if (estop_triggered()) {
             in_estop = true;
             cancel_and_clear_moves(can::ids::ErrorCode::estop_detected);
+            hardware.set_motor_state(BrushedMotorState::UNHOMED);
         } else if (hardware.has_cancel_request()) {
-            if (!hardware.get_stay_enabled()) {
+            if (!hardware.get_stay_enabled() &&
+                hardware.get_motor_state() != BrushedMotorState::UNHOMED) {
                 hardware.set_motor_state(BrushedMotorState::STOPPED);
             }
             cancel_and_clear_moves(can::ids::ErrorCode::stop_requested,

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -199,7 +199,7 @@ class BrushedMotorInterruptHandler {
             cancel_and_clear_moves(can::ids::ErrorCode::estop_detected);
         } else if (hardware.has_cancel_request()) {
             if (!hardware.get_stay_enabled()) {
-                hardware.set_motor_state(BrushedMotorState::UNHOMED);
+                hardware.set_motor_state(BrushedMotorState::STOPPED);
             }
             cancel_and_clear_moves(can::ids::ErrorCode::stop_requested,
                                    can::ids::ErrorSeverity::warning);

--- a/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
+++ b/include/motor-control/core/brushed_motor/brushed_motor_interrupt_handler.hpp
@@ -199,7 +199,6 @@ class BrushedMotorInterruptHandler {
         } else if (estop_triggered()) {
             in_estop = true;
             cancel_and_clear_moves(can::ids::ErrorCode::estop_detected);
-            hardware.set_motor_state(BrushedMotorState::UNHOMED);
         } else if (hardware.has_cancel_request()) {
             if (!hardware.get_stay_enabled() &&
                 hardware.get_motor_state() != BrushedMotorState::UNHOMED) {

--- a/include/motor-control/core/types.hpp
+++ b/include/motor-control/core/types.hpp
@@ -44,5 +44,6 @@ enum class BrushedMotorState : uint8_t {
     UNHOMED = 0x0,
     FORCE_CONTROLLING_HOME = 0x1,
     FORCE_CONTROLLING = 0x2,
-    POSITION_CONTROLLING = 0x3
+    POSITION_CONTROLLING = 0x3,
+    STOPPED = 0x4
 };

--- a/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
+++ b/motor-control/tests/test_brushed_motor_interrupt_handler.cpp
@@ -526,10 +526,10 @@ SCENARIO("handler recovers from error state") {
             test_objs.hw.request_cancel();
             test_objs.handler.run_interrupt();
             THEN(
-                "motor state should become un-homed only if stay engaged is "
-                "falsy") {
+                "motor state should become stopped only if stay engaged is "
+                "false") {
                 REQUIRE(test_objs.hw.get_motor_state() ==
-                        (!stay_engaged ? BrushedMotorState::UNHOMED
+                        (!stay_engaged ? BrushedMotorState::STOPPED
                                        : og_motor_state));
             }
             THEN("a stop requested warning is issued") {


### PR DESCRIPTION
This fixes an error that happens during error recovery where the gripper needs to re-home because the error flow sends a stop request. 

This fixes that by adding a new state called stop, and if the firmware responds with STOPPED instead of UNHOMED then we know we can just continue on without re-homing.

The gripper will still go into a UNHOMED state during the following:
Labware droped
Collision
Estop
