### PR TITLE
feat(eeprom): Store overpressure count

### DIFF
--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -191,6 +191,7 @@ typedef enum {
     can_sensortype_pressure_temperature = 0x4,
     can_sensortype_humidity = 0x5,
     can_sensortype_temperature = 0x6,
+    can_sensortype_unused = 0x7,
 } CANSensorType;
 
 /** Sensor IDs available.

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -62,6 +62,8 @@ typedef enum {
     can_messageid_write_motor_current_request = 0x33,
     can_messageid_read_motor_current_request = 0x34,
     can_messageid_read_motor_current_response = 0x35,
+    can_messageid_read_motor_driver_error_status_request = 0x36,
+    can_messageid_read_motor_driver_error_status_response = 0x37,
     can_messageid_set_brushed_motor_vref_request = 0x40,
     can_messageid_set_brushed_motor_pwm_request = 0x41,
     can_messageid_gripper_grip_request = 0x42,
@@ -103,6 +105,7 @@ typedef enum {
     can_messageid_gear_read_motor_driver_request = 0x507,
     can_messageid_max_sensor_value_request = 0x70,
     can_messageid_max_sensor_value_response = 0x71,
+    can_messageid_batch_read_sensor_response = 0x81,
     can_messageid_read_sensor_request = 0x82,
     can_messageid_write_sensor_request = 0x83,
     can_messageid_baseline_sensor_request = 0x84,
@@ -167,6 +170,7 @@ typedef enum {
     can_errorcode_over_pressure = 0xd,
     can_errorcode_door_open = 0xe,
     can_errorcode_reed_open = 0xf,
+    can_errorcode_motor_driver_error_detected = 0x10,
     can_errorcode_safety_relay_inactive = 0x11,
 } CANErrorCode;
 
@@ -208,6 +212,7 @@ typedef enum {
     can_sensoroutputbinding_report = 0x2,
     can_sensoroutputbinding_max_threshold_sync = 0x4,
     can_sensoroutputbinding_auto_baseline_report = 0x8,
+    can_sensoroutputbinding_multi_sensor_sync = 0x10,
 } CANSensorOutputBinding;
 
 /** How a sensor's threshold should be interpreted. */
@@ -270,5 +275,6 @@ typedef enum {
     can_motorusagevaluetype_right_gear_motor_distance = 0x2,
     can_motorusagevaluetype_force_application_time = 0x3,
     can_motorusagevaluetype_total_error_count = 0x4,
+    can_motorusagevaluetype_overpressure_error_count = 0x5,
 } CANMotorUsageValueType;
 

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -201,7 +201,6 @@ enum class SensorType {
     pressure_temperature = 0x4,
     humidity = 0x5,
     temperature = 0x6,
-    UNUSED = 0x7,
 };
 
 /** Sensor IDs available.
@@ -222,7 +221,7 @@ enum class SensorOutputBinding {
     sync = 0x1,
     report = 0x2,
     max_threshold_sync = 0x4,
-    auto_baseline_report = 0x08,
+    auto_baseline_report = 0x8,
     multi_sensor_sync = 0x10,
 };
 
@@ -277,6 +276,7 @@ enum class MotorUsageValueType {
     right_gear_motor_distance = 0x2,
     force_application_time = 0x3,
     total_error_count = 0x4,
+    overpressure_error_count = 0x5,
 };
 
 }  // namespace can::ids

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -201,6 +201,7 @@ enum class SensorType {
     pressure_temperature = 0x4,
     humidity = 0x5,
     temperature = 0x6,
+    UNUSED = 0x7,
 };
 
 /** Sensor IDs available.

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -139,8 +139,7 @@ void start_tasks(
     sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
     can::ids::NodeId id,
     eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
-    eeprom::dev_data::DevDataTailAccessor<QueueClient>&
-        tail_accessor);
+    eeprom::dev_data::DevDataTailAccessor<QueueClient>& tail_accessor);
 
 void start_tasks(
     CanWriterTask& can_writer, I2CClient& i2c3_task_client,
@@ -151,8 +150,7 @@ void start_tasks(
     sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
     can::ids::NodeId id,
     eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
-    eeprom::dev_data::DevDataTailAccessor<QueueClient>&
-        tail_accessor);
+    eeprom::dev_data::DevDataTailAccessor<QueueClient>& tail_accessor);
 
 /**
  * Access to the sensor tasks singleton

--- a/include/pipettes/core/sensor_tasks.hpp
+++ b/include/pipettes/core/sensor_tasks.hpp
@@ -35,25 +35,6 @@ using I2CClient =
 using I2CPollerClient =
     i2c::poller::Poller<freertos_message_queue::FreeRTOSMessageQueue>;
 
-void start_tasks(
-    CanWriterTask& can_writer, I2CClient& i2c3_task_client,
-    I2CPollerClient& i2c3_poller_client, I2CClient& i2c1_task_client,
-    I2CPollerClient& i2c1_poller_client,
-    sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
-    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
-    can::ids::NodeId id,
-    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware);
-
-void start_tasks(
-    CanWriterTask& can_writer, I2CClient& i2c3_task_client,
-    I2CPollerClient& i2c3_poller_client, I2CClient& i2c1_task_client,
-    I2CPollerClient& i2c1_poller_client,
-    sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
-    sensors::hardware::SensorHardwareBase& sensor_hardware_secondary,
-    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
-    can::ids::NodeId id,
-    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware);
-
 /**
  * Access to all sensor/eeprom tasks. This will be a singleton.
  */
