### PR TITLE
fix(wear-leveling): Reset cached keys

### DIFF
--- a/include/eeprom/core/book_accessor.hpp
+++ b/include/eeprom/core/book_accessor.hpp
@@ -581,6 +581,8 @@ class BookAccessor
         // set table action to write
         action_cmd_m.action = TableAction::WRITE;
 
+        cached_key = -1;
+
         table_action_callback(write_msg);
     }
 


### PR DESCRIPTION
This PR adds one line to the write flow of the EEPROM to reset the cached key after a write has been launched. This fixes a potential issue where a read, a write, and another write performed by the user will result in the second write using stale data.
