### PR TITLE
feat(eeprom): Add resin-tip dispense tracking

### DIFF
--- a/head/core/can_task.cpp
+++ b/head/core/can_task.cpp
@@ -44,7 +44,8 @@ using MotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::SetMotionConstraints, can::messages::ReadLimitSwitchRequest,
     can::messages::MotorPositionRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
-    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest,
+    can::messages::IncreaseEvoDispenseRequest>;
 using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::system::SystemMessageHandler<
         head_tasks::HeadQueueClient>,

--- a/include/bootloader/core/ids.h
+++ b/include/bootloader/core/ids.h
@@ -105,6 +105,7 @@ typedef enum {
     can_messageid_gear_read_motor_driver_request = 0x507,
     can_messageid_max_sensor_value_request = 0x70,
     can_messageid_max_sensor_value_response = 0x71,
+    can_messageid_increase_evo_disp_count_request = 0x80,
     can_messageid_batch_read_sensor_response = 0x81,
     can_messageid_read_sensor_request = 0x82,
     can_messageid_write_sensor_request = 0x83,
@@ -277,5 +278,6 @@ typedef enum {
     can_motorusagevaluetype_force_application_time = 0x3,
     can_motorusagevaluetype_total_error_count = 0x4,
     can_motorusagevaluetype_overpressure_error_count = 0x5,
+    can_motorusagevaluetype_resin_tip_dispense_count = 0x6,
 } CANMotorUsageValueType;
 

--- a/include/can/core/ids.hpp
+++ b/include/can/core/ids.hpp
@@ -107,6 +107,7 @@ enum class MessageId {
     gear_read_motor_driver_request = 0x507,
     max_sensor_value_request = 0x70,
     max_sensor_value_response = 0x71,
+    increase_evo_disp_count_request = 0x80,
     batch_read_sensor_response = 0x81,
     read_sensor_request = 0x82,
     write_sensor_request = 0x83,
@@ -278,6 +279,7 @@ enum class MotorUsageValueType {
     force_application_time = 0x3,
     total_error_count = 0x4,
     overpressure_error_count = 0x5,
+    resin_tip_dispense_count = 0x6,
 };
 
 }  // namespace can::ids

--- a/include/can/core/message_handlers/motion.hpp
+++ b/include/can/core/message_handlers/motion.hpp
@@ -18,7 +18,7 @@ class MotionHandler {
                      GetMotionConstraintsRequest, SetMotionConstraints,
                      ReadLimitSwitchRequest, MotorPositionRequest,
                      UpdateMotorPositionEstimationRequest, GetMotorUsageRequest,
-                     MotorStatusRequest>;
+                     MotorStatusRequest, IncreaseEvoDispenseRequest>;
 
     MotionHandler(MotionTaskClient &motion_client)
         : motion_client{motion_client} {}

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -226,7 +226,8 @@ using ReadLimitSwitchRequest = Empty<MessageId::limit_sw_request>;
 
 using MotorPositionRequest = Empty<MessageId::motor_position_request>;
 
-using IncreaseEvoDispenseRequest = Empty<MessageId::increase_evo_disp_count_request>;
+using IncreaseEvoDispenseRequest =
+    Empty<MessageId::increase_evo_disp_count_request>;
 
 using UpdateMotorPositionEstimationRequest =
     Empty<MessageId::update_motor_position_estimation_request>;

--- a/include/can/core/messages.hpp
+++ b/include/can/core/messages.hpp
@@ -226,6 +226,8 @@ using ReadLimitSwitchRequest = Empty<MessageId::limit_sw_request>;
 
 using MotorPositionRequest = Empty<MessageId::motor_position_request>;
 
+using IncreaseEvoDispenseRequest = Empty<MessageId::increase_evo_disp_count_request>;
+
 using UpdateMotorPositionEstimationRequest =
     Empty<MessageId::update_motor_position_estimation_request>;
 

--- a/include/gantry/core/can_task.hpp
+++ b/include/gantry/core/can_task.hpp
@@ -37,7 +37,8 @@ using MotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::SetMotionConstraints, can::messages::ReadLimitSwitchRequest,
     can::messages::MotorPositionRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
-    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest, can::messages::IncreaseEvoDispenseRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest,
+    can::messages::IncreaseEvoDispenseRequest>;
 using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::system::SystemMessageHandler<
         gantry::queues::QueueClient>,

--- a/include/gantry/core/can_task.hpp
+++ b/include/gantry/core/can_task.hpp
@@ -37,7 +37,7 @@ using MotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::SetMotionConstraints, can::messages::ReadLimitSwitchRequest,
     can::messages::MotorPositionRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
-    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest, can::messages::IncreaseEvoDispenseRequest>;
 using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::system::SystemMessageHandler<
         gantry::queues::QueueClient>,

--- a/include/gripper/core/can_task.hpp
+++ b/include/gripper/core/can_task.hpp
@@ -43,7 +43,8 @@ using MotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::SetMotionConstraints, can::messages::ReadLimitSwitchRequest,
     can::messages::MotorPositionRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
-    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest,
+    can::messages::IncreaseEvoDispenseRequest>;
 using SystemDispatchTarget = can::dispatch::DispatchParseTarget<
     can::message_handlers::system::SystemMessageHandler<
         gripper_tasks::QueueClient>,

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -16,7 +16,7 @@ using MotionControlTaskMessage = std::variant<
     can::messages::HomeRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
     can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest,
-    can::messages::AddSensorMoveRequest>;
+    can::messages::AddSensorMoveRequest, can::messages::IncreaseEvoDispenseRequest>;
 
 using MoveGroupTaskMessage =
     std::variant<std::monostate, can::messages::AddLinearMoveRequest,

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -35,7 +35,8 @@ using MotionControlTaskMessage = std::variant<
     can::messages::MotorPositionRequest, can::messages::ReadLimitSwitchRequest,
     can::messages::HomeRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
-    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest,
+    can::messages::IncreaseEvoDispenseRequest>;
 
 using MoveGroupTaskMessage =
     std::variant<std::monostate, can::messages::AddLinearMoveRequest,

--- a/include/motor-control/core/tasks/messages.hpp
+++ b/include/motor-control/core/tasks/messages.hpp
@@ -16,7 +16,8 @@ using MotionControlTaskMessage = std::variant<
     can::messages::HomeRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
     can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest,
-    can::messages::AddSensorMoveRequest, can::messages::IncreaseEvoDispenseRequest>;
+    can::messages::AddSensorMoveRequest,
+    can::messages::IncreaseEvoDispenseRequest>;
 
 using MoveGroupTaskMessage =
     std::variant<std::monostate, can::messages::AddLinearMoveRequest,

--- a/include/motor-control/core/tasks/motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/motion_controller_task.hpp
@@ -147,8 +147,6 @@ class MotionControllerMessageHandler {
                                     can::messages::ack_from_request(m));
     }
 
-
-
     void handle(const can::messages::HomeRequest& m) {
         LOG("Motion Controller Received home request: velocity=%d, "
             "groupid=%d, seqid=%d\n",

--- a/include/motor-control/core/tasks/motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/motion_controller_task.hpp
@@ -135,10 +135,8 @@ class MotionControllerMessageHandler {
             controller.move(m);
         }
     }
-
+#endif
     void handle(const can::messages::IncreaseEvoDispenseRequest& m) {
-        // We should never have a key = 0 if we're in this define but just in
-        // case
         if (evo_disp_count_key == 0) {
             return;
         }
@@ -149,7 +147,7 @@ class MotionControllerMessageHandler {
                                     can::messages::ack_from_request(m));
     }
 
-#endif
+
 
     void handle(const can::messages::HomeRequest& m) {
         LOG("Motion Controller Received home request: velocity=%d, "

--- a/include/motor-control/core/tasks/motion_controller_task.hpp
+++ b/include/motor-control/core/tasks/motion_controller_task.hpp
@@ -137,8 +137,11 @@ class MotionControllerMessageHandler {
     }
 
     void handle(const can::messages::IncreaseEvoDispenseRequest& m) {
-        // We should never have a key = 0 if we're in this define but just in case
-        if (evo_disp_count_key == 0) { return; }
+        // We should never have a key = 0 if we're in this define but just in
+        // case
+        if (evo_disp_count_key == 0) {
+            return;
+        }
         auto message =
             usage_messages::IncreaseErrorCount{.key = evo_disp_count_key};
         usage_client.send_usage_storage_queue(message);
@@ -225,8 +228,10 @@ class MotionControllerTask {
   public:
     using Messages = TaskMessage;
     using QueueType = QueueImpl<TaskMessage>;
-    MotionControllerTask(QueueType& queue, uint16_t evo_disp_count_key) : queue{queue}, evo_disp_count_key{evo_disp_count_key} {}
-    MotionControllerTask(QueueType& queue) : queue{queue},  evo_disp_count_key{0} {}
+    MotionControllerTask(QueueType& queue, uint16_t evo_disp_count_key)
+        : queue{queue}, evo_disp_count_key{evo_disp_count_key} {}
+    MotionControllerTask(QueueType& queue)
+        : queue{queue}, evo_disp_count_key{0} {}
     MotionControllerTask(const MotionControllerTask& c) = delete;
     MotionControllerTask(const MotionControllerTask&& c) = delete;
     auto operator=(const MotionControllerTask& c) = delete;
@@ -242,8 +247,8 @@ class MotionControllerTask {
     [[noreturn]] void operator()(
         motion_controller::MotionController<MEConfig>* controller,
         CanClient* can_client, UsageClient* usage_client) {
-        auto handler = MotionControllerMessageHandler{*controller, *can_client,
-                                                      *usage_client, evo_disp_count_key};
+        auto handler = MotionControllerMessageHandler{
+            *controller, *can_client, *usage_client, evo_disp_count_key};
         TaskMessage message{};
         bool first_run = true;
         for (;;) {

--- a/include/pipettes/core/dispatch_builder.hpp
+++ b/include/pipettes/core/dispatch_builder.hpp
@@ -76,7 +76,8 @@ using MotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     can::messages::SetMotionConstraints, can::messages::ReadLimitSwitchRequest,
     can::messages::MotorPositionRequest,
     can::messages::UpdateMotorPositionEstimationRequest,
-    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest>;
+    can::messages::GetMotorUsageRequest, can::messages::MotorStatusRequest,
+    can::messages::IncreaseEvoDispenseRequest>;
 
 using GearMotionControllerDispatchTarget = can::dispatch::DispatchParseTarget<
     gear_motion_handler::GearMotorMotionHandler<gear_motor_tasks::QueueClient>,

--- a/include/pipettes/firmware/eeprom_keys.hpp
+++ b/include/pipettes/firmware/eeprom_keys.hpp
@@ -6,7 +6,7 @@ static constexpr uint16_t PLUNGER_MOTOR_STEP_KEY = 0;
 
 static constexpr uint16_t P_SM_ERROR_COUNT_KEY = 1;
 static constexpr uint16_t OVERPRESSURE_COUNT_KEY_SM = 2;
-static constexpr uint16_t EVOTIP_DISPENSEC_COUNT_KEY_SM = 3;
+static constexpr uint16_t EVOTIP_DISPENSE_COUNT_KEY_SM = 3;
 
 static constexpr uint16_t GEAR_LEFT_MOTOR_KEY = 1;
 static constexpr uint16_t GEAR_RIGHT_MOTOR_KEY = 2;
@@ -14,7 +14,7 @@ static constexpr uint16_t P_96_ERROR_COUNT_KEY = 3;
 static constexpr uint16_t L_ERROR_COUNT_KEY = 4;
 static constexpr uint16_t R_ERROR_COUNT_KEY = 5;
 static constexpr uint16_t OVERPRESSURE_COUNT_KEY_96 = 6;
-static constexpr uint16_t EVOTIP_DISPENSEC_COUNT_KEY_96 = 7;
+static constexpr uint16_t EVOTIP_DISPENSE_COUNT_KEY_96 = 7;
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev1_sing_mult;

--- a/include/pipettes/firmware/eeprom_keys.hpp
+++ b/include/pipettes/firmware/eeprom_keys.hpp
@@ -6,6 +6,7 @@ static constexpr uint16_t PLUNGER_MOTOR_STEP_KEY = 0;
 
 static constexpr uint16_t P_SM_ERROR_COUNT_KEY = 1;
 static constexpr uint16_t OVERPRESSURE_COUNT_KEY_SM = 2;
+static constexpr uint16_t EVOTIP_DISPENSEC_COUNT_KEY_SM = 3;
 
 static constexpr uint16_t GEAR_LEFT_MOTOR_KEY = 1;
 static constexpr uint16_t GEAR_RIGHT_MOTOR_KEY = 2;
@@ -13,6 +14,7 @@ static constexpr uint16_t P_96_ERROR_COUNT_KEY = 3;
 static constexpr uint16_t L_ERROR_COUNT_KEY = 4;
 static constexpr uint16_t R_ERROR_COUNT_KEY = 5;
 static constexpr uint16_t OVERPRESSURE_COUNT_KEY_96 = 6;
+static constexpr uint16_t EVOTIP_DISPENSEC_COUNT_KEY_96 = 7;
 
 extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev1_sing_mult;
@@ -20,9 +22,12 @@ extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev2_sing_mult;
 extern const eeprom::data_rev_task::DataTableUpdateMessage
     data_table_rev3_sing_mult;
+extern const eeprom::data_rev_task::DataTableUpdateMessage
+    data_table_rev4_sing_mult;
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch;
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev2_96ch;
 extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_96ch;
+extern const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev4_96ch;
 
 extern const std::vector<eeprom::data_rev_task::DataTableUpdateMessage>
     table_updater;

--- a/pipettes/core/linear_motor_tasks.cpp
+++ b/pipettes/core/linear_motor_tasks.cpp
@@ -1,9 +1,9 @@
 #include "pipettes/core/linear_motor_tasks.hpp"
 
 #include "common/core/freertos_task.hpp"
+#include "pipettes/core/pipette_type.h"
 #include "pipettes/core/sensor_tasks.hpp"
 #include "pipettes/firmware/eeprom_keys.hpp"
-#include "pipettes/core/pipette_type.h"
 
 static auto motion_tasks = linear_motor_tasks::Tasks{};
 static auto motion_queue_client = linear_motor_tasks::QueueClient{};
@@ -16,11 +16,10 @@ static auto tmc2160_tasks = linear_motor_tasks::tmc2160_driver::Tasks{};
 static auto tmc2160_queue_client =
     linear_motor_tasks::tmc2160_driver::QueueClient{};
 
-static auto mc_task_builder =
-    freertos_task::TaskStarter<256,
-                               motion_controller_task::MotionControllerTask, uint16_t>{get_pipette_type() == NINETY_SIX_CHANNEL
-                                    ? OVERPRESSURE_COUNT_KEY_96
-                                    : OVERPRESSURE_COUNT_KEY_SM};
+static auto mc_task_builder = freertos_task::TaskStarter<
+    256, motion_controller_task::MotionControllerTask, uint16_t>{
+    get_pipette_type() == NINETY_SIX_CHANNEL ? OVERPRESSURE_COUNT_KEY_96
+                                             : OVERPRESSURE_COUNT_KEY_SM};
 static auto tmc2130_driver_task_builder =
     freertos_task::TaskStarter<256, tmc2130::tasks::MotorDriverTask>{};
 static auto tmc2160_driver_task_builder =

--- a/pipettes/core/linear_motor_tasks.cpp
+++ b/pipettes/core/linear_motor_tasks.cpp
@@ -3,6 +3,7 @@
 #include "common/core/freertos_task.hpp"
 #include "pipettes/core/sensor_tasks.hpp"
 #include "pipettes/firmware/eeprom_keys.hpp"
+#include "pipettes/core/pipette_type.h"
 
 static auto motion_tasks = linear_motor_tasks::Tasks{};
 static auto motion_queue_client = linear_motor_tasks::QueueClient{};
@@ -17,7 +18,9 @@ static auto tmc2160_queue_client =
 
 static auto mc_task_builder =
     freertos_task::TaskStarter<256,
-                               motion_controller_task::MotionControllerTask>{};
+                               motion_controller_task::MotionControllerTask, uint16_t>{get_pipette_type() == NINETY_SIX_CHANNEL
+                                    ? OVERPRESSURE_COUNT_KEY_96
+                                    : OVERPRESSURE_COUNT_KEY_SM};
 static auto tmc2130_driver_task_builder =
     freertos_task::TaskStarter<256, tmc2130::tasks::MotorDriverTask>{};
 static auto tmc2160_driver_task_builder =

--- a/pipettes/core/linear_motor_tasks.cpp
+++ b/pipettes/core/linear_motor_tasks.cpp
@@ -18,8 +18,8 @@ static auto tmc2160_queue_client =
 
 static auto mc_task_builder = freertos_task::TaskStarter<
     256, motion_controller_task::MotionControllerTask, uint16_t>{
-    get_pipette_type() == NINETY_SIX_CHANNEL ? OVERPRESSURE_COUNT_KEY_96
-                                             : OVERPRESSURE_COUNT_KEY_SM};
+    get_pipette_type() == NINETY_SIX_CHANNEL ? EVOTIP_DISPENSE_COUNT_KEY_96
+                                             : EVOTIP_DISPENSE_COUNT_KEY_SM};
 static auto tmc2130_driver_task_builder =
     freertos_task::TaskStarter<256, tmc2130::tasks::MotorDriverTask>{};
 static auto tmc2160_driver_task_builder =

--- a/pipettes/firmware/eeprom_keys.cpp
+++ b/pipettes/firmware/eeprom_keys.cpp
@@ -22,6 +22,11 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_sing_mult{
     .data_table = {std::make_pair(OVERPRESSURE_COUNT_KEY_SM,
                                   usage_storage_task::error_count_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev4_sing_mult{
+    .data_rev = 4,
+    .data_table = {std::make_pair(EVOTIP_DISPENSEC_COUNT_KEY_SM,
+                                  usage_storage_task::error_count_usage_len)}};
+
 const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch{
     .data_rev = 1,
     .data_table = {
@@ -46,6 +51,11 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_96ch{
     .data_table = {std::make_pair(OVERPRESSURE_COUNT_KEY_96,
                                   usage_storage_task::error_count_usage_len)}};
 
+const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev4_96ch{
+    .data_rev = 4,
+    .data_table = {std::make_pair(EVOTIP_DISPENSEC_COUNT_KEY_96,
+                                  usage_storage_task::error_count_usage_len)}};
+
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
     {
         // anytime there is an update to the data table add a message to this
@@ -55,4 +65,6 @@ const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =
         get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev2_96ch
                                                  : data_table_rev2_sing_mult,
         get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev3_96ch
-                                                 : data_table_rev3_sing_mult};
+                                                 : data_table_rev3_sing_mult,
+        get_pipette_type() == NINETY_SIX_CHANNEL ? data_table_rev4_96ch
+                                                 : data_table_rev4_sing_mult};

--- a/pipettes/firmware/eeprom_keys.cpp
+++ b/pipettes/firmware/eeprom_keys.cpp
@@ -24,7 +24,7 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_sing_mult{
 
 const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev4_sing_mult{
     .data_rev = 4,
-    .data_table = {std::make_pair(EVOTIP_DISPENSEC_COUNT_KEY_SM,
+    .data_table = {std::make_pair(EVOTIP_DISPENSE_COUNT_KEY_SM,
                                   usage_storage_task::error_count_usage_len)}};
 
 const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev1_96ch{
@@ -53,7 +53,7 @@ const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev3_96ch{
 
 const eeprom::data_rev_task::DataTableUpdateMessage data_table_rev4_96ch{
     .data_rev = 4,
-    .data_table = {std::make_pair(EVOTIP_DISPENSEC_COUNT_KEY_96,
+    .data_table = {std::make_pair(EVOTIP_DISPENSE_COUNT_KEY_96,
                                   usage_storage_task::error_count_usage_len)}};
 
 const std::vector<eeprom::data_rev_task::DataTableUpdateMessage> table_updater =

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -74,7 +74,7 @@ auto linear_motor::get_interrupt(motor_hardware::MotorHardware& hw,
 }
 
 struct motor_hardware::UsageEEpromConfig plunger_usage_config {
-    std::array<UsageRequestSet, 3> {
+    std::array<UsageRequestSet, 4> {
         UsageRequestSet{
             .eeprom_key = PLUNGER_MOTOR_STEP_KEY,
             .type_key =
@@ -93,6 +93,14 @@ struct motor_hardware::UsageEEpromConfig plunger_usage_config {
                               : OVERPRESSURE_COUNT_KEY_SM,
             .type_key = uint16_t(
                 can::ids::MotorUsageValueType::overpressure_error_count),
+            .length = usage_storage_task::error_count_usage_len
+        },
+        UsageRequestSet {
+            .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
+                              ? EVOTIP_DISPENSEC_COUNT_KEY_96
+                              : EVOTIP_DISPENSEC_COUNT_KEY_SM,
+            .type_key =
+                uint16_t(can::ids::MotorUsageValueType::resin_tip_dispense_count),
             .length = usage_storage_task::error_count_usage_len
         }
     }

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -96,8 +96,8 @@ struct motor_hardware::UsageEEpromConfig plunger_usage_config {
                 .length = usage_storage_task::error_count_usage_len},
             UsageRequestSet {
             .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
-                              ? EVOTIP_DISPENSEC_COUNT_KEY_96
-                              : EVOTIP_DISPENSEC_COUNT_KEY_SM,
+                              ? EVOTIP_DISPENSE_COUNT_KEY_96
+                              : EVOTIP_DISPENSE_COUNT_KEY_SM,
             .type_key = uint16_t(
                 can::ids::MotorUsageValueType::resin_tip_dispense_count),
             .length = usage_storage_task::error_count_usage_len

--- a/pipettes/firmware/interfaces.cpp
+++ b/pipettes/firmware/interfaces.cpp
@@ -87,20 +87,19 @@ struct motor_hardware::UsageEEpromConfig plunger_usage_config {
                 .type_key =
                     uint16_t(can::ids::MotorUsageValueType::total_error_count),
                 .length = usage_storage_task::error_count_usage_len},
+            UsageRequestSet{
+                .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
+                                  ? OVERPRESSURE_COUNT_KEY_96
+                                  : OVERPRESSURE_COUNT_KEY_SM,
+                .type_key = uint16_t(
+                    can::ids::MotorUsageValueType::overpressure_error_count),
+                .length = usage_storage_task::error_count_usage_len},
             UsageRequestSet {
-            .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
-                              ? OVERPRESSURE_COUNT_KEY_96
-                              : OVERPRESSURE_COUNT_KEY_SM,
-            .type_key = uint16_t(
-                can::ids::MotorUsageValueType::overpressure_error_count),
-            .length = usage_storage_task::error_count_usage_len
-        },
-        UsageRequestSet {
             .eeprom_key = get_pipette_type() == NINETY_SIX_CHANNEL
                               ? EVOTIP_DISPENSEC_COUNT_KEY_96
                               : EVOTIP_DISPENSEC_COUNT_KEY_SM,
-            .type_key =
-                uint16_t(can::ids::MotorUsageValueType::resin_tip_dispense_count),
+            .type_key = uint16_t(
+                can::ids::MotorUsageValueType::resin_tip_dispense_count),
             .length = usage_storage_task::error_count_usage_len
         }
     }


### PR DESCRIPTION
Adds a new can message that the pipette uses to increment it's resin tip dispensing tracker in eeprom.

The new value is can be retrieved with a standard usage request.