@@ -83,6 +64,9 @@ struct Tasks {
         tip_notification_task_front{nullptr};
     sensors::tasks::ReadSensorBoardTask<
         freertos_message_queue::FreeRTOSMessageQueue>* read_sensor_board_task{
+        nullptr};
+    usage_storage_task::UsageStorageTask<
+        freertos_message_queue::FreeRTOSMessageQueue>* usage_storage_task{
         nullptr};
 };
 
@@ -123,6 +107,7 @@ struct QueueClient : can::message_writer::MessageWriter {
 
     void send_tip_notification_queue_front(
         const sensors::tip_presence::TaskMessage& m);
+    void send_usage_storage_queue(const usage_storage_task::TaskMessage& m);
 
     freertos_message_queue::FreeRTOSMessageQueue<eeprom::task::TaskMessage>*
         eeprom_queue{nullptr};
@@ -142,7 +127,32 @@ struct QueueClient : can::message_writer::MessageWriter {
     freertos_message_queue::FreeRTOSMessageQueue<
         sensors::tip_presence::TaskMessage>* tip_notification_queue_front{
         nullptr};
+    freertos_message_queue::FreeRTOSMessageQueue<
+        usage_storage_task::TaskMessage>* usage_storage_queue{nullptr};
 };
+
+void start_tasks(
+    CanWriterTask& can_writer, I2CClient& i2c3_task_client,
+    I2CPollerClient& i2c3_poller_client, I2CClient& i2c1_task_client,
+    I2CPollerClient& i2c1_poller_client,
+    sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
+    can::ids::NodeId id,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
+    eeprom::dev_data::DevDataTailAccessor<QueueClient>&
+        tail_accessor);
+
+void start_tasks(
+    CanWriterTask& can_writer, I2CClient& i2c3_task_client,
+    I2CPollerClient& i2c3_poller_client, I2CClient& i2c1_task_client,
+    I2CPollerClient& i2c1_poller_client,
+    sensors::hardware::SensorHardwareBase& sensor_hardware_primary,
+    sensors::hardware::SensorHardwareBase& sensor_hardware_secondary,
+    sensors::hardware::SensorHardwareVersionSingleton& version_wrapper,
+    can::ids::NodeId id,
+    eeprom::hardware_iface::EEPromHardwareIface& eeprom_hardware,
+    eeprom::dev_data::DevDataTailAccessor<QueueClient>&
+        tail_accessor);
 
 /**
  * Access to the sensor tasks singleton

--- a/include/pipettes/firmware/eeprom_keys.hpp
+++ b/include/pipettes/firmware/eeprom_keys.hpp
@@ -7,14 +7,12 @@ static constexpr uint16_t PLUNGER_MOTOR_STEP_KEY = 0;
 static constexpr uint16_t P_SM_ERROR_COUNT_KEY = 1;
 static constexpr uint16_t OVERPRESSURE_COUNT_KEY_SM = 2;
 
-
 static constexpr uint16_t GEAR_LEFT_MOTOR_KEY = 1;
 static constexpr uint16_t GEAR_RIGHT_MOTOR_KEY = 2;
 static constexpr uint16_t P_96_ERROR_COUNT_KEY = 3;
 static constexpr uint16_t L_ERROR_COUNT_KEY = 4;
 static constexpr uint16_t R_ERROR_COUNT_KEY = 5;
 static constexpr uint16_t OVERPRESSURE_COUNT_KEY_96 = 6;
-
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev1_sing_mult;

--- a/include/pipettes/firmware/eeprom_keys.hpp
+++ b/include/pipettes/firmware/eeprom_keys.hpp
@@ -3,19 +3,28 @@
 #include "eeprom/core/update_data_rev_task.hpp"
 
 static constexpr uint16_t PLUNGER_MOTOR_STEP_KEY = 0;
+
+static constexpr uint16_t P_SM_ERROR_COUNT_KEY = 1;
+static constexpr uint16_t OVERPRESSURE_COUNT_KEY_SM = 2;
+
+
 static constexpr uint16_t GEAR_LEFT_MOTOR_KEY = 1;
 static constexpr uint16_t GEAR_RIGHT_MOTOR_KEY = 2;
 static constexpr uint16_t P_96_ERROR_COUNT_KEY = 3;
-static constexpr uint16_t P_SM_ERROR_COUNT_KEY = 1;
 static constexpr uint16_t L_ERROR_COUNT_KEY = 4;
 static constexpr uint16_t R_ERROR_COUNT_KEY = 5;
+static constexpr uint16_t OVERPRESSURE_COUNT_KEY_96 = 6;
+
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev1_sing_mult;
 extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev2_sing_mult;
+extern const eeprom::data_rev_task::DataTableUpdateMessage
+    data_table_rev3_sing_mult;
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch;
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_96ch;
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_96ch;
 
 extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
     table_updater;

--- a/include/sensors/core/tasks/pressure_driver.hpp
+++ b/include/sensors/core/tasks/pressure_driver.hpp
@@ -12,11 +12,11 @@
 #include "common/core/message_queue.hpp"
 #include "common/core/sensor_buffer.hpp"
 #include "i2c/core/messages.hpp"
+#include "motor-control/core/tasks/usage_storage_task.hpp"
 #include "sensors/core/mmr920.hpp"
 #include "sensors/core/sensor_hardware_interface.hpp"
 #include "sensors/core/sensors.hpp"
 #include "sensors/core/utils.hpp"
-#include "motor-control/core/tasks/usage_storage_task.hpp"
 
 namespace sensors {
 
@@ -45,7 +45,7 @@ class MMR920 {
            sensors::hardware::SensorHardwareBase &hardware,
            const can::ids::SensorId &id,
            std::array<float, SENSOR_BUFFER_SIZE> *sensor_buffer,
-           UsageClient& usage_client, uint16_t pres_err_key)
+           UsageClient &usage_client, uint16_t pres_err_key)
         : writer(writer),
           poller(poller),
           can_client(can_client),
@@ -452,7 +452,7 @@ class MMR920 {
                         .message_index = m.message_index,
                         .severity = can::ids::ErrorSeverity::unrecoverable,
                         .error_code = can::ids::ErrorCode::over_pressure});
-               increase_overpressure_count();
+                increase_overpressure_count();
             } else if (!bind_sync) {
                 // if we're not using bind sync turn off the sync line
                 // we don't do this during bind sync because if it's triggering
@@ -606,7 +606,8 @@ class MMR920 {
     }
 
     void increase_overpressure_count() {
-        auto message = usage_messages::IncreaseErrorCount{.key=pressure_error_key};
+        auto message =
+            usage_messages::IncreaseErrorCount{.key = pressure_error_key};
         usage_client.send_usage_storage_queue(message);
     }
 
@@ -681,8 +682,8 @@ class MMR920 {
     uint16_t sensor_buffer_index_start = 0;
     uint16_t sensor_buffer_index_end = 0;
     bool crossed_buffer_index = false;
+    UsageClient &usage_client;
     uint16_t pressure_error_key;
-    UsageClient& usage_client;
 };
 
 }  // namespace tasks

--- a/pipettes/firmware/eeprom_keys.cpp
+++ b/pipettes/firmware/eeprom_keys.cpp
@@ -17,6 +17,12 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_sing_mult{
     .data_table = {std::make_pair(P_SM_ERROR_COUNT_KEY,
                                   usage_storage_task::error_count_usage_len)}};
 
+
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_sing_mult{
+    .data_rev = 3,
+    .data_table = {std::make_pair(OVERPRESSURE_COUNT_KEY_SM,
+                                  usage_storage_task::error_count_usage_len)}};
+
 const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch{
     .data_rev = 1,
     .data_table = {
@@ -36,6 +42,11 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_96ch{
                    std::make_pair(R_ERROR_COUNT_KEY,
                                   usage_storage_task::error_count_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_96ch{
+    .data_rev = 3,
+    .data_table = {std::make_pair(OVERPRESSURE_COUNT_KEY_96,
+                                  usage_storage_task::error_count_usage_len)}};
+
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
@@ -43,4 +54,6 @@ const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
         get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev1_96ch
                                                  : data_table_rev1_sing_mult,
         get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev2_96ch
-                                                 : data_table_rev2_sing_mult};
+                                                 : data_table_rev2_sing_mult,
+        get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev3_96ch
+                                                 : data_table_rev3_sing_mult};

--- a/pipettes/firmware/eeprom_keys.cpp
+++ b/pipettes/firmware/eeprom_keys.cpp
@@ -17,7 +17,6 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_sing_mult{
     .data_table = {std::make_pair(P_SM_ERROR_COUNT_KEY,
                                   usage_storage_task::error_count_usage_len)}};
 
-
 const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_sing_mult{
     .data_rev = 3,
     .data_table = {std::make_pair(OVERPRESSURE_COUNT_KEY_SM,

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -80,20 +80,19 @@ struct motor_hardware::UsageEEpromConfig plunger_usage_config {
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::linear_motor_distance),
             .length = usage_storage_task::distance_data_usage_len},
+            UsageRequestSet{
+                .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
+                                  ? P_96_ERROR_COUNT_KEY
+                                  : P_SM_ERROR_COUNT_KEY,
+                .type_key =
+                    uint16_t(can::ids::MotorUsageValueType::total_error_count),
+                .length = usage_storage_task::error_count_usage_len},
             UsageRequestSet {
-            .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
-                              ? P_96_ERROR_COUNT_KEY
-                              : P_SM_ERROR_COUNT_KEY,
-            .type_key =
-                uint16_t(can::ids::MotorUsageValueType::total_error_count),
-            .length = usage_storage_task::error_count_usage_len
-        },
-        UsageRequestSet {
             .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
                               ? OVERPRESSURE_COUNT_KEY_96
                               : OVERPRESSURE_COUNT_KEY_SM,
-            .type_key =
-                uint16_t(can::ids::MotorUsageValueType::overpressure_error_count),
+            .type_key = uint16_t(
+                can::ids::MotorUsageValueType::overpressure_error_count),
             .length = usage_storage_task::error_count_usage_len
         }
     }

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -74,7 +74,7 @@ auto linear_motor::get_interrupt(motor_hardware::MotorHardware& hw,
 }
 
 struct motor_hardware::UsageEEpromConfig plunger_usage_config {
-    std::array<UsageRequestSet, 2> {
+    std::array<UsageRequestSet, 3> {
         UsageRequestSet{
             .eeprom_key = PLUNGER_MOTOR_STEP_KEY,
             .type_key =
@@ -86,6 +86,14 @@ struct motor_hardware::UsageEEpromConfig plunger_usage_config {
                               : P_SM_ERROR_COUNT_KEY,
             .type_key =
                 uint16_t(can::ids::MotorUsageValueType::total_error_count),
+            .length = usage_storage_task::error_count_usage_len
+        },
+        UsageRequestSet {
+            .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
+                              ? OVERPRESSURE_COUNT_KEY_96
+                              : OVERPRESSURE_COUNT_KEY_SM,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::overpressure_error_count),
             .length = usage_storage_task::error_count_usage_len
         }
     }

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -191,7 +191,8 @@ auto initialize_motor_tasks(
                               peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware_container.primary,
                               sensor_hardware_container.secondary.value(),
-                              version_wrapper, id, eeprom_hardware_iface, tail_accessor);
+                              version_wrapper, id, eeprom_hardware_iface,
+                              tail_accessor);
 
     initialize_linear_timer(plunger_callback);
     initialize_gear_timer(gear_callback_wrapper);
@@ -218,7 +219,8 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   sensor_hardware_container.primary,
                                   sensor_hardware_container.secondary.value(),
-                                  version_wrapper, id, eeprom_hardware_iface, tail_accessor);
+                                  version_wrapper, id, eeprom_hardware_iface,
+                                  tail_accessor);
     } else {
         sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                                   peripheral_tasks::get_i2c3_client(),
@@ -226,7 +228,8 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_client(),
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   sensor_hardware_container.primary,
-                                  version_wrapper, id, eeprom_hardware_iface, tail_accessor);
+                                  version_wrapper, id, eeprom_hardware_iface,
+                                  tail_accessor);
     }
 
     initialize_linear_timer(plunger_callback);

--- a/pipettes/firmware/main.cpp
+++ b/pipettes/firmware/main.cpp
@@ -191,7 +191,7 @@ auto initialize_motor_tasks(
                               peripheral_tasks::get_i2c1_poller_client(),
                               sensor_hardware_container.primary,
                               sensor_hardware_container.secondary.value(),
-                              version_wrapper, id, eeprom_hardware_iface);
+                              version_wrapper, id, eeprom_hardware_iface, tail_accessor);
 
     initialize_linear_timer(plunger_callback);
     initialize_gear_timer(gear_callback_wrapper);
@@ -218,7 +218,7 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   sensor_hardware_container.primary,
                                   sensor_hardware_container.secondary.value(),
-                                  version_wrapper, id, eeprom_hardware_iface);
+                                  version_wrapper, id, eeprom_hardware_iface, tail_accessor);
     } else {
         sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
                                   peripheral_tasks::get_i2c3_client(),
@@ -226,7 +226,7 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_client(),
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   sensor_hardware_container.primary,
-                                  version_wrapper, id, eeprom_hardware_iface);
+                                  version_wrapper, id, eeprom_hardware_iface, tail_accessor);
     }
 
     initialize_linear_timer(plunger_callback);

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -155,13 +155,14 @@ auto initialize_motor_tasks(
     motor_hardware_task::MotorHardwareTask& lmh_tsk,
     interfaces::gear_motor::UnavailableGearHardwareTasks&) {
     if (get_pipette_type() == EIGHT_CHANNEL) {
-        sensor_tasks::start_tasks(
-            *central_tasks::get_tasks().can_writer,
-            peripheral_tasks::get_i2c3_client(),
-            peripheral_tasks::get_i2c3_poller_client(),
-            peripheral_tasks::get_i2c1_client(),
-            peripheral_tasks::get_i2c1_poller_client(), fake_sensor_hw_primary,
-            fake_sensor_hw_secondary, version_wrapper, id, sim_eeprom, tail_accessor);
+        sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
+                                  peripheral_tasks::get_i2c3_client(),
+                                  peripheral_tasks::get_i2c3_poller_client(),
+                                  peripheral_tasks::get_i2c1_client(),
+                                  peripheral_tasks::get_i2c1_poller_client(),
+                                  fake_sensor_hw_primary,
+                                  fake_sensor_hw_secondary, version_wrapper, id,
+                                  sim_eeprom, tail_accessor);
 
     } else /* single channel */ {
         sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,

--- a/pipettes/simulator/main.cpp
+++ b/pipettes/simulator/main.cpp
@@ -131,7 +131,7 @@ auto initialize_motor_tasks(
                               peripheral_tasks::get_i2c1_client(),
                               peripheral_tasks::get_i2c1_poller_client(),
                               fake_sensor_hw_primary, fake_sensor_hw_secondary,
-                              version_wrapper, id, sim_eeprom);
+                              version_wrapper, id, sim_eeprom, tail_accessor);
 
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,
@@ -161,7 +161,7 @@ auto initialize_motor_tasks(
             peripheral_tasks::get_i2c3_poller_client(),
             peripheral_tasks::get_i2c1_client(),
             peripheral_tasks::get_i2c1_poller_client(), fake_sensor_hw_primary,
-            fake_sensor_hw_secondary, version_wrapper, id, sim_eeprom);
+            fake_sensor_hw_secondary, version_wrapper, id, sim_eeprom, tail_accessor);
 
     } else /* single channel */ {
         sensor_tasks::start_tasks(*central_tasks::get_tasks().can_writer,
@@ -170,7 +170,7 @@ auto initialize_motor_tasks(
                                   peripheral_tasks::get_i2c1_client(),
                                   peripheral_tasks::get_i2c1_poller_client(),
                                   fake_sensor_hw_primary, version_wrapper, id,
-                                  sim_eeprom);
+                                  sim_eeprom, tail_accessor);
     }
     linear_motor_tasks::start_tasks(
         *central_tasks::get_tasks().can_writer, linear_motion_control,

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -70,7 +70,8 @@ SCENARIO("Testing the pressure sensor driver") {
     poller.set_queue(&i2c_poll_queue);
     auto muc = MockUsageClient();
     sensors::tasks::MMR920 driver(writer, poller, queue_client, pressure_queue,
-                                  hardware, sensor_id, &sensor_buffer, muc, overpressure_eeprom_key);
+                                  hardware, sensor_id, &sensor_buffer, muc,
+                                  overpressure_eeprom_key);
 
     can::message_writer_task::TaskMessage empty_can_msg{};
 

--- a/sensors/tests/test_pressure_driver.cpp
+++ b/sensors/tests/test_pressure_driver.cpp
@@ -35,10 +35,17 @@ auto get_message(Queue& q) -> Message {
     q.try_read(&empty_msg);
     return std::get<Message>(empty_msg);
 }
-
+struct MockUsageClient {
+    std::deque<usage_storage_task::TaskMessage> queue{};
+    auto send_usage_storage_queue(const usage_storage_task::TaskMessage& m)
+        -> void {
+        queue.push_back(m);
+    }
+};
 constexpr auto sensor_id = can::ids::SensorId::S0;
 constexpr uint8_t sensor_id_int = 0x0;
 static std::array<float, SENSOR_BUFFER_SIZE> sensor_buffer;
+constexpr uint16_t overpressure_eeprom_key = 123;
 
 SCENARIO("Testing the pressure sensor driver") {
     test_mocks::MockMessageQueue<i2c::writer::TaskMessage> i2c_queue{};
@@ -61,8 +68,9 @@ SCENARIO("Testing the pressure sensor driver") {
     queue_client.set_queue(&can_queue);
     writer.set_queue(&i2c_queue);
     poller.set_queue(&i2c_poll_queue);
+    auto muc = MockUsageClient();
     sensors::tasks::MMR920 driver(writer, poller, queue_client, pressure_queue,
-                                  hardware, sensor_id, &sensor_buffer);
+                                  hardware, sensor_id, &sensor_buffer, muc, overpressure_eeprom_key);
 
     can::message_writer_task::TaskMessage empty_can_msg{};
 

--- a/sensors/tests/test_pressure_sensor.cpp
+++ b/sensors/tests/test_pressure_sensor.cpp
@@ -68,8 +68,9 @@ SCENARIO("Receiving messages through the pressure sensor message handler") {
     poller.set_queue(&i2c_poll_queue);
     auto muc = MockUsageClient();
     auto sensor = sensors::tasks::PressureMessageHandler{
-        writer,  poller,    queue_client,  response_queue,
-        mock_hw, sensor_id, &sensor_buffer, muc, overpressure_eeprom_key};
+        writer,         poller,  queue_client,
+        response_queue, mock_hw, sensor_id,
+        &sensor_buffer, muc,     overpressure_eeprom_key};
 
     GIVEN("A TransactionResponse message") {
         can_queue.reset();


### PR DESCRIPTION
Store lifetime overpressures in the eeprom, this will now report out when a GetMotorUsageRequest is sent to the plunger node.