### PR TITLE
feat(wear leveling): Boundary Setting Mechanism

### DIFF
--- a/eeprom/tests/CMakeLists.txt
+++ b/eeprom/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
         test_data_rev.cpp
         test_revision.cpp
         test_dev_data.cpp
+        test_update_data_rev_task.cpp
 )
 
 target_include_directories(eeprom PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/eeprom/tests/test_dev_data.cpp
+++ b/eeprom/tests/test_dev_data.cpp
@@ -39,7 +39,7 @@ SCENARIO("initalizing a data accessor") {
         auto data = types::EepromData{};
         // 256 byte chips have a zeroed out memory
         data.fill(0x00);
-        THEN("accessor recieves config from task") {
+        THEN("accessor receives config from task") {
             // make sure the second message is a config request
             REQUIRE(std::get_if<message::ConfigRequestMessage>(
                         &queue_client.messages[0]) != nullptr);

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -1,0 +1,44 @@
+#include <cstring>
+#include "../../include/eeprom/core/dev_data.hpp"
+
+extern "C" {
+    void vTaskDelay(const int x) {std::ignore = x;}
+    void vTaskDelete(void* x) {std::ignore = x;}
+}
+
+#include "../../include/eeprom/core/types.hpp"
+#include "../../include/eeprom/core/update_data_rev_task.hpp"
+#include "../../include/eeprom/tests/mock_eeprom_task_client.hpp"
+#include "../../stm32-tools/catch2/src/single_include/catch2/catch.hpp"
+
+using namespace eeprom;
+
+SCENARIO("Sending migrate data message") {
+    // migrate data message
+    const uint16_t data_revision = 1;
+    std::vector<std::pair<types::address, types::data_length>> data = {
+        {0, 8},
+        {1, 8},
+        {2, 8},
+    };
+
+    const data_rev_task::MigrateDataMessage mock_data_message{
+        .data_rev = data_revision,
+        .data_table = data
+    };
+
+    // Test handler
+    auto eeprom_client = MockEEPromTaskClient{};
+    auto tail_accessor = eeprom::dev_data::DevDataTailAccessor{eeprom_client};
+    auto data_rev_handler = data_rev_task::UpdateDataRevHandler{
+    eeprom_client, tail_accessor};
+
+    GIVEN("Finding boundary of old data") {
+        data_rev_handler.handle_message(mock_data_message);
+
+        THEN("address should have updated to reflect the new location") {
+            REQUIRE(addresses::ot_library_begin == addresses::data_address_begin);
+            REQUIRE(addresses::ot_library_end == 64);
+        }
+    }
+}

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -1,6 +1,9 @@
 #include <cstdint>
 #include <cstring>
-#include <tuple>
+#include <iostream>
+
+#include "eeprom/core/dev_data.hpp"
+#include "eeprom/core/hardware_iface.hpp"
 
 extern "C" {
 void vTaskDelay(const int x) { std::ignore = x; }
@@ -8,8 +11,6 @@ void vTaskDelete(void* x) { std::ignore = x; }
 }
 
 #include "catch2/catch.hpp"
-#include "eeprom/core/dev_data.hpp"
-#include "eeprom/core/hardware_iface.hpp"
 #include "eeprom/core/types.hpp"
 #include "eeprom/core/update_data_rev_task.hpp"
 
@@ -65,15 +66,12 @@ SCENARIO("Sending migrate data message") {
 
             data_rev_handler.handle_message(mock_data_message);
 
-            // The end address is set to this value because the program should
-       successfully exclude the
-            // final page of data (64 bytes)
             types::address end_address = eeprom_length - 64;
 
             THEN("address should have updated to reflect the new location") {
                 REQUIRE(addresses::DataAddressWrapper::get_ot_library_begin() ==
-                        192); // 192 to reflect the 3 pages now reserved for the
-       lookup table and header REQUIRE(
+                        192);
+                REQUIRE(
                     eeprom::addresses::DataAddressWrapper::get_ot_library_end()
        == end_address);
             }
@@ -92,5 +90,6 @@ SCENARIO("Sending migrate data message") {
             // the value
             THEN("The data address lock should hold") {
                 REQUIRE(addresses::ot_library_end == end_address);
-            }*/
+            }
+}*/
 }

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -66,12 +66,15 @@ SCENARIO("Sending migrate data message") {
 
             data_rev_handler.handle_message(mock_data_message);
 
+            // The end address is set to this value because the program should
+       successfully exclude the
+            // final page of data (64 bytes)
             types::address end_address = eeprom_length - 64;
 
             THEN("address should have updated to reflect the new location") {
                 REQUIRE(addresses::DataAddressWrapper::get_ot_library_begin() ==
-                        192);
-                REQUIRE(
+                        192); // 192 to reflect the 3 pages now reserved for the
+       lookup table and header REQUIRE(
                     eeprom::addresses::DataAddressWrapper::get_ot_library_end()
        == end_address);
             }

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -1,15 +1,15 @@
 #include <cstring>
-#include "../../include/eeprom/core/dev_data.hpp"
+#include "eeprom/core/dev_data.hpp"
 
 extern "C" {
     void vTaskDelay(const int x) {std::ignore = x;}
     void vTaskDelete(void* x) {std::ignore = x;}
 }
 
-#include "../../include/eeprom/core/types.hpp"
-#include "../../include/eeprom/core/update_data_rev_task.hpp"
-#include "../../include/eeprom/tests/mock_eeprom_task_client.hpp"
-#include "../../stm32-tools/catch2/src/single_include/catch2/catch.hpp"
+#include "eeprom/core/types.hpp"
+#include "eeprom/core/update_data_rev_task.hpp"
+#include "eeprom/tests/mock_eeprom_task_client.hpp"
+#include "catch2/catch.hpp"
 
 using namespace eeprom;
 

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -1,6 +1,6 @@
 #include <cstdint>
 #include <cstring>
-#include <iostream>
+#include <tuple>
 
 extern "C" {
 void vTaskDelay(const int x) { std::ignore = x; }

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -1,5 +1,9 @@
+#include <cstdint>
 #include <cstring>
-#include <tuple>
+#include <iostream>
+
+#include "eeprom/core/dev_data.hpp"
+#include "eeprom/core/hardware_iface.hpp"
 
 extern "C" {
 void vTaskDelay(const int x) { std::ignore = x; }
@@ -7,12 +11,36 @@ void vTaskDelete(void* x) { std::ignore = x; }
 }
 
 #include "catch2/catch.hpp"
-#include "eeprom/core/dev_data.hpp"
 #include "eeprom/core/types.hpp"
 #include "eeprom/core/update_data_rev_task.hpp"
-#include "eeprom/tests/mock_eeprom_task_client.hpp"
 
 using namespace eeprom;
+
+struct MockEEPromTaskClient {
+    void send_eeprom_queue(const task::TaskMessage& m) {
+        messages.push_back(m);
+
+        if (auto* config_message =
+                std::get_if<eeprom::message::ConfigRequestMessage>(&m)) {
+            const eeprom::message::ConfigRequestCallback& callback =
+                config_message->callback;
+            void* callback_param = config_message->callback_param;
+
+            eeprom::message::ConfigResponseMessage response =
+                eeprom::message::ConfigResponseMessage{};
+
+            response.chip =
+                eeprom::hardware_iface::EEPromChipType::ST_M24128_DR;
+            response.addr_bytes = sizeof(uint8_t);
+            response.mem_size = static_cast<types::address>(
+                hardware_iface::EEpromMemorySize::ST_16_KBYTE);
+            response.default_byte_value = 0xFF;
+
+            callback(response, callback_param);
+        }
+    }
+    std::vector<task::TaskMessage> messages{};
+};
 
 SCENARIO("Sending migrate data message") {
     // migrate data message
@@ -33,16 +61,20 @@ SCENARIO("Sending migrate data message") {
         data_rev_task::UpdateDataRevHandler{eeprom_client, tail_accessor};
 
     GIVEN("Finding boundary of old data") {
+        types::address eeprom_length = static_cast<types::address>(
+            hardware_iface::EEpromMemorySize::ST_16_KBYTE);
+
         data_rev_handler.handle_message(mock_data_message);
 
-        THEN("address should have updated to reflect the new location") {
-            REQUIRE(addresses::ot_library_begin ==
-                    addresses::data_address_begin);
-            REQUIRE(addresses::ot_library_end == 64);
-        }
+        types::address end_address = eeprom_length - 64;
 
-        const std::optional<types::address> end_address =
-            addresses::ot_library_end;
+        THEN("address should have updated to reflect the new location") {
+            REQUIRE(addresses::DataAddressWrapper::get_ot_library_begin() ==
+                    192);
+            REQUIRE(
+                eeprom::addresses::DataAddressWrapper::get_ot_library_end() ==
+                end_address);
+        }
 
         const std::vector<std::pair<types::address, types::data_length>>
             additional = {{4, 8}, {5, 8}, {6, 8}, {7, 8}, {8, 8}, {9, 8}};

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -40,5 +40,31 @@ SCENARIO("Sending migrate data message") {
             REQUIRE(addresses::ot_library_begin == addresses::data_address_begin);
             REQUIRE(addresses::ot_library_end == 64);
         }
-    }
+
+        const std::optional<types::address> end_address = addresses::ot_library_end;
+
+        const std::vector<std::pair<types::address, types::data_length>>  additional= {
+            {4, 8},
+            {5, 8},
+            {6, 8},
+            {7, 8},
+            {8, 8},
+            {9, 8}
+        };
+
+        data.insert(data.end(), additional.begin(), additional.end());
+
+        const data_rev_task::MigrateDataMessage dummy_data_message{
+        .data_rev = data_revision+1,
+        .data_table = data
+        };
+
+        data_rev_handler.handle_message(dummy_data_message);
+
+        // The lock should hold, the value embedded within shouldn't change
+        // the value
+        THEN("The data address lock should hold") {
+            REQUIRE(addresses::ot_library_end == end_address);
+        }
+   }
 }

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -1,15 +1,16 @@
 #include <cstring>
-#include "eeprom/core/dev_data.hpp"
+#include <tuple>
 
 extern "C" {
-    void vTaskDelay(const int x) {std::ignore = x;}
-    void vTaskDelete(void* x) {std::ignore = x;}
+void vTaskDelay(const int x) { std::ignore = x; }
+void vTaskDelete(void* x) { std::ignore = x; }
 }
 
+#include "catch2/catch.hpp"
+#include "eeprom/core/dev_data.hpp"
 #include "eeprom/core/types.hpp"
 #include "eeprom/core/update_data_rev_task.hpp"
 #include "eeprom/tests/mock_eeprom_task_client.hpp"
-#include "catch2/catch.hpp"
 
 using namespace eeprom;
 
@@ -23,41 +24,33 @@ SCENARIO("Sending migrate data message") {
     };
 
     const data_rev_task::MigrateDataMessage mock_data_message{
-        .data_rev = data_revision,
-        .data_table = data
-    };
+        .data_rev = data_revision, .data_table = data};
 
     // Test handler
     auto eeprom_client = MockEEPromTaskClient{};
     auto tail_accessor = eeprom::dev_data::DevDataTailAccessor{eeprom_client};
-    auto data_rev_handler = data_rev_task::UpdateDataRevHandler{
-    eeprom_client, tail_accessor};
+    auto data_rev_handler =
+        data_rev_task::UpdateDataRevHandler{eeprom_client, tail_accessor};
 
     GIVEN("Finding boundary of old data") {
         data_rev_handler.handle_message(mock_data_message);
 
         THEN("address should have updated to reflect the new location") {
-            REQUIRE(addresses::ot_library_begin == addresses::data_address_begin);
+            REQUIRE(addresses::ot_library_begin ==
+                    addresses::data_address_begin);
             REQUIRE(addresses::ot_library_end == 64);
         }
 
-        const std::optional<types::address> end_address = addresses::ot_library_end;
+        const std::optional<types::address> end_address =
+            addresses::ot_library_end;
 
-        const std::vector<std::pair<types::address, types::data_length>>  additional= {
-            {4, 8},
-            {5, 8},
-            {6, 8},
-            {7, 8},
-            {8, 8},
-            {9, 8}
-        };
+        const std::vector<std::pair<types::address, types::data_length>>
+            additional = {{4, 8}, {5, 8}, {6, 8}, {7, 8}, {8, 8}, {9, 8}};
 
         data.insert(data.end(), additional.begin(), additional.end());
 
         const data_rev_task::MigrateDataMessage dummy_data_message{
-        .data_rev = data_revision+1,
-        .data_table = data
-        };
+            .data_rev = data_revision + 1, .data_table = data};
 
         data_rev_handler.handle_message(dummy_data_message);
 
@@ -66,5 +59,5 @@ SCENARIO("Sending migrate data message") {
         THEN("The data address lock should hold") {
             REQUIRE(addresses::ot_library_end == end_address);
         }
-   }
+    }
 }

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -2,15 +2,14 @@
 #include <cstring>
 #include <iostream>
 
-#include "eeprom/core/dev_data.hpp"
-#include "eeprom/core/hardware_iface.hpp"
-
 extern "C" {
 void vTaskDelay(const int x) { std::ignore = x; }
 void vTaskDelete(void* x) { std::ignore = x; }
 }
 
 #include "catch2/catch.hpp"
+#include "eeprom/core/dev_data.hpp"
+#include "eeprom/core/hardware_iface.hpp"
 #include "eeprom/core/types.hpp"
 #include "eeprom/core/update_data_rev_task.hpp"
 
@@ -94,5 +93,4 @@ SCENARIO("Sending migrate data message") {
             THEN("The data address lock should hold") {
                 REQUIRE(addresses::ot_library_end == end_address);
             }*/
-}
 }

--- a/eeprom/tests/test_update_data_rev_task.cpp
+++ b/eeprom/tests/test_update_data_rev_task.cpp
@@ -59,37 +59,37 @@ SCENARIO("Sending migrate data message") {
     auto tail_accessor = eeprom::dev_data::DevDataTailAccessor{eeprom_client};
     auto data_rev_handler =
         data_rev_task::UpdateDataRevHandler{eeprom_client, tail_accessor};
+    /* IF BOUNDARY SETTING IS EVER REACTIVATED, UNCOMMENT
+        GIVEN("Finding boundary of old data") {
+            types::address eeprom_length = static_cast<types::address>(
+                hardware_iface::EEpromMemorySize::ST_16_KBYTE);
 
-    GIVEN("Finding boundary of old data") {
-        types::address eeprom_length = static_cast<types::address>(
-            hardware_iface::EEpromMemorySize::ST_16_KBYTE);
+            data_rev_handler.handle_message(mock_data_message);
 
-        data_rev_handler.handle_message(mock_data_message);
+            types::address end_address = eeprom_length - 64;
 
-        types::address end_address = eeprom_length - 64;
+            THEN("address should have updated to reflect the new location") {
+                REQUIRE(addresses::DataAddressWrapper::get_ot_library_begin() ==
+                        192);
+                REQUIRE(
+                    eeprom::addresses::DataAddressWrapper::get_ot_library_end()
+       == end_address);
+            }
 
-        THEN("address should have updated to reflect the new location") {
-            REQUIRE(addresses::DataAddressWrapper::get_ot_library_begin() ==
-                    192);
-            REQUIRE(
-                eeprom::addresses::DataAddressWrapper::get_ot_library_end() ==
-                end_address);
-        }
+            const std::vector<std::pair<types::address, types::data_length>>
+                additional = {{4, 8}, {5, 8}, {6, 8}, {7, 8}, {8, 8}, {9, 8}};
 
-        const std::vector<std::pair<types::address, types::data_length>>
-            additional = {{4, 8}, {5, 8}, {6, 8}, {7, 8}, {8, 8}, {9, 8}};
+            data.insert(data.end(), additional.begin(), additional.end());
 
-        data.insert(data.end(), additional.begin(), additional.end());
+            const data_rev_task::MigrateDataMessage dummy_data_message{
+                .data_rev = data_revision + 1, .data_table = data};
 
-        const data_rev_task::MigrateDataMessage dummy_data_message{
-            .data_rev = data_revision + 1, .data_table = data};
+            data_rev_handler.handle_message(dummy_data_message);
 
-        data_rev_handler.handle_message(dummy_data_message);
-
-        // The lock should hold, the value embedded within shouldn't change
-        // the value
-        THEN("The data address lock should hold") {
-            REQUIRE(addresses::ot_library_end == end_address);
-        }
-    }
+            // The lock should hold, the value embedded within shouldn't change
+            // the value
+            THEN("The data address lock should hold") {
+                REQUIRE(addresses::ot_library_end == end_address);
+            }*/
+}
 }

