### PR TITLE
fix(motor-control): improve stop request handling

### DIFF
--- a/include/motor-control/core/tasks/brushed_move_group_task.hpp
+++ b/include/motor-control/core/tasks/brushed_move_group_task.hpp
@@ -82,11 +82,15 @@ class MoveGroupMessageHandler {
         can_client.send_can_message(can::ids::NodeId::host, response);
     }
 
-    void handle(const can::messages::ClearAllMoveGroupsRequest& m) {
-        LOG("Received clear move groups request");
+    void clear_move_groups() {
         for (auto& group : move_groups) {
             group.clear();
         }
+    }
+
+    void handle(const can::messages::ClearAllMoveGroupsRequest& m) {
+        LOG("Received clear move groups request");
+        this->clear_move_groups();
         can_client.send_can_message(can::ids::NodeId::host,
                                     can::messages::ack_from_request(m));
     }
@@ -104,9 +108,7 @@ class MoveGroupMessageHandler {
 
     void handle(const can::messages::StopRequest& m) {
         LOG("Recieved StopRequest in MoveGroup");
-        auto clear_req =
-            can::messages::ClearAllMoveGroupsRequest{.message_index = 0};
-        this->handle(clear_req);
+        this->clear_move_groups();
         // pass the stop message to motion controller to kill pwm
         // and any running moves
         mc_client.send_brushed_motion_controller_queue(m);

--- a/include/motor-control/core/tasks/move_group_task.hpp
+++ b/include/motor-control/core/tasks/move_group_task.hpp
@@ -80,11 +80,15 @@ class MoveGroupMessageHandler {
         can_client.send_can_message(can::ids::NodeId::host, response);
     }
 
-    void handle(const can::messages::ClearAllMoveGroupsRequest& m) {
-        LOG("Received clear move groups request");
+    void clear_move_groups() {
         for (auto& group : move_groups) {
             group.clear();
         }
+    }
+
+    void handle(const can::messages::ClearAllMoveGroupsRequest& m) {
+        LOG("Received clear move groups request");
+        this->clear_move_groups();
         can_client.send_can_message(can::ids::NodeId::host,
                                     can::messages::ack_from_request(m));
     }
@@ -102,9 +106,7 @@ class MoveGroupMessageHandler {
 
     void handle(const can::messages::StopRequest& m) {
         LOG("Received StopRequest in MoveGroup");
-        auto clear_req =
-            can::messages::ClearAllMoveGroupsRequest{.message_index = 0};
-        this->handle(clear_req);
+        this->clear_move_groups();
         // pass the stop message to motion controller to kill pwm
         // and any running moves
         mc_client.send_motion_controller_queue(m);

--- a/include/pipettes/core/tasks/move_group_task.hpp
+++ b/include/pipettes/core/tasks/move_group_task.hpp
@@ -72,11 +72,15 @@ class MoveGroupMessageHandler {
         can_client.send_can_message(can::ids::NodeId::host, response);
     }
 
-    void handle(const can::messages::ClearAllMoveGroupsRequest& m) {
-        LOG("Received clear move groups request");
+    void clear_move_groups() {
         for (auto& group : move_groups) {
             group.clear();
         }
+    }
+
+    void handle(const can::messages::ClearAllMoveGroupsRequest& m) {
+        LOG("Received clear move groups request");
+        this->clear_move_groups();
         can_client.send_can_message(can::ids::NodeId::host,
                                     can::messages::ack_from_request(m));
     }
@@ -94,9 +98,7 @@ class MoveGroupMessageHandler {
 
     void handle(const can::messages::StopRequest& m) {
         LOG("Received StopRequest in MoveGroup");
-        auto clear_req =
-            can::messages::ClearAllMoveGroupsRequest{.message_index = 0};
-        this->handle(clear_req);
+        this->clear_move_groups();
         // pass the stop message to motion controller to kill pwm
         // and any running moves
         mc_client.send_motion_controller_queue(m);


### PR DESCRIPTION
So when a stop request is broadcast it was previously sending out 2-3 responses per motor axis. 1 from the move group controller, 1 from the motor controller and 1 from the motor interrupt handler if the motor has been previously enabled (which is always true except right after a firmware update or power cycle.)

This PR removes the response from the move group controller, since this message always responded with a message index 0 which is unhelpful and will reduce the number of messages by 1/3 and prevents many of the "Error 1008 CAN_BUS_ERROR: error frame encountered" instances