### PR TITLE
fix(motor-control): improve brake delay time

### DIFF
--- a/motor-control/firmware/motor_control_hardware.c
+++ b/motor-control/firmware/motor_control_hardware.c
@@ -133,7 +133,8 @@ uint16_t motor_hardware_get_stopwatch_pulses(void* stopwatch_handle, uint8_t cle
 }
 
 void motor_hardware_delay(uint32_t delay) {
-    vTaskDelay(delay);
+    const TickType_t xDelay = delay * portTICK_PERIOD_MS;
+    vTaskDelay(xDelay);
 }
 
 

--- a/motor-control/firmware/stepper_motor/motor_hardware.cpp
+++ b/motor-control/firmware/stepper_motor/motor_hardware.cpp
@@ -18,16 +18,18 @@ void MotorHardware::activate_motor() {
     gpio::set(pins.enable);
     if (pins.ebrake.has_value()) {
         // allow time for the motor current to stablize before releasing the
-        // brake
+        // brake spec is < 1ms so this is plenty
         motor_hardware_delay(20);
         gpio::reset(pins.ebrake.value());
-        motor_hardware_delay(20);
+        // Brake spec is 50ms to engage/disengage
+        motor_hardware_delay(100);
     }
 }
 void MotorHardware::deactivate_motor() {
     if (pins.ebrake.has_value()) {
         gpio::set(pins.ebrake.value());
-        motor_hardware_delay(20);
+        // Brake spec is 50ms to engage/disengage
+        motor_hardware_delay(100);
     }
     gpio::reset(pins.enable);
 }


### PR DESCRIPTION
So we haven't seen much problems with our old 20ms delay, however the spec on the brakes is 50ms.

Recently there have been some bad batches from the supplier that take longer to engage/disengage so we are going to delay 100ms now to make sure we can accommodate any brake that's in-spec to slightly over spec,