--- a/include/common/core/message_utils.hpp
+++ b/include/common/core/message_utils.hpp
@@ -73,4 +73,4 @@ struct VariantCat<std::variant<VariantAContents...>,
     using type = std::variant<VariantAContents..., VariantBContents...>;
 };
 
-};  // namespace utils
+}  // namespace utils

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -1,9 +1,10 @@
 #pragma once
+#include <iostream>
 
-#include "types.hpp"
-#include "messages.hpp"
 #include "common/core/bit_utils.hpp"
+#include "messages.hpp"
 #include "task.hpp"
+#include "types.hpp"
 
 namespace eeprom {
 namespace addresses {
@@ -107,61 +108,73 @@ constexpr types::address lookup_table_tail_end =
 
 constexpr types::address data_address_begin = lookup_table_tail_end;
 
+// create ot_library variables
+constexpr types::address ot_library_begin = 192;
+constexpr types::address ot_library_end =
+    static_cast<types::address>(hardware_iface::EEpromMemorySize::ST_16_KBYTE) -
+    64;
+
 /*
  *Wrapper class for ot_library_end and ot_library_begin
  *included here because there we need a way to enforce
  *that ot_library addresses can only be written to once
  *
+ *NOTE This is no longer necessary for the ot_library implementation
+ See confluence "Ot-Library Migration" docs for more information
  *NOTE: ot_library_begin and ot_library_end WILL BE NULL VALUES until
  *set_data_boundary is called.
  */
-//template <task::TaskClient EEpromClient>
+// template <task::TaskClient EEpromClient>
 class DataAddressWrapper {
-    public:
-        static const auto& get_ot_library_begin() {return _ot_library_begin;}
-        static const auto& get_ot_library_end() {return _ot_library_end;}
+  public:
+    static auto get_ot_library_begin() -> types::address {
+        return _ot_library_begin.value();
+    }
+    static auto get_ot_library_end() -> types::address {
+        return _ot_library_end.value();
+    }
 
-        //sets the ot_library boundary with old data
-        // FYI: this _boundary_address is the actual address that will be stored at the location of the
-        // above boundary_address
-        // Basicalsy _boundary_address = value
-        //            boundary_address = header location that contains _boundary_address
-        static void set_data_boundary(types::address _boundary_address,
-            auto& eeprom_client) {
-            // if either these have been written to, don't do anything
-            if (_ot_library_end || _ot_library_begin) {
-                return;
-            }
-
-            if (_boundary_address % 64 != 0) {
-                _boundary_address += 64 - (_boundary_address % 64);
-            }
-
-            // reassign everything
-            _ot_library_begin = data_address_begin;
-            _ot_library_end = _boundary_address;
-
-            // TODO: Ask Ryan if this would even work
-            message::WriteEepromMessage write;
-            write.memory_address = boundary_address_begin;
-            write.length = boundary_address_length;
-
-
-            auto* write_iter = write.data.begin();
-            write_iter = bit_utils::int_to_bytes(
-                _boundary_address, write_iter, write_iter + write.length);
-
-            eeprom_client.send_eeprom_queue(write);
+    // sets the ot_library boundary with old data
+    //  FYI: this _boundary_address is the actual address that will be stored at
+    //  the location of the above boundary_address Basicalsy _boundary_address =
+    //  value
+    //             boundary_address = header location that contains
+    //             _boundary_address
+    static void set_data_boundary(types::address _boundary_address,
+                                  auto& eeprom_client) {
+        // if either these have been written to, don't do anything
+        if (_ot_library_end || _ot_library_begin) {
+            return;
         }
 
-    private:
-        static inline std::optional<types::address> _ot_library_begin;
-        static inline std::optional<types::address> _ot_library_end;
-};
+        if (_boundary_address % 64 != 0) {
+            uint16_t divided = _boundary_address / 64;
+            uint16_t page_aligned = divided * 64;
 
-// create ot_library variables
-static const auto& ot_library_begin = DataAddressWrapper::get_ot_library_begin();
-static const auto& ot_library_end = DataAddressWrapper::get_ot_library_end();
+            _boundary_address -= _boundary_address - page_aligned;
+        }
+
+        // reassign everything
+        // _ot_library_begin is set to 192 to give the lookup table enough room
+        // to grow It amounts to 3 pages at the beginning of the eeprom
+        _ot_library_begin = 192;
+        _ot_library_end = _boundary_address;
+
+        message::WriteEepromMessage write;
+        write.memory_address = boundary_address_begin;
+        write.length = boundary_address_length;
+
+        auto* write_iter = write.data.begin();
+        write_iter = bit_utils::int_to_bytes(_boundary_address, write_iter,
+                                             write_iter + write.length);
+
+        eeprom_client.send_eeprom_queue(write);
+    }
+
+  private:
+    static inline std::optional<types::address> _ot_library_begin;
+    static inline std::optional<types::address> _ot_library_end;
+};
 
 }  // namespace addresses
 }  // namespace eeprom

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "types.hpp"
+#include "messages.hpp"
+#include "common/core/bit_utils.hpp"
 
 namespace eeprom {
 namespace addresses {
@@ -11,7 +13,7 @@ namespace addresses {
  *
  * [20 bytes]    [4 bytes] [4 bytes]    [2 bytes]      [2 bytes]
  *
- * [                   32 bytes                       ]
+ * [                         32 bytes                          ]
  *
  * overall eeprom organization
  * [header] [lookup table] [unallocated] [data]
@@ -82,8 +84,13 @@ constexpr types::address revision_address_begin = serial_number_address_end;
 constexpr types::address revision_address_end =
     revision_address_begin + revision_length;
 
-constexpr types::data_length reserved_length = 4;
-constexpr types::address reserved_address_begin = revision_address_end;
+constexpr types::data_length boundary_address_length = 2;
+constexpr types::address boundary_address_begin = revision_address_end;
+constexpr types::address boundary_address_end =
+    boundary_address_begin + boundary_address_length;
+
+constexpr types::data_length reserved_length = 2;
+constexpr types::address reserved_address_begin = boundary_address_end;
 constexpr types::address reserved_address_end =
     reserved_address_begin + reserved_length;
 
@@ -97,7 +104,54 @@ constexpr types::address lookup_table_tail_begin = data_revision_address_end;
 constexpr types::address lookup_table_tail_end =
     lookup_table_tail_begin + lookup_table_tail_length;
 
-constexpr types::address data_address_begin = lookup_table_tail_end;
+/*
+ *Wrapper class for ot_library_end and ot_library_begin
+ *included here because there we need a way to enforce
+ *that ot_library addresses can only be written to once
+ *
+ *NOTE: ot_library_begin and ot_library_end WILL BE NULL VALUES until
+ *set_data_boundary is called.
+ */
+class DataAddressWrapper {
+    public:
+        static const auto& get_data_address_begin() {return _data_address_begin;}
+        static const auto& get_ot_library_begin() {return _ot_library_begin;}
+        static const auto& get_ot_library_end() {return _ot_library_end;}
+
+        //sets the ot_library boundary with old data
+        static void set_data_boundary(types::address _boundary_address,
+            TaskClient& eeprom_client) {
+            // if either these have been written to, don't do anything
+            if (_ot_library_end || _ot_library_begin) {
+                return;
+            }
+
+            // reassign everything
+            _ot_library_begin = _data_address_begin;
+            _ot_library_end = _boundary_address;
+            _data_address_begin = _boundary_address;
+
+            // TODO: Ask Ryan if this would even work
+            message::WriteEepromMessage write;
+            write.memory_address = boundary_address_begin;
+            write.length = boundary_address_length;
+            auto* write_iter = write.data.begin();
+            write_iter = bit_utils::int_to_bytes(
+                _boundary_address, write_iter, write_iter + write.length);
+        }
+
+    //TODO: make sure this aligns to the first page (modulo math?)
+
+    private:
+        static inline types::address _data_address_begin = lookup_table_tail_begin;
+        static inline std::optional<types::address> _ot_library_begin;
+        static inline std::optional<types::address> _ot_library_end;
+};
+
+// create ot_library variables
+const auto& data_address_begin = DataAddressWrapper::get_data_address_begin();
+const auto& ot_library_begin = DataAddressWrapper::get_ot_library_begin();
+const auto& ot_library_end = DataAddressWrapper::get_ot_library_end();
 
 }  // namespace addresses
 }  // namespace eeprom

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -156,8 +156,6 @@ class DataAddressWrapper {
             eeprom_client.send_eeprom_queue(write);
         }
 
-    //TODO: make sure this aligns to the first page (modulo math?)
-
     private:
         static inline std::optional<types::address> _ot_library_begin;
         static inline std::optional<types::address> _ot_library_end;

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -147,7 +147,9 @@ class DataAddressWrapper {
             return;
         }
 
-        if (_boundary_address % 64 != 0) {
+        uint8_t byte_size = 64;
+
+        if (_boundary_address % byte_size != 0) {
             uint16_t divided = _boundary_address / 64;
             uint16_t page_aligned = divided * 64;
 

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -122,11 +122,19 @@ class DataAddressWrapper {
         static const auto& get_ot_library_end() {return _ot_library_end;}
 
         //sets the ot_library boundary with old data
+        // FYI: this _boundary_address is the actual address that will be stored at the location of the
+        // above boundary_address
+        // Basicalsy _boundary_address = value
+        //            boundary_address = header location that contains _boundary_address
         static void set_data_boundary(types::address _boundary_address,
             auto& eeprom_client) {
             // if either these have been written to, don't do anything
             if (_ot_library_end || _ot_library_begin) {
                 return;
+            }
+
+            if (_boundary_address % 64 != 0) {
+                _boundary_address += 64 - (_boundary_address % 64);
             }
 
             // reassign everything

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -146,9 +146,7 @@ class DataAddressWrapper {
             write.memory_address = boundary_address_begin;
             write.length = boundary_address_length;
 
-            // Where does this data come from? it's currently stored in RAM,
-            // we never tell the computer where to find it.
-            // Ask Ryan for clarification when he gets back
+
             auto* write_iter = write.data.begin();
             write_iter = bit_utils::int_to_bytes(
                 _boundary_address, write_iter, write_iter + write.length);

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -1,9 +1,7 @@
 #pragma once
-#include <iostream>
 
 #include "common/core/bit_utils.hpp"
 #include "messages.hpp"
-#include "task.hpp"
 #include "types.hpp"
 
 namespace eeprom {

--- a/include/eeprom/core/addresses.hpp
+++ b/include/eeprom/core/addresses.hpp
@@ -3,6 +3,7 @@
 #include "types.hpp"
 #include "messages.hpp"
 #include "common/core/bit_utils.hpp"
+#include "task.hpp"
 
 namespace eeprom {
 namespace addresses {
@@ -104,6 +105,8 @@ constexpr types::address lookup_table_tail_begin = data_revision_address_end;
 constexpr types::address lookup_table_tail_end =
     lookup_table_tail_begin + lookup_table_tail_length;
 
+constexpr types::address data_address_begin = lookup_table_tail_end;
+
 /*
  *Wrapper class for ot_library_end and ot_library_begin
  *included here because there we need a way to enforce
@@ -112,46 +115,49 @@ constexpr types::address lookup_table_tail_end =
  *NOTE: ot_library_begin and ot_library_end WILL BE NULL VALUES until
  *set_data_boundary is called.
  */
+//template <task::TaskClient EEpromClient>
 class DataAddressWrapper {
     public:
-        static const auto& get_data_address_begin() {return _data_address_begin;}
         static const auto& get_ot_library_begin() {return _ot_library_begin;}
         static const auto& get_ot_library_end() {return _ot_library_end;}
 
         //sets the ot_library boundary with old data
         static void set_data_boundary(types::address _boundary_address,
-            TaskClient& eeprom_client) {
+            auto& eeprom_client) {
             // if either these have been written to, don't do anything
             if (_ot_library_end || _ot_library_begin) {
                 return;
             }
 
             // reassign everything
-            _ot_library_begin = _data_address_begin;
+            _ot_library_begin = data_address_begin;
             _ot_library_end = _boundary_address;
-            _data_address_begin = _boundary_address;
 
             // TODO: Ask Ryan if this would even work
             message::WriteEepromMessage write;
             write.memory_address = boundary_address_begin;
             write.length = boundary_address_length;
+
+            // Where does this data come from? it's currently stored in RAM,
+            // we never tell the computer where to find it.
+            // Ask Ryan for clarification when he gets back
             auto* write_iter = write.data.begin();
             write_iter = bit_utils::int_to_bytes(
                 _boundary_address, write_iter, write_iter + write.length);
+
+            eeprom_client.send_eeprom_queue(write);
         }
 
     //TODO: make sure this aligns to the first page (modulo math?)
 
     private:
-        static inline types::address _data_address_begin = lookup_table_tail_begin;
         static inline std::optional<types::address> _ot_library_begin;
         static inline std::optional<types::address> _ot_library_end;
 };
 
 // create ot_library variables
-const auto& data_address_begin = DataAddressWrapper::get_data_address_begin();
-const auto& ot_library_begin = DataAddressWrapper::get_ot_library_begin();
-const auto& ot_library_end = DataAddressWrapper::get_ot_library_end();
+static const auto& ot_library_begin = DataAddressWrapper::get_ot_library_begin();
+static const auto& ot_library_end = DataAddressWrapper::get_ot_library_end();
 
 }  // namespace addresses
 }  // namespace eeprom

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -29,10 +29,18 @@ struct table_entry_action {
  *
  * @tparam EEPromTaskClient client of eeprom task
  **/
+// intermediate base class for DevDataTailAccessor
+struct DevDataTailIntermediate {
+    protected:
+        DataTailType data_tail_buff = DataTailType{};
+};
+
+
 // helper class to handle reading writing the data_tail value
 template <task::TaskClient EEPromTaskClient>
 class DevDataTailAccessor
-    : public accessor::EEPromAccessor<EEPromTaskClient,
+    : DevDataTailIntermediate,
+        public accessor::EEPromAccessor<EEPromTaskClient,
                                       addresses::lookup_table_tail_begin>,
       accessor::ReadListener {
     using accessor::EEPromAccessor<
@@ -142,7 +150,6 @@ class DevDataTailAccessor
         self->increase_tail_callback(msg);
     }
 
-    DataTailType data_tail_buff = DataTailType{};
     types::address data_tail = 0;
     bool tail_updated{false};
     bool config_updated{false};

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -31,16 +31,15 @@ struct table_entry_action {
  **/
 // intermediate base class for DevDataTailAccessor
 struct DevDataTailIntermediate {
-    protected:
-        DataTailType data_tail_buff = DataTailType{};
+  protected:
+    DataTailType data_tail_buff = DataTailType{};
 };
-
 
 // helper class to handle reading writing the data_tail value
 template <task::TaskClient EEPromTaskClient>
 class DevDataTailAccessor
     : DevDataTailIntermediate,
-        public accessor::EEPromAccessor<EEPromTaskClient,
+      public accessor::EEPromAccessor<EEPromTaskClient,
                                       addresses::lookup_table_tail_begin>,
       accessor::ReadListener {
     using accessor::EEPromAccessor<
@@ -354,19 +353,21 @@ class DevDataAccessor
         return table_ready() && tail_accessor.data_rev_complete();
     }
 
-	/*
-	OT-Library Methods
-	*/
+    /*
+    OT-Library Methods
+    */
 
-	// Migration
+    // Migration
     auto find_data_end(uint16_t key, uint16_t len) -> types::address {
-		// find address of current key
-		types::address current_key_start_address = calculate_table_entry_start(key);
+        // find address of current key
+        types::address current_key_start_address =
+            calculate_table_entry_start(key);
 
-        types::address current_key_end_address = current_key_start_address + len;
+        types::address current_key_end_address =
+            current_key_start_address - len;
 
         return current_key_end_address;
-	}
+    }
 
   private:
     DevDataTailAccessor<EEPromTaskClient>& tail_accessor;

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <array>
-#include <iostream>
 
 #include "accessor.hpp"
 #include "addresses.hpp"

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -347,6 +347,20 @@ class DevDataAccessor
         return table_ready() && tail_accessor.data_rev_complete();
     }
 
+	/*
+	OT-Library Methods
+	*/
+
+	// Migration
+    auto find_data_end(uint16_t key, uint16_t len) -> types::address {
+		// find address of current key
+		types::address current_key_start_address = calculate_table_entry_start(key);
+
+        types::address current_key_end_address = current_key_start_address + len;
+
+        return current_key_end_address;
+	}
+
   private:
     DevDataTailAccessor<EEPromTaskClient>& tail_accessor;
     message::ConfigResponseMessage conf = message::ConfigResponseMessage{};

--- a/include/eeprom/core/dev_data.hpp
+++ b/include/eeprom/core/dev_data.hpp
@@ -1,6 +1,6 @@
 #pragma once
-
 #include <array>
+#include <iostream>
 
 #include "accessor.hpp"
 #include "addresses.hpp"
@@ -363,10 +363,14 @@ class DevDataAccessor
         types::address current_key_start_address =
             calculate_table_entry_start(key);
 
-        types::address current_key_end_address =
-            current_key_start_address - len;
+        types::address key_end_address = current_key_start_address + len;
 
-        return current_key_end_address;
+        types::address true_key_end_address =
+            static_cast<types::address>(
+                hardware_iface::EEpromMemorySize::ST_16_KBYTE) -
+            key_end_address;
+
+        return true_key_end_address;
     }
 
   private:

--- a/include/eeprom/core/types.hpp
+++ b/include/eeprom/core/types.hpp
@@ -6,6 +6,9 @@ namespace types {
 // 0-65535
 using address = uint16_t;
 
+// 0-64
+using book_address = uint8_t;
+
 // 0-8
 using data_length = uint16_t;
 

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -5,6 +5,7 @@
 #include "common/core/bit_utils.hpp"
 #include "eeprom/core/data_rev.hpp"
 #include "eeprom/core/dev_data.hpp"
+#include "eeprom/core/ot_library.hpp"
 #include "eeprom/core/task.hpp"
 
 namespace eeprom {
@@ -16,7 +17,21 @@ struct DataTableUpdateMessage {
     std::vector<std::pair<types::address, types::data_length>> data_table;
 };
 
-using TaskMessage = std::variant<std::monostate, DataTableUpdateMessage>;
+// Message to migrate data from old to new
+struct MigrateDataMessage {
+    uint16_t data_rev;
+    // previous data table
+    std::vector<std::pair<types::address, types::data_length>> data_table;
+};
+
+struct OTLibraryUpdateMessage {
+    uint16_t data_rev;
+    std::vector<std::pair<types::book_address, types::data_length>>
+        ot_library_table;
+};
+
+using TaskMessage = std::variant<std::monostate, DataTableUpdateMessage,
+                                 MigrateDataMessage, OTLibraryUpdateMessage>;
 
 template <task::TaskClient EEPromClient>
 class UpdateDataRevHandler : accessor::ReadListener {
@@ -51,6 +66,55 @@ class UpdateDataRevHandler : accessor::ReadListener {
                     vTaskDelay(10);
                 }
             }
+            std::ignore = bit_utils::int_to_bytes(
+                m.data_rev, data_rev_backing.begin(), data_rev_backing.end());
+            data_rev_accessor.write(data_rev_backing, 0);
+            current_data_rev = m.data_rev;
+        }
+    }
+
+    void visit(MigrateDataMessage& m) {
+
+        if (m.data_rev == current_data_rev + 1) {
+            // sort the data table to make sure keys are properly ordered
+            auto data_table_length = m.data_table.size();
+            std::sort(m.data_table.begin(), m.data_table.end());
+
+            // access final pair of data table and extract contents
+            std::pair<types::address, types::data_length> data_end =
+                m.data_table[data_table_length - 1];
+            types::address key = data_end.first;
+            types::data_length length = data_end.second;
+
+            // update the "tail" of ot_library (through ot_library_end address)
+            // to end of previous data
+            addresses::DataAddressWrapper::set_data_boundary(
+                table_creator.find_data_end(key, length));
+
+            // TODO: Make an OTLibraryAccessor
+
+            for (const auto& i : m.data_table) {
+                // TODO: add a table_creator method to migrate data
+                // 1. get value here
+                // 2. move to same index in new_location
+                // in DevDataAccessor you can just say "the tail of the last
+                // data is the beginning of our new data".
+                // Since table_creator seems to be what actually writes the data
+            }
+            std::ignore = bit_utils::int_to_bytes(
+                m.data_rev, data_rev_backing.begin(), data_rev_backing.end());
+            data_rev_accessor.write(data_rev_backing, 0);
+            current_data_rev = m.data_rev;
+        }
+    }
+
+    void visit(const OTLibraryUpdateMessage& m) {
+        if (m.data_rev == current_data_rev + 1) {
+            for (const auto& i : m.ot_library_table) {
+                // create new table_creator method to handle the new file system
+                // TODO: add a table_creator method to add data in new format
+            }
+
             std::ignore = bit_utils::int_to_bytes(
                 m.data_rev, data_rev_backing.begin(), data_rev_backing.end());
             data_rev_accessor.write(data_rev_backing, 0);

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -5,7 +5,6 @@
 #include "common/core/bit_utils.hpp"
 #include "eeprom/core/data_rev.hpp"
 #include "eeprom/core/dev_data.hpp"
-#include "eeprom/core/ot_library.hpp"
 #include "eeprom/core/task.hpp"
 
 namespace eeprom {
@@ -40,7 +39,8 @@ class UpdateDataRevHandler : accessor::ReadListener {
         EEPromClient& eeprom_client,
         dev_data::DevDataTailAccessor<EEPromClient>& tail_accessor)
         : table_creator{eeprom_client, *this, accessor_backing, tail_accessor},
-          data_rev_accessor{eeprom_client, *this, data_rev_backing} {
+          data_rev_accessor{eeprom_client, *this, data_rev_backing},
+          eeprom_client(eeprom_client) {
         data_rev_accessor.start_read(0);
     }
 
@@ -89,18 +89,19 @@ class UpdateDataRevHandler : accessor::ReadListener {
             // update the "tail" of ot_library (through ot_library_end address)
             // to end of previous data
             addresses::DataAddressWrapper::set_data_boundary(
-                table_creator.find_data_end(key, length));
+                table_creator.find_data_end(key, length), eeprom_client);
 
             // TODO: Make an OTLibraryAccessor
 
-            for (const auto& i : m.data_table) {
+            /*for (const auto& i : m.data_table) {
                 // TODO: add a table_creator method to migrate data
                 // 1. get value here
                 // 2. move to same index in new_location
                 // in DevDataAccessor you can just say "the tail of the last
                 // data is the beginning of our new data".
                 // Since table_creator seems to be what actually writes the data
-            }
+            }*/
+
             std::ignore = bit_utils::int_to_bytes(
                 m.data_rev, data_rev_backing.begin(), data_rev_backing.end());
             data_rev_accessor.write(data_rev_backing, 0);
@@ -109,7 +110,7 @@ class UpdateDataRevHandler : accessor::ReadListener {
     }
 
     void visit(const OTLibraryUpdateMessage& m) {
-        if (m.data_rev == current_data_rev + 1) {
+        /*if (m.data_rev == current_data_rev + 1) {
             for (const auto& i : m.ot_library_table) {
                 // create new table_creator method to handle the new file system
                 // TODO: add a table_creator method to add data in new format
@@ -119,7 +120,9 @@ class UpdateDataRevHandler : accessor::ReadListener {
                 m.data_rev, data_rev_backing.begin(), data_rev_backing.end());
             data_rev_accessor.write(data_rev_backing, 0);
             current_data_rev = m.data_rev;
-        }
+        }*/
+        // placeholder for now
+        std::ignore = m;
     }
 
     void read_complete(uint32_t) final {
@@ -146,6 +149,7 @@ class UpdateDataRevHandler : accessor::ReadListener {
     data_revision::DataRevisionType data_rev_backing =
         data_revision::DataRevisionType{};
     data_revision::DataRevAccessor<EEPromClient> data_rev_accessor;
+    EEPromClient& eeprom_client;
 };
 
 /**

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -6,6 +6,7 @@
 #include "eeprom/core/data_rev.hpp"
 #include "eeprom/core/dev_data.hpp"
 #include "eeprom/core/task.hpp"
+#include "eeprom/core/types.hpp"
 
 namespace eeprom {
 namespace data_rev_task {
@@ -74,32 +75,14 @@ class UpdateDataRevHandler : accessor::ReadListener {
     }
 
     void visit(MigrateDataMessage& m) {
-
         if (m.data_rev == current_data_rev + 1) {
-            // sort the data table to make sure keys are properly ordered
-            auto data_table_length = m.data_table.size();
-            std::sort(m.data_table.begin(), m.data_table.end());
-
-            // access final pair of data table and extract contents
-            std::pair<types::address, types::data_length> data_end =
-                m.data_table[data_table_length - 1];
-            types::address key = data_end.first;
-            types::data_length length = data_end.second;
-
-            // update the "tail" of ot_library (through ot_library_end address)
-            // to end of previous data
-            addresses::DataAddressWrapper::set_data_boundary(
-                table_creator.find_data_end(key, length), eeprom_client);
-
+            set_ot_library_boundary(m);
             // TODO: Make an OTLibraryAccessor
 
             /*for (const auto& i : m.data_table) {
                 // TODO: add a table_creator method to migrate data
                 // 1. get value here
                 // 2. move to same index in new_location
-                // in DevDataAccessor you can just say "the tail of the last
-                // data is the beginning of our new data".
-                // Since table_creator seems to be what actually writes the data
             }*/
 
             std::ignore = bit_utils::int_to_bytes(
@@ -107,6 +90,23 @@ class UpdateDataRevHandler : accessor::ReadListener {
             data_rev_accessor.write(data_rev_backing, 0);
             current_data_rev = m.data_rev;
         }
+    }
+
+    void set_ot_library_boundary(MigrateDataMessage& m) {
+        // sort the data table to make sure keys are properly ordered
+        auto data_table_length = m.data_table.size();
+        std::sort(m.data_table.begin(), m.data_table.end());
+
+        // access final pair of data table and extract contents
+        std::pair<types::address, types::data_length> data_end =
+            m.data_table[data_table_length - 1];
+        types::address key = data_end.first;
+        types::data_length length = data_end.second;
+
+        // update the "tail" of ot_library (through ot_library_end address)
+        // to end of previous data
+        addresses::DataAddressWrapper::set_data_boundary(
+            table_creator.find_data_end(key, length), eeprom_client);
     }
 
     void visit(const OTLibraryUpdateMessage& m) {
@@ -156,7 +156,7 @@ class UpdateDataRevHandler : accessor::ReadListener {
  * The task type.
  */
 template <template <class> class QueueImpl>
-requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
+    requires MessageQueue<QueueImpl<TaskMessage>, TaskMessage>
 class UpdateDataRevTask {
   public:
     using Messages = TaskMessage;

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -76,8 +76,8 @@ class UpdateDataRevHandler : accessor::ReadListener {
 
     void visit(MigrateDataMessage& m) {
         if (m.data_rev == current_data_rev + 1) {
-            set_ot_library_boundary(m);
-            // TODO: Make an OTLibraryAccessor
+            // set_ot_library_boundary(m);
+            //  TODO: Make an OTLibraryAccessor
 
             /*for (const auto& i : m.data_table) {
                 // TODO: add a table_creator method to migrate data

--- a/include/eeprom/core/update_data_rev_task.hpp
+++ b/include/eeprom/core/update_data_rev_task.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <vector>
-
 #include "common/core/bit_utils.hpp"
 #include "eeprom/core/data_rev.hpp"
 #include "eeprom/core/dev_data.hpp"

--- a/include/i2c/core/hardware_iface.hpp
+++ b/include/i2c/core/hardware_iface.hpp
@@ -34,6 +34,6 @@ class I2CBase {
         -> bool = 0;
 };
 
-};  // namespace hardware
+}  // namespace hardware
 
-};  // namespace i2c
+}  // namespace i2c

--- a/include/i2c/core/messages.hpp
+++ b/include/i2c/core/messages.hpp
@@ -189,5 +189,5 @@ struct ConfigureMultiRegisterContinuousPolling {
     ResponseWriter response_writer;
 };
 
-};  // namespace messages
-};  // namespace i2c
+}  // namespace messages
+}  // namespace i2c

--- a/include/i2c/simulation/i2c_sim.hpp
+++ b/include/i2c/simulation/i2c_sim.hpp
@@ -35,5 +35,5 @@ class SimI2C : public I2CBase {
     std::vector<uint8_t> next_receive{};
     uint16_t last_receive_length = 0;
 };
-};  // namespace hardware
+}  // namespace hardware
 }  // namespace i2c

--- a/include/i2c/tests/mock_response_queue.hpp
+++ b/include/i2c/tests/mock_response_queue.hpp
@@ -70,4 +70,4 @@ inline auto launder_response(Message& msg, Queue& q,
     return get_response(q);
 }
 
-};  // namespace test_mocks
+}  // namespace test_mocks

--- a/include/sensors/core/mmr920.hpp
+++ b/include/sensors/core/mmr920.hpp
@@ -369,5 +369,5 @@ using RegisterSerializedType = uint8_t;
 // Command Registers are all 8 bits
 // Type definition to allow type aliasing for pointer dereferencing
 using RegisterSerializedTypeA = __attribute__((__may_alias__)) uint8_t;
-};  // namespace mmr920
-};  // namespace sensors
+}  // namespace mmr920
+}  // namespace sensors

--- a/include/sensors/core/utils.hpp
+++ b/include/sensors/core/utils.hpp
@@ -92,5 +92,5 @@ template <typename RegType>
 [[nodiscard]] inline constexpr auto reg_from_id(uint32_t id) -> RegType {
     return static_cast<RegType>(static_cast<uint8_t>((id >> 8) & 0xff));
 }
-};  // namespace utils
-};  // namespace sensors
+}  // namespace utils
+}  // namespace sensors


### PR DESCRIPTION
# Overview
The decision has been made to exclude all of the locations on the EEPROM that had been used before wear-leveling had been implemented. This PR includes the logic to find that edge and write it to a new "boundary" location in the EEPROM header. 

## Changelog
### `update_data_rev_handler.hpp`
There are now 2 new messages that update_data_rev handler can handle: MigrateDataMessage, OTLibraryUpdateMessage.
The latter is to be implemented at a later date. 

The MigrateDataMessage handler will now pass a key-value pair into the `find_data_end()` method in DevDataAccessor. It then collects that result, and writes it to the EEPROM using the `set_data_boundary()` method in the addresses::DataAddressWrapper singleton.

### `dev_data.hpp`
Inside the DevDataAccessor class, a new `find_data_end(key, length)` method is created. This function simply finds the end of a data entry.

### `addresses.hpp`
A new DataAddressWrapper singleton class was created for the start and end addresses of the OT-Library. to allow for one write in any given runtime. There are a number of reasons for this
1. We don't want anyone accidentally modifying the addresses multiple times
2. We need a way for all classes to be able to see the addresses stored in this class
3. By constraining enforcement scope to runtime, we are allowing for multiple migration events and OT-Library updates

### `types.hpp`
a new 8-bit integer "book_address" type was introduced to prepare for future accessing implementations.

I also removed a bunch of semicolons after the curly braces that signify the end of a namespace since clang kept getting upset.

## Testing
New unit testing file `test_data_update_rev.cpp` included to test that data is properly cutoff at page boundary and that data is properly locked post-cutoff.

## Questions
since the EEPROM writes addresses from back to front, I'm assuming that writes begin at the most significant address  and aend at the least significant. If that's the case, should I change the final data boundary calculation to use a minus instead of a plus to compensate?


## Risk Assessment
Medium. Touching critical machine hardware, but doesn't do anything too extreme just yet. 