### PR TITLE
fix: move-complete message retries

### DIFF
--- a/head/firmware/can.c
+++ b/head/firmware/can.c
@@ -17,7 +17,7 @@ HAL_StatusTypeDef MX_FDCAN1_Init(
     handle->Init.FrameFormat = FDCAN_FRAME_FD_NO_BRS;
     handle->Init.Mode = FDCAN_MODE_NORMAL;
     handle->Init.AutoRetransmission = ENABLE;
-    handle->Init.TransmitPause = DISABLE;
+    handle->Init.TransmitPause = ENABLE;
     handle->Init.ProtocolException = DISABLE;
     handle->Init.NominalPrescaler = clock_divider;
     handle->Init.NominalSyncJumpWidth = max_sync_jump_width;

--- a/include/motor-control/core/tasks/move_status_reporter_task.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task.hpp
@@ -5,11 +5,11 @@
 #include "can/core/can_writer_task.hpp"
 #include "can/core/ids.hpp"
 #include "can/core/messages.hpp"
+#include "common/core/hardware_delay.hpp"
 #include "motor-control/core/linear_motion_system.hpp"
 #include "motor-control/core/tasks/messages.hpp"
 #include "motor-control/core/tasks/usage_storage_task.hpp"
 #include "motor-control/core/utils.hpp"
-#include "common/core/hardware_delay.hpp"
 
 namespace move_status_reporter_task {
 

--- a/include/motor-control/core/tasks/move_status_reporter_task.hpp
+++ b/include/motor-control/core/tasks/move_status_reporter_task.hpp
@@ -9,6 +9,7 @@
 #include "motor-control/core/tasks/messages.hpp"
 #include "motor-control/core/tasks/usage_storage_task.hpp"
 #include "motor-control/core/utils.hpp"
+#include "common/core/hardware_delay.hpp"
 
 namespace move_status_reporter_task {
 
@@ -46,7 +47,9 @@ class MoveStatusMessageHandler {
     void handle_message(std::monostate&) {}
 
     void handle_message(const can::messages::ErrorMessage& msg) {
-        can_client.send_can_message(can::ids::NodeId::host, msg);
+        while (!can_client.send_can_message(can::ids::NodeId::host, msg)) {
+            vtask_hardware_delay(1);
+        }
     }
 
     void handle_message(const can::messages::StopRequest& msg) {
@@ -69,7 +72,9 @@ class MoveStatusMessageHandler {
             .encoder_position_um = end_position,
             .position_flags = message.position_flags,
             .ack_id = static_cast<uint8_t>(message.ack_id)};
-        can_client.send_can_message(can::ids::NodeId::host, msg);
+        while (!can_client.send_can_message(can::ids::NodeId::host, msg)) {
+            vtask_hardware_delay(1);
+        }
 
         int32_t distance_traveled_um =
             end_position - fixed_point_multiply(um_per_encoder_pulse,
@@ -90,7 +95,9 @@ class MoveStatusMessageHandler {
             .encoder_position = fixed_point_multiply(
                 um_per_encoder_pulse, message.encoder_pulses, radix_offset_0{}),
             .position_flags = message.position_flags};
-        can_client.send_can_message(can::ids::NodeId::host, msg);
+        while (!can_client.send_can_message(can::ids::NodeId::host, msg)) {
+            vtask_hardware_delay(1);
+        }
     }
 
     void handle_message(const usage_messages::IncreaseForceTimeUsage& message) {

--- a/motor-control/tests/test_move_status_handling.cpp
+++ b/motor-control/tests/test_move_status_handling.cpp
@@ -19,8 +19,9 @@ struct MockCanClient {
     std::deque<std::pair<can::ids::NodeId, can::messages::ResponseMessageType>>
         queue{};
     auto send_can_message(can::ids::NodeId node_id,
-                          const can::messages::ResponseMessageType& m) -> void {
+                          const can::messages::ResponseMessageType& m) -> bool {
         queue.push_back(std::make_pair(node_id, m));
+        return true;
     }
 };
 struct MockUsageClient {

--- a/pipettes/tests/test_gear_move_status_handling.cpp
+++ b/pipettes/tests/test_gear_move_status_handling.cpp
@@ -19,8 +19,9 @@ struct MockCanClient {
     std::deque<std::pair<can::ids::NodeId, can::messages::ResponseMessageType>>
         queue{};
     auto send_can_message(can::ids::NodeId node_id,
-                          const can::messages::ResponseMessageType& m) -> void {
+                          const can::messages::ResponseMessageType& m) -> bool {
         queue.push_back(std::make_pair(node_id, m));
+        return true;
     }
 };
 struct MockUsageClient {


### PR DESCRIPTION
A couple passes on improving (very) occasional missed move-complete messages:
- Set the can tx delay flag system wide to avoid thundering-herd message problems
- Propagate queue backpressure up to the move status reporter

## testing
- [x] put it on a robot and do a firmware update and see that it works
- [x] run the tinymoves stressor protocol and see that it works